### PR TITLE
[IMPROVEMENT] improve rule about cidr and source security group id

### DIFF
--- a/alicloud/resource_alicloud_security_group_rule.go
+++ b/alicloud/resource_alicloud_security_group_rule.go
@@ -66,10 +66,9 @@ func resourceAliyunSecurityGroupRule() *schema.Resource {
 			},
 
 			"cidr_ip": &schema.Schema{
-				Type:          schema.TypeString,
-				Optional:      true,
-				ForceNew:      true,
-				ConflictsWith: []string{"source_security_group_id"},
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: true,
 			},
 
 			"source_security_group_id": &schema.Schema{
@@ -97,6 +96,12 @@ func resourceAliyunSecurityGroupRuleCreate(d *schema.ResourceData, meta interfac
 	ptl := d.Get("ip_protocol").(string)
 	port := d.Get("port_range").(string)
 	nicType := d.Get("nic_type").(string)
+
+	if _, ok := d.GetOk("cidr_ip"); !ok {
+		if _, ok := d.GetOk("source_security_group_id"); !ok {
+			return fmt.Errorf("Either 'cidr_ip' or 'source_security_group_id' must be specified.")
+		}
+	}
 
 	var autherr error
 	switch GroupRuleDirection(direction) {

--- a/website/docs/r/security_group_rule.html.markdown
+++ b/website/docs/r/security_group_rule.html.markdown
@@ -11,7 +11,7 @@ description: |-
 Provides a security group rule resource.
 Represents a single `ingress` or `egress` group rule, which can be added to external Security Groups.
 
-~> **NOTE:**  `nic_type` should set to `intranet` when security group type is `vpc`. In this situation it does not distinguish between intranet and internet, the rule is effective on them both.
+~> **NOTE:**  `nic_type` should set to `intranet` when security group type is `vpc` or specifying the `source_security_group_id`. In this situation it does not distinguish between intranet and internet, the rule is effective on them both.
 
 
 ## Example Usage
@@ -47,8 +47,10 @@ The following arguments are supported:
 * `policy` - (Optional, Forces new resource) Authorization policy, can be either `accept` or `drop`, the default value is `accept`.
 * `priority` - (Optional, Forces new resource) Authorization policy priority, with parameter values: `1-100`, default value: 1.
 * `cidr_ip` - (Optional, Forces new resource) The target IP address range. The default value is 0.0.0.0/0 (which means no restriction will be applied). Other supported formats include 10.159.6.18/12. Only IPv4 is supported.
-* `source_security_group_id` - (Optional, Forces new resource) The target security group ID within the same region. Either the `source_security_group_id` or `cidr_ip` must be set. If both are set, then `cidr_ip` is authorized by default. If this field is specified, but no `cidr_ip` is specified, the `nic_type` can only select `intranet`.
+* `source_security_group_id` - (Optional, Forces new resource) The target security group ID within the same region. If this field is specified, the `nic_type` can only select `intranet`.
 * `source_group_owner_account` - (Optional, Forces new resource) The Alibaba Cloud user account Id of the target security group when security groups are authorized across accounts.  This parameter is invalid if `cidr_ip` has already been set.
+
+~> **NOTE:**  Either the `source_security_group_id` or `cidr_ip` must be set.
 
 ## Attributes Reference
 


### PR DESCRIPTION
The PR improves rule parameters setting about cidr_ip and source_security_group_id.

The running test as follows:

TF_ACC=1 go test -v ./alicloud -run=TestAccAlicloudSecurityGroupRule -timeout 120m
=== RUN   TestAccAlicloudSecurityGroupRule_Ingress
--- PASS: TestAccAlicloudSecurityGroupRule_Ingress (11.02s)
=== RUN   TestAccAlicloudSecurityGroupRule_Egress
--- PASS: TestAccAlicloudSecurityGroupRule_Egress (10.97s)
=== RUN   TestAccAlicloudSecurityGroupRule_EgressDefaultNicType
--- PASS: TestAccAlicloudSecurityGroupRule_EgressDefaultNicType (11.73s)
=== RUN   TestAccAlicloudSecurityGroupRule_Vpc_Ingress
--- PASS: TestAccAlicloudSecurityGroupRule_Vpc_Ingress (19.78s)
=== RUN   TestAccAlicloudSecurityGroupRule_MissParameterSourceCidrIp
--- PASS: TestAccAlicloudSecurityGroupRule_MissParameterSourceCidrIp (11.37s)
=== RUN   TestAccAlicloudSecurityGroupRule_SourceSecurityGroup
--- PASS: TestAccAlicloudSecurityGroupRule_SourceSecurityGroup (13.09s)
=== RUN   TestAccAlicloudSecurityGroupRule_Multi
--- PASS: TestAccAlicloudSecurityGroupRule_Multi (33.52s)
PASS
ok      github.com/alibaba/terraform-provider/alicloud  111.511s