### PR TITLE
provider/alicloud: Fix attaching multiple disks bug and set disk-attachment's parameter 'device_name' as deprecated

### DIFF
--- a/alicloud/errors.go
+++ b/alicloud/errors.go
@@ -12,6 +12,7 @@ const (
 	DiskCreatingSnapshot      = "DiskCreatingSnapshot"
 	InstanceLockedForSecurity = "InstanceLockedForSecurity"
 	SystemDiskNotFound        = "SystemDiskNotFound"
+	DiskOperationConflict     = "OperationConflict"
 	// eip
 	EipIncorrectStatus      = "IncorrectEipStatus"
 	InstanceIncorrectStatus = "IncorrectInstanceStatus"


### PR DESCRIPTION
This PR does the following work:
1. Fix alicloud_disk_attachment bug that when attaching multiple diskes, it will be failed and only attach one disk;
2. Set device_name as deprecated because of when attaching disk it will be allocated automatically by system.

The running results of test case as following:

TF_ACC=1 go test ./alicloud/ -v -run=TestAccAlicloudDisk -timeout 120m
=== RUN   TestAccAlicloudDiskAttachment
--- PASS: TestAccAlicloudDiskAttachment (117.73s)
=== RUN   TestAccAlicloudDiskMultiAttachment
--- PASS: TestAccAlicloudDiskMultiAttachment (269.15s)
=== RUN   TestAccAlicloudDisk_basic
--- PASS: TestAccAlicloudDisk_basic (64.18s)
=== RUN   TestAccAlicloudDisk_withTags
--- PASS: TestAccAlicloudDisk_withTags (63.69s)
PASS
ok      github.com/terraform-providers/terraform-provider-alicloud/alicloud     514.764s
