### PR TITLE
[NEW DATASOURCE]  add new data source key_pairs

### DIFF
--- a/alicloud/data_source_alicloud_common.go
+++ b/alicloud/data_source_alicloud_common.go
@@ -2,8 +2,12 @@ package alicloud
 
 import (
 	"bytes"
+	"encoding/json"
 	"fmt"
 	"github.com/hashicorp/terraform/helper/hashcode"
+	"github.com/hashicorp/terraform/helper/schema"
+	"io/ioutil"
+	"os"
 )
 
 // Generates a hash for the set hash function used by the ID
@@ -15,4 +19,65 @@ func dataResourceIdHash(ids []string) string {
 	}
 
 	return fmt.Sprintf("%d", hashcode.String(buf.String()))
+}
+
+func writeToFile(filePath string, data interface{}) {
+	os.Remove(filePath)
+	if bs, err := json.MarshalIndent(data, "", "\t"); err == nil {
+		str := string(bs)
+		ioutil.WriteFile(filePath, []byte(str), 777)
+	}
+}
+
+func outputInstancesSchema() map[string]*schema.Schema {
+	return map[string]*schema.Schema{
+		"instance_id": {
+			Type:     schema.TypeString,
+			Computed: true,
+		},
+		"instance_name": {
+			Type:     schema.TypeString,
+			Computed: true,
+		},
+		"description": {
+			Type:     schema.TypeString,
+			Computed: true,
+		},
+		"image_id": {
+			Type:     schema.TypeString,
+			Computed: true,
+		},
+		"region_id": {
+			Type:     schema.TypeString,
+			Computed: true,
+		},
+		"availability_zone": {
+			Type:     schema.TypeString,
+			Computed: true,
+		},
+		"instance_type": {
+			Type:     schema.TypeString,
+			Computed: true,
+		},
+		"vswitch_id": {
+			Type:     schema.TypeString,
+			Computed: true,
+		},
+		"public_ip": {
+			Type:     schema.TypeString,
+			Computed: true,
+		},
+		"private_ip": {
+			Type:     schema.TypeString,
+			Computed: true,
+		},
+		"key_name": {
+			Type:     schema.TypeString,
+			Computed: true,
+		},
+		"status": {
+			Type:     schema.TypeString,
+			Computed: true,
+		},
+	}
 }

