### PR TITLE
[IMPORT] Add Import function for route entry and deprecate router_id

### DIFF
--- a/alicloud/errors.go
+++ b/alicloud/errors.go
@@ -9,7 +9,9 @@ const (
 	// common
 	Notfound = "Not found"
 	// ecs
-	InstanceNotfound = "Instance.Notfound"
+	InstanceNotfound        = "Instance.Notfound"
+	InstanceNotFound        = "Instance.Notfound"
+	MessageInstanceNotFound = "instance is not found"
 	// disk
 	DiskIncorrectStatus       = "IncorrectDiskStatus"
 	DiskCreatingSnapshot      = "DiskCreatingSnapshot"
@@ -64,6 +66,16 @@ func GetNotFoundErrorFromString(str string) error {
 		},
 		StatusCode: -1,
 	}
+}
+
+func NotFoundError(err error) bool {
+	if e, ok := err.(*common.Error); ok &&
+		(e.Code == InstanceNotFound || e.Code == RamInstanceNotFound ||
+			strings.Contains(strings.ToLower(e.Message), MessageInstanceNotFound)) {
+		return true
+	}
+
+	return false
 }
 
 func IsExceptedError(err error, expectCode string) bool {

--- a/alicloud/resource_alicloud_vroute_entry_test.go
+++ b/alicloud/resource_alicloud_vroute_entry_test.go
@@ -110,12 +110,8 @@ func testAccCheckRouteEntryDestroy(s *terraform.State) error {
 		if re != nil {
 			return fmt.Errorf("Error Route Entry still exist")
 		}
-
 		// Verify the error is what we want
-		if err != nil {
-			if notFoundError(err) {
-				return nil
-			}
+		if err != nil && !NotFoundError(err) {
 			return err
 		}
 	}
@@ -140,8 +136,7 @@ resource "alicloud_vswitch" "foo" {
 }
 
 resource "alicloud_route_entry" "foo" {
-	router_id = "${alicloud_vpc.foo.router_id}"
-	route_table_id = "${alicloud_vpc.foo.router_table_id}"
+	route_table_id = "${alicloud_vpc.foo.route_table_id}"
 	destination_cidrblock = "172.11.1.1/32"
 	nexthop_type = "Instance"
 	nexthop_id = "${alicloud_instance.foo.id}"
@@ -171,12 +166,11 @@ resource "alicloud_instance" "foo" {
 	vswitch_id = "${alicloud_vswitch.foo.id}"
 	allocate_public_ip = true
 
-	# series II
+	# series III
 	instance_charge_type = "PostPaid"
-	instance_type = "ecs.n1.small"
+	instance_type = "ecs.n4.small"
 	internet_charge_type = "PayByTraffic"
 	internet_max_bandwidth_out = 5
-	io_optimized = "optimized"
 
 	system_disk_category = "cloud_efficiency"
 	image_id = "ubuntu_140405_64_40G_cloudinit_20161115.vhd"

--- a/website/docs/r/vroute_entry.html.markdown
+++ b/website/docs/r/vroute_entry.html.markdown
@@ -21,7 +21,6 @@ resource "alicloud_vpc" "vpc" {
 }
 
 resource "alicloud_route_entry" "default" {
-  router_id             = "${alicloud_vpc.default.router_id}"
   route_table_id        = "${alicloud_vpc.default.router_table_id}"
   destination_cidrblock = "${var.entry_cidr}"
   nexthop_type          = "Instance"
@@ -36,7 +35,7 @@ resource "alicloud_instance" "snat" {
 
 The following arguments are supported:
 
-* `router_id` - (Required, Forces new resource) The ID of the virtual router attached to Vpc.
+* `router_id` - (Deprecated) This argument has beeb deprecated. Please use other arguments to launch a custom route entry.
 * `route_table_id` - (Required, Forces new resource) The ID of the route table.
 * `destination_cidrblock` - (Required, Forces new resource) The RouteEntry's target network segment.
 * `nexthop_type` - (Required, Forces new resource) The next hop type. Available value is Instance.
@@ -46,8 +45,8 @@ The following arguments are supported:
 
 The following attributes are exported:
 
-* `router_id` - (Required, Forces new resource) The ID of the virtual router attached to Vpc.
-* `route_table_id` - (Required, Forces new resource) The ID of the route table.
-* `destination_cidrblock` - (Required, Forces new resource) The RouteEntry's target network segment.
-* `nexthop_type` - (Required, Forces new resource) The next hop type. Available value is Instance.
-* `nexthop_id` - (Required, Forces new resource) The route entry's next hop.
+* `router_id` - The ID of the virtual router attached to Vpc.
+* `route_table_id` - The ID of the route table.
+* `destination_cidrblock` - The RouteEntry's target network segment.
+* `nexthop_type` - The next hop type. Available value is Instance.
+* `nexthop_id` - The route entry's next hop.


### PR DESCRIPTION
The PR add 'import resource' function for resource alicloud_route_entry and deprecate 'router_id'.

This PR has a dependency on #32.


The running results of route entry's import testcase as following:

TF_ACC=1 go test ./alicloud -v -run=TestAccAlicloudRoute -timeout=120m
=== RUN   TestAccAlicloudRouteEntry_importBasic
--- PASS: TestAccAlicloudRouteEntry_importBasic (135.32s)
=== RUN   TestAccAlicloudRouteEntry_Basic
--- PASS: TestAccAlicloudRouteEntry_Basic (139.69s)
PASS
ok      github.com/alibaba/terraform-provider/alicloud  275.047s
