### PR TITLE
[IMPROVEMENT] Filter and get valid instance types and disk category

### DIFF
--- a/alicloud/data_source_alicloud_instance_types.go
+++ b/alicloud/data_source_alicloud_instance_types.go
@@ -12,6 +12,11 @@ func dataSourceAlicloudInstanceTypes() *schema.Resource {
 		Read: dataSourceAlicloudInstanceTypesRead,
 
 		Schema: map[string]*schema.Schema{
+			"availability_zone": &schema.Schema{
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: true,
+			},
 			"instance_type_family": {
 				Type:     schema.TypeString,
 				Optional: true,
@@ -26,6 +31,10 @@ func dataSourceAlicloudInstanceTypes() *schema.Resource {
 				Type:     schema.TypeFloat,
 				Optional: true,
 				ForceNew: true,
+			},
+			"is_outdated": &schema.Schema{
+				Type:     schema.TypeBool,
+				Optional: true,
 			},
 			"output_file": {
 				Type:     schema.TypeString,
@@ -61,10 +70,16 @@ func dataSourceAlicloudInstanceTypes() *schema.Resource {
 }
 
 func dataSourceAlicloudInstanceTypesRead(d *schema.ResourceData, meta interface{}) error {
-	conn := meta.(*AliyunClient).ecsconn
+	client := meta.(*AliyunClient)
+	// Ensure instance_type is generation three, and get generation three families
+	validData, err := client.CheckParameterValidity(d, meta)
 
-	cpu, _ := d.Get("cpu_core_count").(int)
-	mem, _ := d.Get("memory_size").(float64)
+	if err != nil {
+		return err
+	}
+
+	cpu := d.Get("cpu_core_count").(int)
+	mem := d.Get("memory_size").(float64)
 
 	args, err := buildAliyunAlicloudInstanceTypesArgs(d, meta)
 
@@ -72,13 +87,26 @@ func dataSourceAlicloudInstanceTypesRead(d *schema.ResourceData, meta interface{
 		return err
 	}
 
-	resp, err := conn.DescribeInstanceTypesNew(args)
+	resp, err := client.ecsconn.DescribeInstanceTypesNew(args)
 	if err != nil {
 		return err
 	}
 
+	validInstanceTypes := make(map[string]string)
+	if val, ok := validData[UpgradedInstanceTypeKey]; ok {
+		validInstanceTypes = val.(map[string]string)
+	}
+	if val, ok := validData[OutdatedInstanceTypeKey]; d.Get("is_outdated").(bool) && ok {
+		validInstanceTypes = val.(map[string]string)
+	}
+
 	var instanceTypes []ecs.InstanceTypeItemType
 	for _, types := range resp {
+		// Only filter series three instance type.
+		if _, ok := validInstanceTypes[types.InstanceTypeId]; !ok {
+			continue
+		}
+
 		if cpu > 0 && types.CpuCoreCount != cpu {
 			continue
 		}

--- a/alicloud/errors.go
+++ b/alicloud/errors.go
@@ -9,7 +9,9 @@ const (
 	// common
 	Notfound = "Not found"
 	// ecs
-	InstanceNotfound = "Instance.Notfound"
+	InstanceNotfound        = "Instance.Notfound"
+	InstanceNotFound        = "Instance.Notfound"
+	MessageInstanceNotFound = "instance is not found"
 	// disk
 	DiskIncorrectStatus       = "IncorrectDiskStatus"
 	DiskCreatingSnapshot      = "DiskCreatingSnapshot"
@@ -64,6 +66,16 @@ func GetNotFoundErrorFromString(str string) error {
 		},
 		StatusCode: -1,
 	}
+}
+
+func NotFoundError(err error) bool {
+	if e, ok := err.(*common.Error); ok &&
+		(e.Code == InstanceNotFound || e.Code == RamInstanceNotFound ||
+			strings.Contains(strings.ToLower(e.Message), MessageInstanceNotFound)) {
+		return true
+	}
+
+	return false
 }
 
 func IsExceptedError(err error, expectCode string) bool {

--- a/alicloud/extension_ecs.go
+++ b/alicloud/extension_ecs.go
@@ -1,5 +1,7 @@
 package alicloud
 
+import "github.com/denverdino/aliyungo/ecs"
+
 type GroupRuleDirection string
 
 const (
@@ -39,3 +41,16 @@ const (
 const GenerationOne = "ecs-1"
 const GenerationTwo = "ecs-2"
 const GenerationThree = "ecs-3"
+const GenerationFour = "ecs-4"
+
+var NoneIoOptimizedFamily = map[string]string{"ecs.t1": "", "ecs.t2": "", "ecs.s1": ""}
+var NoneIoOptimizedInstanceType = map[string]string{"ecs.s2.small": ""}
+var HalfIoOptimizedFamily = map[string]string{"ecs.s2": "", "ecs.s3": "", "ecs.m1": "", "ecs.m2": "", "ecs.c1": "", "ecs.c2": ""}
+
+var OutdatedDiskCategory = map[ecs.DiskCategory]ecs.DiskCategory{
+	ecs.DiskCategoryCloud: ecs.DiskCategoryCloud}
+
+var SupportedDiskCategory = map[ecs.DiskCategory]ecs.DiskCategory{
+	ecs.DiskCategoryCloudSSD:        ecs.DiskCategoryCloudSSD,
+	ecs.DiskCategoryCloudEfficiency: ecs.DiskCategoryCloudEfficiency,
+	ecs.DiskCategoryCloud:           ecs.DiskCategoryCloud}

--- a/alicloud/resource_alicloud_instance.go
+++ b/alicloud/resource_alicloud_instance.go
@@ -5,7 +5,6 @@ import (
 	"log"
 
 	"encoding/base64"
-	"encoding/json"
 	"github.com/denverdino/aliyungo/common"
 	"github.com/denverdino/aliyungo/ecs"
 	"github.com/hashicorp/terraform/helper/resource"
@@ -40,6 +39,7 @@ func resourceAliyunInstance() *schema.Resource {
 			"instance_type": &schema.Schema{
 				Type:     schema.TypeString,
 				Required: true,
+				ForceNew: true,
 			},
 
 			"security_groups": &schema.Schema{
@@ -71,6 +71,7 @@ func resourceAliyunInstance() *schema.Resource {
 				Type:         schema.TypeString,
 				Optional:     true,
 				ForceNew:     true,
+				Computed:     true,
 				ValidateFunc: validateInternetChargeType,
 			},
 			"internet_max_bandwidth_in": &schema.Schema{
@@ -95,23 +96,20 @@ func resourceAliyunInstance() *schema.Resource {
 				Sensitive: true,
 			},
 			"io_optimized": &schema.Schema{
-				Type:         schema.TypeString,
-				Required:     true,
-				ForceNew:     true,
-				ValidateFunc: validateIoOptimized,
+				Type:       schema.TypeString,
+				Optional:   true,
+				Deprecated: "Attribute io_optimized has been deprecated on instance resource. All the launched alicloud instances will be IO optimized. Suggest to remove it from your template.",
 			},
-
-			"system_disk_category": &schema.Schema{
-				Type:     schema.TypeString,
-				Default:  "cloud_efficiency",
+			"is_outdated": &schema.Schema{
+				Type:     schema.TypeBool,
 				Optional: true,
-				ForceNew: true,
-				ValidateFunc: validateAllowedStringValue([]string{
-					string(ecs.DiskCategoryCloud),
-					string(ecs.DiskCategoryCloudSSD),
-					string(ecs.DiskCategoryCloudEfficiency),
-					string(ecs.DiskCategoryEphemeralSSD),
-				}),
+			},
+			"system_disk_category": &schema.Schema{
+				Type:         schema.TypeString,
+				Default:      ecs.DiskCategoryCloudEfficiency,
+				Optional:     true,
+				ForceNew:     true,
+				ValidateFunc: validateDiskCategory,
 			},
 			"system_disk_size": &schema.Schema{
 				Type:         schema.TypeInt,
@@ -139,6 +137,7 @@ func resourceAliyunInstance() *schema.Resource {
 				Optional:     true,
 				ForceNew:     true,
 				ValidateFunc: validateInstanceChargeType,
+				Default:      common.PostPaid,
 			},
 			"period": &schema.Schema{
 				Type:     schema.TypeInt,
@@ -176,15 +175,17 @@ func resourceAliyunInstance() *schema.Resource {
 func resourceAliyunInstanceCreate(d *schema.ResourceData, meta interface{}) error {
 	conn := meta.(*AliyunClient).ecsconn
 
-	// create postpaid instance by runInstances API
-	if v := d.Get("instance_charge_type").(string); v != string(common.PrePaid) {
-		return resourceAliyunRunInstance(d, meta)
+	// Ensure instance_type is generation three
+	validData, err := meta.(*AliyunClient).CheckParameterValidity(d, meta)
+	if err != nil {
+		return err
 	}
 
 	args, err := buildAliyunInstanceArgs(d, meta)
 	if err != nil {
 		return err
 	}
+	args.IoOptimized = validData[IoOptimizedKey].(ecs.IoOptimized)
 
 	instanceID, err := conn.CreateInstance(args)
 	if err != nil {
@@ -192,8 +193,6 @@ func resourceAliyunInstanceCreate(d *schema.ResourceData, meta interface{}) erro
 	}
 
 	d.SetId(instanceID)
-
-	d.Set("password", d.Get("password"))
 
 	// after instance created, its status is pending,
 	// so we need to wait it become to stopped and then start it
@@ -209,59 +208,8 @@ func resourceAliyunInstanceCreate(d *schema.ResourceData, meta interface{}) erro
 		return fmt.Errorf("Start instance got error: %#v", err)
 	}
 
-	if err := conn.WaitForInstanceAsyn(d.Id(), ecs.Running, defaultTimeout); err != nil {
-		return fmt.Errorf("[DEBUG] WaitForInstance %s got error: %#v", ecs.Running, err)
-	}
-
-	return resourceAliyunInstanceUpdate(d, meta)
-}
-
-func resourceAliyunRunInstance(d *schema.ResourceData, meta interface{}) error {
-	conn := meta.(*AliyunClient).ecsconn
-	newConn := meta.(*AliyunClient).ecsNewconn
-
-	args, err := buildAliyunInstanceArgs(d, meta)
-	if err != nil {
-		return err
-	}
-
-	if args.IoOptimized == "optimized" {
-		args.IoOptimized = ecs.IoOptimized("true")
-	} else {
-		args.IoOptimized = ecs.IoOptimized("false")
-	}
-
-	runArgs, err := buildAliyunRunInstancesArgs(d, meta)
-	if err != nil {
-		return err
-	}
-
-	runArgs.CreateInstanceArgs = *args
-
-	// runInstances is support in version 2016-03-14
-	instanceIds, err := newConn.RunInstances(runArgs)
-
-	if err != nil {
-		return fmt.Errorf("Error creating Aliyun ecs instance: %#v", err)
-	}
-
-	d.SetId(instanceIds[0])
-
-	d.Set("password", d.Get("password"))
-	d.Set("system_disk_category", d.Get("system_disk_category"))
-	d.Set("system_disk_size", d.Get("system_disk_size"))
-
-	// after instance created, its status change from pending, starting to running
-	if err := conn.WaitForInstanceAsyn(d.Id(), ecs.Running, defaultTimeout); err != nil {
-		return fmt.Errorf("[DEBUG] WaitForInstance %s got error: %#v", ecs.Running, err)
-	}
-
-	if err := allocateIpAndBandWidthRelative(d, meta); err != nil {
-		return fmt.Errorf("allocateIpAndBandWidthRelative err: %#v", err)
-	}
-
-	if err := conn.WaitForInstanceAsyn(d.Id(), ecs.Running, defaultTimeout); err != nil {
-		return fmt.Errorf("[DEBUG] WaitForInstance %s got error: %#v", ecs.Running, err)
+	if err := conn.WaitForInstanceAsyn(d.Id(), ecs.Running, 500); err != nil {
+		return fmt.Errorf("WaitForInstance %s got error: %#v", ecs.Running, err)
 	}
 
 	return resourceAliyunInstanceUpdate(d, meta)
@@ -274,7 +222,7 @@ func resourceAliyunInstanceRead(d *schema.ResourceData, meta interface{}) error 
 	instance, err := client.QueryInstancesById(d.Id())
 
 	if err != nil {
-		if notFoundError(err) {
+		if NotFoundError(err) {
 			d.SetId("")
 			return nil
 		}
@@ -284,7 +232,7 @@ func resourceAliyunInstanceRead(d *schema.ResourceData, meta interface{}) error 
 	disk, diskErr := client.QueryInstanceSystemDisk(d.Id())
 
 	if diskErr != nil {
-		if notFoundError(diskErr) {
+		if NotFoundError(diskErr) {
 			d.SetId("")
 			return nil
 		}
@@ -300,29 +248,36 @@ func resourceAliyunInstanceRead(d *schema.ResourceData, meta interface{}) error 
 	d.Set("instance_type", instance.InstanceType)
 	d.Set("system_disk_category", disk.Category)
 	d.Set("system_disk_size", disk.Size)
+	d.Set("password", d.Get("password"))
+	d.Set("internet_max_bandwidth_out", instance.InternetMaxBandwidthOut)
+	d.Set("internet_max_bandwidth_in", instance.InternetMaxBandwidthIn)
+	d.Set("instance_charge_type", instance.InstanceChargeType)
 
-	// In Classic network, internet_charge_type is valid in any case, and its default value is 'PayByBanwidth'.
-	// In VPC network, internet_charge_type is valid when instance has public ip, and its default value is 'PayByBanwidth'.
+	// In VPC network, internet_charge_type is "" when instance without public ip.
 	d.Set("internet_charge_type", instance.InternetChargeType)
 
-	if d.Get("allocate_public_ip").(bool) {
+	if len(instance.PublicIpAddress.IpAddress) > 0 {
 		d.Set("public_ip", instance.PublicIpAddress.IpAddress[0])
+	} else {
+		d.Set("public_ip", "")
 	}
 
-	if ecs.StringOrBool(instance.IoOptimized).Value {
-		d.Set("io_optimized", "optimized")
+	d.Set("subnet_id", instance.VpcAttributes.VSwitchId)
+	d.Set("vswitch_id", instance.VpcAttributes.VSwitchId)
+
+	if len(instance.VpcAttributes.PrivateIpAddress.IpAddress) > 0 {
+		d.Set("private_ip", instance.VpcAttributes.PrivateIpAddress.IpAddress[0])
 	} else {
-		d.Set("io_optimized", "none")
+		d.Set("private_ip", strings.Join(ecs.IpAddressSetType(instance.InnerIpAddress).IpAddress, ","))
 	}
 
-	if d.Get("subnet_id").(string) != "" || d.Get("vswitch_id").(string) != "" {
-		ipAddress := instance.VpcAttributes.PrivateIpAddress.IpAddress[0]
-		d.Set("private_ip", ipAddress)
-		d.Set("subnet_id", instance.VpcAttributes.VSwitchId)
-		d.Set("vswitch_id", instance.VpcAttributes.VSwitchId)
-	} else {
-		ipAddress := strings.Join(ecs.IpAddressSetType(instance.InnerIpAddress).IpAddress, ",")
-		d.Set("private_ip", ipAddress)
+	sgs := make([]string, 0, len(instance.SecurityGroupIds.SecurityGroupId))
+	for _, sg := range instance.SecurityGroupIds.SecurityGroupId {
+		sgs = append(sgs, sg)
+	}
+	log.Printf("[DEBUG] Setting Security Group Ids: %#v", sgs)
+	if err := d.Set("security_groups", sgs); err != nil {
+		return err
 	}
 
 	if d.Get("user_data").(string) != "" {
@@ -478,8 +433,9 @@ func resourceAliyunInstanceUpdate(d *schema.ResourceData, meta interface{}) erro
 				return fmt.Errorf("StartInstance got error: %#v", err)
 			}
 		}
-		// Start instance sometimes costs more than 6 minutes when os type is centos.
-		if err := conn.WaitForInstance(d.Id(), ecs.Running, 400); err != nil {
+
+		// Start instance sometimes costs more than 8 minutes when os type is centos.
+		if err := conn.WaitForInstance(d.Id(), ecs.Running, 500); err != nil {
 			return fmt.Errorf("WaitForInstance got error: %#v", err)
 		}
 	}
@@ -519,7 +475,7 @@ func resourceAliyunInstanceDelete(d *schema.ResourceData, meta interface{}) erro
 	return resource.Retry(5*time.Minute, func() *resource.RetryError {
 		instance, err := client.QueryInstancesById(d.Id())
 		if err != nil {
-			if notFoundError(err) {
+			if NotFoundError(err) {
 				return nil
 			}
 		}
@@ -555,31 +511,6 @@ func allocateIpAndBandWidthRelative(d *schema.ResourceData, meta interface{}) er
 		}
 	}
 	return nil
-}
-
-func buildAliyunRunInstancesArgs(d *schema.ResourceData, meta interface{}) (*ecs.RunInstanceArgs, error) {
-	args := &ecs.RunInstanceArgs{
-		MaxAmount: DEFAULT_INSTANCE_COUNT,
-		MinAmount: DEFAULT_INSTANCE_COUNT,
-	}
-
-	bussStr, err := json.Marshal(DefaultBusinessInfo)
-	if err != nil {
-		log.Printf("Failed to translate bussiness info %#v from json to string", DefaultBusinessInfo)
-	}
-
-	args.BusinessInfo = string(bussStr)
-
-	subnetValue := d.Get("subnet_id").(string)
-	vswitchValue := d.Get("vswitch_id").(string)
-	//networkValue := d.Get("instance_network_type").(string)
-
-	// because runInstance is not compatible with createInstance, force NetworkType value to classic
-	if subnetValue == "" && vswitchValue == "" {
-		args.NetworkType = string(ClassicNet)
-	}
-
-	return args, nil
 }
 
 func buildAliyunInstanceArgs(d *schema.ResourceData, meta interface{}) (*ecs.CreateInstanceArgs, error) {
@@ -656,10 +587,6 @@ func buildAliyunInstanceArgs(d *schema.ResourceData, meta interface{}) (*ecs.Cre
 
 	if v := d.Get("password").(string); v != "" {
 		args.Password = v
-	}
-
-	if v := d.Get("io_optimized").(string); v != "" {
-		args.IoOptimized = ecs.IoOptimized(v)
 	}
 
 	vswitchValue := d.Get("subnet_id").(string)

--- a/website/alicloud.erb
+++ b/website/alicloud.erb
@@ -10,9 +10,12 @@
                     <a href="/docs/providers/alicloud/index.html">Alicloud Provider</a>
                 </li>
 
-                 <li<%= sidebar_current("docs-alicloud-datasource") %>>
+                 <li<%= sidebar_current(/^docs-alicloud-datasource/) %>>
                     <a href="#">Data Sources</a>
                     <ul class="nav nav-visible">
+                        <li<%= sidebar_current("docs-alicloud-datasource-regions") %>>
+                            <a href="/docs/providers/alicloud/d/regions.html">alicloud_regions</a>
+                        </li>
                         <li<%= sidebar_current("docs-alicloud-datasource-instance-types") %>>
                             <a href="/docs/providers/alicloud/d/instance_types.html">alicloud_instance_types</a>
                         </li>
@@ -25,7 +28,7 @@
                     </ul>
                 </li>
 
-                <li<%= sidebar_current("docs-alicloud-resource-ecs") %>>
+                <li<%= sidebar_current(/^docs-alicloud-resource-ecs/) %>>
                     <a href="#">ECS Resources</a>
                     <ul class="nav nav-visible">
                         <li<%= sidebar_current("docs-alicloud-resource-disk") %>>
@@ -36,6 +39,12 @@
                         </li>
                         <li<%= sidebar_current("docs-alicloud-resource-instance") %>>
                             <a href="/docs/providers/alicloud/r/instance.html">alicloud_instance</a>
+                        </li>
+                        <li<%= sidebar_current("docs-alicloud-resource-security-group") %>>
+                            <a href="/docs/providers/alicloud/r/security_group.html">alicloud_security_group</a>
+                        </li>
+                        <li<%= sidebar_current("docs-alicloud-resource-security-group-rule") %>>
+                            <a href="/docs/providers/alicloud/r/security_group_rule.html">alicloud_security_group_rule</a>
                         </li>
                         <li<%= sidebar_current("docs-alicloud-resource-eip") %>>
                             <a href="/docs/providers/alicloud/r/eip.html">alicloud_eip</a>
@@ -70,14 +79,14 @@
                         <li<%= sidebar_current("docs-alicloud-resource-route-entry") %>>
                             <a href="/docs/providers/alicloud/r/vroute_entry.html">alicloud_route_entry</a>
                         </li>
-                        <li<%= sidebar_current("docs-alicloud-resource-security-group") %>>
-                            <a href="/docs/providers/alicloud/r/security_group.html">alicloud_security_group</a>
-                        </li>
-                        <li<%= sidebar_current("docs-alicloud-resource-security-group-rule") %>>
-                                                    <a href="/docs/providers/alicloud/r/security_group_rule.html">alicloud_security_group_rule</a>
-                                                </li>
                         <li<%= sidebar_current("docs-alicloud-resource-nat-gateway") %>>
                             <a href="/docs/providers/alicloud/r/nat_gateway.html">alicloud_nat_gateway</a>
+                        </li>
+                        <li<%= sidebar_current("docs-alicloud-resource-forward-entry") %>>
+                            <a href="/docs/providers/alicloud/r/forward.html">alicloud_forward_entry</a>
+                        </li>
+                        <li<%= sidebar_current("docs-alicloud-resource-snat-entry") %>>
+                            <a href="/docs/providers/alicloud/r/snat.html">alicloud_snat_entry</a>
                         </li>
                     </ul>
                 </li>

--- a/website/docs/d/instance_types.html.markdown
+++ b/website/docs/d/instance_types.html.markdown
@@ -10,6 +10,9 @@ description: |-
 
 The Instance Types data source list the ecs_instance_types of Alicloud.
 
+~> **NOTE:** Default to provide upgraded instance types. If you want to get outdated instance types, you should set `is_outdated` to true.
+
+
 ## Example Usage
 
 ```
@@ -33,10 +36,12 @@ resource "alicloud_instance" "instance" {
 
 The following arguments are supported:
 
+* `availability_zone` - (Optional) The Zone that supports available instance types.
 * `cpu_core_count` - (Optional) Limit search to specific cpu core count.
 * `memory_size` - (Optional) Limit search to specific memory size.
 * `instance_type_family` - (Optional) Allows to filter list of Instance Types based on their
 family name, for example 'ecs.n4'.
+* `is_outdated` - (Optional) Whether to export outdated instance types. Default to false.
 * `output_file` - (Optional) The name of file that can save instance types data source after running `terraform plan`.
 
 ## Attributes Reference

--- a/website/docs/r/ess_scaling_configuration.html.markdown
+++ b/website/docs/r/ess_scaling_configuration.html.markdown
@@ -10,6 +10,8 @@ description: |-
 
 Provides a ESS scaling configuration resource.
 
+~> **NOTE:** Several instance types have outdated in some regions and availability zones, such as `ecs.t1.*`, `ecs.s2.*`, `ecs.n1.*` and so on. If you want to keep them, you should set `is_outdated` to true. For more about the upgraded instance type, refer to `alicloud_instance_types` datasource.
+
 ## Example Usage
 
 ```
@@ -26,7 +28,7 @@ resource "alicloud_ess_scaling_configuration" "config" {
   scaling_group_id  = "${alicloud_ess_scaling_group.scaling.id}"
 
   image_id          = "ubuntu_140405_64_40G_cloudinit_20161115.vhd"
-  instance_type     = "ecs.s2.large"
+  instance_type     = "ecs.n4.large"
   security_group_id = "${alicloud_security_group.classic.id}"
 }
 
@@ -39,13 +41,14 @@ The following arguments are supported:
 * `scaling_group_id` - (Required) ID of the scaling group of a scaling configuration.
 * `image_id` - (Required) ID of an image file, indicating the image resource selected when an instance is enabled.
 * `instance_type` - (Required) Resource type of an ECS instance.
-* `io_optimized` - (Required) Valid values are `none`, `optimized`, If `optimized`, the launched ECS instance will be I/O optimized.
+* `io_optimized` - (Deprecated) It has been deprecated on instance resource. All the launched alicloud instances will be I/O optimized.
+* `is_outdated` - (Optional) Whether to use outdated instance type. Default to false.
 * `security_group_id` - (Required) ID of the security group to which a newly created instance belongs.
 * `scaling_configuration_name` - (Optional) Name shown for the scheduled task. If this parameter value is not specified, the default value is ScalingConfigurationId.
 * `internet_charge_type` - (Optional) Network billing type, Values: PayByBandwidth or PayByTraffic. If this parameter value is not specified, the default value is PayByBandwidth.
 * `internet_max_bandwidth_in` - (Optional) Maximum incoming bandwidth from the public network, measured in Mbps (Mega bit per second). The value range is [1,200].
 * `internet_max_bandwidth_out` - (Optional) Maximum outgoing bandwidth from the public network, measured in Mbps (Mega bit per second). The value range for PayByBandwidth is [1,100].
-* `system_disk_category` - (Optional) Category of the system disk. The parameter value options are cloud and ephemeral. 
+* `system_disk_category` - (Optional) Category of the system disk. The parameter value options are `cloud_efficiency`, `cloud_ssd` and `cloud`. `cloud` only is used to some no I/O optimized instance. Default to `cloud_efficiency`.
 * `data_disk` - (Optional) DataDisk mappings to attach to ecs instance. See [Block datadisk](#block-datadisk) below for details. 
 * `instance_ids` - (Optional) ID of the ECS instance to be attached to the scaling group after it is enabled. You can input up to 20 IDs. 
 
@@ -78,7 +81,6 @@ The following attributes are exported:
 * `active` - Wether the current scaling configuration is actived.
 * `image_id` - The ecs instance Image id.
 * `instance_type` - The ecs instance type.
-* `io_optimized` - The ecs instance whether I/O optimized.
 * `security_group_id` - ID of the security group to which a newly created instance belongs.
 * `scaling_configuration_name` - Name of scaling configuration.
 * `internet_charge_type` - Internet charge type of ecs instance.

--- a/website/docs/r/ess_scaling_group.html.markdown
+++ b/website/docs/r/ess_scaling_group.html.markdown
@@ -10,6 +10,8 @@ description: |-
 
 Provides a ESS scaling group resource.
 
+~> **NOTE:** You can launch an ECS instance for a VPC network via specifying parameter `vswitch_id`. One instance can only belong to one VSwitch.
+
 ## Example Usage
 
 ```

--- a/website/docs/r/instance.html.markdown
+++ b/website/docs/r/instance.html.markdown
@@ -98,7 +98,6 @@ The following attributes are exported:
 * `status` - The instance status.
 * `image_id` - The instance Image Id.
 * `instance_type` - The instance type.
-* `instance_network_type` - The instance network type and it has two values: `vpc` and `classic`.
 * `private_ip` - The instance private ip.
 * `public_ip` - The instance public ip.
 * `vswitch_id` - If the instance created in VPC, then this value is  virtual switch ID.

--- a/website/docs/r/instance.html.markdown
+++ b/website/docs/r/instance.html.markdown
@@ -10,43 +10,51 @@ description: |-
 
 Provides a ECS instance resource.
 
+~> **NOTE:** You can launch an ECS instance for a VPC network via specifying parameter `vswitch_id`. One instance can only belong to one VSwitch.
+
+~> **NOTE:** If a VSwitchId is specified for creating an instance, SecurityGroupId and VSwitchId must belong to one VPC.
+
+~> **NOTE:** Several instance types have outdated in some regions and availability zones, such as `ecs.t1.*`, `ecs.s2.*`, `ecs.n1.*` and so on. If you want to keep them, you should set `is_outdated` to true. For more about the upgraded instance type, refer to `alicloud_instance_types` datasource.
+
 ## Example Usage
 
 ```
-# Create a new ECS instance for classic
-resource "alicloud_security_group" "classic" {
+# Create a new ECS instance for a VPC
+resource "alicloud_security_group" "group" {
   name        = "tf_test_foo"
   description = "foo"
+  vpc_id = "${alicloud_vpc.vpc.id}"
 }
 
-resource "alicloud_instance" "classic" {
+resource "alicloud_instance" "instance" {
   # cn-beijing
   availability_zone = "cn-beijing-b"
-  security_groups = ["${alicloud_security_group.classic.*.id}"]
+  security_groups = ["${alicloud_security_group.group.*.id}"]
 
   allocate_public_ip = true
 
-  # series II
-  instance_type        = "ecs.n1.medium"
-  io_optimized         = "optimized"
+  # series III
+  instance_type        = "ecs.n4.large"
   system_disk_category = "cloud_efficiency"
   image_id             = "ubuntu_140405_64_40G_cloudinit_20161115.vhd"
   instance_name        = "test_foo"
+  vswitch_id = "${alicloud_vswitch.vswitch.id}"
 }
 
 # Create a new ECS instance for VPC
-resource "alicloud_vpc" "default" {
+resource "alicloud_vpc" "vpc" {
   # Other parameters...
 }
 
-resource "alicloud_vswitch" "default" {
+resource "alicloud_vswitch" "vswitch" {
+  vpc_id = "${alicloud_vpc.vpc.id}"
   # Other parameters...
 }
 
-resource "alicloud_slb" "vpc" {
+resource "alicloud_slb" "slb" {
   name       = "test-slb-tf"
-  vpc_id     = "${alicloud_vpc.default.id}"
-  vswitch_id = "${alicloud_vswitch.default.id}"
+  vpc_id     = "${alicloud_vpc.vpc.id}"
+  vswitch_id = "${alicloud_vswitch.vswitch.id}"
 }
 ```
 
@@ -56,16 +64,17 @@ The following arguments are supported:
 
 * `image_id` - (Required) The Image to use for the instance. ECS instance's image can be replaced via changing 'image_id'.
 * `instance_type` - (Required) The type of instance to start.
-* `io_optimized` - (Required) Valid values are `none`, `optimized`, If `optimized`, the launched ECS instance will be I/O optimized.
+* `io_optimized` - (Deprecated) It has been deprecated on instance resource. All the launched alicloud instances will be I/O optimized.
+* `is_outdated` - (Optional) Whether to use outdated instance type. Default to false.
 * `security_groups` - (Required)  A list of security group ids to associate with.
 * `availability_zone` - (Optional) The Zone to start the instance in.
 * `instance_name` - (Optional) The name of the ECS. This instance_name can have a string of 2 to 128 characters, must contain only alphanumeric characters or hyphens, such as "-",".","_", and must not begin or end with a hyphen, and must not begin with http:// or https://. If not specified, 
 Terraform will autogenerate a default name is `ECS-Instance`.
 * `allocate_public_ip` - (Optional) Associate a public ip address with an instance in a VPC or Classic. Boolean value, Default is false.
-* `system_disk_category` - (Optional) Valid values are `cloud`, `cloud_efficiency`, `cloud_ssd`, For I/O optimized instance type, `cloud_ssd` and `cloud_efficiency` disks are supported. For non I/O Optimized instance type, `cloud` disk are supported. 
+* `system_disk_category` - (Optional) Valid values are `cloud_efficiency`, `cloud_ssd` and `cloud`. `cloud` only is used to some no I/O optimized instance. Default to `cloud_efficiency`.
 * `system_disk_size` - (Optional) Size of the system disk, value range: 40GB ~ 500GB. Default is 40GB. ECS instance's system disk can be reset when replacing system disk.
 * `description` - (Optional) Description of the instance, This description can have a string of 2 to 256 characters, It cannot begin with http:// or https://. Default value is null.
-* `internet_charge_type` - (Optional) Internet charge type of the instance, Valid values are `PayByBandwidth`, `PayByTraffic`. Default is `PayByBandwidth`.
+* `internet_charge_type` - (Optional) Internet charge type of the instance, Valid values are `PayByBandwidth`, `PayByTraffic`. Default is `PayByTraffic`.
 * `internet_max_bandwidth_in` - (Optional) Maximum incoming bandwidth from the public network, measured in Mbps (Mega bit per second). Value range: [1, 200]. If this value is not specified, then automatically sets it to 200 Mbps.
 * `internet_max_bandwidth_out` - (Optional) Maximum outgoing bandwidth to the public network, measured in Mbps (Mega bit per second). Value range:  [0, 100], If this value is not specified, then automatically sets it to 0 Mbps.
 * `host_name` - (Optional) Host name of the ECS, which is a string of at least two characters. “hostname” cannot start or end with “.” or “-“. In addition, two or more consecutive “.” or “-“ symbols are not allowed. On Windows, the host name can contain a maximum of 15 characters, which can be a combination of uppercase/lowercase letters, numerals, and “-“. The host name cannot contain dots (“.”) or contain only numeric characters.
@@ -90,7 +99,6 @@ The following attributes are exported:
 * `image_id` - The instance Image Id.
 * `instance_type` - The instance type.
 * `instance_network_type` - The instance network type and it has two values: `vpc` and `classic`.
-* `io_optimized` - The instance whether I/O optimized.
 * `private_ip` - The instance private ip.
 * `public_ip` - The instance public ip.
 * `vswitch_id` - If the instance created in VPC, then this value is  virtual switch ID.


### PR DESCRIPTION
At present, alicloud will make a upgrade for instance type, and it will only support generation three instance types gradually. So the PR add function to filter all instance types in the current zones or region, and get the generation three instance types. If the instance type of users input doesn't fit it, there will output valid tips and choices.

Because all the launched ecs instances by using generation three instance type are IO optimized, the PR set the parameter 'io_optimized' as Deprecated.

In addition, the generation three instance types only support 'clould_ssd' and 'cloud_efficiency' disk, so the PR adds category limit for disk.

The PRs also change all instance_type's values to generation three's and remove 'io_optimized' from related test cases.

In addition, the PR removes RunInstance API and using CreateInstance API when creating Pay-As-You-Go ECS instance.

The running results of test cases as follows:
 
TF_ACC=1 go test -v ./alicloud -run=TestAccAlicloudInstance -timeout=120m
=== RUN   TestAccAlicloudInstanceTypesDataSource_basic
--- PASS: TestAccAlicloudInstanceTypesDataSource_basic (16.71s)
=== RUN   TestAccAlicloudInstance_importBasic
--- PASS: TestAccAlicloudInstance_importBasic (82.17s)
=== RUN   TestAccAlicloudInstance_importVpc
--- PASS: TestAccAlicloudInstance_importVpc (114.26s)
=== RUN   TestAccAlicloudInstance_importUserData
--- PASS: TestAccAlicloudInstance_importUserData (118.88s)
=== RUN   TestAccAlicloudInstance_importMultiSecurityGroup
--- PASS: TestAccAlicloudInstance_importMultiSecurityGroup (70.25s)
=== RUN   TestAccAlicloudInstance_importTags
--- PASS: TestAccAlicloudInstance_importTags (78.68s)
=== RUN   TestAccAlicloudInstance_importVpcRule
--- PASS: TestAccAlicloudInstance_importVpcRule (104.70s)
=== RUN   TestAccAlicloudInstance_basic
--- PASS: TestAccAlicloudInstance_basic (93.76s)
=== RUN   TestAccAlicloudInstance_vpc
--- PASS: TestAccAlicloudInstance_vpc (112.52s)
=== RUN   TestAccAlicloudInstance_userData
--- PASS: TestAccAlicloudInstance_userData (105.98s)
=== RUN   TestAccAlicloudInstance_multipleRegions
--- PASS: TestAccAlicloudInstance_multipleRegions (346.91s)
=== RUN   TestAccAlicloudInstance_multiSecurityGroup
--- PASS: TestAccAlicloudInstance_multiSecurityGroup (69.56s)
=== RUN   TestAccAlicloudInstance_multiSecurityGroupByCount
--- PASS: TestAccAlicloudInstance_multiSecurityGroupByCount (73.63s)
=== RUN   TestAccAlicloudInstance_NetworkInstanceSecurityGroups
--- PASS: TestAccAlicloudInstance_NetworkInstanceSecurityGroups (116.32s)
=== RUN   TestAccAlicloudInstance_tags
--- PASS: TestAccAlicloudInstance_tags (77.42s)
=== RUN   TestAccAlicloudInstance_update
--- PASS: TestAccAlicloudInstance_update (68.73s)
=== RUN   TestAccAlicloudInstanceImage_update
--- PASS: TestAccAlicloudInstanceImage_update (238.49s)
=== RUN   TestAccAlicloudInstance_privateIP
--- PASS: TestAccAlicloudInstance_privateIP (101.42s)
=== RUN   TestAccAlicloudInstance_associatePublicIP
--- PASS: TestAccAlicloudInstance_associatePublicIP (114.54s)
=== RUN   TestAccAlicloudInstance_vpcRule
--- PASS: TestAccAlicloudInstance_vpcRule (114.95s)
=== RUN   TestAccAlicloudInstance_keyPair
--- PASS: TestAccAlicloudInstance_keyPair (125.79s)
PASS
ok github.com/alibaba/terraform-provider/alicloud  2345.720s