--- a/alicloud/data_source_alicloud_key_pairs.go
+++ b/alicloud/data_source_alicloud_key_pairs.go
@@ -1,0 +1,173 @@
+package alicloud
+
+import (
+	"fmt"
+	"github.com/denverdino/aliyungo/ecs"
+	"github.com/hashicorp/terraform/helper/schema"
+	"log"
+	"regexp"
+)
+
+func dataSourceAlicloudKeyPairs() *schema.Resource {
+	return &schema.Resource{
+		Read: dataSourceAlicloudKeyPairsRead,
+
+		Schema: map[string]*schema.Schema{
+			"name_regex": &schema.Schema{
+				Type:         schema.TypeString,
+				Optional:     true,
+				ForceNew:     true,
+				ValidateFunc: validateNameRegex,
+			},
+
+			"finger_print": &schema.Schema{
+				Type:     schema.TypeBool,
+				Optional: true,
+				Computed: true,
+			},
+			"output_file": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+
+			//Computed value
+			"key_pairs": &schema.Schema{
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"key_name": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"finger_print": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"instances": {
+							Type:     schema.TypeList,
+							Computed: true,
+							Elem:     &schema.Resource{Schema: outputInstancesSchema()},
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func dataSourceAlicloudKeyPairsRead(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AliyunClient).ecsconn
+
+	var regex *regexp.Regexp
+	if name, ok := d.GetOk("name_regex"); ok {
+		regex = regexp.MustCompile(name.(string))
+	}
+
+	args := &ecs.DescribeKeyPairsArgs{
+		RegionId: getRegion(d, meta),
+	}
+	if fingerPrint, ok := d.GetOk("finger_print"); ok {
+		args.KeyPairFingerPrint = fingerPrint.(string)
+	}
+	var keyPairs []ecs.KeyPairItemType
+	pagination := getPagination(1, 50)
+	for true {
+		args.Pagination = pagination
+		results, _, err := conn.DescribeKeyPairs(args)
+		if err != nil {
+			return fmt.Errorf("Error DescribekeyPairs: %#v", err)
+		}
+		for _, key := range results {
+			if regex == nil || (regex != nil && regex.MatchString(key.KeyPairName)) {
+				keyPairs = append(keyPairs, key)
+			}
+		}
+		if len(results) < pagination.PageSize {
+			break
+		}
+		pagination.PageNumber += 1
+	}
+
+	if len(keyPairs) < 1 {
+		return fmt.Errorf("Your query key pairs returned no results. Please change your search criteria and try again.")
+	}
+
+	keyPairsAttach := make(map[string][]map[string]interface{})
+	pagination.PageNumber = 1
+	for true {
+		instances, _, err := conn.DescribeInstances(&ecs.DescribeInstancesArgs{
+			RegionId:   getRegion(d, meta),
+			Pagination: pagination,
+		})
+		if err != nil {
+			return fmt.Errorf("Error DescribeInstances: %#v", err)
+		}
+		for _, inst := range instances {
+			if inst.KeyPairName != "" {
+				public_ip := inst.EipAddress.IpAddress
+				if public_ip == "" && len(inst.PublicIpAddress.IpAddress) > 0 {
+					public_ip = inst.PublicIpAddress.IpAddress[0]
+				}
+				var private_ip string
+				if len(inst.InnerIpAddress.IpAddress) > 0 {
+					private_ip = inst.InnerIpAddress.IpAddress[0]
+				} else if len(inst.VpcAttributes.PrivateIpAddress.IpAddress) > 0 {
+					private_ip = inst.VpcAttributes.PrivateIpAddress.IpAddress[0]
+				}
+				mapping := map[string]interface{}{
+					"availability_zone": inst.ZoneId,
+					"instance_id":       inst.InstanceId,
+					"instance_name":     inst.InstanceName,
+					"vswitch_id":        inst.VpcAttributes.VSwitchId,
+					"public_ip":         public_ip,
+					"private_ip":        private_ip,
+				}
+				if val, ok := keyPairsAttach[inst.KeyPairName]; ok {
+					val = append(val, mapping)
+					keyPairsAttach[inst.KeyPairName] = val
+				} else {
+					keyPairsAttach[inst.KeyPairName] = append(make([]map[string]interface{}, 0, 1), mapping)
+				}
+			}
+		}
+		if len(instances) < pagination.PageSize {
+			break
+		}
+		pagination.PageNumber += 1
+	}
+
+	return keyPairsDescriptionAttributes(d, keyPairs, keyPairsAttach)
+}
+
+func keyPairsDescriptionAttributes(d *schema.ResourceData, keyPairs []ecs.KeyPairItemType, keyPairsAttach map[string][]map[string]interface{}) error {
+	var names []string
+	var s []map[string]interface{}
+	for _, key := range keyPairs {
+		mapping := map[string]interface{}{
+			"id":           key.KeyPairName,
+			"key_name":     key.KeyPairName,
+			"finger_print": key.KeyPairFingerPrint,
+			"instances":    keyPairsAttach[key.KeyPairName],
+		}
+
+		log.Printf("[DEBUG] alicloud_key_pairs - adding keypair mapping: %v", mapping)
+		names = append(names, string(key.KeyPairName))
+		s = append(s, mapping)
+	}
+
+	d.SetId(dataResourceIdHash(names))
+	if err := d.Set("key_pairs", s); err != nil {
+		return err
+	}
+
+	// create a json file in current directory and write data source to it.
+	if output, ok := d.GetOk("output_file"); ok && output != nil {
+		writeToFile(output.(string), s)
+	}
+	return nil
+}

--- a/alicloud/data_source_alicloud_key_pairs_test.go
+++ b/alicloud/data_source_alicloud_key_pairs_test.go
@@ -1,0 +1,29 @@
+package alicloud
+
+import (
+	"github.com/hashicorp/terraform/helper/resource"
+	"testing"
+)
+
+func TestAccAlicloudKeyPairsDataSource_basic(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+		},
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCheckAlicloudKeyPairsDataSourceBasic,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAlicloudDataSourceID("data.alicloud_key_pairs.name_regex"),
+				),
+			},
+		},
+	})
+}
+
+const testAccCheckAlicloudKeyPairsDataSourceBasic = `
+data "alicloud_key_pairs" "name_regex" {
+	name_regex = "test"
+}
+`

