### PR TITLE
alicloud/privider: Add 'Import' function for alicloud_instance

### DIFF
--- a/alicloud/import_alicloud_instance_test.go
+++ b/alicloud/import_alicloud_instance_test.go
@@ -1,0 +1,139 @@
+package alicloud
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform/helper/resource"
+)
+
+func TestAccAlicloudInstance_importBasic(t *testing.T) {
+	resourceName := "alicloud_instance.foo"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckInstanceDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccInstanceConfig,
+			},
+
+			resource.TestStep{
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"allocate_public_ip"},
+			},
+		},
+	})
+}
+
+func TestAccAlicloudInstance_importVpc(t *testing.T) {
+	resourceName := "alicloud_instance.foo"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckInstanceDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccInstanceConfigVPC,
+			},
+
+			resource.TestStep{
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"allocate_public_ip"},
+			},
+		},
+	})
+}
+
+func TestAccAlicloudInstance_importUserData(t *testing.T) {
+	resourceName := "alicloud_instance.foo"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckInstanceDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccInstanceConfigUserData,
+			},
+
+			resource.TestStep{
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"allocate_public_ip", "user_data"},
+			},
+		},
+	})
+}
+
+func TestAccAlicloudInstance_importMultiSecurityGroup(t *testing.T) {
+	resourceName := "alicloud_instance.foo"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckInstanceDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccInstanceConfig_multiSecurityGroup,
+			},
+
+			resource.TestStep{
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"allocate_public_ip"},
+			},
+		},
+	})
+}
+
+func TestAccAlicloudInstance_importTags(t *testing.T) {
+	resourceName := "alicloud_instance.foo"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckInstanceDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccCheckInstanceConfigTags,
+			},
+
+			resource.TestStep{
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"allocate_public_ip"},
+			},
+		},
+	})
+}
+
+func TestAccAlicloudInstance_importVpcRule(t *testing.T) {
+	resourceName := "alicloud_instance.foo"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckInstanceDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccVpcInstanceWithSecurityRule,
+			},
+
+			resource.TestStep{
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"allocate_public_ip"},
+			},
+		},
+	})
+}

--- a/alicloud/resource_alicloud_instance.go
+++ b/alicloud/resource_alicloud_instance.go
@@ -20,6 +20,9 @@ func resourceAliyunInstance() *schema.Resource {
 		Read:   resourceAliyunInstanceRead,
 		Update: resourceAliyunInstanceUpdate,
 		Delete: resourceAliyunInstanceDelete,
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
 
 		Schema: map[string]*schema.Schema{
 			"availability_zone": &schema.Schema{
@@ -100,7 +103,7 @@ func resourceAliyunInstance() *schema.Resource {
 
 			"system_disk_category": &schema.Schema{
 				Type:     schema.TypeString,
-				Default:  "cloud",
+				Default:  "cloud_efficiency",
 				Optional: true,
 				ForceNew: true,
 				ValidateFunc: validateAllowedStringValue([]string{


### PR DESCRIPTION
The PR add 'import resource' function for resource alicloud_instance.

The running results of instance's import testcase as following:

TF_ACC=1 go test ./alicloud -v -run=TestAccAlicloudInstance_import -timeout=120m
=== RUN   TestAccAlicloudInstance_importBasic
--- PASS: TestAccAlicloudInstance_importBasic (99.26s)
=== RUN   TestAccAlicloudInstance_importVpc
--- PASS: TestAccAlicloudInstance_importVpc (115.33s)
=== RUN   TestAccAlicloudInstance_importUserData
--- PASS: TestAccAlicloudInstance_importUserData (112.53s)
=== RUN   TestAccAlicloudInstance_importMultiSecurityGroup
--- PASS: TestAccAlicloudInstance_importMultiSecurityGroup (77.39s)
=== RUN   TestAccAlicloudInstance_importTags
--- PASS: TestAccAlicloudInstance_importTags (81.65s)
=== RUN   TestAccAlicloudInstance_importVpcRule
--- PASS: TestAccAlicloudInstance_importVpcRule (108.85s)
PASS
ok      github.com/alibaba/terraform-provider/alicloud  595.041s