### PR TITLE
alicloud/privider: Add 'Import' function for ess schedule

### DIFF
--- a/alicloud/import_alicloud_ess_schedule_test.go
+++ b/alicloud/import_alicloud_ess_schedule_test.go
@@ -1,0 +1,28 @@
+package alicloud
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform/helper/resource"
+)
+
+func TestAccAlicloudEssSchedule_importBasic(t *testing.T) {
+	resourceName := "alicloud_ess_schedule.foo"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckInstanceDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccEssScheduleConfig,
+			},
+
+			resource.TestStep{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}

--- a/alicloud/resource_alicloud_ess_scalingrule.go
+++ b/alicloud/resource_alicloud_ess_scalingrule.go
@@ -16,6 +16,9 @@ func resourceAlicloudEssScalingRule() *schema.Resource {
 		Read:   resourceAliyunEssScalingRuleRead,
 		Update: resourceAliyunEssScalingRuleUpdate,
 		Delete: resourceAliyunEssScalingRuleDelete,
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
 
 		Schema: map[string]*schema.Schema{
 			"scaling_group_id": &schema.Schema{


### PR DESCRIPTION
The PR add 'import resource' function for resource alicloud_ess_schedule.

The running results of ess schedule's import testcase as following:

TF_ACC=1 go test ./alicloud -v -run=TestAccAlicloudEssSchedule_import -timeout=120m
=== RUN   TestAccAlicloudEssSchedule_importBasic
--- PASS: TestAccAlicloudEssSchedule_importBasic (20.94s)
PASS
ok      github.com/alibaba/terraform-provider/alicloud  20.966s
