### PR TITLE
[IMPORT] Add Import function for VPC and modify a output field

### DIFF
--- a/alicloud/import_alicloud_vpc_test.go
+++ b/alicloud/import_alicloud_vpc_test.go
@@ -1,0 +1,28 @@
+package alicloud
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform/helper/resource"
+)
+
+func TestAccAlicloudVpc_importBasic(t *testing.T) {
+	resourceName := "alicloud_vpc.foo"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckInstanceDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccVpcConfig,
+			},
+
+			resource.TestStep{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}

--- a/alicloud/resource_alicloud_vpc_test.go
+++ b/alicloud/resource_alicloud_vpc_test.go
@@ -32,7 +32,7 @@ func TestAccAlicloudVpc_basic(t *testing.T) {
 					resource.TestCheckResourceAttrSet(
 						"alicloud_vpc.foo", "router_id"),
 					resource.TestCheckResourceAttrSet(
-						"alicloud_vpc.foo", "router_table_id"),
+						"alicloud_vpc.foo", "route_table_id"),
 				),
 			},
 		},

--- a/website/docs/r/vpc.html.markdown
+++ b/website/docs/r/vpc.html.markdown
@@ -39,3 +39,4 @@ The following attributes are exported:
 * `name` - The name of the VPC.
 * `description` - The description of the VPC.
 * `router_id` - The ID of the router created by default on VPC creation.
+* `route_table_id` - The route table ID of the router created by default on VPC creation.


### PR DESCRIPTION
The PR add 'import resource' function for resource alicloud_vpc and deprecate 'router_table_id' and add a new output field route_table_id

The running results of vpc's import testcase as following:

TF_ACC=1 go test ./alicloud -v -run=TestAccAlicloudVpc_ -timeout=120m
=== RUN   TestAccAlicloudVpc_importBasic
--- PASS: TestAccAlicloudVpc_importBasic (16.68s)
=== RUN   TestAccAlicloudVpc_basic
--- PASS: TestAccAlicloudVpc_basic (22.39s)
=== RUN   TestAccAlicloudVpc_update
--- PASS: TestAccAlicloudVpc_update (23.47s)
PASS
ok      github.com/alibaba/terraform-provider/alicloud  62.577s