--- a/alicloud/provider.go
+++ b/alicloud/provider.go
@@ -37,6 +37,7 @@ func Provider() terraform.ResourceProvider {
 			"alicloud_regions":        dataSourceAlicloudRegions(),
 			"alicloud_zones":          dataSourceAlicloudZones(),
 			"alicloud_instance_types": dataSourceAlicloudInstanceTypes(),
+			"alicloud_key_pairs":      dataSourceAlicloudKeyPairs(),
 		},
 		ResourcesMap: map[string]*schema.Resource{
 			"alicloud_instance":                  resourceAliyunInstance(),
@@ -83,7 +84,6 @@ func providerConfigure(d *schema.ResourceData) (interface{}, error) {
 			region = DEFAULT_REGION
 		}
 	}
-
 	config := Config{
 		AccessKey: accesskey.(string),
 		SecretKey: secretkey.(string),

--- a/website/alicloud.erb
+++ b/website/alicloud.erb
@@ -13,6 +13,9 @@
                  <li<%= sidebar_current("docs-alicloud-datasource") %>>
                     <a href="#">Data Sources</a>
                     <ul class="nav nav-visible">
+                        <li<%= sidebar_current("docs-alicloud-datasource-regions") %>>
+                            <a href="/docs/providers/alicloud/d/regions.html">alicloud_regions</a>
+                        </li>
                         <li<%= sidebar_current("docs-alicloud-datasource-instance-types") %>>
                             <a href="/docs/providers/alicloud/d/instance_types.html">alicloud_instance_types</a>
                         </li>
@@ -21,6 +24,9 @@
                         </li>
                         <li<%= sidebar_current("docs-alicloud-datasource-zones") %>>
                             <a href="/docs/providers/alicloud/d/zones.html">alicloud_zones</a>
+                        </li>
+                        <li<%= sidebar_current("docs-alicloud-datasource-key-pairs") %>>
+                            <a href="/docs/providers/alicloud/d/key_pairs.html">alicloud_key-pairs</a>
                         </li>
                     </ul>
                 </li>

--- a/website/docs/d/key_pairs.html.markdown
+++ b/website/docs/d/key_pairs.html.markdown
@@ -1,0 +1,52 @@
+---
+layout: "alicloud"
+page_title: "Alicloud: alicloud_key_pairs"
+sidebar_current: "docs-alicloud-datasource-key-pairs"
+description: |-
+    Provides a list of Availability Key Pairs which can be used by an Alicloud account.
+---
+
+# alicloud\_key\_pairs
+
+The Key Pairs data source provides a list of Alicloud Key Pairs in an Alicloud account according to the specified filters.
+
+## Example Usage
+
+```
+# Declare the data source
+data "alicloud_key_pairs" "name_regex" {
+	name_regex = "test"
+	output_file = "my_key_pairs.json"
+}
+
+# Bind a key pair for several ecs instances using the first matched key pair
+
+resource "alicloud_key_pair_attachment" "attachment" {
+  key_name = "${data.alicloud_key_pairs.default.key_pairs.0.id}"
+  instance_ids = [...]
+}
+
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `name_regex` - A regex string to apply to the key pair list returned by Alicloud.
+* `finger_print` - A finger print used to retrieve specified key pair.
+* `output_file` - (Optional) The name of file that can save key pairs data source after running `terraform plan`.
+
+## Attributes Reference
+
+A list of key pairs will be exported and its every element contains the following attributes:
+
+* `id` - ID of the key pair.
+* `key_name` - Name of the key pair.
+* `finger_print` - Finger print of the key pair.
+* `instances` - A List of ECS instances that has been bound a specified key pair.
+    * `availability_zone` - The ID of availability zone that ECS instance launched.
+    * `instance_id` - The ID of ECS instance.
+    * `instance_name` - The name of ECS instance.
+    * `vswitch_id` - The ID of VSwitch that ECS instance launched.
+    * `public_ip` - The public IP address or EIP of the ECS instance.
+    * `private_ip` - The private IP address of the ECS instance.


### PR DESCRIPTION
This PR add a new alicloud data source key_pairs, and it can be used to show matching specified conditions key pairs infomation. The PR contains key_pair data source provider, testcase and introduction documents.

The running results of key pair's test cases as follows:

TF_ACC=1 go test -v ./alicloud -run=TestAccAlicloudKeyPairsDataSource -timeout=120m
=== RUN   TestAccAlicloudKeyPairsDataSource_basic
--- PASS: TestAccAlicloudKeyPairsDataSource_basic (1.37s)
PASS
ok    github.com/alibaba/terraform-provider/alicloud  1.395s
