### PR TITLE
[NEW DATASOURCE] add new data source alicloud_vpcs

### DIFF
--- a/alicloud/data_source_alicloud_vpcs.go
+++ b/alicloud/data_source_alicloud_vpcs.go
@@ -1,0 +1,227 @@
+package alicloud
+
+import (
+	"fmt"
+	"github.com/denverdino/aliyungo/ecs"
+	"github.com/hashicorp/terraform/helper/schema"
+	"log"
+	"regexp"
+)
+
+func dataSourceAlicloudVpcs() *schema.Resource {
+	return &schema.Resource{
+		Read: dataSourceAlicloudVpcsRead,
+
+		Schema: map[string]*schema.Schema{
+			"cidr_block": {
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: true,
+			},
+			"status": {
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: true,
+			},
+			"name_regex": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ValidateFunc: validateNameRegex,
+				ForceNew:     true,
+			},
+			"is_default": {
+				Type:     schema.TypeBool,
+				Optional: true,
+				ForceNew: true,
+			},
+			"vswitch_id": {
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: true,
+			},
+			"output_file": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+
+			// Computed values
+			"vpcs": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"region_id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"status": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"vpc_name": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"vswitch_ids": {
+							Type:     schema.TypeList,
+							Computed: true,
+							Elem:     &schema.Schema{Type: schema.TypeString},
+						},
+						"cidr_block": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"vrouter_id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"route_table_id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"description": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"is_default": {
+							Type:     schema.TypeBool,
+							Computed: true,
+						},
+						"creation_time": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+					},
+				},
+			},
+		},
+	}
+}
+func dataSourceAlicloudVpcsRead(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AliyunClient).ecsconn
+
+	args := &ecs.DescribeVpcsArgs{
+		RegionId: getRegion(d, meta),
+	}
+
+	var allVpcs []ecs.VpcSetType
+
+	for {
+		vpcs, paginationResult, err := conn.DescribeVpcs(args)
+		if err != nil {
+			return err
+		}
+
+		allVpcs = append(allVpcs, vpcs...)
+
+		pagination := paginationResult.NextPage()
+		if pagination == nil {
+			break
+		}
+
+		args.Pagination = *pagination
+	}
+
+	var filteredVpcsTemp []ecs.VpcSetType
+	var route_tables []string
+
+	for _, vpc := range allVpcs {
+		if cidrBlock, ok := d.GetOk("cidr_block"); ok && vpc.CidrBlock != cidrBlock.(string) {
+			continue
+		}
+
+		if status, ok := d.GetOk("status"); ok && string(vpc.Status) != status.(string) {
+			continue
+		}
+
+		if isDefault, ok := d.GetOk("is_default"); ok && vpc.IsDefault != isDefault.(bool) {
+			continue
+		}
+
+		if vswitchId, ok := d.GetOk("vswitch_id"); ok && !vpcVswitchIdListContains(vpc.VSwitchIds.VSwitchId, vswitchId.(string)) {
+			continue
+		}
+
+		vrouters, _, err := meta.(*AliyunClient).vpcconn.DescribeVRouters(&ecs.DescribeVRoutersArgs{
+			VRouterId: vpc.VRouterId,
+			RegionId:  getRegion(d, meta),
+		})
+		if err != nil {
+			return fmt.Errorf("Error DescribVRouters by vrouter_id %s: %#v", vpc.VRouterId, err)
+		}
+		if len(vrouters) > 0 && len(vrouters[0].RouteTableIds.RouteTableId) > 0 {
+			route_tables = append(route_tables, vrouters[0].RouteTableIds.RouteTableId[0])
+		} else {
+			route_tables = append(route_tables, "")
+		}
+
+		filteredVpcsTemp = append(filteredVpcsTemp, vpc)
+	}
+
+	var filteredVpcs []ecs.VpcSetType
+
+	if nameRegex, ok := d.GetOk("name_regex"); ok {
+		if r, err := regexp.Compile(nameRegex.(string)); err == nil {
+			for _, vpc := range filteredVpcsTemp {
+				if r.MatchString(vpc.VpcName) {
+					filteredVpcs = append(filteredVpcs, vpc)
+				}
+			}
+		}
+	} else {
+		filteredVpcs = filteredVpcsTemp[:]
+	}
+
+	if len(filteredVpcs) < 1 {
+		return fmt.Errorf("Your query returned no results. Please change your search criteria and try again.")
+	}
+
+	log.Printf("[DEBUG] alicloud_vpc - VPCs found: %#v", allVpcs)
+
+	return vpcsDecriptionAttributes(d, filteredVpcsTemp, route_tables, meta)
+}
+func vpcVswitchIdListContains(vswitchIdList []string, vswitchId string) bool {
+	for _, idListItem := range vswitchIdList {
+		if idListItem == vswitchId {
+			return true
+		}
+	}
+	return false
+}
+func vpcsDecriptionAttributes(d *schema.ResourceData, vpcSetTypes []ecs.VpcSetType, route_tables []string, meta interface{}) error {
+	var ids []string
+	var s []map[string]interface{}
+	for index, vpc := range vpcSetTypes {
+		mapping := map[string]interface{}{
+			"id":             vpc.VpcId,
+			"region_id":      vpc.RegionId,
+			"status":         vpc.Status,
+			"vpc_name":       vpc.VpcName,
+			"vswitch_ids":    vpc.VSwitchIds.VSwitchId,
+			"cidr_block":     vpc.CidrBlock,
+			"vrouter_id":     vpc.VRouterId,
+			"route_table_id": route_tables[index],
+			"description":    vpc.Description,
+			"is_default":     vpc.IsDefault,
+			"creation_time":  vpc.CreationTime.String(),
+		}
+		log.Printf("[DEBUG] alicloud_vpc - adding vpc: %v", mapping)
+		ids = append(ids, vpc.VpcId)
+		s = append(s, mapping)
+	}
+
+	d.SetId(dataResourceIdHash(ids))
+	if err := d.Set("vpcs", s); err != nil {
+		return err
+	}
+
+	// create a json file in current directory and write data source to it.
+	if output, ok := d.GetOk("output_file"); ok && output.(string) != "" {
+		writeToFile(output.(string), s)
+	}
+	return nil
+}

