### PR TITLE
[IMPROVEMENT] remove runInstance and using createInstance

### DIFF
--- a/alicloud/errors.go
+++ b/alicloud/errors.go
@@ -9,7 +9,9 @@ const (
 	// common
 	Notfound = "Not found"
 	// ecs
-	InstanceNotfound = "Instance.Notfound"
+	InstanceNotfound        = "Instance.Notfound"
+	InstanceNotFound        = "Instance.Notfound"
+	MessageInstanceNotFound = "instance is not found"
 	// disk
 	DiskIncorrectStatus       = "IncorrectDiskStatus"
 	DiskCreatingSnapshot      = "DiskCreatingSnapshot"
@@ -64,6 +66,16 @@ func GetNotFoundErrorFromString(str string) error {
 		},
 		StatusCode: -1,
 	}
+}
+
+func NotFoundError(err error) bool {
+	if e, ok := err.(*common.Error); ok &&
+		(e.Code == InstanceNotFound || e.Code == RamInstanceNotFound ||
+			strings.Contains(strings.ToLower(e.Message), MessageInstanceNotFound)) {
+		return true
+	}
+
+	return false
 }
 
 func IsExceptedError(err error, expectCode string) bool {

--- a/website/docs/r/instance.html.markdown
+++ b/website/docs/r/instance.html.markdown
@@ -26,9 +26,8 @@ resource "alicloud_instance" "classic" {
 
   allocate_public_ip = true
 
-  # series II
-  instance_type        = "ecs.n1.medium"
-  io_optimized         = "optimized"
+  # series III
+  instance_type        = "ecs.n4.large"
   system_disk_category = "cloud_efficiency"
   image_id             = "ubuntu_140405_64_40G_cloudinit_20161115.vhd"
   instance_name        = "test_foo"
@@ -65,7 +64,7 @@ Terraform will autogenerate a default name is `ECS-Instance`.
 * `system_disk_category` - (Optional) Valid values are `cloud`, `cloud_efficiency`, `cloud_ssd`, For I/O optimized instance type, `cloud_ssd` and `cloud_efficiency` disks are supported. For non I/O Optimized instance type, `cloud` disk are supported. 
 * `system_disk_size` - (Optional) Size of the system disk, value range: 40GB ~ 500GB. Default is 40GB. ECS instance's system disk can be reset when replacing system disk.
 * `description` - (Optional) Description of the instance, This description can have a string of 2 to 256 characters, It cannot begin with http:// or https://. Default value is null.
-* `internet_charge_type` - (Optional) Internet charge type of the instance, Valid values are `PayByBandwidth`, `PayByTraffic`. Default is `PayByBandwidth`.
+* `internet_charge_type` - (Optional) Internet charge type of the instance, Valid values are `PayByBandwidth`, `PayByTraffic`. Default is `PayByTraffic`.
 * `internet_max_bandwidth_in` - (Optional) Maximum incoming bandwidth from the public network, measured in Mbps (Mega bit per second). Value range: [1, 200]. If this value is not specified, then automatically sets it to 200 Mbps.
 * `internet_max_bandwidth_out` - (Optional) Maximum outgoing bandwidth to the public network, measured in Mbps (Mega bit per second). Value range:  [0, 100], If this value is not specified, then automatically sets it to 0 Mbps.
 * `host_name` - (Optional) Host name of the ECS, which is a string of at least two characters. “hostname” cannot start or end with “.” or “-“. In addition, two or more consecutive “.” or “-“ symbols are not allowed. On Windows, the host name can contain a maximum of 15 characters, which can be a combination of uppercase/lowercase letters, numerals, and “-“. The host name cannot contain dots (“.”) or contain only numeric characters.


### PR DESCRIPTION
This PR remove RunInstance API and using CreateInstance API when creating Pay-As-You-Go ECS instance.

The running results of instance's test cases as follows:

TF_ACC=1 go test -v ./alicloud -run=TestAccAlicloudInstance -timeout=120m
=== RUN   TestAccAlicloudInstanceTypesDataSource_basic
--- PASS: TestAccAlicloudInstanceTypesDataSource_basic (16.71s)
=== RUN   TestAccAlicloudInstance_importBasic
--- PASS: TestAccAlicloudInstance_importBasic (82.17s)
=== RUN   TestAccAlicloudInstance_importVpc
--- PASS: TestAccAlicloudInstance_importVpc (114.26s)
=== RUN   TestAccAlicloudInstance_importUserData
--- PASS: TestAccAlicloudInstance_importUserData (118.88s)
=== RUN   TestAccAlicloudInstance_importMultiSecurityGroup
--- PASS: TestAccAlicloudInstance_importMultiSecurityGroup (70.25s)
=== RUN   TestAccAlicloudInstance_importTags
--- PASS: TestAccAlicloudInstance_importTags (78.68s)
=== RUN   TestAccAlicloudInstance_importVpcRule
--- PASS: TestAccAlicloudInstance_importVpcRule (104.70s)
=== RUN   TestAccAlicloudInstance_basic
--- PASS: TestAccAlicloudInstance_basic (93.76s)
=== RUN   TestAccAlicloudInstance_vpc
--- PASS: TestAccAlicloudInstance_vpc (112.52s)
=== RUN   TestAccAlicloudInstance_userData
--- PASS: TestAccAlicloudInstance_userData (105.98s)
=== RUN   TestAccAlicloudInstance_multipleRegions
--- PASS: TestAccAlicloudInstance_multipleRegions (346.91s)
=== RUN   TestAccAlicloudInstance_multiSecurityGroup
--- PASS: TestAccAlicloudInstance_multiSecurityGroup (69.56s)
=== RUN   TestAccAlicloudInstance_multiSecurityGroupByCount
--- PASS: TestAccAlicloudInstance_multiSecurityGroupByCount (73.63s)
=== RUN   TestAccAlicloudInstance_NetworkInstanceSecurityGroups
--- PASS: TestAccAlicloudInstance_NetworkInstanceSecurityGroups (116.32s)
=== RUN   TestAccAlicloudInstance_tags
--- PASS: TestAccAlicloudInstance_tags (77.42s)
=== RUN   TestAccAlicloudInstance_update
--- PASS: TestAccAlicloudInstance_update (68.73s)
=== RUN   TestAccAlicloudInstanceImage_update
--- PASS: TestAccAlicloudInstanceImage_update (238.49s)
=== RUN   TestAccAlicloudInstance_privateIP
--- PASS: TestAccAlicloudInstance_privateIP (101.42s)
=== RUN   TestAccAlicloudInstance_associatePublicIP
--- PASS: TestAccAlicloudInstance_associatePublicIP (114.54s)
=== RUN   TestAccAlicloudInstance_vpcRule
--- PASS: TestAccAlicloudInstance_vpcRule (114.95s)
=== RUN   TestAccAlicloudInstance_keyPair
--- PASS: TestAccAlicloudInstance_keyPair (125.79s)
PASS
ok github.com/alibaba/terraform-provider/alicloud  2345.720s