### PR TITLE
provider/alicloud: Set EIP's output parameter 'instance' deprecated

### DIFF
--- a/website/docs/r/eip.html.markdown
+++ b/website/docs/r/eip.html.markdown
@@ -35,4 +35,3 @@ The following attributes are exported:
 * `internet_charge_type` - The EIP internet charge type.
 * `status` - The EIP current status.
 * `ip_address` - The elastic ip address
-* `instance` - The ID of the instance which is associated with the EIP.


### PR DESCRIPTION
The PR sets EIP's output parameter 'instance' and removes it from the EIP's docs.

The running results of test case as follows according to this change:

TF_ACC=1 go test ./alicloud/ -v -run=TestAccAlicloudEIP -timeout 120m
=== RUN   TestAccAlicloudEIPAssociation
--- PASS: TestAccAlicloudEIPAssociation (101.55s)
=== RUN   TestAccAlicloudEIP_basic
--- PASS: TestAccAlicloudEIP_basic (9.55s)
PASS
ok      github.com/terraform-providers/terraform-provider-alicloud/alicloud     111.120s
