### PR TITLE
[IMPROVEMENT] improve route entry and add new nexthop type

### DIFF
--- a/alicloud/resource_alicloud_vroute_entry.go
+++ b/alicloud/resource_alicloud_vroute_entry.go
@@ -3,8 +3,10 @@ package alicloud
 import (
 	"fmt"
 	"github.com/denverdino/aliyungo/ecs"
+	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/helper/schema"
 	"strings"
+	"time"
 )
 
 func resourceAliyunRouteEntry() *schema.Resource {
@@ -56,6 +58,20 @@ func resourceAliyunRouteEntryCreate(d *schema.ResourceData, meta interface{}) er
 	nt := d.Get("nexthop_type").(string)
 	ni := d.Get("nexthop_id").(string)
 
+	table, err := meta.(*AliyunClient).QueryRouteTableById(rtId)
+
+	if err != nil {
+		if NotFoundError(err) {
+			d.SetId("")
+			return nil
+		}
+		return fmt.Errorf("Error query route table: %#v", err)
+	}
+
+	if err := conn.WaitForAllRouteEntriesAvailable(table.VRouterId, rtId, defaultTimeout); err != nil {
+		return fmt.Errorf("WaitFor route entry got error: %#v", err)
+	}
+
 	args, err := buildAliyunRouteEntryArgs(d, meta)
 	if err != nil {
 		return err
@@ -65,15 +81,7 @@ func resourceAliyunRouteEntryCreate(d *schema.ResourceData, meta interface{}) er
 		return err
 	}
 	// route_table_id:router_id:destination_cidrblock:nexthop_type:nexthop_id
-	table, err := meta.(*AliyunClient).QueryRouteTableById(rtId)
 
-	if err != nil {
-		if NotFoundError(err) {
-			d.SetId("")
-			return nil
-		}
-		return fmt.Errorf("Error query route entry: %#v", err)
-	}
 	d.SetId(rtId + ":" + table.VRouterId + ":" + cidr + ":" + nt + ":" + ni)
 
 	if err := conn.WaitForAllRouteEntriesAvailable(table.VRouterId, rtId, defaultTimeout); err != nil {
@@ -116,7 +124,32 @@ func resourceAliyunRouteEntryDelete(d *schema.ResourceData, meta interface{}) er
 	if err != nil {
 		return err
 	}
-	return con.DeleteRouteEntry(args)
+	client := meta.(*AliyunClient)
+	parts := strings.Split(d.Id(), ":")
+	rtId := parts[0]
+	cidr := parts[2]
+	nexthop_type := parts[3]
+	nexthop_id := parts[4]
+
+	return resource.Retry(5*time.Minute, func() *resource.RetryError {
+		en, err := client.QueryRouteEntry(rtId, cidr, nexthop_type, nexthop_id)
+		if err != nil {
+			if NotFoundError(err) {
+				return nil
+			}
+			return resource.NonRetryableError(fmt.Errorf("Error route entry: %#v", err))
+		}
+
+		if en.Status != ecs.RouteEntryStatusAvailable {
+			return resource.RetryableError(fmt.Errorf("Waiting for RouteEntry's status is Available - trying again."))
+		}
+
+		if err := con.DeleteRouteEntry(args); err != nil {
+			return resource.RetryableError(fmt.Errorf("RouteEntry in use - trying again while it is deleted."))
+		}
+
+		return nil
+	})
 }
 
 func buildAliyunRouteEntryArgs(d *schema.ResourceData, meta interface{}) (*ecs.CreateRouteEntryArgs, error) {

--- a/alicloud/validators.go
+++ b/alicloud/validators.go
@@ -1,19 +1,19 @@
 package alicloud
 
 import (
+	"encoding/json"
 	"fmt"
 	"net"
+	"regexp"
 	"strconv"
 	"strings"
+	"time"
 
-	"encoding/json"
 	"github.com/aliyun/aliyun-oss-go-sdk/oss"
 	"github.com/denverdino/aliyungo/common"
 	"github.com/denverdino/aliyungo/ecs"
 	"github.com/denverdino/aliyungo/slb"
 	"github.com/hashicorp/terraform/helper/schema"
-	"regexp"
-	"time"
 )
 
 // common
@@ -42,8 +42,12 @@ func validateInstanceProtocol(v interface{}, k string) (ws []string, errors []er
 // ecs
 func validateDiskCategory(v interface{}, k string) (ws []string, errors []error) {
 	category := ecs.DiskCategory(v.(string))
-	if category != ecs.DiskCategoryCloud && category != ecs.DiskCategoryCloudEfficiency && category != ecs.DiskCategoryCloudSSD {
-		errors = append(errors, fmt.Errorf("%s must be one of %s %s %s", k, ecs.DiskCategoryCloud, ecs.DiskCategoryCloudEfficiency, ecs.DiskCategoryCloudSSD))
+	if _, ok := SupportedDiskCategory[category]; !ok {
+		var valid []string
+		for key := range SupportedDiskCategory {
+			valid = append(valid, string(key))
+		}
+		errors = append(errors, fmt.Errorf("%s must be one of %s", k, strings.Join(valid, ", ")))
 	}
 
 	return
@@ -133,7 +137,7 @@ func validateSecurityRuleType(v interface{}, k string) (ws []string, errors []er
 func validateSecurityRuleIpProtocol(v interface{}, k string) (ws []string, errors []error) {
 	pt := GroupRuleIpProtocol(v.(string))
 	if pt != GroupRuleTcp && pt != GroupRuleUdp && pt != GroupRuleIcmp && pt != GroupRuleGre && pt != GroupRuleAll {
-		errors = append(errors, fmt.Errorf("%s must be one of %s %s %s %s %s", k,
+		errors = append(errors, fmt.Errorf("%s must be one of %s, %s, %s, %s and %s", k,
 			GroupRuleTcp, GroupRuleUdp, GroupRuleIcmp, GroupRuleGre, GroupRuleAll))
 	}
 
@@ -191,9 +195,9 @@ func validateCIDRNetworkAddress(v interface{}, k string) (ws []string, errors []
 
 func validateRouteEntryNextHopType(v interface{}, k string) (ws []string, errors []error) {
 	nht := ecs.NextHopType(v.(string))
-	if nht != ecs.NextHopIntance && nht != ecs.NextHopTunnel {
+	if nht != ecs.NextHopIntance && nht != ecs.NextHopTunnelRouterInterface {
 		errors = append(errors, fmt.Errorf("%s must be one of %s %s", k,
-			ecs.NextHopIntance, ecs.NextHopTunnel))
+			ecs.NextHopIntance, ecs.NextHopTunnelRouterInterface))
 	}
 
 	return

--- a/alicloud/validators_test.go
+++ b/alicloud/validators_test.go
@@ -39,7 +39,7 @@ func TestValidateInstanceProtocol(t *testing.T) {
 }
 
 func TestValidateInstanceDiskCategory(t *testing.T) {
-	validDiskCategory := []string{"cloud", "cloud_efficiency", "cloud_ssd"}
+	validDiskCategory := []string{"cloud_efficiency", "cloud_ssd"}
 	for _, v := range validDiskCategory {
 		_, errors := validateDiskCategory(v, "instance_disk_category")
 		if len(errors) != 0 {
@@ -237,7 +237,7 @@ func TestValidateCIDRNetworkAddress(t *testing.T) {
 }
 
 func TestValidateRouteEntryNextHopType(t *testing.T) {
-	validNexthopType := []string{"Instance", "Tunnel"}
+	validNexthopType := []string{"Instance", "RouterInterface"}
 	for _, v := range validNexthopType {
 		_, errors := validateRouteEntryNextHopType(v, "route_entry_nexthop_type")
 		if len(errors) != 0 {

--- a/examples/ecs/main.tf
+++ b/examples/ecs/main.tf
@@ -1,5 +1,5 @@
 data "alicloud_instance_types" "instance_type" {
-  instance_type_family = "ecs.n1"
+  instance_type_family = "ecs.n4"
   cpu_core_count = "1"
   memory_size = "2"
 }
@@ -55,8 +55,6 @@ resource "alicloud_instance" "instance" {
 
   allocate_public_ip = "${var.allocate_public_ip}"
 
-  io_optimized = "${var.io_optimized}"
-
   instance_charge_type = "PostPaid"
   system_disk_category = "cloud_efficiency"
 
@@ -72,5 +70,4 @@ resource "alicloud_disk_attachment" "instance-attachment" {
   count = "${var.count}"
   disk_id = "${element(alicloud_disk.disk.*.id, count.index)}"
   instance_id = "${element(alicloud_instance.instance.*.id, count.index)}"
-  device_name = "${var.device_name}"
 }

--- a/vendor/github.com/denverdino/aliyungo/cdn/client.go
+++ b/vendor/github.com/denverdino/aliyungo/cdn/client.go
@@ -1,0 +1,30 @@
+package cdn
+
+import (
+	"github.com/denverdino/aliyungo/common"
+	"os"
+)
+
+const (
+	// CDNDefaultEndpoint is the default API endpoint of CDN services
+	CDNDefaultEndpoint = "https://cdn.aliyuncs.com"
+	CDNAPIVersion      = "2014-11-11"
+)
+
+type CdnClient struct {
+	common.Client
+}
+
+func NewClient(accessKeyId string, accessKeySecret string) *CdnClient {
+	endpoint := os.Getenv("CDN_ENDPOINT")
+	if endpoint == "" {
+		endpoint = CDNDefaultEndpoint
+	}
+	return NewClientWithEndpoint(endpoint, accessKeyId, accessKeySecret)
+}
+
+func NewClientWithEndpoint(endpoint string, accessKeyId string, accessKeySecret string) *CdnClient {
+	client := &CdnClient{}
+	client.Init(endpoint, CDNAPIVersion, accessKeyId, accessKeySecret)
+	return client
+}

--- a/vendor/github.com/denverdino/aliyungo/cdn/config.go
+++ b/vendor/github.com/denverdino/aliyungo/cdn/config.go
@@ -1,0 +1,385 @@
+package cdn
+
+type DomainConfigRequest struct {
+	DomainName string
+	// optional
+	ConfigList string
+}
+
+type DomainConfigResponse struct {
+	CdnCommonResponse
+	DomainConfigs DomainConfigs
+}
+
+type DomainConfigs struct {
+	PageCompressConfig struct {
+		Enable   string
+		ConfigId string
+		Status   string
+	}
+	WafConfig struct {
+		Enable string
+	}
+	IgnoreQueryStringConfig struct {
+		Enable      string
+		ConfigId    string
+		Status      string
+		HashKeyArgs string
+	}
+	VideoSeekConfig struct {
+		Enable   string
+		ConfigId string
+		Status   string
+	}
+	ReqAuthConfig struct {
+		Key1     string
+		Key2     string
+		AuthType string
+		TimeOut  string
+	}
+	RangeConfig struct {
+		Enable   string
+		ConfigId string
+		Status   string
+	}
+	SrcHostConfig struct {
+		DomainName string
+	}
+	OptimizeConfig struct {
+		Enable   string
+		ConfigId string
+		Status   string
+	}
+	ErrorPageConfig struct {
+		PageType      string
+		CustomPageUrl string
+		ErrorCode     string
+	}
+	RefererConfig struct {
+		AllowEmpty string
+		ReferType  string
+		ReferList  string
+	}
+	CcConfig struct {
+		Enable   string
+		AllowIps string
+		BlockIps string
+		ConfigId string
+		Status   string
+	}
+	HttpHeaderConfigs struct {
+		HttpHeaderConfig []HttpHeaderConfig
+	}
+	CacheExpiredConfigs struct {
+		CacheExpiredConfig []CacheExpiredConfig
+	}
+	NotifyUrlConfig struct {
+		Enable    string
+		NotifyUrl string
+	}
+	RedirectTypeConfig struct {
+		RedirectType string
+	}
+}
+
+type HttpHeaderConfig struct {
+	Status      string
+	HeaderKey   string
+	HeaderValue string
+	ConfigId    string
+}
+
+type CacheExpiredConfig struct {
+	Status       string
+	TTL          string
+	CacheType    string
+	Weight       string
+	CacheContent string
+	ConfigId     string
+}
+
+type ConfigRequest struct {
+	DomainName string
+	Enable     string
+}
+
+type QueryStringConfigRequest struct {
+	DomainName string
+	Enable     string
+	// optional
+	HashKeyArgs string
+}
+
+type HostConfigRequest struct {
+	DomainName    string
+	BackSrcDomain string
+}
+
+type ErrorPageConfigRequest struct {
+	DomainName string
+	PageType   string
+	// optional
+	CustomPageUrl string
+}
+
+type RedirectConfigRequest struct {
+	DomainName   string
+	RedirectType string
+}
+
+type ReferConfigRequest struct {
+	DomainName string
+	ReferType  string
+	// optional
+	ReferList  string
+	AllowEmpty string
+}
+
+type CacheConfigRequest struct {
+	DomainName   string
+	CacheContent string
+	TTL          string
+	// optional
+	Weight string
+}
+
+type ModifyCacheConfigRequest struct {
+	CacheConfigRequest
+	ConfigID string
+}
+
+type DeleteCacheConfigRequest struct {
+	DomainName string
+	CacheType  string
+	ConfigID   string
+}
+
+type ReqAuthConfigRequest struct {
+	DomainName string
+	AuthType   string
+	// optional
+	Key1    string
+	Key2    string
+	Timeout string
+}
+
+type HttpHeaderConfigRequest struct {
+	DomainName  string
+	HeaderKey   string
+	HeaderValue string
+}
+
+type ModifyHttpHeaderConfigRequest struct {
+	HttpHeaderConfigRequest
+	ConfigID string
+}
+
+type DeleteHttpHeaderConfigRequest struct {
+	DomainName string
+	ConfigID   string
+}
+
+type CertificateRequest struct {
+	DomainName              string
+	CertName                string
+	ServerCertificateStatus string
+	// optional
+	ServerCertificate string
+	PrivateKey        string
+}
+
+type IpBlackRequest struct {
+	DomainName string
+	// optional
+	Enable   string
+	BlockIps string
+}
+
+func (client *CdnClient) DescribeDomainConfigs(req DomainConfigRequest) (DomainConfigResponse, error) {
+	var resp DomainConfigResponse
+	err := client.Invoke("DescribeDomainConfigs", req, &resp)
+	if err != nil {
+		return DomainConfigResponse{}, err
+	}
+	return resp, nil
+}
+
+func (client *CdnClient) SetOptimizeConfig(req ConfigRequest) (CdnCommonResponse, error) {
+	var resp CdnCommonResponse
+	err := client.Invoke("SetOptimizeConfig", req, &resp)
+	if err != nil {
+		return CdnCommonResponse{}, err
+	}
+	return resp, nil
+}
+
+func (client *CdnClient) SetPageCompressConfig(req ConfigRequest) (CdnCommonResponse, error) {
+	var resp CdnCommonResponse
+	err := client.Invoke("SetPageCompressConfig", req, &resp)
+	if err != nil {
+		return CdnCommonResponse{}, err
+	}
+	return resp, nil
+}
+
+func (client *CdnClient) SetIgnoreQueryStringConfig(req QueryStringConfigRequest) (CdnCommonResponse, error) {
+	var resp CdnCommonResponse
+	err := client.Invoke("SetIgnoreQueryStringConfig", req, &resp)
+	if err != nil {
+		return CdnCommonResponse{}, err
+	}
+	return resp, nil
+}
+
+func (client *CdnClient) SetRangeConfig(req ConfigRequest) (CdnCommonResponse, error) {
+	var resp CdnCommonResponse
+	err := client.Invoke("SetRangeConfig", req, &resp)
+	if err != nil {
+		return CdnCommonResponse{}, err
+	}
+	return resp, nil
+}
+
+func (client *CdnClient) SetVideoSeekConfig(req ConfigRequest) (CdnCommonResponse, error) {
+	var resp CdnCommonResponse
+	err := client.Invoke("SetVideoSeekConfig", req, &resp)
+	if err != nil {
+		return CdnCommonResponse{}, err
+	}
+	return resp, nil
+}
+
+func (client *CdnClient) SetSourceHostConfig(req HostConfigRequest) (CdnCommonResponse, error) {
+	var resp CdnCommonResponse
+	err := client.Invoke("SetSourceHostConfig", req, &resp)
+	if err != nil {
+		return CdnCommonResponse{}, err
+	}
+	return resp, nil
+}
+
+func (client *CdnClient) SetErrorPageConfig(req ErrorPageConfigRequest) (CdnCommonResponse, error) {
+	var resp CdnCommonResponse
+	err := client.Invoke("SetErrorPageConfig", req, &resp)
+	if err != nil {
+		return CdnCommonResponse{}, err
+	}
+	return resp, nil
+}
+
+func (client *CdnClient) SetForceRedirectConfig(req RedirectConfigRequest) (CdnCommonResponse, error) {
+	var resp CdnCommonResponse
+	err := client.Invoke("SetForceRedirectConfig", req, &resp)
+	if err != nil {
+		return CdnCommonResponse{}, err
+	}
+	return resp, nil
+}
+
+func (client *CdnClient) SetRefererConfig(req ReferConfigRequest) (CdnCommonResponse, error) {
+	var resp CdnCommonResponse
+	err := client.Invoke("SetRefererConfig", req, &resp)
+	if err != nil {
+		return CdnCommonResponse{}, err
+	}
+	return resp, nil
+}
+
+func (client *CdnClient) SetFileCacheExpiredConfig(req CacheConfigRequest) (CdnCommonResponse, error) {
+	var resp CdnCommonResponse
+	err := client.Invoke("SetFileCacheExpiredConfig", req, &resp)
+	if err != nil {
+		return CdnCommonResponse{}, err
+	}
+	return resp, nil
+}
+
+func (client *CdnClient) SetPathCacheExpiredConfig(req CacheConfigRequest) (CdnCommonResponse, error) {
+	var resp CdnCommonResponse
+	err := client.Invoke("SetPathCacheExpiredConfig", req, &resp)
+	if err != nil {
+		return CdnCommonResponse{}, err
+	}
+	return resp, nil
+}
+
+func (client *CdnClient) ModifyFileCacheExpiredConfig(req ModifyCacheConfigRequest) (CdnCommonResponse, error) {
+	var resp CdnCommonResponse
+	err := client.Invoke("ModifyFileCacheExpiredConfig", req, &resp)
+	if err != nil {
+		return CdnCommonResponse{}, err
+	}
+	return resp, nil
+}
+
+func (client *CdnClient) ModifyPathCacheExpiredConfig(req ModifyCacheConfigRequest) (CdnCommonResponse, error) {
+	var resp CdnCommonResponse
+	err := client.Invoke("ModifyPathCacheExpiredConfig", req, &resp)
+	if err != nil {
+		return CdnCommonResponse{}, err
+	}
+	return resp, nil
+}
+
+func (client *CdnClient) DeleteCacheExpiredConfig(req DeleteCacheConfigRequest) (CdnCommonResponse, error) {
+	var resp CdnCommonResponse
+	err := client.Invoke("DeleteCacheExpiredConfig", req, &resp)
+	if err != nil {
+		return CdnCommonResponse{}, err
+	}
+	return resp, nil
+}
+
+func (client *CdnClient) SetReqAuthConfig(req ReqAuthConfigRequest) (CdnCommonResponse, error) {
+	var resp CdnCommonResponse
+	err := client.Invoke("SetReqAuthConfig", req, &resp)
+	if err != nil {
+		return CdnCommonResponse{}, err
+	}
+	return resp, nil
+}
+
+func (client *CdnClient) SetHttpHeaderConfig(req HttpHeaderConfigRequest) (CdnCommonResponse, error) {
+	var resp CdnCommonResponse
+	err := client.Invoke("SetHttpHeaderConfig", req, &resp)
+	if err != nil {
+		return CdnCommonResponse{}, err
+	}
+	return resp, nil
+}
+
+func (client *CdnClient) ModifyHttpHeaderConfig(req ModifyHttpHeaderConfigRequest) (CdnCommonResponse, error) {
+	var resp CdnCommonResponse
+	err := client.Invoke("ModifyHttpHeaderConfig", req, &resp)
+	if err != nil {
+		return CdnCommonResponse{}, err
+	}
+	return resp, nil
+}
+
+func (client *CdnClient) DeleteHttpHeaderConfig(req DeleteHttpHeaderConfigRequest) (CdnCommonResponse, error) {
+	var resp CdnCommonResponse
+	err := client.Invoke("DeleteHttpHeaderConfig", req, &resp)
+	if err != nil {
+		return CdnCommonResponse{}, err
+	}
+	return resp, nil
+}
+
+func (client *CdnClient) SetDomainServerCertificate(req CertificateRequest) (CdnCommonResponse, error) {
+	var resp CdnCommonResponse
+	err := client.Invoke("SetDomainServerCertificate", req, &resp)
+	if err != nil {
+		return CdnCommonResponse{}, err
+	}
+	return resp, nil
+}
+
+func (client *CdnClient) SetIpBlackListConfig(req IpBlackRequest) (CdnCommonResponse, error) {
+	var resp CdnCommonResponse
+	err := client.Invoke("SetCcConfig", req, &resp)
+	if err != nil {
+		return CdnCommonResponse{}, err
+	}
+	return resp, nil
+}

--- a/vendor/github.com/denverdino/aliyungo/cdn/domain.go
+++ b/vendor/github.com/denverdino/aliyungo/cdn/domain.go
@@ -1,0 +1,165 @@
+package cdn
+
+import "github.com/denverdino/aliyungo/common"
+
+type AddDomainRequest struct {
+	DomainName string
+	CdnType    string
+	//optional
+	SourceType string
+	SourcePort int
+	Sources    string
+	Scope      string
+}
+
+type DescribeDomainsRequest struct {
+	//optional
+	common.Pagination
+	DomainName       string
+	DomainStatus     string
+	DomainSearchType string
+}
+
+type DomainsResponse struct {
+	CdnCommonResponse
+	common.PaginationResult
+	Domains struct {
+		PageData []Domains
+	}
+}
+
+type DescribeDomainRequest struct {
+	DomainName string
+}
+
+type DomainResponse struct {
+	CdnCommonResponse
+	GetDomainDetailModel DomainDetail
+}
+
+type DomainDetail struct {
+	DomainName              string
+	Cname                   string
+	HttpsCname              string
+	Scope                   string
+	CdnType                 string
+	SourceType              string
+	GmtCreated              string
+	GmtModified             string
+	DomainStatus            string
+	CertificateName         string
+	ServerCertificate       string
+	ServerCertificateStatus string
+	Sources struct {
+		Source []string
+	}
+}
+
+type ModifyDomainRequest struct {
+	DomainName string
+	SourceType string
+	SourcePort int
+	Sources    string
+}
+
+type DescribeDomainsBySourceRequest struct {
+	Sources string
+}
+
+type DomainInfo struct {
+	DomainName  string
+	Status      string
+	CreateTime  string
+	UpdateTime  string
+	DomainCname string
+}
+
+type DomainsData struct {
+	Source string
+	Domains struct {
+		domainNames []string
+	}
+	DomainInfos struct {
+		domainInfo []DomainInfo
+	}
+}
+
+type DomainBySourceResponse struct {
+	CdnCommonResponse
+	Sources string
+	DomainsList struct {
+		DomainsData []DomainsData
+	}
+}
+
+func (client *CdnClient) AddCdnDomain(req AddDomainRequest) (CdnCommonResponse, error) {
+	var resp CdnCommonResponse
+	err := client.Invoke("AddCdnDomain", req, &resp)
+	if err != nil {
+		return CdnCommonResponse{}, err
+	}
+	return resp, nil
+}
+
+func (client *CdnClient) DescribeUserDomains(req DescribeDomainsRequest) (DomainsResponse, error) {
+	var resp DomainsResponse
+	err := client.Invoke("DescribeUserDomains", req, &resp)
+	if err != nil {
+		return DomainsResponse{}, err
+	}
+	return resp, nil
+}
+
+func (client *CdnClient) DescribeCdnDomainDetail(req DescribeDomainRequest) (DomainResponse, error) {
+	var resp DomainResponse
+	err := client.Invoke("DescribeCdnDomainDetail", req, &resp)
+	if err != nil {
+		return DomainResponse{}, err
+	}
+	return resp, nil
+}
+
+func (client *CdnClient) ModifyCdnDomain(req ModifyDomainRequest) (CdnCommonResponse, error) {
+	var resp CdnCommonResponse
+	err := client.Invoke("ModifyCdnDomain", req, &resp)
+	if err != nil {
+		return CdnCommonResponse{}, err
+	}
+	return resp, nil
+}
+
+func (client *CdnClient) StartCdnDomain(req DescribeDomainRequest) (CdnCommonResponse, error) {
+	var resp CdnCommonResponse
+	err := client.Invoke("StartCdnDomain", req, &resp)
+	if err != nil {
+		return CdnCommonResponse{}, err
+	}
+	return resp, nil
+}
+
+func (client *CdnClient) StopCdnDomain(req DescribeDomainRequest) (CdnCommonResponse, error) {
+	var resp CdnCommonResponse
+	err := client.Invoke("StopCdnDomain", req, &resp)
+	if err != nil {
+		return CdnCommonResponse{}, err
+	}
+	return resp, nil
+}
+
+func (client *CdnClient) DeleteCdnDomain(req DescribeDomainRequest) (CdnCommonResponse, error) {
+	var resp CdnCommonResponse
+	err := client.Invoke("DeleteCdnDomain", req, &resp)
+	if err != nil {
+		return CdnCommonResponse{}, err
+	}
+	return resp, nil
+}
+
+func (client *CdnClient) DescribeDomainsBySource(req DescribeDomainsBySourceRequest) (DomainBySourceResponse, error) {
+	var resp DomainBySourceResponse
+	err := client.Invoke("DescribeDomainsBySource", req, &resp)
+	if err != nil {
+		return DomainBySourceResponse{}, err
+	}
+	return resp, nil
+}

--- a/vendor/github.com/denverdino/aliyungo/cdn/refresh.go
+++ b/vendor/github.com/denverdino/aliyungo/cdn/refresh.go
@@ -1,0 +1,90 @@
+package cdn
+
+import (
+	"time"
+	"github.com/denverdino/aliyungo/common"
+)
+
+type RefreshRequest struct {
+	ObjectPath string
+	// optional
+	ObjectType string
+}
+
+type RefreshResponse struct {
+	CdnCommonResponse
+	RefreshTaskId string
+}
+
+type PushResponse struct {
+	CdnCommonResponse
+	PushTaskId string
+}
+
+type DescribeRequest struct {
+	// optional
+	TaskId     string
+	ObjectPath string
+	common.Pagination
+}
+
+type Task struct {
+	TaskId       string
+	ObjectPath   string
+	Status       string
+	Process      string
+	CreationTime time.Time
+	Description  string
+}
+
+type DescribeResponse struct {
+	CdnCommonResponse
+	common.PaginationResult
+	Tasks struct {
+		CDNTask []Task
+	}
+}
+
+type QuotaResponse struct {
+	CdnCommonResponse
+	UrlQuota  string
+	DirQuota  string
+	UrlRemain string
+	DirRemain string
+}
+
+func (client *CdnClient) RefreshObjectCaches(req RefreshRequest) (RefreshResponse, error) {
+	var resp RefreshResponse
+	err := client.Invoke("RefreshObjectCaches", req, &resp)
+	if err != nil {
+		return RefreshResponse{}, err
+	}
+	return resp, nil
+}
+
+func (client *CdnClient) PushObjectCache(req RefreshRequest) (PushResponse, error) {
+	var resp PushResponse
+	err := client.Invoke("PushObjectCache", req, &resp)
+	if err != nil {
+		return PushResponse{}, err
+	}
+	return resp, nil
+}
+
+func (client *CdnClient) DescribeRefreshTasks(req DescribeRequest) (DescribeResponse, error) {
+	var resp DescribeResponse
+	err := client.Invoke("DescribeRefreshTasks", req, &resp)
+	if err != nil {
+		return DescribeResponse{}, err
+	}
+	return resp, nil
+}
+
+func (client *CdnClient) DescribeRefreshQuota() (QuotaResponse, error) {
+	var resp QuotaResponse
+	err := client.Invoke("DescribeRefreshQuota", struct{}{}, &resp)
+	if err != nil {
+		return QuotaResponse{}, err
+	}
+	return resp, nil
+}

--- a/vendor/github.com/denverdino/aliyungo/cdn/service.go
+++ b/vendor/github.com/denverdino/aliyungo/cdn/service.go
@@ -1,0 +1,49 @@
+package cdn
+
+import "time"
+
+type ServiceRequest struct {
+	InternetChargeType string
+}
+
+type Service struct {
+	InternetChargeType string
+	OpeningTime        string
+	ChangingChargeType string
+	ChangingAffectTime time.Time
+	OperationLocks struct {
+		LockReason []string
+	}
+}
+
+type ServiceResponse struct {
+	CdnCommonResponse
+	Service
+}
+
+func (client *CdnClient) OpenCdnService(req ServiceRequest) (CdnCommonResponse, error) {
+	var resp CdnCommonResponse
+	err := client.Invoke("OpenCdnService", req, &resp)
+	if err != nil {
+		return CdnCommonResponse{}, err
+	}
+	return resp, nil
+}
+
+func (client *CdnClient) DescribeCdnService() (ServiceResponse, error) {
+	var resp ServiceResponse
+	err := client.Invoke("DescribeCdnService", struct{}{}, &resp)
+	if err != nil {
+		return ServiceResponse{}, err
+	}
+	return resp, nil
+}
+
+func (client *CdnClient) ModifyCdnService(req ServiceRequest) (CdnCommonResponse, error) {
+	var resp CdnCommonResponse
+	err := client.Invoke("ModifyCdnService", req, &resp)
+	if err != nil {
+		return CdnCommonResponse{}, err
+	}
+	return resp, nil
+}

--- a/vendor/github.com/denverdino/aliyungo/cdn/types.go
+++ b/vendor/github.com/denverdino/aliyungo/cdn/types.go
@@ -1,0 +1,70 @@
+package cdn
+
+import (
+	"time"
+	"github.com/denverdino/aliyungo/common"
+)
+
+const (
+	Web                       = "web"
+	Download                  = "download"
+	video                     = "video"
+	LiveStream                = "liveStream"
+	Ipaddr                    = "ipaddr"
+	Domain                    = "domain"
+	OSS                       = "oss"
+	Domestic                  = "domestic"
+	Overseas                  = "overseas"
+	Global                    = "global"
+	ContentType               = "Content-Type"
+	CacheControl              = "Cache-Control"
+	ContentDisposition        = "Content-Disposition"
+	ContentLanguage           = "Content-Language"
+	Expires                   = "Expires"
+	AccessControlAllowOrigin  = "Access-Control-Allow-Origin"
+	AccessControlAllowMethods = "Access-Control-Allow-Methods"
+	AccessControlMaxAge       = "Access-Control-Max-Age"
+)
+
+var CdnTypes = []string{Web, Download, video, LiveStream}
+var SourceTypes = []string{Ipaddr, Domain, OSS}
+var Scopes = []string{Domestic, Overseas, Global}
+var HeaderKeys = []string{ContentType, CacheControl, ContentDisposition, ContentLanguage, Expires, AccessControlAllowMethods, AccessControlAllowOrigin, AccessControlMaxAge}
+
+type CdnCommonResponse struct {
+	common.Response
+}
+
+type Domains struct {
+	DomainName   string
+	Cname        string
+	CdnType      string
+	DomainStatus string
+	GmtCreated   string
+	GmtModified  string
+	Description  string
+}
+
+type MonitorDataItem struct {
+	TimeStamp         string
+	QueryPerSecond    string
+	BytesHitRate      string
+	BytesPerSecond    string
+	RequestHitRate    string
+	AverageObjectSize string
+}
+
+type TaskItem struct {
+	TaskId       string
+	ObjectPath   string
+	Status       string
+	CreationTime time.Time
+}
+
+type LogDetail struct {
+	LogName   string
+	LogPath   string
+	LogSize   int32
+	StartTime string
+	EndTime   string
+}

--- a/vendor/github.com/denverdino/aliyungo/dns/AddDomain.go
+++ b/vendor/github.com/denverdino/aliyungo/dns/AddDomain.go
@@ -1,0 +1,41 @@
+package dns
+
+import (
+	"log"
+
+	"github.com/denverdino/aliyungo/common"
+)
+
+type AddDomainArgs struct {
+	DomainName string
+
+	//optional
+	GroupId string
+}
+
+type AddDomainResponse struct {
+	common.Response
+	DomainId   string
+	DomainName string
+	GroupId    string
+	GroupName  string
+	PunyCode   string
+	DnsServers struct {
+		DnsServer []string
+	}
+}
+
+// AddDomain
+//
+// You can read doc at https://help.aliyun.com/document_detail/29749.html?spm=5176.doc29805.6.592.6LMqlG
+func (client *Client) AddDomain(args *AddDomainArgs) (response *AddDomainResponse, err error) {
+	action := "AddDomain"
+	response = &AddDomainResponse{}
+	err = client.Invoke(action, args, response)
+	if err == nil {
+		return response, nil
+	} else {
+		log.Printf("%s error, %v", action, err)
+		return response, err
+	}
+}

--- a/vendor/github.com/denverdino/aliyungo/dns/AddDomainGroup.go
+++ b/vendor/github.com/denverdino/aliyungo/dns/AddDomainGroup.go
@@ -1,0 +1,32 @@
+package dns
+
+import (
+	"log"
+
+	"github.com/denverdino/aliyungo/common"
+)
+
+type AddDomainGroupArgs struct {
+	GroupName string
+}
+
+type AddDomainGroupResponse struct {
+	common.Response
+	GroupId   string
+	GroupName string
+}
+
+// AddDomainGroup
+//
+// You can read doc at https://help.aliyun.com/document_detail/29762.html?spm=5176.doc29749.6.604.PJtwG1
+func (client *Client) AddDomainGroup(args *AddDomainGroupArgs) (response *AddDomainGroupResponse, err error) {
+	action := "AddDomainGroup"
+	response = &AddDomainGroupResponse{}
+	err = client.Invoke(action, args, response)
+	if err == nil {
+		return response, nil
+	} else {
+		log.Printf("%s error, %v", action, err)
+		return response, err
+	}
+}

--- a/vendor/github.com/denverdino/aliyungo/dns/AddDomainRecord.go
+++ b/vendor/github.com/denverdino/aliyungo/dns/AddDomainRecord.go
@@ -1,0 +1,40 @@
+package dns
+
+import (
+	"log"
+
+	"github.com/denverdino/aliyungo/common"
+)
+
+type AddDomainRecordArgs struct {
+	DomainName string
+	RR         string
+	Type       string
+	Value      string
+
+	//optional
+	TTL      int32
+	Priority int
+	Line     string
+}
+
+type AddDomainRecordResponse struct {
+	common.Response
+	InstanceId string
+	RecordId   string
+}
+
+// AddDomainRecord
+//
+// You can read doc at https://docs.aliyun.com/#/pub/dns/api-reference/record-related&AddDomainRecord
+func (client *Client) AddDomainRecord(args *AddDomainRecordArgs) (response *AddDomainRecordResponse, err error) {
+	action := "AddDomainRecord"
+	response = &AddDomainRecordResponse{}
+	err = client.Invoke(action, args, response)
+	if err == nil {
+		return response, nil
+	} else {
+		log.Printf("%s error, %v", action, err)
+		return response, err
+	}
+}

--- a/vendor/github.com/denverdino/aliyungo/dns/ChangeDomainGroup.go
+++ b/vendor/github.com/denverdino/aliyungo/dns/ChangeDomainGroup.go
@@ -1,0 +1,33 @@
+package dns
+
+import (
+	"log"
+
+	"github.com/denverdino/aliyungo/common"
+)
+
+type ChangeDomainGroupArgs struct {
+	DomainName string
+	GroupId string
+}
+
+type ChangeDomainGroupResponse struct {
+	common.Response
+	GroupId   string
+	GroupName string
+}
+
+// ChangeDomainGroup
+//
+// You can read doc at https://help.aliyun.com/document_detail/29765.html?spm=5176.doc29764.6.607.WUJQgE
+func (client *Client) ChangeDomainGroup(args *ChangeDomainGroupArgs) (response *ChangeDomainGroupResponse, err error) {
+	action := "ChangeDomainGroup"
+	response = &ChangeDomainGroupResponse{}
+	err = client.Invoke(action, args, response)
+	if err == nil {
+		return response, nil
+	} else {
+		log.Printf("%s error, %v", action, err)
+		return response, err
+	}
+}

--- a/vendor/github.com/denverdino/aliyungo/dns/DeleteDomain.go
+++ b/vendor/github.com/denverdino/aliyungo/dns/DeleteDomain.go
@@ -1,0 +1,31 @@
+package dns
+
+import (
+	"log"
+
+	"github.com/denverdino/aliyungo/common"
+)
+
+type DeleteDomainArgs struct {
+	DomainName string
+}
+
+type DeleteDomainResponse struct {
+	common.Response
+	DomainName string
+}
+
+// DeleteDomain
+//
+// You can read doc at https://help.aliyun.com/document_detail/29750.html?spm=5176.doc29766.6.593.eELaZ7
+func (client *Client) DeleteDomain(args *DeleteDomainArgs) (response *DeleteDomainResponse, err error) {
+	action := "DeleteDomain"
+	response = &DeleteDomainResponse{}
+	err = client.Invoke(action, args, response)
+	if err == nil {
+		return response, nil
+	} else {
+		log.Printf("%s error, %v", action, err)
+		return response, err
+	}
+}

--- a/vendor/github.com/denverdino/aliyungo/dns/DeleteDomainGroup.go
+++ b/vendor/github.com/denverdino/aliyungo/dns/DeleteDomainGroup.go
@@ -1,0 +1,31 @@
+package dns
+
+import (
+	"log"
+
+	"github.com/denverdino/aliyungo/common"
+)
+
+type DeleteDomainGroupArgs struct {
+	GroupId string
+}
+
+type DeleteDomainGroupResponse struct {
+	common.Response
+	GroupName string
+}
+
+// DeleteDomainGroup
+//
+// You can read doc at https://help.aliyun.com/document_detail/29764.html?spm=5176.doc29763.6.606.Vm3FyC
+func (client *Client) DeleteDomainGroup(args *DeleteDomainGroupArgs) (response *DeleteDomainGroupResponse, err error) {
+	action := "DeleteDomainGroup"
+	response = &DeleteDomainGroupResponse{}
+	err = client.Invoke(action, args, response)
+	if err == nil {
+		return response, nil
+	} else {
+		log.Printf("%s error, %v", action, err)
+		return response, err
+	}
+}

--- a/vendor/github.com/denverdino/aliyungo/dns/DeleteDomainRecord.go
+++ b/vendor/github.com/denverdino/aliyungo/dns/DeleteDomainRecord.go
@@ -1,0 +1,27 @@
+package dns
+
+import "github.com/denverdino/aliyungo/common"
+
+type DeleteDomainRecordArgs struct {
+	RecordId string
+}
+
+type DeleteDomainRecordResponse struct {
+	common.Response
+	InstanceId string
+	RecordId   string
+}
+
+// DeleteDomainRecord
+//
+// You can read doc at https://docs.aliyun.com/#/pub/dns/api-reference/record-related&DeleteDomainRecord
+func (client *Client) DeleteDomainRecord(args *DeleteDomainRecordArgs) (response *DeleteDomainRecordResponse, err error) {
+	action := "DeleteDomainRecord"
+	response = &DeleteDomainRecordResponse{}
+	err = client.Invoke(action, args, response)
+	if err == nil {
+		return response, nil
+	} else {
+		return nil, err
+	}
+}

--- a/vendor/github.com/denverdino/aliyungo/dns/DeleteSubDomainRecords.go
+++ b/vendor/github.com/denverdino/aliyungo/dns/DeleteSubDomainRecords.go
@@ -1,0 +1,32 @@
+package dns
+
+import "github.com/denverdino/aliyungo/common"
+
+type DeleteSubDomainRecordsArgs struct {
+	DomainName string
+	RR         string
+
+	//optional
+	Type string
+}
+
+type DeleteSubDomainRecordsResponse struct {
+	common.Response
+	InstanceId string
+	RR         string
+	//	TotalCount int32
+}
+
+// DeleteSubDomainRecords
+//
+// You can read doc at https://docs.aliyun.com/#/pub/dns/api-reference/record-related&DeleteSubDomainRecords
+func (client *Client) DeleteSubDomainRecords(args *DeleteSubDomainRecordsArgs) (response *DeleteSubDomainRecordsResponse, err error) {
+	action := "DeleteSubDomainRecords"
+	response = &DeleteSubDomainRecordsResponse{}
+	err = client.Invoke(action, args, response)
+	if err == nil {
+		return response, nil
+	} else {
+		return nil, err
+	}
+}

--- a/vendor/github.com/denverdino/aliyungo/dns/DescribeDomainGroups.go
+++ b/vendor/github.com/denverdino/aliyungo/dns/DescribeDomainGroups.go
@@ -1,0 +1,42 @@
+package dns
+
+import (
+	"log"
+
+	"github.com/denverdino/aliyungo/common"
+)
+
+type DomainGroupType struct {
+	GroupId   string
+	GroupName string
+}
+
+type DescribeDomainGroupsArgs struct {
+	//optional
+	common.Pagination
+	KeyWord    string
+}
+
+type DescribeDomainGroupsResponse struct {
+	response   common.Response
+	common.PaginationResult
+	DomainGroups struct {
+		DomainGroup []DomainGroupType
+	}
+}
+
+// DescribeDomainGroups
+//
+// You can read doc at https://help.aliyun.com/document_detail/29766.html?spm=5176.doc29765.6.608.qcQr2R
+func (client *Client) DescribeDomainGroups(args *DescribeDomainGroupsArgs) (groups []DomainGroupType, err error) {
+	action := "DescribeDomainGroups"
+	response := &DescribeDomainGroupsResponse{}
+	err = client.Invoke(action, args, response)
+
+	if err != nil {
+		log.Printf("%s error, %v", action, err)
+		return nil, err
+	}
+
+	return response.DomainGroups.DomainGroup, nil
+}

--- a/vendor/github.com/denverdino/aliyungo/dns/DescribeDomainInfo.go
+++ b/vendor/github.com/denverdino/aliyungo/dns/DescribeDomainInfo.go
@@ -1,0 +1,46 @@
+package dns
+
+import (
+	"log"
+
+	"github.com/denverdino/aliyungo/common"
+)
+
+type DomainType struct {
+	DomainId    string
+	DomainName  string
+	AliDomain   bool
+	GroupId     string
+	GroupName   string
+	InstanceId  string
+	VersionCode string
+	PunyCode    string
+	DnsServers struct {
+		DnsServer []string
+	}
+}
+
+type DescribeDomainInfoArgs struct {
+	DomainName string
+}
+
+type DescribeDomainInfoResponse struct {
+	response common.Response
+	DomainType
+}
+
+// DescribeDomainInfo
+//
+// You can read doc at https://help.aliyun.com/document_detail/29752.html?spm=5176.doc29751.6.595.VJM3Gy
+func (client *Client) DescribeDomainInfo(args *DescribeDomainInfoArgs) (domain DomainType, err error) {
+	action := "DescribeDomainInfo"
+	response := &DescribeDomainInfoResponse{}
+	err = client.Invoke(action, args, response)
+
+	if err != nil {
+		log.Printf("%s error, %v", action, err)
+		return DomainType{}, err
+	}
+
+	return response.DomainType, nil
+}

--- a/vendor/github.com/denverdino/aliyungo/dns/DescribeDomainRecordInfo.go
+++ b/vendor/github.com/denverdino/aliyungo/dns/DescribeDomainRecordInfo.go
@@ -1,0 +1,26 @@
+package dns
+
+import "github.com/denverdino/aliyungo/common"
+
+type DescribeDomainRecordInfoArgs struct {
+	RecordId string
+}
+
+type DescribeDomainRecordInfoResponse struct {
+	common.Response
+	RecordType
+}
+
+// DescribeDomainRecordInfo
+//
+// You can read doc at https://docs.aliyun.com/#/pub/dns/api-reference/record-related&DescribeDomainRecordInfo
+func (client *Client) DescribeDomainRecordInfo(args *DescribeDomainRecordInfoArgs) (response *DescribeDomainRecordInfoResponse, err error) {
+	action := "DescribeDomainRecordInfo"
+	response = &DescribeDomainRecordInfoResponse{}
+	err = client.Invoke(action, args, response)
+	if err == nil {
+		return response, nil
+	} else {
+		return nil, err
+	}
+}

--- a/vendor/github.com/denverdino/aliyungo/dns/DescribeDomainRecordInfoNew.go
+++ b/vendor/github.com/denverdino/aliyungo/dns/DescribeDomainRecordInfoNew.go
@@ -1,0 +1,40 @@
+package dns
+
+import "github.com/denverdino/aliyungo/common"
+
+// endpoint change to 'http://alidns.aliyuncs.com' then record ttl and priority change to string
+type RecordTypeNew struct {
+	DomainName string
+	RecordId   string
+	RR         string
+	Type       string
+	Value      string
+	TTL        float64
+	Priority   string
+	Line       string
+	Status     string
+	Locked     bool
+}
+
+type DescribeDomainRecordInfoNewArgs struct {
+	RecordId string
+}
+
+type DescribeDomainRecordInfoNewResponse struct {
+	common.Response
+	RecordTypeNew
+}
+
+// DescribeDomainRecordInformation
+//
+// You can read doc at https://docs.aliyun.com/#/pub/dns/api-reference/record-related&DescribeDomainRecordInfo
+func (client *Client) DescribeDomainRecordInfoNew(args *DescribeDomainRecordInfoNewArgs) (response *DescribeDomainRecordInfoNewResponse, err error) {
+	action := "DescribeDomainRecordInfo"
+	response = &DescribeDomainRecordInfoNewResponse{}
+	err = client.Invoke(action, args, response)
+	if err == nil {
+		return response, nil
+	} else {
+		return nil, err
+	}
+}

--- a/vendor/github.com/denverdino/aliyungo/dns/DescribeDomainRecords.go
+++ b/vendor/github.com/denverdino/aliyungo/dns/DescribeDomainRecords.go
@@ -1,0 +1,36 @@
+package dns
+
+import "github.com/denverdino/aliyungo/common"
+
+type DescribeDomainRecordsArgs struct {
+	DomainName string
+
+	//optional
+	common.Pagination
+	RRKeyWord    string
+	TypeKeyWord  string
+	ValueKeyWord string
+}
+
+type DescribeDomainRecordsResponse struct {
+	common.Response
+	common.PaginationResult
+	InstanceId    string
+	DomainRecords struct {
+		Record []RecordType
+	}
+}
+
+// DescribeDomainRecords
+//
+// You can read doc at https://docs.aliyun.com/#/pub/dns/api-reference/record-related&DescribeDomainRecords
+func (client *Client) DescribeDomainRecords(args *DescribeDomainRecordsArgs) (response *DescribeDomainRecordsResponse, err error) {
+	action := "DescribeDomainRecords"
+	response = &DescribeDomainRecordsResponse{}
+	err = client.Invoke(action, args, response)
+	if err == nil {
+		return response, nil
+	} else {
+		return nil, err
+	}
+}

--- a/vendor/github.com/denverdino/aliyungo/dns/DescribeDomainRecordsNew.go
+++ b/vendor/github.com/denverdino/aliyungo/dns/DescribeDomainRecordsNew.go
@@ -1,0 +1,36 @@
+package dns
+
+import "github.com/denverdino/aliyungo/common"
+
+type DescribeDomainRecordsNewArgs struct {
+	DomainName string
+
+	//optional
+	common.Pagination
+	RRKeyWord    string
+	TypeKeyWord  string
+	ValueKeyWord string
+}
+
+type DescribeDomainRecordsNewResponse struct {
+	common.Response
+	common.PaginationResult
+	InstanceId    string
+	DomainRecords struct {
+		Record []RecordTypeNew
+	}
+}
+
+// DescribeDomainRecordsNew
+//
+// You can read doc at https://docs.aliyun.com/#/pub/dns/api-reference/record-related&DescribeDomainRecords
+func (client *Client) DescribeDomainRecordsNew(args *DescribeDomainRecordsNewArgs) (response *DescribeDomainRecordsNewResponse, err error) {
+	action := "DescribeDomainRecords"
+	response = &DescribeDomainRecordsNewResponse{}
+	err = client.Invoke(action, args, response)
+	if err == nil {
+		return response, nil
+	} else {
+		return nil, err
+	}
+}

--- a/vendor/github.com/denverdino/aliyungo/dns/DescribeDomains.go
+++ b/vendor/github.com/denverdino/aliyungo/dns/DescribeDomains.go
@@ -1,0 +1,38 @@
+package dns
+
+import (
+	"log"
+
+	"github.com/denverdino/aliyungo/common"
+)
+
+type DescribeDomainsArgs struct {
+	// optional
+	common.Pagination
+	KeyWord    string
+	GroupId    string
+}
+
+type DescribeDomainsResponse struct {
+	response   common.Response
+	common.PaginationResult
+	Domains struct {
+		Domain []DomainType
+	}
+}
+
+// DescribeDomains
+//
+// You can read doc at https://help.aliyun.com/document_detail/29751.html?spm=5176.doc29750.6.594.dvyRJV
+func (client *Client) DescribeDomains(args *DescribeDomainsArgs) (domains []DomainType, err error) {
+	action := "DescribeDomains"
+	response := &DescribeDomainsResponse{}
+	err = client.Invoke(action, args, response)
+
+	if err != nil {
+		log.Printf("%s error, %v", action, err)
+		return nil, err
+	}
+
+	return response.Domains.Domain, err
+}

--- a/vendor/github.com/denverdino/aliyungo/dns/DescribeSubDomainRecords.go
+++ b/vendor/github.com/denverdino/aliyungo/dns/DescribeSubDomainRecords.go
@@ -1,0 +1,37 @@
+package dns
+
+import "github.com/denverdino/aliyungo/common"
+
+type DescribeSubDomainRecordsArgs struct {
+	SubDomain string
+
+	//optional
+	PageNumber int32
+	PageSize   int32
+	Type       string
+}
+
+type DescribeSubDomainRecordsResponse struct {
+	common.Response
+	InstanceId    string
+	TotalCount    int32
+	PageNumber    int32
+	PageSize      int32
+	DomainRecords struct {
+		Record []RecordType
+	}
+}
+
+// DescribeSubDomainRecords
+//
+// You can read doc at https://docs.aliyun.com/#/pub/dns/api-reference/record-related&DescribeSubDomainRecords
+func (client *Client) DescribeSubDomainRecords(args *DescribeSubDomainRecordsArgs) (response *DescribeSubDomainRecordsResponse, err error) {
+	action := "DescribeSubDomainRecords"
+	response = &DescribeSubDomainRecordsResponse{}
+	err = client.Invoke(action, args, response)
+	if err == nil {
+		return response, nil
+	} else {
+		return nil, err
+	}
+}

--- a/vendor/github.com/denverdino/aliyungo/dns/GetMainDomainName.go
+++ b/vendor/github.com/denverdino/aliyungo/dns/GetMainDomainName.go
@@ -1,0 +1,29 @@
+package dns
+
+import "github.com/denverdino/aliyungo/common"
+
+type GetMainDomainNameArgs struct {
+	InputString string
+}
+
+type GetMainDomainNameResponse struct {
+	common.Response
+	InstanceId  string
+	DomainName  string
+	RR          string
+	DomainLevel int32
+}
+
+// GetMainDomainName
+//
+// You can read doc at https://docs.aliyun.com/#/pub/dns/api-reference/domain-related&GetMainDomainName
+func (client *Client) GetMainDomainName(args *GetMainDomainNameArgs) (response *GetMainDomainNameResponse, err error) {
+	action := "GetMainDomainName"
+	response = &GetMainDomainNameResponse{}
+	err = client.Invoke(action, args, response)
+	if err == nil {
+		return response, nil
+	} else {
+		return nil, err
+	}
+}

--- a/vendor/github.com/denverdino/aliyungo/dns/UpdateDomainGroup.go
+++ b/vendor/github.com/denverdino/aliyungo/dns/UpdateDomainGroup.go
@@ -1,0 +1,33 @@
+package dns
+
+import (
+	"log"
+
+	"github.com/denverdino/aliyungo/common"
+)
+
+type UpdateDomainGroupArgs struct {
+	GroupId   string
+	GroupName string
+}
+
+type UpdateDomainGroupResponse struct {
+	common.Response
+	GroupId   string
+	GroupName string
+}
+
+// UpdateDomainGroup
+//
+// You can read doc at https://help.aliyun.com/document_detail/29763.html?spm=5176.doc29762.6.605.iFRKjn
+func (client *Client) UpdateDomainGroup(args *UpdateDomainGroupArgs) (response *UpdateDomainGroupResponse, err error) {
+	action := "UpdateDomainGroup"
+	response = &UpdateDomainGroupResponse{}
+	err = client.Invoke(action, args, response)
+	if err == nil {
+		return response, nil
+	} else {
+		log.Printf("%s error, %v", action, err)
+		return response, err
+	}
+}

--- a/vendor/github.com/denverdino/aliyungo/dns/UpdateDomainRecord.go
+++ b/vendor/github.com/denverdino/aliyungo/dns/UpdateDomainRecord.go
@@ -1,0 +1,35 @@
+package dns
+
+import "github.com/denverdino/aliyungo/common"
+
+type UpdateDomainRecordArgs struct {
+	RecordId string
+	RR       string
+	Type     string
+	Value    string
+
+	//optional
+	TTL      int32
+	Priority int32
+	Line     string
+}
+
+type UpdateDomainRecordResponse struct {
+	common.Response
+	InstanceId string
+	RecordId   string
+}
+
+// UpdateDomainRecord
+//
+// You can read doc at https://docs.aliyun.com/#/pub/dns/api-reference/record-related&UpdateDomainRecord
+func (client *Client) UpdateDomainRecord(args *UpdateDomainRecordArgs) (response *UpdateDomainRecordResponse, err error) {
+	action := "UpdateDomainRecord"
+	response = &UpdateDomainRecordResponse{}
+	err = client.Invoke(action, args, response)
+	if err == nil {
+		return response, nil
+	} else {
+		return nil, err
+	}
+}

--- a/vendor/github.com/denverdino/aliyungo/dns/client.go
+++ b/vendor/github.com/denverdino/aliyungo/dns/client.go
@@ -1,0 +1,49 @@
+package dns
+
+import (
+	"github.com/denverdino/aliyungo/common"
+	"os"
+)
+
+type Client struct {
+	common.Client
+}
+
+const (
+	// DNSDefaultEndpoint is the default API endpoint of DNS services
+	DNSDefaultEndpoint = "http://dns.aliyuncs.com"
+	DNSAPIVersion      = "2015-01-09"
+
+	DNSDefaultEndpointNew = "http://alidns.aliyuncs.com"
+)
+
+// NewClient creates a new instance of DNS client
+func NewClient(accessKeyId, accessKeySecret string) *Client {
+	endpoint := os.Getenv("DNS_ENDPOINT")
+	if endpoint == "" {
+		endpoint = DNSDefaultEndpoint
+	}
+	return NewClientWithEndpoint(endpoint, accessKeyId, accessKeySecret)
+}
+
+// NewClientNew creates a new instance of DNS client, with http://alidns.aliyuncs.com as default endpoint
+func NewClientNew(accessKeyId, accessKeySecret string) *Client {
+	endpoint := os.Getenv("DNS_ENDPOINT")
+	if endpoint == "" {
+		endpoint = DNSDefaultEndpointNew
+	}
+	return NewClientWithEndpoint(endpoint, accessKeyId, accessKeySecret)
+}
+
+// NewCustomClient creates a new instance of ECS client with customized API endpoint
+func NewCustomClient(accessKeyId, accessKeySecret string, endpoint string) *Client {
+	client := &Client{}
+	client.Init(endpoint, DNSAPIVersion, accessKeyId, accessKeySecret)
+	return client
+}
+
+func NewClientWithEndpoint(endpoint string, accessKeyId, accessKeySecret string) *Client {
+	client := &Client{}
+	client.Init(endpoint, DNSAPIVersion, accessKeyId, accessKeySecret)
+	return client
+}

--- a/vendor/github.com/denverdino/aliyungo/dns/record.go
+++ b/vendor/github.com/denverdino/aliyungo/dns/record.go
@@ -1,0 +1,28 @@
+package dns
+
+//
+//you can read doc at https://docs.aliyun.com/#/pub/dns/api-reference/enum-type&record-format
+const (
+	ARecord           = "A"
+	NSRecord          = "NS"
+	MXRecord          = "MX"
+	TXTRecord         = "TXT"
+	CNAMERecord       = "CNAME"
+	SRVRecord         = "SRV"
+	AAAARecord        = "AAAA"
+	RedirectURLRecord = "REDIRECT_URL"
+	ForwordURLRecord  = "FORWORD_URL"
+)
+
+type RecordType struct {
+	DomainName string
+	RecordId   string
+	RR         string
+	Type       string
+	Value      string
+	TTL        int32
+	Priority   int32
+	Line       string
+	Status     string
+	Locked     bool
+}

--- a/vendor/github.com/denverdino/aliyungo/ecs/disks.go
+++ b/vendor/github.com/denverdino/aliyungo/ecs/disks.go
@@ -135,6 +135,7 @@ type CreateDiskArgs struct {
 	ZoneId       string
 	DiskName     string
 	Description  string
+	Encrypted    bool
 	DiskCategory DiskCategory
 	Size         int
 	SnapshotId   string

--- a/vendor/github.com/denverdino/aliyungo/ecs/instances.go
+++ b/vendor/github.com/denverdino/aliyungo/ecs/instances.go
@@ -536,6 +536,7 @@ type CreateInstanceArgs struct {
 	AutoRenewPeriod         int
 	SpotStrategy            SpotStrategyType
 	KeyPairName             string
+	RamRoleName             string
 }
 
 type CreateInstanceResponse struct {

--- a/vendor/github.com/denverdino/aliyungo/ecs/networks.go
+++ b/vendor/github.com/denverdino/aliyungo/ecs/networks.go
@@ -36,8 +36,8 @@ func (client *Client) AllocatePublicIpAddress(instanceId string) (ipAddress stri
 
 type ModifyInstanceNetworkSpec struct {
 	InstanceId              string
-	InternetMaxBandwidthOut *int
-	InternetMaxBandwidthIn  *int
+	InternetMaxBandwidthOut int
+	InternetMaxBandwidthIn  int
 }
 
 type ModifyInstanceNetworkSpecResponse struct {

--- a/vendor/github.com/denverdino/aliyungo/ecs/route_tables.go
+++ b/vendor/github.com/denverdino/aliyungo/ecs/route_tables.go
@@ -102,6 +102,7 @@ type NextHopType string
 const (
 	NextHopIntance = NextHopType("Instance") //Default
 	NextHopTunnel  = NextHopType("Tunnel")
+	NextHopTunnelRouterInterface = NextHopType("RouterInterface")
 )
 
 type CreateRouteEntryArgs struct {

--- a/vendor/github.com/denverdino/aliyungo/ecs/router_interface.go
+++ b/vendor/github.com/denverdino/aliyungo/ecs/router_interface.go
@@ -1,0 +1,227 @@
+package ecs
+
+import (
+	"github.com/denverdino/aliyungo/common"
+)
+
+type EcsCommonResponse struct {
+	common.Response
+}
+type RouterType string
+type InterfaceStatus string
+type Role string
+type Spec string
+
+const (
+	VRouter = RouterType("VRouter")
+	VBR     = RouterType("VBR")
+
+	Idl      = InterfaceStatus("Idl")
+	Active   = InterfaceStatus("Active")
+	Inactive = InterfaceStatus("Inactive")
+
+	InitiatingSide = Role("InitiatingSide")
+	AcceptingSide  = Role("AcceptingSide")
+
+	Small1  = Spec("Small.1")
+	Small2  = Spec("Small.2")
+	Small5  = Spec("Small.5")
+	Middle1 = Spec("Middle.1")
+	Middle2 = Spec("Middle.2")
+	Middle5 = Spec("Middle.5")
+	Large1  = Spec("Large.1")
+	Large2  = Spec("Large.2")
+)
+
+type CreateRouterInterfaceArgs struct {
+	RegionId                 common.Region
+	OppositeRegionId         common.Region
+	RouterType               RouterType
+	OppositeRouterType       RouterType
+	RouterId                 string
+	OppositeRouterId         string
+	Role                     Role
+	Spec                     Spec
+	AccessPointId            string
+	OppositeAccessPointId    string
+	OppositeInterfaceId      string
+	OppositeInterfaceOwnerId string
+	Name                     string
+	Description              string
+	HealthCheckSourceIp      string
+	HealthCheckTargetIp      string
+}
+
+type CreateRouterInterfaceResponse struct {
+	common.Response
+	RouterInterfaceId string
+}
+
+// CreateRouterInterface create Router interface
+//
+// You can read doc at https://help.aliyun.com/document_detail/36032.html?spm=5176.product27706.6.664.EbBsxC
+func (client *Client) CreateRouterInterface(args *CreateRouterInterfaceArgs) (response *CreateRouterInterfaceResponse, err error) {
+	response = &CreateRouterInterfaceResponse{}
+	err = client.Invoke("CreateRouterInterface", args, &response)
+	if err != nil {
+		return response, err
+	}
+	return response, nil
+}
+
+type Filter struct {
+	Key   string
+	Value []string
+}
+
+type DescribeRouterInterfacesArgs struct {
+	RegionId common.Region
+	common.Pagination
+	Filter   []Filter
+}
+
+type RouterInterfaceItemType struct {
+	ChargeType                      string
+	RouterInterfaceId               string
+	AccessPointId                   string
+	OppositeRegionId                string
+	OppositeAccessPointId           string
+	Role                            Role
+	Spec                            Spec
+	Name                            string
+	Description                     string
+	RouterId                        string
+	RouterType                      RouterType
+	CreationTime                    string
+	Status                          string
+	BusinessStatus                  string
+	ConnectedTime                   string
+	OppositeInterfaceId             string
+	OppositeInterfaceSpec           string
+	OppositeInterfaceStatus         string
+	OppositeInterfaceBusinessStatus string
+	OppositeRouterId                string
+	OppositeRouterType              RouterType
+	OppositeInterfaceOwnerId        string
+	HealthCheckSourceIp             string
+	HealthCheckTargetIp             string
+}
+
+type DescribeRouterInterfacesResponse struct {
+	RouterInterfaceSet struct {
+		RouterInterfaceType []RouterInterfaceItemType
+	}
+	common.PaginationResult
+}
+
+// DescribeRouterInterfaces describe Router interfaces
+//
+// You can read doc at https://help.aliyun.com/document_detail/36032.html?spm=5176.product27706.6.664.EbBsxC
+func (client *Client) DescribeRouterInterfaces(args *DescribeRouterInterfacesArgs) (response *DescribeRouterInterfacesResponse, err error) {
+	response = &DescribeRouterInterfacesResponse{}
+	err = client.Invoke("DescribeRouterInterfaces", args, &response)
+	if err != nil {
+		return response, err
+	}
+	return response, nil
+}
+
+type OperateRouterInterfaceArgs struct {
+	RegionId          common.Region
+	RouterInterfaceId string
+}
+
+// ConnectRouterInterface
+//
+// You can read doc at https://help.aliyun.com/document_detail/36031.html?spm=5176.doc36035.6.666.wkyljN
+func (client *Client) ConnectRouterInterface(args *OperateRouterInterfaceArgs) (response *EcsCommonResponse, err error) {
+	response = &EcsCommonResponse{}
+	err = client.Invoke("ConnectRouterInterface", args, &response)
+	if err != nil {
+		return response, err
+	}
+	return response, nil
+}
+
+// ActivateRouterInterface active Router Interface
+//
+// You can read doc at https://help.aliyun.com/document_detail/36030.html?spm=5176.doc36031.6.667.DAuZLD
+func (client *Client) ActivateRouterInterface(args *OperateRouterInterfaceArgs) (response *EcsCommonResponse, err error) {
+	response = &EcsCommonResponse{}
+	err = client.Invoke("ActivateRouterInterface", args, &response)
+	if err != nil {
+		return response, err
+	}
+	return response, nil
+}
+
+// DeactivateRouterInterface deactivate Router Interface
+//
+// You can read doc at https://help.aliyun.com/document_detail/36033.html?spm=5176.doc36030.6.668.JqCWUz
+func (client *Client) DeactivateRouterInterface(args *OperateRouterInterfaceArgs) (response *EcsCommonResponse, err error) {
+	response = &EcsCommonResponse{}
+	err = client.Invoke("DeactivateRouterInterface", args, &response)
+	if err != nil {
+		return response, err
+	}
+	return response, nil
+}
+
+type ModifyRouterInterfaceSpecArgs struct {
+	RegionId          common.Region
+	RouterInterfaceId string
+	Spec              Spec
+}
+
+type ModifyRouterInterfaceSpecResponse struct {
+	common.Response
+	Spec Spec
+}
+
+// ModifyRouterInterfaceSpec
+//
+// You can read doc at https://help.aliyun.com/document_detail/36037.html?spm=5176.doc36036.6.669.McKiye
+func (client *Client) ModifyRouterInterfaceSpec(args *ModifyRouterInterfaceSpecArgs) (response *ModifyRouterInterfaceSpecResponse, err error) {
+	response = &ModifyRouterInterfaceSpecResponse{}
+	err = client.Invoke("ModifyRouterInterfaceSpec", args, &response)
+	if err != nil {
+		return response, err
+	}
+	return response, nil
+}
+
+type ModifyRouterInterfaceAttributeArgs struct {
+	RegionId                 common.Region
+	RouterInterfaceId        string
+	Name                     string
+	Description              string
+	OppositeInterfaceId      string
+	OppositeRouterId         string
+	OppositeInterfaceOwnerId string
+	HealthCheckSourceIp      string
+	HealthCheckTargetIp      string
+}
+
+// ModifyRouterInterfaceAttribute
+//
+// You can read doc at https://help.aliyun.com/document_detail/36036.html?spm=5176.doc36037.6.670.Dcz3xS
+func (client *Client) ModifyRouterInterfaceAttribute(args *ModifyRouterInterfaceAttributeArgs) (response *EcsCommonResponse, err error) {
+	response = &EcsCommonResponse{}
+	err = client.Invoke("ModifyRouterInterfaceAttribute", args, &response)
+	if err != nil {
+		return response, err
+	}
+	return response, nil
+}
+
+// DeleteRouterInterface delete Router Interface
+//
+// You can read doc at https://help.aliyun.com/document_detail/36034.html?spm=5176.doc36036.6.671.y2xpNt
+func (client *Client) DeleteRouterInterface(args *OperateRouterInterfaceArgs) (response *EcsCommonResponse, err error) {
+	response = &EcsCommonResponse{}
+	err = client.Invoke("DeleteRouterInterface", args, &response)
+	if err != nil {
+		return response, err
+	}
+	return response, nil
+}

--- a/vendor/github.com/denverdino/aliyungo/ess/configuration.go
+++ b/vendor/github.com/denverdino/aliyungo/ess/configuration.go
@@ -125,3 +125,23 @@ func (client *Client) DeleteScalingConfiguration(args *DeleteScalingConfiguratio
 	}
 	return &response, nil
 }
+
+type DeactivateScalingConfigurationArgs struct {
+	ScalingConfigurationId string
+}
+
+type DeactivateScalingConfigurationResponse struct {
+	common.Response
+}
+
+// DeactivateScalingConfiguration deactivate scaling configuration
+//
+func (client *Client) DeactivateScalingConfiguration(args *DeactivateScalingConfigurationArgs) (resp *DeactivateScalingConfigurationResponse, err error) {
+	response := DeactivateScalingConfigurationResponse{}
+	err = client.InvokeByFlattenMethod("DeactivateScalingConfiguration", args, &response)
+
+	if err != nil {
+		return nil, err
+	}
+	return &response, nil
+}

--- a/vendor/github.com/denverdino/aliyungo/ess/group.go
+++ b/vendor/github.com/denverdino/aliyungo/ess/group.go
@@ -240,3 +240,39 @@ func (client *Client) DeleteScalingGroup(args *DeleteScalingGroupArgs) (resp *De
 	}
 	return &response, nil
 }
+
+type AttachInstancesArgs struct {
+	ScalingGroupId string
+	InstanceId     common.FlattenArray
+}
+
+type AttachInstancesResponse struct {
+	common.Response
+	ScalingActivityId string
+}
+
+// AttachInstances attach instances to scaling group
+//
+// You can read doc at https://help.aliyun.com/document_detail/25954.html?spm=5176.product25855.6.633.y5gmzX
+func (client *Client) AttachInstances(args *AttachInstancesArgs) (resp *AttachInstancesResponse, err error) {
+	response := AttachInstancesResponse{}
+	err = client.InvokeByFlattenMethod("AttachInstances", args, &response)
+
+	if err != nil {
+		return nil, err
+	}
+	return &response, nil
+}
+
+// RemoveInstances detach instances from scaling group
+//
+// You can read doc at https://help.aliyun.com/document_detail/25955.html?spm=5176.doc25954.6.634.GtpzuJ
+func (client *Client) RemoveInstances(args *AttachInstancesArgs) (resp *AttachInstancesResponse, err error) {
+	response := AttachInstancesResponse{}
+	err = client.InvokeByFlattenMethod("RemoveInstances", args, &response)
+
+	if err != nil {
+		return nil, err
+	}
+	return &response, nil
+}

--- a/vendor/github.com/denverdino/aliyungo/ram/account.go
+++ b/vendor/github.com/denverdino/aliyungo/ram/account.go
@@ -1,0 +1,78 @@
+package ram
+
+type UserRequest struct {
+	User
+}
+
+type UserResponse struct {
+	RamCommonResponse
+	User User
+}
+
+type UpdateUserRequest struct {
+	UserName       string
+	NewUserName    string
+	NewDisplayName string
+	NewMobilePhone string
+	NewEmail       string
+	NewComments    string
+}
+
+type ListUserRequest struct {
+	Marker   string
+	MaxItems int8
+}
+
+type ListUserResponse struct {
+	RamCommonResponse
+	IsTruncated bool
+	Marker      string
+	Users       struct {
+		User []User
+	}
+}
+
+func (client *RamClient) CreateUser(user UserRequest) (UserResponse, error) {
+	var userResponse UserResponse
+	err := client.Invoke("CreateUser", user, &userResponse)
+	if err != nil {
+		return UserResponse{}, err
+	}
+	return userResponse, nil
+}
+
+func (client *RamClient) GetUser(userQuery UserQueryRequest) (UserResponse, error) {
+	var userResponse UserResponse
+	err := client.Invoke("GetUser", userQuery, &userResponse)
+	if err != nil {
+		return UserResponse{}, nil
+	}
+	return userResponse, nil
+}
+
+func (client *RamClient) UpdateUser(newUser UpdateUserRequest) (UserResponse, error) {
+	var userResponse UserResponse
+	err := client.Invoke("UpdateUser", newUser, &userResponse)
+	if err != nil {
+		return UserResponse{}, err
+	}
+	return userResponse, nil
+}
+
+func (client *RamClient) DeleteUser(userQuery UserQueryRequest) (RamCommonResponse, error) {
+	var commonResp RamCommonResponse
+	err := client.Invoke("DeleteUser", userQuery, &commonResp)
+	if err != nil {
+		return RamCommonResponse{}, err
+	}
+	return commonResp, nil
+}
+
+func (client *RamClient) ListUsers(listParams ListUserRequest) (ListUserResponse, error) {
+	var userList ListUserResponse
+	err := client.Invoke("ListUsers", listParams, &userList)
+	if err != nil {
+		return ListUserResponse{}, err
+	}
+	return userList, nil
+}

--- a/vendor/github.com/denverdino/aliyungo/ram/ak.go
+++ b/vendor/github.com/denverdino/aliyungo/ram/ak.go
@@ -1,0 +1,63 @@
+package ram
+
+/*
+	CreateAccessKey()
+	UpdateAccessKey()
+	DeleteAccessKey()
+	ListAccessKeys()
+*/
+type State string
+
+type AccessKeyResponse struct {
+	RamCommonResponse
+	AccessKey AccessKey
+}
+
+type UpdateAccessKeyRequest struct {
+	UserAccessKeyId string
+	Status          State
+	UserName        string
+}
+
+type AccessKeyListResponse struct {
+	RamCommonResponse
+	AccessKeys struct {
+		AccessKey []AccessKey
+	}
+}
+
+func (client *RamClient) CreateAccessKey(userQuery UserQueryRequest) (AccessKeyResponse, error) {
+	var accesskeyResp AccessKeyResponse
+	err := client.Invoke("CreateAccessKey", userQuery, &accesskeyResp)
+	if err != nil {
+		return AccessKeyResponse{}, err
+	}
+	return accesskeyResp, nil
+}
+
+func (client *RamClient) UpdateAccessKey(accessKeyRequest UpdateAccessKeyRequest) (RamCommonResponse, error) {
+	var commonResp RamCommonResponse
+	err := client.Invoke("UpdateAccessKey", accessKeyRequest, &commonResp)
+	if err != nil {
+		return RamCommonResponse{}, err
+	}
+	return commonResp, nil
+}
+
+func (client *RamClient) DeleteAccessKey(accessKeyRequest UpdateAccessKeyRequest) (RamCommonResponse, error) {
+	var commonResp RamCommonResponse
+	err := client.Invoke("DeleteAccessKey", accessKeyRequest, &commonResp)
+	if err != nil {
+		return RamCommonResponse{}, err
+	}
+	return commonResp, nil
+}
+
+func (client *RamClient) ListAccessKeys(userQuery UserQueryRequest) (AccessKeyListResponse, error) {
+	var accessKeyListResp AccessKeyListResponse
+	err := client.Invoke("ListAccessKeys", userQuery, &accessKeyListResp)
+	if err != nil {
+		return AccessKeyListResponse{}, err
+	}
+	return accessKeyListResp, nil
+}

--- a/vendor/github.com/denverdino/aliyungo/ram/api.go
+++ b/vendor/github.com/denverdino/aliyungo/ram/api.go
@@ -1,0 +1,84 @@
+package ram
+
+/*
+	ringtail 2016/1/19
+	All RAM apis provided
+*/
+
+type RamClientInterface interface {
+	//ram user
+	CreateUser(user UserRequest) (UserResponse, error)
+	GetUser(userQuery UserQueryRequest) (UserResponse, error)
+	UpdateUser(newUser UpdateUserRequest) (UserResponse, error)
+	DeleteUser(userQuery UserQueryRequest) (RamCommonResponse, error)
+	ListUsers(listParams ListUserRequest) (ListUserResponse, error)
+
+	//ram login profile
+	CreateLoginProfile(req ProfileRequest) (ProfileResponse, error)
+	GetLoginProfile(req UserQueryRequest) (ProfileResponse, error)
+	DeleteLoginProfile(req UserQueryRequest) (RamCommonResponse, error)
+	UpdateLoginProfile(req ProfileRequest) (ProfileResponse, error)
+
+	//ram ak
+	CreateAccessKey(userQuery UserQueryRequest) (AccessKeyResponse, error)
+	UpdateAccessKey(accessKeyRequest UpdateAccessKeyRequest) (RamCommonResponse, error)
+	DeleteAccessKey(accessKeyRequest UpdateAccessKeyRequest) (RamCommonResponse, error)
+	ListAccessKeys(userQuery UserQueryRequest) (AccessKeyListResponse, error)
+
+	//ram mfa
+	CreateVirtualMFADevice(req MFARequest) (MFAResponse, error)
+	ListVirtualMFADevices() (MFAListResponse, error)
+	DeleteVirtualMFADevice(req MFADeleteRequest) (RamCommonResponse, error)
+	BindMFADevice(req MFABindRequest) (RamCommonResponse, error)
+	UnbindMFADevice(req UserQueryRequest) (MFAUserResponse, error)
+	GetUserMFAInfo(req UserQueryRequest) (MFAUserResponse, error)
+
+	//ram group
+	CreateGroup(req GroupRequest) (GroupResponse, error)
+	GetGroup(req GroupQueryRequest) (GroupResponse, error)
+	UpdateGroup(req GroupUpdateRequest) (GroupResponse, error)
+	ListGroup(req GroupListRequest) (GroupListResponse, error)
+	DeleteGroup(req GroupQueryRequest) (RamCommonResponse, error)
+	AddUserToGroup(req UserRelateGroupRequest) (RamCommonResponse, error)
+	RemoveUserFromGroup(req UserRelateGroupRequest) (RamCommonResponse, error)
+	ListGroupsForUser(req UserQueryRequest) (GroupListResponse, error)
+	ListUsersForGroup(req GroupQueryRequest) (ListUserResponse, error)
+
+	CreateRole(role RoleRequest) (RoleResponse, error)
+	GetRole(roleQuery RoleQueryRequest) (RoleResponse, error)
+	UpdateRole(newRole UpdateRoleRequest) (RoleResponse, error)
+	ListRoles() (ListRoleResponse, error)
+	DeleteRole(roleQuery RoleQueryRequest) (RamCommonResponse, error)
+
+	//DONE policy
+	CreatePolicy(policyReq PolicyRequest) (PolicyResponse, error)
+	GetPolicy(policyReq PolicyRequest) (PolicyResponse, error)
+	DeletePolicy(policyReq PolicyRequest) (RamCommonResponse, error)
+	ListPolicies(policyQuery PolicyQueryRequest) (PolicyQueryResponse, error)
+	ListPoliciesForUser(userQuery UserQueryRequest) (PolicyListResponse, error)
+
+	//ram policy version
+	CreatePolicyVersion(policyReq PolicyRequest) (PolicyVersionResponse, error)
+	GetPolicyVersion(policyReq PolicyRequest) (PolicyVersionResponse, error)
+	GetPolicyVersionNew(policyReq PolicyRequest) (PolicyVersionResponseNew, error)
+	DeletePolicyVersion(policyReq PolicyRequest) (RamCommonResponse, error)
+	ListPolicyVersions(policyReq PolicyRequest) (PolicyVersionResponse, error)
+	ListPolicyVersionsNew(policyReq PolicyRequest) (PolicyVersionsResponse, error)
+	AttachPolicyToUser(attachPolicyRequest AttachPolicyRequest) (RamCommonResponse, error)
+	DetachPolicyFromUser(attachPolicyRequest AttachPolicyRequest) (RamCommonResponse, error)
+	ListEntitiesForPolicy(policyReq PolicyRequest) (PolicyListEntitiesResponse, error)
+	SetDefaultPolicyVersion(policyReq PolicyRequest) (RamCommonResponse, error)
+	ListPoliciesForGroup(groupQuery GroupQueryRequest) (PolicyListResponse, error)
+	AttachPolicyToGroup(attachPolicyRequest AttachPolicyToGroupRequest) (RamCommonResponse, error)
+	DetachPolicyFromGroup(attachPolicyRequest AttachPolicyToGroupRequest) (RamCommonResponse, error)
+	AttachPolicyToRole(attachPolicyRequest AttachPolicyToRoleRequest) (RamCommonResponse, error)
+	DetachPolicyFromRole(attachPolicyRequest AttachPolicyToRoleRequest) (RamCommonResponse, error)
+	ListPoliciesForRole(roleQuery RoleQueryRequest) (PolicyListResponse, error)
+
+	//ram security
+	SetAccountAlias(accountAlias AccountAliasRequest) (RamCommonResponse, error)
+	GetAccountAlias() (AccountAliasResponse, error)
+	ClearAccountAlias() (RamCommonResponse, error)
+	SetPasswordPolicy(passwordPolicy PasswordPolicyRequest) (PasswordPolicyResponse, error)
+	GetPasswordPolicy() (PasswordPolicyResponse, error)
+}

--- a/vendor/github.com/denverdino/aliyungo/ram/client.go
+++ b/vendor/github.com/denverdino/aliyungo/ram/client.go
@@ -1,0 +1,30 @@
+package ram
+
+import (
+	"github.com/denverdino/aliyungo/common"
+	"os"
+)
+
+const (
+	// RAMDefaultEndpoint is the default API endpoint of RAM services
+	RAMDefaultEndpoint = "https://ram.aliyuncs.com"
+	RAMAPIVersion      = "2015-05-01"
+)
+
+type RamClient struct {
+	common.Client
+}
+
+func NewClient(accessKeyId string, accessKeySecret string) RamClientInterface {
+	endpoint := os.Getenv("RAM_ENDPOINT")
+	if endpoint == "" {
+		endpoint = RAMDefaultEndpoint
+	}
+	return NewClientWithEndpoint(endpoint, accessKeyId, accessKeySecret)
+}
+
+func NewClientWithEndpoint(endpoint string, accessKeyId string, accessKeySecret string) RamClientInterface {
+	client := &RamClient{}
+	client.Init(endpoint, RAMAPIVersion, accessKeyId, accessKeySecret)
+	return client
+}

--- a/vendor/github.com/denverdino/aliyungo/ram/error.go
+++ b/vendor/github.com/denverdino/aliyungo/ram/error.go
@@ -1,0 +1,4 @@
+package ram
+
+//common errors
+var ()

--- a/vendor/github.com/denverdino/aliyungo/ram/group.go
+++ b/vendor/github.com/denverdino/aliyungo/ram/group.go
@@ -1,0 +1,120 @@
+package ram
+
+type GroupRequest struct {
+	Group
+}
+
+type GroupQueryRequest struct {
+	GroupName string
+}
+
+type GroupUpdateRequest struct {
+	GroupName    string
+	NewGroupName string
+	NewComments  string
+}
+
+type GroupListRequest struct {
+	Marker   string
+	MaxItems int8
+}
+
+type UserRelateGroupRequest struct {
+	UserName  string
+	GroupName string
+}
+
+type GroupResponse struct {
+	RamCommonResponse
+	Group Group
+}
+
+type GroupListResponse struct {
+	RamCommonResponse
+	IsTruncated bool
+	Marker      string
+	Groups struct {
+		Group []Group
+	}
+}
+
+func (client *RamClient) CreateGroup(req GroupRequest) (GroupResponse, error) {
+	var resp GroupResponse
+	err := client.Invoke("CreateGroup", req, &resp)
+	if err != nil {
+		return GroupResponse{}, err
+	}
+	return resp, nil
+}
+
+func (client *RamClient) GetGroup(req GroupQueryRequest) (GroupResponse, error) {
+	var resp GroupResponse
+	err := client.Invoke("GetGroup", req, &resp)
+	if err != nil {
+		return GroupResponse{}, err
+	}
+	return resp, nil
+}
+
+func (client *RamClient) UpdateGroup(req GroupUpdateRequest) (GroupResponse, error) {
+	var resp GroupResponse
+	err := client.Invoke("UpdateGroup", req, &resp)
+	if err != nil {
+		return GroupResponse{}, err
+	}
+	return resp, nil
+}
+
+func (client *RamClient) ListGroup(req GroupListRequest) (GroupListResponse, error) {
+	var resp GroupListResponse
+	err := client.Invoke("ListGroups", req, &resp)
+	if err != nil {
+		return GroupListResponse{}, err
+	}
+	return resp, nil
+}
+
+func (client *RamClient) DeleteGroup(req GroupQueryRequest) (RamCommonResponse, error) {
+	var resp RamCommonResponse
+	err := client.Invoke("DeleteGroup", req, &resp)
+	if err != nil {
+		return RamCommonResponse{}, err
+	}
+	return resp, nil
+}
+
+func (client *RamClient) AddUserToGroup(req UserRelateGroupRequest) (RamCommonResponse, error) {
+	var resp RamCommonResponse
+	err := client.Invoke("AddUserToGroup", req, &resp)
+	if err != nil {
+		return RamCommonResponse{}, err
+	}
+	return resp, nil
+}
+
+func (client *RamClient) RemoveUserFromGroup(req UserRelateGroupRequest) (RamCommonResponse, error) {
+	var resp RamCommonResponse
+	err := client.Invoke("RemoveUserFromGroup", req, &resp)
+	if err != nil {
+		return RamCommonResponse{}, err
+	}
+	return resp, nil
+}
+
+func (client *RamClient) ListGroupsForUser(req UserQueryRequest) (GroupListResponse, error) {
+	var resp GroupListResponse
+	err := client.Invoke("ListGroupsForUser", req, &resp)
+	if err != nil {
+		return GroupListResponse{}, err
+	}
+	return resp, nil
+}
+
+func (client *RamClient) ListUsersForGroup(req GroupQueryRequest) (ListUserResponse, error) {
+	var resp ListUserResponse
+	err := client.Invoke("ListUsersForGroup", req, &resp)
+	if err != nil {
+		return ListUserResponse{}, err
+	}
+	return resp, nil
+}

--- a/vendor/github.com/denverdino/aliyungo/ram/mfa.go
+++ b/vendor/github.com/denverdino/aliyungo/ram/mfa.go
@@ -1,0 +1,87 @@
+package ram
+
+type MFARequest struct {
+	VirtualMFADeviceName string
+}
+
+type MFADeleteRequest struct {
+	MFADevice
+}
+
+type MFABindRequest struct {
+	SerialNumber        string
+	UserName            string
+	AuthenticationCode1 string
+	AuthenticationCode2 string
+}
+
+type MFAResponse struct {
+	RamCommonResponse
+	VirtualMFADevice VirtualMFADevice
+}
+
+type MFAListResponse struct {
+	RamCommonResponse
+	VirtualMFADevices struct {
+		VirtualMFADevice []VirtualMFADevice
+	}
+}
+
+type MFAUserResponse struct {
+	RamCommonResponse
+	MFADevice MFADevice
+}
+
+func (client *RamClient) CreateVirtualMFADevice(req MFARequest) (MFAResponse, error) {
+	var resp MFAResponse
+	err := client.Invoke("CreateVirtualMFADevice", req, &resp)
+	if err != nil {
+		return MFAResponse{}, err
+	}
+	return resp, nil
+}
+
+func (client *RamClient) ListVirtualMFADevices() (MFAListResponse, error) {
+	var resp MFAListResponse
+	err := client.Invoke("ListVirtualMFADevices", struct{}{}, &resp)
+	if err != nil {
+		return MFAListResponse{}, err
+	}
+	return resp, nil
+}
+
+func (client *RamClient) DeleteVirtualMFADevice(req MFADeleteRequest) (RamCommonResponse, error) {
+	var resp RamCommonResponse
+	err := client.Invoke("DeleteVirtualMFADevice", req, &resp)
+	if err != nil {
+		return RamCommonResponse{}, err
+	}
+	return resp, nil
+}
+
+func (client *RamClient) BindMFADevice(req MFABindRequest) (RamCommonResponse, error) {
+	var resp RamCommonResponse
+	err := client.Invoke("BindMFADevice", req, &resp)
+	if err != nil {
+		return RamCommonResponse{}, err
+	}
+	return resp, nil
+}
+
+func (client *RamClient) UnbindMFADevice(req UserQueryRequest) (MFAUserResponse, error) {
+	var resp MFAUserResponse
+	err := client.Invoke("UnbindMFADevice", req, &resp)
+	if err != nil {
+		return MFAUserResponse{}, err
+	}
+	return resp, nil
+}
+
+func (client *RamClient) GetUserMFAInfo(req UserQueryRequest) (MFAUserResponse, error) {
+	var resp MFAUserResponse
+	err := client.Invoke("GetUserMFAInfo", req, &resp)
+	if err != nil {
+		return MFAUserResponse{}, err
+	}
+	return resp, nil
+}

--- a/vendor/github.com/denverdino/aliyungo/ram/policy.go
+++ b/vendor/github.com/denverdino/aliyungo/ram/policy.go
@@ -1,0 +1,291 @@
+package ram
+
+type Type string
+
+const (
+	Custom Type = "Custom"
+	System Type = "System"
+)
+
+type PolicyRequest struct {
+	PolicyName     string
+	PolicyType     Type
+	Description    string
+	PolicyDocument string
+	SetAsDefault   string
+	VersionId      string
+}
+type PolicyListResponse struct {
+	RamCommonResponse
+	Policies struct {
+		Policy []Policy
+	}
+}
+
+type PolicyResponse struct {
+	RamCommonResponse
+	Policy Policy
+}
+
+type PolicyQueryRequest struct {
+	PolicyType Type
+	Marker     string
+	MaxItems   int8
+}
+
+type PolicyQueryResponse struct {
+	RamCommonResponse
+	IsTruncated bool
+	Marker      string
+	Policies struct {
+		Policy []Policy
+	}
+}
+
+type PolicyVersionResponse struct {
+	RamCommonResponse
+	IsDefaultVersion bool
+	VersionId        string
+	CreateDate       string
+	PolicyDocument   string
+}
+
+type AttachPolicyRequest struct {
+	PolicyRequest
+	UserName string
+}
+
+type AttachPolicyToRoleRequest struct {
+	PolicyRequest
+	RoleName string
+}
+
+type PolicyVersionResponseNew struct {
+	RamCommonResponse
+	PolicyVersion struct {
+		IsDefaultVersion bool
+		VersionId        string
+		CreateDate       string
+		PolicyDocument   string
+	}
+}
+
+type AttachPolicyToGroupRequest struct {
+	PolicyRequest
+	GroupName string
+}
+
+type PolicyVersionsResponse struct {
+	RamCommonResponse
+	PolicyVersions struct {
+		PolicyVersion []PolicyVersion
+	}
+}
+
+type PolicyListEntitiesResponse struct {
+	RamCommonResponse
+	Groups struct {
+		Group []Group
+	}
+	Users struct {
+		User []User
+	}
+	Roles struct {
+		Role []Role
+	}
+}
+
+func (client *RamClient) CreatePolicy(policyReq PolicyRequest) (PolicyResponse, error) {
+	var resp PolicyResponse
+	err := client.Invoke("CreatePolicy", policyReq, &resp)
+	if err != nil {
+		return PolicyResponse{}, err
+	}
+	return resp, nil
+}
+
+func (client *RamClient) GetPolicy(policyReq PolicyRequest) (PolicyResponse, error) {
+	var resp PolicyResponse
+	err := client.Invoke("GetPolicy", policyReq, &resp)
+	if err != nil {
+		return PolicyResponse{}, err
+	}
+	return resp, nil
+}
+
+func (client *RamClient) DeletePolicy(policyReq PolicyRequest) (RamCommonResponse, error) {
+	var resp RamCommonResponse
+	err := client.Invoke("DeletePolicy", policyReq, &resp)
+	if err != nil {
+		return RamCommonResponse{}, err
+	}
+	return resp, nil
+}
+
+func (client *RamClient) ListPolicies(policyQuery PolicyQueryRequest) (PolicyQueryResponse, error) {
+	var resp PolicyQueryResponse
+	err := client.Invoke("ListPolicies", policyQuery, &resp)
+	if err != nil {
+		return PolicyQueryResponse{}, err
+	}
+	return resp, nil
+}
+
+func (client *RamClient) CreatePolicyVersion(policyReq PolicyRequest) (PolicyVersionResponse, error) {
+	var resp PolicyVersionResponse
+	err := client.Invoke("CreatePolicyVersion", policyReq, &resp)
+	if err != nil {
+		return PolicyVersionResponse{}, err
+	}
+	return resp, nil
+}
+
+func (client *RamClient) GetPolicyVersion(policyReq PolicyRequest) (PolicyVersionResponse, error) {
+	var resp PolicyVersionResponse
+	err := client.Invoke("GetPolicyVersion", policyReq, &resp)
+	if err != nil {
+		return PolicyVersionResponse{}, err
+	}
+	return resp, nil
+}
+
+func (client *RamClient) GetPolicyVersionNew(policyReq PolicyRequest) (PolicyVersionResponseNew, error) {
+	var resp PolicyVersionResponseNew
+	err := client.Invoke("GetPolicyVersion", policyReq, &resp)
+	if err != nil {
+		return PolicyVersionResponseNew{}, err
+	}
+	return resp, nil
+}
+
+func (client *RamClient) DeletePolicyVersion(policyReq PolicyRequest) (RamCommonResponse, error) {
+	var resp RamCommonResponse
+	err := client.Invoke("DeletePolicyVersion", policyReq, &resp)
+	if err != nil {
+		return RamCommonResponse{}, err
+	}
+	return resp, nil
+}
+
+func (client *RamClient) ListPolicyVersions(policyReq PolicyRequest) (PolicyVersionResponse, error) {
+	var resp PolicyVersionResponse
+	err := client.Invoke("ListPolicyVersions", policyReq, &resp)
+	if err != nil {
+		return PolicyVersionResponse{}, err
+	}
+	return resp, nil
+}
+
+func (client *RamClient) ListPolicyVersionsNew(policyReq PolicyRequest) (PolicyVersionsResponse, error) {
+	var resp PolicyVersionsResponse
+	err := client.Invoke("ListPolicyVersions", policyReq, &resp)
+	if err != nil {
+		return PolicyVersionsResponse{}, err
+	}
+	return resp, nil
+}
+
+func (client *RamClient) SetDefaultPolicyVersion(policyReq PolicyRequest) (RamCommonResponse, error) {
+	var resp RamCommonResponse
+	err := client.Invoke("SetDefaultPolicyVersion", policyReq, &resp)
+	if err != nil {
+		return RamCommonResponse{}, err
+	}
+	return resp, nil
+}
+
+func (client *RamClient) AttachPolicyToUser(attachPolicyRequest AttachPolicyRequest) (RamCommonResponse, error) {
+	var resp RamCommonResponse
+	err := client.Invoke("AttachPolicyToUser", attachPolicyRequest, &resp)
+	if err != nil {
+		return RamCommonResponse{}, err
+	}
+	return resp, nil
+}
+
+func (client *RamClient) DetachPolicyFromUser(attachPolicyRequest AttachPolicyRequest) (RamCommonResponse, error) {
+	var resp RamCommonResponse
+	err := client.Invoke("DetachPolicyFromUser", attachPolicyRequest, &resp)
+	if err != nil {
+		return RamCommonResponse{}, err
+	}
+	return resp, nil
+}
+
+func (client *RamClient) ListEntitiesForPolicy(policyReq PolicyRequest) (PolicyListEntitiesResponse, error) {
+	var resp PolicyListEntitiesResponse
+	err := client.Invoke("ListEntitiesForPolicy", policyReq, &resp)
+	if err != nil {
+		return PolicyListEntitiesResponse{}, err
+	}
+	return resp, nil
+}
+
+func (client *RamClient) ListPoliciesForUser(userQuery UserQueryRequest) (PolicyListResponse, error) {
+	var resp PolicyListResponse
+	err := client.Invoke("ListPoliciesForUser", userQuery, &resp)
+	if err != nil {
+		return PolicyListResponse{}, err
+	}
+	return resp, nil
+}
+
+//
+//Role related
+//
+func (client *RamClient) AttachPolicyToRole(attachPolicyRequest AttachPolicyToRoleRequest) (RamCommonResponse, error) {
+	var resp RamCommonResponse
+	err := client.Invoke("AttachPolicyToRole", attachPolicyRequest, &resp)
+	if err != nil {
+		return RamCommonResponse{}, err
+	}
+	return resp, nil
+}
+
+func (client *RamClient) DetachPolicyFromRole(attachPolicyRequest AttachPolicyToRoleRequest) (RamCommonResponse, error) {
+	var resp RamCommonResponse
+	err := client.Invoke("DetachPolicyFromRole", attachPolicyRequest, &resp)
+	if err != nil {
+		return RamCommonResponse{}, err
+	}
+	return resp, nil
+}
+
+func (client *RamClient) ListPoliciesForRole(roleQuery RoleQueryRequest) (PolicyListResponse, error) {
+	var resp PolicyListResponse
+	err := client.Invoke("ListPoliciesForRole", roleQuery, &resp)
+	if err != nil {
+		return PolicyListResponse{}, err
+	}
+	return resp, nil
+}
+
+//
+//Group related
+//
+func (client *RamClient) AttachPolicyToGroup(attachPolicyRequest AttachPolicyToGroupRequest) (RamCommonResponse, error) {
+	var resp RamCommonResponse
+	err := client.Invoke("AttachPolicyToGroup", attachPolicyRequest, &resp)
+	if err != nil {
+		return RamCommonResponse{}, err
+	}
+	return resp, nil
+}
+
+func (client *RamClient) DetachPolicyFromGroup(attachPolicyRequest AttachPolicyToGroupRequest) (RamCommonResponse, error) {
+	var resp RamCommonResponse
+	err := client.Invoke("DetachPolicyFromGroup", attachPolicyRequest, &resp)
+	if err != nil {
+		return RamCommonResponse{}, err
+	}
+	return resp, nil
+}
+
+func (client *RamClient) ListPoliciesForGroup(groupQuery GroupQueryRequest) (PolicyListResponse, error) {
+	var resp PolicyListResponse
+	err := client.Invoke("ListPoliciesForGroup", groupQuery, &resp)
+	if err != nil {
+		return PolicyListResponse{}, err
+	}
+	return resp, nil
+}

--- a/vendor/github.com/denverdino/aliyungo/ram/profile.go
+++ b/vendor/github.com/denverdino/aliyungo/ram/profile.go
@@ -1,0 +1,56 @@
+package ram
+
+/*
+	CreateLoginProfile()
+	GetLoginProfile()
+	DeleteLoginProfile()
+	UpdateLoginProfile()
+*/
+
+type ProfileRequest struct {
+	UserName              string
+	Password              string
+	PasswordResetRequired bool
+	MFABindRequired       bool
+}
+
+type ProfileResponse struct {
+	RamCommonResponse
+	LoginProfile LoginProfile
+}
+
+func (client *RamClient) CreateLoginProfile(req ProfileRequest) (ProfileResponse, error) {
+	var resp ProfileResponse
+	err := client.Invoke("CreateLoginProfile", req, &resp)
+	if err != nil {
+		return ProfileResponse{}, err
+	}
+	return resp, nil
+}
+
+func (client *RamClient) GetLoginProfile(req UserQueryRequest) (ProfileResponse, error) {
+	var resp ProfileResponse
+	err := client.Invoke("GetLoginProfile", req, &resp)
+	if err != nil {
+		return ProfileResponse{}, err
+	}
+	return resp, nil
+}
+
+func (client *RamClient) DeleteLoginProfile(req UserQueryRequest) (RamCommonResponse, error) {
+	var resp RamCommonResponse
+	err := client.Invoke("DeleteLoginProfile", req, &resp)
+	if err != nil {
+		return RamCommonResponse{}, err
+	}
+	return resp, nil
+}
+
+func (client *RamClient) UpdateLoginProfile(req ProfileRequest) (ProfileResponse, error) {
+	var resp ProfileResponse
+	err := client.Invoke("UpdateLoginProfile", req, &resp)
+	if err != nil {
+		return ProfileResponse{}, err
+	}
+	return resp, nil
+}

--- a/vendor/github.com/denverdino/aliyungo/ram/role.go
+++ b/vendor/github.com/denverdino/aliyungo/ram/role.go
@@ -1,0 +1,73 @@
+package ram
+
+type RoleRequest struct {
+	RoleName                 string
+	AssumeRolePolicyDocument string
+	Description              string
+}
+
+type RoleResponse struct {
+	RamCommonResponse
+	Role Role
+}
+
+type RoleQueryRequest struct {
+	RoleName string
+}
+
+type UpdateRoleRequest struct {
+	RoleName                    string
+	NewAssumeRolePolicyDocument string
+}
+
+type ListRoleResponse struct {
+	RamCommonResponse
+	Roles struct {
+		Role []Role
+	}
+}
+
+func (client *RamClient) CreateRole(role RoleRequest) (RoleResponse, error) {
+	var roleResponse RoleResponse
+	err := client.Invoke("CreateRole", role, &roleResponse)
+	if err != nil {
+		return RoleResponse{}, err
+	}
+	return roleResponse, nil
+}
+
+func (client *RamClient) GetRole(roleQuery RoleQueryRequest) (RoleResponse, error) {
+	var roleResponse RoleResponse
+	err := client.Invoke("GetRole", roleQuery, &roleResponse)
+	if err != nil {
+		return RoleResponse{}, nil
+	}
+	return roleResponse, nil
+}
+
+func (client *RamClient) UpdateRole(newRole UpdateRoleRequest) (RoleResponse, error) {
+	var roleResponse RoleResponse
+	err := client.Invoke("UpdateRole", newRole, &roleResponse)
+	if err != nil {
+		return RoleResponse{}, err
+	}
+	return roleResponse, nil
+}
+
+func (client *RamClient) ListRoles() (ListRoleResponse, error) {
+	var roleList ListRoleResponse
+	err := client.Invoke("ListRoles", struct{}{}, &roleList)
+	if err != nil {
+		return ListRoleResponse{}, err
+	}
+	return roleList, nil
+}
+
+func (client *RamClient) DeleteRole(roleQuery RoleQueryRequest) (RamCommonResponse, error) {
+	var commonResp RamCommonResponse
+	err := client.Invoke("DeleteRole", roleQuery, &commonResp)
+	if err != nil {
+		return RamCommonResponse{}, err
+	}
+	return commonResp, nil
+}

--- a/vendor/github.com/denverdino/aliyungo/ram/security.go
+++ b/vendor/github.com/denverdino/aliyungo/ram/security.go
@@ -1,0 +1,72 @@
+package ram
+
+//TODO implement ram api about security
+/*
+	SetAccountAlias()
+	GetAccountAlias()
+	ClearAccountAlias()
+	SetPasswordPolicy()
+	GetPasswordPolicy()
+*/
+type AccountAliasResponse struct {
+	RamCommonResponse
+	AccountAlias string
+}
+
+type PasswordPolicyResponse struct {
+	RamCommonResponse
+	PasswordPolicy
+}
+
+type PasswordPolicyRequest struct {
+	PasswordPolicy
+}
+
+type AccountAliasRequest struct {
+	AccountAlias string
+}
+
+func (client *RamClient) SetAccountAlias(accountalias AccountAliasRequest) (RamCommonResponse, error) {
+	var resp RamCommonResponse
+	err := client.Invoke("SetAccountAlias", accountalias, &resp)
+	if err != nil {
+		return RamCommonResponse{}, err
+	}
+	return resp, nil
+}
+
+func (client *RamClient) GetAccountAlias() (AccountAliasResponse, error) {
+	var resp AccountAliasResponse
+	err := client.Invoke("GetAccountAlias", struct{}{}, &resp)
+	if err != nil {
+		return AccountAliasResponse{}, err
+	}
+	return resp, nil
+}
+
+func (client *RamClient) ClearAccountAlias() (RamCommonResponse, error) {
+	var resp RamCommonResponse
+	err := client.Invoke("ClearAccountAlias", struct{}{}, &resp)
+	if err != nil {
+		return RamCommonResponse{}, err
+	}
+	return resp, nil
+}
+
+func (client *RamClient) SetPasswordPolicy(passwordPolicy PasswordPolicyRequest) (PasswordPolicyResponse, error) {
+	var resp PasswordPolicyResponse
+	err := client.Invoke("SetPasswordPolicy", passwordPolicy, &resp)
+	if err != nil {
+		return PasswordPolicyResponse{}, err
+	}
+	return resp, nil
+}
+
+func (client *RamClient) GetPasswordPolicy() (PasswordPolicyResponse, error) {
+	var resp PasswordPolicyResponse
+	err := client.Invoke("GetPasswordPolicy", struct{}{}, &resp)
+	if err != nil {
+		return PasswordPolicyResponse{}, err
+	}
+	return resp, nil
+}

--- a/vendor/github.com/denverdino/aliyungo/ram/types.go
+++ b/vendor/github.com/denverdino/aliyungo/ram/types.go
@@ -1,0 +1,144 @@
+package ram
+
+import (
+	"github.com/denverdino/aliyungo/common"
+)
+
+/*
+	All common struct
+*/
+
+const (
+	Active   State = "Active"
+	Inactive State = "Inactive"
+)
+
+/*
+	AccountAlias
+	类型：String
+	必须：是
+	描述：指定云账号的别名, 长度限制为3-63个字符
+	限制：^[a-z0-9](([a-z0-9]|-(?!-))*[a-z0-9])?$
+*/
+type AccountAlias string
+
+type UserQueryRequest struct {
+	UserName string
+}
+
+type User struct {
+	UserId        string
+	UserName      string
+	DisplayName   string
+	MobilePhone   string
+	Email         string
+	Comments      string
+	CreateDate    string
+	UpdateDate    string
+	LastLoginDate string
+}
+
+type LoginProfile struct {
+	UserName              string
+	PasswordResetRequired bool
+	MFABindRequired       bool
+}
+
+type MFADevice struct {
+	SerialNumber string
+}
+
+type VirtualMFADevice struct {
+	SerialNumber     string
+	Base32StringSeed string
+	QRCodePNG        string
+	ActivateDate     string
+	User             User
+}
+
+type AccessKey struct {
+	AccessKeyId     string
+	AccessKeySecret string
+	Status          State
+	CreateDate      string
+}
+
+type Group struct {
+	GroupName string
+	Comments  string
+}
+
+type Role struct {
+	RoleId                   string
+	RoleName                 string
+	Arn                      string
+	Description              string
+	AssumeRolePolicyDocument string
+	CreateDate               string
+	UpdateDate               string
+}
+
+type Policy struct {
+	PolicyName      string
+	PolicyType      string
+	Description     string
+	DefaultVersion  string
+	CreateDate      string
+	UpdateDate      string
+	AttachmentCount int64
+}
+
+type PolicyVersion struct {
+	VersionId        string
+	IsDefaultVersion bool
+	CreateDate       string
+	PolicyDocument   string
+}
+
+type PolicyDocument struct {
+	Statement []PolicyItem
+	Version   string
+}
+
+type PolicyItem struct {
+	Action   string
+	Effect   string
+	Resource string
+}
+
+type AssumeRolePolicyDocument struct {
+	Statement []AssumeRolePolicyItem
+	Version   string
+}
+
+type AssumeRolePolicyItem struct {
+	Action    string
+	Effect    string
+	Principal AssumeRolePolicyPrincpal
+}
+
+type AssumeRolePolicyPrincpal struct {
+	RAM []string
+}
+
+/*
+	"PasswordPolicy": {
+        "MinimumPasswordLength": 12,
+        "RequireLowercaseCharacters": true,
+        "RequireUppercaseCharacters": true,
+        "RequireNumbers": true,
+        "RequireSymbols": true
+    }
+*/
+
+type PasswordPolicy struct {
+	MinimumPasswordLength      int8
+	RequireLowercaseCharacters bool
+	RequireUppercaseCharacters bool
+	RequireNumbers             bool
+	RequireSymbols             bool
+}
+
+type RamCommonResponse struct {
+	common.Response
+}

--- a/vendor/github.com/denverdino/aliyungo/rds/instances.go
+++ b/vendor/github.com/denverdino/aliyungo/rds/instances.go
@@ -143,6 +143,43 @@ func (client *Client) CreateOrder(args *CreateOrderArgs) (resp CreateOrderRespon
 	return response, err
 }
 
+type CreateDBInstanceArgs struct {
+	RegionId              common.Region
+	ZoneId                string
+	Engine                Engine
+	EngineVersion         string
+	DBInstanceClass       string
+	DBInstanceStorage     int
+	DBInstanceNetType     common.NetType
+	DBInstanceDescription string
+	SecurityIPList        string
+	PayType               DBPayType
+	Period                common.TimeType
+	UsedTime              string
+	ClientToken           string
+	InstanceNetworkType   common.NetworkType
+	ConnectionMode        ConnectionMode
+	VPCId                 string
+	VSwitchId             string
+	PrivateIpAddress      string
+}
+
+type CreateDBInstanceResponse struct {
+	common.Response
+	DBInstanceId     string
+	OrderId          string
+	ConnectionString string
+	Port             string
+}
+
+// CreateDBInstance create db instance
+// https://help.aliyun.com/document_detail/26228.html
+func (client *Client) CreateDBInstance(args *CreateDBInstanceArgs) (resp CreateDBInstanceResponse, err error) {
+	response := CreateDBInstanceResponse{}
+	err = client.Invoke("CreateDBInstance", args, &response)
+	return response, err
+}
+
 type DescribeDBInstancesArgs struct {
 	DBInstanceId string
 }
@@ -192,8 +229,13 @@ type DBInstanceAttribute struct {
 	VpcId                       string
 }
 
+
 type ReadOnlyDBInstanceIds struct {
-	ReadOnlyDBInstanceId []string
+	ReadOnlyDBInstanceId []ReadOnlyDBInstanceId
+}
+
+type ReadOnlyDBInstanceId struct {
+	DBInstanceId string
 }
 
 // DescribeDBInstanceAttribute describes db instance
@@ -643,10 +685,12 @@ type CreateAccountResponse struct {
 	common.Response
 }
 
-type AccountType struct {
-	Normal string
-	Super  string
-}
+type AccountType string
+
+const (
+	Normal = AccountType("Normal")
+	Super  = AccountType("Super")
+)
 
 type CreateAccountArgs struct {
 	DBInstanceId       string
@@ -670,8 +714,8 @@ func (client *Client) CreateAccount(args *CreateAccountArgs) (resp *CreateAccoun
 }
 
 type ResetAccountPasswordArgs struct {
-	DBInstanceId string
-	AccountName  string
+	DBInstanceId    string
+	AccountName     string
 	AccountPassword string
 }
 
@@ -680,8 +724,8 @@ type ResetAccountPasswordArgs struct {
 // You can read doc at https://help.aliyun.com/document_detail/26269.html?spm=5176.doc26268.6.842.hFnVQU
 func (client *Client) ResetAccountPassword(instanceId, accountName, accountPassword string) (resp *common.Response, err error) {
 	args := ResetAccountPasswordArgs{
-		DBInstanceId: instanceId,
-		AccountName:  accountName,
+		DBInstanceId:    instanceId,
+		AccountName:     accountName,
 		AccountPassword: accountPassword,
 	}
 

--- a/vendor/github.com/denverdino/aliyungo/rds/monitoring.go
+++ b/vendor/github.com/denverdino/aliyungo/rds/monitoring.go
@@ -7,7 +7,7 @@ import (
 
 type DescribeDBInstancePerformanceArgs struct {
 	DBInstanceId string
-	key          string
+	Key          string
 	StartTime    string
 	EndTime      string
 }
@@ -38,7 +38,7 @@ type DescribeDBInstancePerformanceResponse struct {
 }
 
 func (client *DescribeDBInstancePerformanceArgs) Setkey(key string) {
-	client.key = key
+	client.Key = key
 }
 
 func (client *Client) DescribeDBInstancePerformance(args *DescribeDBInstancePerformanceArgs) (resp DescribeDBInstancePerformanceResponse, err error) {

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -233,46 +233,64 @@
 			"revisionTime": "2016-10-29T20:57:26Z"
 		},
 		{
+			"checksumSHA1": "9JK6TQ6tSG68roB1KWs3NIxw6zY=",
+			"path": "github.com/denverdino/aliyungo/cdn",
+			"revision": "199fa376135951b938a53634048bb32e5dc823c1",
+			"revisionTime": "2017-10-16T07:52:46Z"
+		},
+		{
 			"checksumSHA1": "b2m7aICkBOz9JqmnX2kdDN4wgjI=",
 			"path": "github.com/denverdino/aliyungo/common",
-			"revision": "502426b9d74ec6879e291f8ce56c040595695c4d",
-			"revisionTime": "2017-08-15T03:28:57Z"
+			"revision": "199fa376135951b938a53634048bb32e5dc823c1",
+			"revisionTime": "2017-10-16T07:52:46Z"
 		},
 		{
-			"checksumSHA1": "Pcc38l0JuDlo6338k76SevxdwwY=",
+			"checksumSHA1": "zHBzMaiaG1TbhrU15Wp/7Rbl4ZY=",
+			"path": "github.com/denverdino/aliyungo/dns",
+			"revision": "199fa376135951b938a53634048bb32e5dc823c1",
+			"revisionTime": "2017-10-16T07:52:46Z"
+		},
+		{
+			"checksumSHA1": "t+oOAxTaWYS0iZVry7iaFgYX5Eo=",
 			"path": "github.com/denverdino/aliyungo/ecs",
-			"revision": "502426b9d74ec6879e291f8ce56c040595695c4d",
-			"revisionTime": "2017-08-15T03:28:57Z"
+			"revision": "199fa376135951b938a53634048bb32e5dc823c1",
+			"revisionTime": "2017-10-16T07:52:46Z"
 		},
 		{
-			"checksumSHA1": "BgIs8qwCMRM8xL6oLeo2Ki1QwBc=",
+			"checksumSHA1": "P9SMbUnwF+sBLZc1BspupVholKc=",
 			"path": "github.com/denverdino/aliyungo/ess",
-			"revision": "502426b9d74ec6879e291f8ce56c040595695c4d",
-			"revisionTime": "2017-08-15T03:28:57Z"
+			"revision": "199fa376135951b938a53634048bb32e5dc823c1",
+			"revisionTime": "2017-10-16T07:52:46Z"
 		},
 		{
 			"checksumSHA1": "CPuR3s7LzQkT57Z20zMHXQM2MYQ=",
 			"path": "github.com/denverdino/aliyungo/location",
-			"revision": "502426b9d74ec6879e291f8ce56c040595695c4d",
-			"revisionTime": "2017-08-15T03:28:57Z"
+			"revision": "199fa376135951b938a53634048bb32e5dc823c1",
+			"revisionTime": "2017-10-16T07:52:46Z"
 		},
 		{
-			"checksumSHA1": "WY9RR7Q7qjDIEqcyRmL7VfrP9fw=",
+			"checksumSHA1": "Cc/BNEn/OKuBLhztBhg00YI23Zo=",
+			"path": "github.com/denverdino/aliyungo/ram",
+			"revision": "199fa376135951b938a53634048bb32e5dc823c1",
+			"revisionTime": "2017-10-16T07:52:46Z"
+		},
+		{
+			"checksumSHA1": "EaiPS3gTXG0g4DZGeTB07SARwr0=",
 			"path": "github.com/denverdino/aliyungo/rds",
-			"revision": "fe3c5e111942dcf748b0e195657c758f1e6a96f8",
-			"revisionTime": "2017-08-08T09:43:50Z"
+			"revision": "199fa376135951b938a53634048bb32e5dc823c1",
+			"revisionTime": "2017-10-16T07:52:46Z"
 		},
 		{
 			"checksumSHA1": "pQHH9wpyS0e4wpW0erxe3D7OILM=",
 			"path": "github.com/denverdino/aliyungo/slb",
-			"revision": "502426b9d74ec6879e291f8ce56c040595695c4d",
-			"revisionTime": "2017-08-15T03:28:57Z"
+			"revision": "199fa376135951b938a53634048bb32e5dc823c1",
+			"revisionTime": "2017-10-16T07:52:46Z"
 		},
 		{
 			"checksumSHA1": "piZlmhWPLGxYkXLysTrjcXllO4c=",
 			"path": "github.com/denverdino/aliyungo/util",
-			"revision": "502426b9d74ec6879e291f8ce56c040595695c4d",
-			"revisionTime": "2017-08-15T03:28:57Z"
+			"revision": "199fa376135951b938a53634048bb32e5dc823c1",
+			"revisionTime": "2017-10-16T07:52:46Z"
 		},
 		{
 			"checksumSHA1": "BCv50o5pDkoSG3vYKOSai1Z8p3w=",

--- a/website/docs/r/vroute_entry.html.markdown
+++ b/website/docs/r/vroute_entry.html.markdown
@@ -8,7 +8,7 @@ description: |-
 
 # alicloud\_route\_entry
 
-Provides a route entry resource.
+Provides a route entry resource. A route entry represents a route item of one VPC route table.
 
 ## Example Usage
 
@@ -38,8 +38,8 @@ The following arguments are supported:
 * `router_id` - (Deprecated) This argument has beeb deprecated. Please use other arguments to launch a custom route entry.
 * `route_table_id` - (Required, Forces new resource) The ID of the route table.
 * `destination_cidrblock` - (Required, Forces new resource) The RouteEntry's target network segment.
-* `nexthop_type` - (Required, Forces new resource) The next hop type. Available value is Instance.
-* `nexthop_id` - (Required, Forces new resource) The route entry's next hop.
+* `nexthop_type` - (Required, Forces new resource) The next hop type. Available value is `Instance` and `RouterInterface`. `Instance` points to ECS Instance.
+* `nexthop_id` - (Required, Forces new resource) The route entry's next hop. ECS instance ID or VPC router interface ID.
 
 ## Attributes Reference
 
@@ -48,5 +48,5 @@ The following attributes are exported:
 * `router_id` - The ID of the virtual router attached to Vpc.
 * `route_table_id` - The ID of the route table.
 * `destination_cidrblock` - The RouteEntry's target network segment.
-* `nexthop_type` - The next hop type. Available value is Instance.
+* `nexthop_type` - The next hop type.
 * `nexthop_id` - The route entry's next hop.


### PR DESCRIPTION
The PR adds new nexthop type 'RouterInterface' for route entry.

The running result of test case as follows:

TF_ACC=1 go test -v ./alicloud -run=TestAccAlicloudRouteEntry -timeout 120m
=== RUN   TestAccAlicloudRouteEntry_importBasic
--- PASS: TestAccAlicloudRouteEntry_importBasic (109.52s)
=== RUN   TestAccAlicloudRouteEntry_Basic
--- PASS: TestAccAlicloudRouteEntry_Basic (104.51s)
=== RUN   TestAccAlicloudRouteEntry_RouteInterface
--- PASS: TestAccAlicloudRouteEntry_RouteInterface (32.22s)
PASS
ok      github.com/alibaba/terraform-provider/alicloud  246.277s

The PR has a dependency on terraform-providers/terraform-provider-alicloud#40.