### PR TITLE
provider/alicloud: Remove EIP's output parameter 'instance'

### DIFF
--- a/alicloud/resource_alicloud_eip.go
+++ b/alicloud/resource_alicloud_eip.go
@@ -64,9 +64,14 @@ func resourceAliyunEipCreate(d *schema.ResourceData, meta interface{}) error {
 		return err
 	}
 
+	err = conn.WaitForEip(getRegion(d, meta), allocationID, ecs.EipStatusAvailable, 60)
+	if err != nil {
+		return fmt.Errorf("Error Waitting for EIP available: %#v", err)
+	}
+
 	d.SetId(allocationID)
 
-	return resourceAliyunEipRead(d, meta)
+	return resourceAliyunEipUpdate(d, meta)
 }
 
 func resourceAliyunEipRead(d *schema.ResourceData, meta interface{}) error {
@@ -81,11 +86,11 @@ func resourceAliyunEipRead(d *schema.ResourceData, meta interface{}) error {
 		return fmt.Errorf("Error Describe Eip Attribute: %#v", err)
 	}
 
+	// Output parameter 'instance' would be deprecated in the next version.
 	if eip.InstanceId != "" {
 		d.Set("instance", eip.InstanceId)
 	} else {
 		d.Set("instance", "")
-		return nil
 	}
 
 	bandwidth, _ := strconv.Atoi(eip.Bandwidth)
@@ -103,7 +108,7 @@ func resourceAliyunEipUpdate(d *schema.ResourceData, meta interface{}) error {
 
 	d.Partial(true)
 
-	if d.HasChange("bandwidth") {
+	if d.HasChange("bandwidth") && !d.IsNewResource() {
 		err := conn.ModifyEipAddressAttribute(d.Id(), d.Get("bandwidth").(int))
 		if err != nil {
 			return err
@@ -114,7 +119,7 @@ func resourceAliyunEipUpdate(d *schema.ResourceData, meta interface{}) error {
 
 	d.Partial(false)
 
-	return nil
+	return resourceAliyunEipRead(d, meta)
 }
 
 func resourceAliyunEipDelete(d *schema.ResourceData, meta interface{}) error {

--- a/alicloud/resource_alicloud_eip_association.go
+++ b/alicloud/resource_alicloud_eip_association.go
@@ -46,6 +46,10 @@ func resourceAliyunEipAssociationCreate(d *schema.ResourceData, meta interface{}
 		return err
 	}
 
+	if err := conn.WaitForEip(getRegion(d, meta), allocationId, ecs.EipStatusInUse, 60); err != nil {
+		return fmt.Errorf("Error Waitting for EIP allocated: %#v", err)
+	}
+
 	d.SetId(allocationId + ":" + instanceId)
 
 	return resourceAliyunEipAssociationRead(d, meta)

--- a/website/docs/r/eip.html.markdown
+++ b/website/docs/r/eip.html.markdown
@@ -35,4 +35,3 @@ The following attributes are exported:
 * `internet_charge_type` - The EIP internet charge type.
 * `status` - The EIP current status.
 * `ip_address` - The elastic ip address
-* `instance` - The ID of the instance which is associated with the EIP.


### PR DESCRIPTION
The PR sets EIP's output parameter 'instance' and removes it from the EIP's docs.

The running results of test case as follows according to this change:

TF_ACC=1 go test ./alicloud/ -v -run=TestAccAlicloudEIP -timeout 120m
=== RUN TestAccAlicloudEIPAssociation
--- PASS: TestAccAlicloudEIPAssociation (101.55s)
=== RUN TestAccAlicloudEIP_basic
--- PASS: TestAccAlicloudEIP_basic (9.55s)
PASS
ok github.com/terraform-providers/terraform-provider-alicloud/alicloud 111.120s