### PR TITLE
alicloud/privider: Add 'Import' function for ess scaling group

### DIFF
--- a/alicloud/import_alicloud_ess_scalinggroup_test.go
+++ b/alicloud/import_alicloud_ess_scalinggroup_test.go
@@ -1,0 +1,28 @@
+package alicloud
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform/helper/resource"
+)
+
+func TestAccAlicloudEssScalingGroup_importBasic(t *testing.T) {
+	resourceName := "alicloud_ess_scaling_group.foo"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckInstanceDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccEssScalingGroupConfig,
+			},
+
+			resource.TestStep{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}

--- a/alicloud/resource_alicloud_ess_scalinggroup.go
+++ b/alicloud/resource_alicloud_ess_scalinggroup.go
@@ -16,6 +16,9 @@ func resourceAlicloudEssScalingGroup() *schema.Resource {
 		Read:   resourceAliyunEssScalingGroupRead,
 		Update: resourceAliyunEssScalingGroupUpdate,
 		Delete: resourceAliyunEssScalingGroupDelete,
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
 
 		Schema: map[string]*schema.Schema{
 			"min_size": &schema.Schema{


### PR DESCRIPTION
The PR add 'import resource' function for resource alicloud_ess_scalinggroup.

The running results of ess scaling group's import testcase as following:

TF_ACC=1 go test ./alicloud -v -run=TestAccAlicloudEssScalingGroup_import -timeout=120m
=== RUN   TestAccAlicloudEssScalingGroup_importBasic
--- PASS: TestAccAlicloudEssScalingGroup_importBasic (12.25s)
PASS
ok      github.com/alibaba/terraform-provider/alicloud  12.283s
