### PR TITLE
[BUG] Fix security group rule bug

### DIFF
--- a/alicloud/errors.go
+++ b/alicloud/errors.go
@@ -9,7 +9,9 @@ const (
 	// common
 	Notfound = "Not found"
 	// ecs
-	InstanceNotfound = "Instance.Notfound"
+	InstanceNotfound        = "Instance.Notfound"
+	InstanceNotFound        = "Instance.Notfound"
+	MessageInstanceNotFound = "instance is not found"
 	// disk
 	DiskIncorrectStatus       = "IncorrectDiskStatus"
 	DiskCreatingSnapshot      = "DiskCreatingSnapshot"
@@ -64,6 +66,16 @@ func GetNotFoundErrorFromString(str string) error {
 		},
 		StatusCode: -1,
 	}
+}
+
+func NotFoundError(err error) bool {
+	if e, ok := err.(*common.Error); ok &&
+		(e.Code == InstanceNotFound || e.Code == RamInstanceNotFound ||
+			strings.Contains(strings.ToLower(e.Message), MessageInstanceNotFound)) {
+		return true
+	}
+
+	return false
 }
 
 func IsExceptedError(err error, expectCode string) bool {

--- a/alicloud/resource_alicloud_security_group_rule.go
+++ b/alicloud/resource_alicloud_security_group_rule.go
@@ -145,7 +145,7 @@ func resourceAliyunSecurityGroupRuleRead(d *schema.ResourceData, meta interface{
 	rules, err := client.DescribeSecurityByAttr(sgId, direction, nic_type)
 
 	if err != nil {
-		if notFoundError(err) {
+		if NotFoundError(err) {
 			d.SetId("")
 			return nil
 		}
@@ -162,7 +162,7 @@ func resourceAliyunSecurityGroupRuleRead(d *schema.ResourceData, meta interface{
 			}
 			if GroupRuleDirection(direction) == GroupRuleEgress {
 				if cidr = ru.DestCidrIp; cidr == "" {
-					cidr = ru.DestCidrIp
+					cidr = ru.DestGroupId
 				}
 			}
 			if cidr == cidr_ip {
@@ -233,7 +233,7 @@ func resourceAliyunSecurityGroupRuleDelete(d *schema.ResourceData, meta interfac
 
 		_, err = client.DescribeSecurityGroupRule(sgId, direction, nic_type, ip_protocol, port_range)
 		if err != nil {
-			if notFoundError(err) {
+			if NotFoundError(err) {
 				return nil
 			}
 			return resource.NonRetryableError(err)


### PR DESCRIPTION
The PR fix security group rule's diff bug by modifying 'DestCidrIp' to 'DestGroupId' when running read.

The running results of rule's import test cases as following:

TF_ACC=1 go test -v ./alicloud -run=TestAccAlicloudSecurityGroupRule -timeout=120m
=== RUN   TestAccAlicloudSecurityGroupRule_Ingress
--- PASS: TestAccAlicloudSecurityGroupRule_Ingress (10.57s)
=== RUN   TestAccAlicloudSecurityGroupRule_Egress
--- PASS: TestAccAlicloudSecurityGroupRule_Egress (10.68s)
=== RUN   TestAccAlicloudSecurityGroupRule_EgressDefaultNicType
--- PASS: TestAccAlicloudSecurityGroupRule_EgressDefaultNicType (10.99s)
=== RUN   TestAccAlicloudSecurityGroupRule_Vpc_Ingress
--- PASS: TestAccAlicloudSecurityGroupRule_Vpc_Ingress (23.87s)
=== RUN   TestAccAlicloudSecurityGroupRule_MissParameterSourceCidrIp
--- PASS: TestAccAlicloudSecurityGroupRule_MissParameterSourceCidrIp (11.00s)
=== RUN   TestAccAlicloudSecurityGroupRule_SourceSecurityGroup
--- PASS: TestAccAlicloudSecurityGroupRule_SourceSecurityGroup (11.30s)
=== RUN   TestAccAlicloudSecurityGroupRule_Multi
--- PASS: TestAccAlicloudSecurityGroupRule_Multi (32.14s)
PASS
ok      github.com/alibaba/terraform-provider/alicloud  110.583s
