### PR TITLE
alicloud/privider: Add 'Import' function for NAT gateway

### DIFF
--- a/alicloud/import_alicloud_nat_gateway_test.go
+++ b/alicloud/import_alicloud_nat_gateway_test.go
@@ -1,0 +1,49 @@
+package alicloud
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform/helper/resource"
+)
+
+func TestAccAlicloudNatGateway_importBasic(t *testing.T) {
+	resourceName := "alicloud_nat_gateway.foo"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckInstanceDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccNatGatewayConfig,
+			},
+
+			resource.TestStep{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccAlicloudNatGateway_importSpec(t *testing.T) {
+	resourceName := "alicloud_nat_gateway.foo"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckInstanceDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccNatGatewayConfigSpec,
+			},
+
+			resource.TestStep{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}

--- a/alicloud/resource_alicloud_nat_gateway.go
+++ b/alicloud/resource_alicloud_nat_gateway.go
@@ -19,6 +19,9 @@ func resourceAliyunNatGateway() *schema.Resource {
 		Read:   resourceAliyunNatGatewayRead,
 		Update: resourceAliyunNatGatewayUpdate,
 		Delete: resourceAliyunNatGatewayDelete,
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
 
 		Schema: map[string]*schema.Schema{
 			"vpc_id": &schema.Schema{


### PR DESCRIPTION
The PR add 'import resource' function for resource alicloud_nat_gateway.

The running results of nat gateway's import testcase as following:

TF_ACC=1 go test ./alicloud -v -run=TestAccAlicloudNatGateway_import -timeout=120m
=== RUN   TestAccAlicloudNatGateway_importBasic
--- PASS: TestAccAlicloudNatGateway_importBasic (61.35s)
=== RUN   TestAccAlicloudNatGateway_importSpec
--- PASS: TestAccAlicloudNatGateway_importSpec (47.83s)
PASS
ok      github.com/alibaba/terraform-provider/alicloud  109.232s
