### PR TITLE
alicloud/provider: Fix diff error about rds security_ips

### DIFF
--- a/alicloud/resource_alicloud_db_instance.go
+++ b/alicloud/resource_alicloud_db_instance.go
@@ -217,7 +217,7 @@ func resourceAlicloudDBInstanceCreate(d *schema.ResourceData, meta interface{}) 
 	d.Set("period_type", d.Get("period_type"))
 
 	// wait instance status change from Creating to running
-	if err := conn.WaitForInstance(d.Id(), rds.Running, defaultLongTimeout); err != nil {
+	if err := conn.WaitForInstanceAsyn(d.Id(), rds.Running, defaultLongTimeout); err != nil {
 		return fmt.Errorf("WaitForInstance %s got error: %#v", rds.Running, err)
 	}
 
@@ -403,7 +403,7 @@ func resourceAlicloudDBInstanceRead(d *schema.ResourceData, meta interface{}) er
 	}
 	d.Set("connections", flattenDBConnections(resn.DBInstanceNetInfos.DBInstanceNetInfo))
 
-	ips, err := client.GetSecurityIps(d.Id())
+	ips, err := client.GetSecurityIps(d.Id(), d.Get("security_ips"))
 	if err != nil {
 		log.Printf("Describe DB security ips error: %#v", err)
 	}


### PR DESCRIPTION
The PR fixes an rds error that after setting security_ips for rds instance, there is changes when running terraform plan every time.

The running results of rds test cases as following:

TF_ACC=1 go test ./alicloud -v -run=TestAccAlicloudDBInstance -timeout=120m
=== RUN   TestAccAlicloudDBInstance_basic
--- PASS: TestAccAlicloudDBInstance_basic (438.04s)
=== RUN   TestAccAlicloudDBInstance_vpc
--- PASS: TestAccAlicloudDBInstance_vpc (424.95s)
=== RUN   TestAccAlicloudDBInstance_multiIZ
--- PASS: TestAccAlicloudDBInstance_multiIZ (444.45s)
=== RUN   TestAccAlicloudDBInstance_database
--- PASS: TestAccAlicloudDBInstance_database (694.01s)
=== RUN   TestAccAlicloudDBInstance_account
--- PASS: TestAccAlicloudDBInstance_account (641.79s)
=== RUN   TestAccAlicloudDBInstance_allocatePublicConnection
--- PASS: TestAccAlicloudDBInstance_allocatePublicConnection (535.22s)
=== RUN   TestAccAlicloudDBInstance_backupPolicy
--- PASS: TestAccAlicloudDBInstance_backupPolicy (455.48s)
=== RUN   TestAccAlicloudDBInstance_securityIps
--- PASS: TestAccAlicloudDBInstance_securityIps (531.87s)
=== RUN   TestAccAlicloudDBInstance_upgradeClass
--- PASS: TestAccAlicloudDBInstance_upgradeClass (910.60s)
PASS
ok      github.com/alibaba/terraform-provider/alicloud  5076.440s