--- a/alicloud/data_source_alicloud_vpcs_test.go
+++ b/alicloud/data_source_alicloud_vpcs_test.go
@@ -1,0 +1,32 @@
+package alicloud
+
+import (
+	"github.com/hashicorp/terraform/helper/resource"
+	"testing"
+)
+
+func TestAccAlicloudVpcsDataSource_cidr_block(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+		},
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCheckAlicloudVpcsDataSourceCidrBlockConfig,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAlicloudDataSourceID("data.alicloud_vpcs.vpc"),
+					resource.TestCheckResourceAttr("data.alicloud_vpcs.vpc", "vpcs.0.region_id", "cn-beijing"),
+					resource.TestCheckResourceAttr("data.alicloud_vpcs.vpc", "vpcs.0.status", "Available"),
+					resource.TestCheckResourceAttr("data.alicloud_vpcs.vpc", "vpcs.0.is_default", "false"),
+				),
+			},
+		},
+	})
+}
+
+const testAccCheckAlicloudVpcsDataSourceCidrBlockConfig = `
+data "alicloud_vpcs" "vpc" {
+  cidr_block = "172.16.0.0/12"
+}
+`

--- a/website/alicloud.erb
+++ b/website/alicloud.erb
@@ -13,6 +13,9 @@
                  <li<%= sidebar_current("docs-alicloud-datasource") %>>
                     <a href="#">Data Sources</a>
                     <ul class="nav nav-visible">
+                        <li<%= sidebar_current("docs-alicloud-datasource-regions") %>>
+                            <a href="/docs/providers/alicloud/d/regions.html">alicloud_regions</a>
+                        </li>
                         <li<%= sidebar_current("docs-alicloud-datasource-instance-types") %>>
                             <a href="/docs/providers/alicloud/d/instance_types.html">alicloud_instance_types</a>
                         </li>
@@ -21,6 +24,9 @@
                         </li>
                         <li<%= sidebar_current("docs-alicloud-datasource-zones") %>>
                             <a href="/docs/providers/alicloud/d/zones.html">alicloud_zones</a>
+                        </li>
+                        <li<%= sidebar_current("docs-alicloud-datasource-vpcs") %>>
+                            <a href="/docs/providers/alicloud/d/vpcs.html">alicloud_vpcs</a>
                         </li>
                     </ul>
                 </li>

--- a/website/docs/d/vpcs.html.markdown
+++ b/website/docs/d/vpcs.html.markdown
@@ -1,0 +1,49 @@
+---
+layout: "alicloud"
+page_title: "Alicloud: alicloud_vpcs"
+sidebar_current: "docs-alicloud-datasource-vpcs"
+description: |-
+    Provides a list of VPCs which owned by an Alicloud account.
+---
+
+# alicloud\_vpcs
+
+The VPCs data source lists a number of VPCs resource information owned by an Alicloud account.
+
+## Example Usage
+
+```
+data "alicloud_vpcs" "multi_vpc"{
+	cidr_block="172.16.0.0/12"
+	status="Available"
+	name_regex="^foo"
+}
+
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `cidr_block` - (Optional) Limit search to specific cidr block,like "172.16.0.0/12".
+* `status` - (Optional) Limit search to specific status - valid value is "Pending" or "Available".
+* `name_regex` - (Optional) A regex string of VPC name.
+* `is_default` - (Optional) Whether the VPC is the default VPC in the specified region - valid value is true or false.
+* `vswitch_id` - (Optional) Retrieving VPC according to the specified VSwitch.
+* `output_file` - (Optional) The name of file that can save vpcs data source after running `terraform plan`.
+
+## Attributes Reference
+
+The following attributes are exported:
+
+* `id` - ID of the VPC.
+* `region_id` - ID of the region where VPC belongs.
+* `status` - Status of the VPC.
+* `vpc_name` - Name of the VPC.
+* `vswitch_ids` - List of VSwitch IDs in the specified VPC
+* `cidr_block` - CIDR block of the VPC.
+* `vrouter_id` - ID of the VRouter
+* `route_table_id` - Route table ID of the VRouter
+* `description` - Description of the VPC
+* `is_default` - Whether the VPC is the default VPC in the belonging region.
+* `creation_time` - Time of creation.


### PR DESCRIPTION
This PR add a new data source alicloud_vpcs and it can retrieving the all of vpcs belongs one account in the specified region.

The running results of alicloud_vpcs' test cases as follows:

TF_ACC=1 go test ./alicloud -v -run=TestAccAlicloudVpcsData -timeout=120m
=== RUN   TestAccAlicloudVpcsDataSource_cidr_block
--- PASS: TestAccAlicloudVpcsDataSource_cidr_block (15.40s)
PASS
ok      github.com/alibaba/terraform-provider/alicloud  15.425s
