### PR TITLE
fix dns record priority bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,11 @@
-## 1.1.0 (Unreleased)
+## 1.3.0 (Unreleased)
+
+## 1.2.0 (December 14, 2017)
+
+IMPROVEMENTS:
+
+- resource/dns-record: Fix setting dns priority failed [GH-58]
+
 
 ## 1.0.0 (December 11, 2017)
 

--- a/alicloud/data_source_alicloud_dns_domains_test.go
+++ b/alicloud/data_source_alicloud_dns_domains_test.go
@@ -17,8 +17,7 @@ func TestAccAlicloudDnsDomainsDataSource_ali_domain(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAlicloudDataSourceID("data.alicloud_dns_domains.domain"),
 					resource.TestCheckResourceAttr("data.alicloud_dns_domains.domain", "domains.#", "1"),
-					resource.TestCheckResourceAttr("data.alicloud_dns_domains.domain", "domains.0.domain_name", "xiaozhu.top"),
-					resource.TestCheckResourceAttr("data.alicloud_dns_domains.domain", "domains.0.puny_code", "xiaozhu.top"),
+					resource.TestCheckResourceAttr("data.alicloud_dns_domains.domain", "domains.0.ali_domain", "true"),
 				),
 			},
 		},
@@ -91,7 +90,7 @@ data "alicloud_dns_domains" "domain" {
 
 const testAccCheckAlicloudDomainsDataSourceNameRegexConfig = `
 data "alicloud_dns_domains" "domain" {
-  domain_name_regex = "cloud*"
+  domain_name_regex = ".*"
 }`
 
 const testAccCheckAlicloudDomainsDataSourceGroupNameRegexConfig = `

--- a/alicloud/data_source_alicloud_dns_groups_test.go
+++ b/alicloud/data_source_alicloud_dns_groups_test.go
@@ -17,8 +17,7 @@ func TestAccAlicloudDnsGroupsDataSource_name_regex(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAlicloudDataSourceID("data.alicloud_dns_groups.group"),
 					resource.TestCheckResourceAttr("data.alicloud_dns_groups.group", "groups.#", "1"),
-					resource.TestCheckResourceAttr("data.alicloud_dns_groups.group", "groups.0.group_id", "520fa32a-076b-4f80-854d-987046e223fe"),
-					resource.TestCheckResourceAttr("data.alicloud_dns_groups.group", "groups.0.group_name", "yuy"),
+					resource.TestCheckResourceAttr("data.alicloud_dns_groups.group", "groups.0.group_name", "ALL\n"),
 				),
 			},
 		},
@@ -27,5 +26,5 @@ func TestAccAlicloudDnsGroupsDataSource_name_regex(t *testing.T) {
 
 const testAccCheckAlicloudDnsGroupsDataSourceNameRegexConfig = `
 data "alicloud_dns_groups" "group" {
-  name_regex = "^yu"
+  name_regex = "^ALL"
 }`

--- a/alicloud/data_source_alicloud_dns_records.go
+++ b/alicloud/data_source_alicloud_dns_records.go
@@ -95,7 +95,7 @@ func dataSourceAlicloudDnsRecords() *schema.Resource {
 							Computed: true,
 						},
 						"priority": {
-							Type:     schema.TypeString,
+							Type:     schema.TypeInt,
 							Computed: true,
 						},
 						"line": {
@@ -196,7 +196,7 @@ func recordsDecriptionAttributes(d *schema.ResourceData, recordTypes []dns.Recor
 			"host_record": record.RR,
 			"type":        record.Type,
 			"value":       record.Value,
-			"status":      record.Status,
+			"status":      strings.ToLower(record.Status),
 			"locked":      record.Locked,
 			"ttl":         record.TTL,
 			"priority":    record.Priority,

--- a/alicloud/data_source_alicloud_dns_records_test.go
+++ b/alicloud/data_source_alicloud_dns_records_test.go
@@ -17,14 +17,8 @@ func TestAccAlicloudDnsRecordsDataSource_host_record_regex(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAlicloudDataSourceID("data.alicloud_dns_records.record"),
 					resource.TestCheckResourceAttr("data.alicloud_dns_records.record", "records.#", "1"),
-					resource.TestCheckResourceAttr("data.alicloud_dns_records.record", "records.0.record_id", "3438492787133440"),
-					resource.TestCheckResourceAttr("data.alicloud_dns_records.record", "records.0.domain_name", "heguimin.top"),
 					resource.TestCheckResourceAttr("data.alicloud_dns_records.record", "records.0.host_record", "smtp"),
-					resource.TestCheckResourceAttr("data.alicloud_dns_records.record", "records.0.status", "ENABLE"),
-					resource.TestCheckResourceAttr("data.alicloud_dns_records.record", "records.0.ttl", "600"),
 					resource.TestCheckResourceAttr("data.alicloud_dns_records.record", "records.0.type", "CNAME"),
-					resource.TestCheckResourceAttr("data.alicloud_dns_records.record", "records.0.value", "smtp.mxhichina.com"),
-					resource.TestCheckResourceAttr("data.alicloud_dns_records.record", "records.0.line", "default"),
 				),
 			},
 		},
@@ -42,7 +36,7 @@ func TestAccAlicloudDnsRecordsDataSource_type(t *testing.T) {
 				Config: testAccCheckAlicloudDnsRecordsDataSourceTypeConfig,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAlicloudDataSourceID("data.alicloud_dns_records.record"),
-					resource.TestCheckResourceAttr("data.alicloud_dns_records.record", "records.#", "7"),
+					resource.TestCheckResourceAttr("data.alicloud_dns_records.record", "records.0.type", "CNAME"),
 				),
 			},
 		},
@@ -60,7 +54,7 @@ func TestAccAlicloudDnsRecordsDataSource_value_regex(t *testing.T) {
 				Config: testAccCheckAlicloudDnsRecordsDataSourceValueRegexConfig,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAlicloudDataSourceID("data.alicloud_dns_records.record"),
-					resource.TestCheckResourceAttr("data.alicloud_dns_records.record", "records.#", "3"),
+					resource.TestCheckResourceAttr("data.alicloud_dns_records.record", "records.0.value", "mail.mxhichina.com"),
 				),
 			},
 		},
@@ -78,7 +72,7 @@ func TestAccAlicloudDnsRecordsDataSource_line(t *testing.T) {
 				Config: testAccCheckAlicloudDnsRecordsDataSourceLineConfig,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAlicloudDataSourceID("data.alicloud_dns_records.record"),
-					resource.TestCheckResourceAttr("data.alicloud_dns_records.record", "records.#", "17"),
+					resource.TestCheckResourceAttr("data.alicloud_dns_records.record", "records.0.line", "default"),
 				),
 			},
 		},
@@ -96,7 +90,7 @@ func TestAccAlicloudDnsRecordsDataSource_status(t *testing.T) {
 				Config: testAccCheckAlicloudDnsRecordsDataSourceStatusConfig,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAlicloudDataSourceID("data.alicloud_dns_records.record"),
-					resource.TestCheckResourceAttr("data.alicloud_dns_records.record", "records.#", "17"),
+					resource.TestCheckResourceAttr("data.alicloud_dns_records.record", "records.0.status", "enable"),
 				),
 			},
 		},
@@ -114,7 +108,7 @@ func TestAccAlicloudDnsRecordsDataSource_is_locked(t *testing.T) {
 				Config: testAccCheckAlicloudDnsRecordsDataSourceIsLockedConfig,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAlicloudDataSourceID("data.alicloud_dns_records.record"),
-					resource.TestCheckResourceAttr("data.alicloud_dns_records.record", "records.#", "17"),
+					resource.TestCheckResourceAttr("data.alicloud_dns_records.record", "records.0.locked", "false"),
 				),
 			},
 		},
@@ -122,37 +116,49 @@ func TestAccAlicloudDnsRecordsDataSource_is_locked(t *testing.T) {
 }
 
 const testAccCheckAlicloudDnsRecordsDataSourceHostRecordRegexConfig = `
+data "alicloud_dns_domains" "domains" {}
+
 data "alicloud_dns_records" "record" {
-  domain_name = "heguimin.top"
-  host_record_regex = ".*smtp.*"
+  domain_name = "${data.alicloud_dns_domains.domains.domains.0.domain_name}"
+  host_record_regex = "^smtp"
 }`
 
 const testAccCheckAlicloudDnsRecordsDataSourceTypeConfig = `
+data "alicloud_dns_domains" "domains" {}
+
 data "alicloud_dns_records" "record" {
-  domain_name = "heguimin.top"
+  domain_name = "${data.alicloud_dns_domains.domains.domains.0.domain_name}"
   type = "CNAME"
 }`
 
 const testAccCheckAlicloudDnsRecordsDataSourceValueRegexConfig = `
+data "alicloud_dns_domains" "domains" {}
+
 data "alicloud_dns_records" "record" {
-  domain_name = "heguimin.top"
-  value_regex = "^mail.mxhichina"
+  domain_name = "${data.alicloud_dns_domains.domains.domains.0.domain_name}"
+  value_regex = "^mail"
 }`
 
 const testAccCheckAlicloudDnsRecordsDataSourceStatusConfig = `
+data "alicloud_dns_domains" "domains" {}
+
 data "alicloud_dns_records" "record" {
-  domain_name = "heguimin.top"
+  domain_name = "${data.alicloud_dns_domains.domains.domains.0.domain_name}"
   status = "enable"
 }`
 
 const testAccCheckAlicloudDnsRecordsDataSourceIsLockedConfig = `
+data "alicloud_dns_domains" "domains" {}
+
 data "alicloud_dns_records" "record" {
-  domain_name = "heguimin.top"
+  domain_name = "${data.alicloud_dns_domains.domains.domains.0.domain_name}"
   is_locked = false
 }`
 
 const testAccCheckAlicloudDnsRecordsDataSourceLineConfig = `
+data "alicloud_dns_domains" "domains" {}
+
 data "alicloud_dns_records" "record" {
-  domain_name = "heguimin.top"
+  domain_name = "${data.alicloud_dns_domains.domains.domains.0.domain_name}"
   line = "default"
 }`

--- a/alicloud/diff_suppress_funcs.go
+++ b/alicloud/diff_suppress_funcs.go
@@ -1,6 +1,7 @@
 package alicloud
 
 import (
+	"github.com/denverdino/aliyungo/dns"
 	"github.com/denverdino/aliyungo/slb"
 	"github.com/hashicorp/terraform/helper/schema"
 )
@@ -70,6 +71,13 @@ func httpHttpsTcpDiffSuppressFunc(k, old, new string, d *schema.ResourceData) bo
 }
 func sslCertificateIdDiffSuppressFunc(k, old, new string, d *schema.ResourceData) bool {
 	if protocol, ok := d.GetOk("protocol"); ok && Protocol(protocol.(string)) == Https {
+		return false
+	}
+	return true
+}
+
+func dnsPriorityDiffSuppressFunc(k, old, new string, d *schema.ResourceData) bool {
+	if recordType, ok := d.GetOk("type"); ok && recordType.(string) == dns.MXRecord {
 		return false
 	}
 	return true

--- a/alicloud/resource_alicloud_dns_record_test.go
+++ b/alicloud/resource_alicloud_dns_record_test.go
@@ -31,10 +31,6 @@ func TestAccAlicloudDnsRecord_basic(t *testing.T) {
 						"alicloud_dns_record.record", &v),
 					resource.TestCheckResourceAttr(
 						"alicloud_dns_record.record",
-						"name",
-						"heguimin.top"),
-					resource.TestCheckResourceAttr(
-						"alicloud_dns_record.record",
 						"type",
 						"CNAME"),
 				),
@@ -73,6 +69,36 @@ func testAccCheckDnsRecordExists(n string, record *dns.RecordTypeNew) resource.T
 	}
 }
 
+func TestAccAlicloudDnsRecord_priority(t *testing.T) {
+	var v dns.RecordTypeNew
+
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+		},
+
+		// module name
+		IDRefreshName: "alicloud_dns_record.record",
+
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckDnsRecordDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccDnsRecordPriority,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckDnsRecordExists(
+						"alicloud_dns_record.record", &v),
+					resource.TestCheckResourceAttr(
+						"alicloud_dns_record.record", "type", "MX"),
+					resource.TestCheckResourceAttr(
+						"alicloud_dns_record.record", "priority", "10"),
+				),
+			},
+		},
+	})
+
+}
+
 func testAccCheckDnsRecordDestroy(s *terraform.State) error {
 
 	for _, rs := range s.RootModule().Resources {
@@ -99,11 +125,25 @@ func testAccCheckDnsRecordDestroy(s *terraform.State) error {
 }
 
 const testAccDnsRecordConfig = `
+data "alicloud_dns_domains" "domains" {}
+
 resource "alicloud_dns_record" "record" {
-  name = "heguimin.top"
-  host_record = "alimailskajdh"
+  name = "${data.alicloud_dns_domains.domains.domains.0.domain_name}"
+  host_record = "alimail"
   type = "CNAME"
   value = "mail.mxhichin.com"
   count = 1
+}
+`
+const testAccDnsRecordPriority = `
+data "alicloud_dns_domains" "domains" {}
+
+resource "alicloud_dns_record" "record" {
+  name = "${data.alicloud_dns_domains.domains.domains.0.domain_name}"
+  host_record = "alipriority"
+  type = "MX"
+  value = "www.aliyun.com"
+  count = 1
+  priority = 10
 }
 `

--- a/alicloud/resource_alicloud_ess_scalinggroup.go
+++ b/alicloud/resource_alicloud_ess_scalinggroup.go
@@ -197,7 +197,7 @@ func buildAlicloudEssScalingGroupArgs(d *schema.ResourceData, meta interface{}) 
 	lbs, ok := d.GetOk("loadbalancer_ids")
 	if ok {
 		lbsStrings := lbs.([]interface{})
-		args.LoadBalancerId = strings.Join(expandStringList(lbsStrings), COMMA_SEPARATED)
+		args.LoadBalancerIds = strings.Join(expandStringList(lbsStrings), COMMA_SEPARATED)
 	}
 
 	return args, nil

--- a/alicloud/resource_alicloud_vroute_entry.go
+++ b/alicloud/resource_alicloud_vroute_entry.go
@@ -78,7 +78,6 @@ func resourceAliyunRouteEntryCreate(d *schema.ResourceData, meta interface{}) er
 		if err != nil {
 			return resource.NonRetryableError(fmt.Errorf("Building CreateRouteEntryArgs got an error: %#v", err))
 		}
-		//args.ClientToken = fmt.Sprintf("%s-%d", args.ClientToken, timeNow)
 
 		if err := conn.CreateRouteEntry(args); err != nil {
 			// Route Entry does not support concurrence when creating or deleting it;

--- a/vendor/github.com/denverdino/aliyungo/dns/AddDomainRecord.go
+++ b/vendor/github.com/denverdino/aliyungo/dns/AddDomainRecord.go
@@ -14,7 +14,7 @@ type AddDomainRecordArgs struct {
 
 	//optional
 	TTL      int32
-	Priority int
+	Priority int32
 	Line     string
 }
 

--- a/vendor/github.com/denverdino/aliyungo/dns/DescribeDomainRecordInfoNew.go
+++ b/vendor/github.com/denverdino/aliyungo/dns/DescribeDomainRecordInfoNew.go
@@ -10,7 +10,7 @@ type RecordTypeNew struct {
 	Type       string
 	Value      string
 	TTL        float64
-	Priority   string
+	Priority   int32
 	Line       string
 	Status     string
 	Locked     bool

--- a/vendor/github.com/denverdino/aliyungo/ess/group.go
+++ b/vendor/github.com/denverdino/aliyungo/ess/group.go
@@ -16,7 +16,7 @@ const (
 type CreateScalingGroupArgs struct {
 	RegionId         common.Region
 	ScalingGroupName string
-	LoadBalancerId   string
+	LoadBalancerIds   string
 	VpcId            string
 	VSwitchId        string
 	// NOTE: Set MinSize, MaxSize and DefaultCooldown type to int pointer to distinguish zero value from unset value.

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -235,68 +235,68 @@
 		{
 			"checksumSHA1": "9JK6TQ6tSG68roB1KWs3NIxw6zY=",
 			"path": "github.com/denverdino/aliyungo/cdn",
-			"revision": "d7c7e038ca2b9ffd3c2b5525d9eae4a31b0704c7",
-			"revisionTime": "2017-12-07T06:26:40Z"
+			"revision": "4bae75444be7f963b8e8b707611f552c9352d098",
+			"revisionTime": "2017-12-13T12:38:21Z"
 		},
 		{
 			"checksumSHA1": "qvFutFkayxTxJN3E1AENo4kHEzA=",
 			"path": "github.com/denverdino/aliyungo/common",
-			"revision": "d7c7e038ca2b9ffd3c2b5525d9eae4a31b0704c7",
-			"revisionTime": "2017-12-07T06:26:40Z"
+			"revision": "4bae75444be7f963b8e8b707611f552c9352d098",
+			"revisionTime": "2017-12-13T12:38:21Z"
 		},
 		{
 			"checksumSHA1": "iINyIl3tdnJ1149OjjDIYM8o7gk=",
 			"path": "github.com/denverdino/aliyungo/cs",
-			"revision": "d7c7e038ca2b9ffd3c2b5525d9eae4a31b0704c7",
-			"revisionTime": "2017-12-07T06:26:40Z"
+			"revision": "4bae75444be7f963b8e8b707611f552c9352d098",
+			"revisionTime": "2017-12-13T12:38:21Z"
 		},
 		{
-			"checksumSHA1": "zHBzMaiaG1TbhrU15Wp/7Rbl4ZY=",
+			"checksumSHA1": "r3LvtjLkVZzM8X1HKSOznMs2FSA=",
 			"path": "github.com/denverdino/aliyungo/dns",
-			"revision": "d7c7e038ca2b9ffd3c2b5525d9eae4a31b0704c7",
-			"revisionTime": "2017-12-07T06:26:40Z"
+			"revision": "4bae75444be7f963b8e8b707611f552c9352d098",
+			"revisionTime": "2017-12-13T12:38:21Z"
 		},
 		{
 			"checksumSHA1": "dRCnl3Jccqs69IUO8s90ZUez/Vc=",
 			"path": "github.com/denverdino/aliyungo/ecs",
-			"revision": "d7c7e038ca2b9ffd3c2b5525d9eae4a31b0704c7",
-			"revisionTime": "2017-12-07T06:26:40Z"
+			"revision": "4bae75444be7f963b8e8b707611f552c9352d098",
+			"revisionTime": "2017-12-13T12:38:21Z"
 		},
 		{
-			"checksumSHA1": "0qcm0qCFWDyeYjG+y596rgwEcQ4=",
+			"checksumSHA1": "VH9KnFDd2UcZcldPHlOmMM8kNJ4=",
 			"path": "github.com/denverdino/aliyungo/ess",
-			"revision": "d7c7e038ca2b9ffd3c2b5525d9eae4a31b0704c7",
-			"revisionTime": "2017-12-07T06:26:40Z"
+			"revision": "4bae75444be7f963b8e8b707611f552c9352d098",
+			"revisionTime": "2017-12-13T12:38:21Z"
 		},
 		{
 			"checksumSHA1": "CPuR3s7LzQkT57Z20zMHXQM2MYQ=",
 			"path": "github.com/denverdino/aliyungo/location",
-			"revision": "d7c7e038ca2b9ffd3c2b5525d9eae4a31b0704c7",
-			"revisionTime": "2017-12-07T06:26:40Z"
+			"revision": "4bae75444be7f963b8e8b707611f552c9352d098",
+			"revisionTime": "2017-12-13T12:38:21Z"
 		},
 		{
 			"checksumSHA1": "sievsBvgtVF2iZ2FjmDZppH3+Ro=",
 			"path": "github.com/denverdino/aliyungo/ram",
-			"revision": "d7c7e038ca2b9ffd3c2b5525d9eae4a31b0704c7",
-			"revisionTime": "2017-12-07T06:26:40Z"
+			"revision": "4bae75444be7f963b8e8b707611f552c9352d098",
+			"revisionTime": "2017-12-13T12:38:21Z"
 		},
 		{
 			"checksumSHA1": "5muc4YGlXvIK6BwWNXQppIEcEkg=",
 			"path": "github.com/denverdino/aliyungo/rds",
-			"revision": "d7c7e038ca2b9ffd3c2b5525d9eae4a31b0704c7",
-			"revisionTime": "2017-12-07T06:26:40Z"
+			"revision": "4bae75444be7f963b8e8b707611f552c9352d098",
+			"revisionTime": "2017-12-13T12:38:21Z"
 		},
 		{
 			"checksumSHA1": "lCoboKg3pzrdnhtP+mcu6F48+UY=",
 			"path": "github.com/denverdino/aliyungo/slb",
-			"revision": "d7c7e038ca2b9ffd3c2b5525d9eae4a31b0704c7",
-			"revisionTime": "2017-12-07T06:26:40Z"
+			"revision": "4bae75444be7f963b8e8b707611f552c9352d098",
+			"revisionTime": "2017-12-13T12:38:21Z"
 		},
 		{
 			"checksumSHA1": "cKVBRn7GKT+0IqfGUc/NnKDWzCw=",
 			"path": "github.com/denverdino/aliyungo/util",
-			"revision": "d7c7e038ca2b9ffd3c2b5525d9eae4a31b0704c7",
-			"revisionTime": "2017-12-07T06:26:40Z"
+			"revision": "4bae75444be7f963b8e8b707611f552c9352d098",
+			"revisionTime": "2017-12-13T12:38:21Z"
 		},
 		{
 			"checksumSHA1": "BCv50o5pDkoSG3vYKOSai1Z8p3w=",


### PR DESCRIPTION
The PR fixed dns_record sets priority failed bug.

The result of running test cases as follows:

$ TF_ACC=1 go test -v ./alicloud -run=TestAccAlicloudDnsRecord -timeout 120m
=== RUN   TestAccAlicloudDnsRecordsDataSource_host_record_regex
--- PASS: TestAccAlicloudDnsRecordsDataSource_host_record_regex (11.47s)
=== RUN   TestAccAlicloudDnsRecordsDataSource_type
--- PASS: TestAccAlicloudDnsRecordsDataSource_type (11.35s)
=== RUN   TestAccAlicloudDnsRecordsDataSource_value_regex
--- PASS: TestAccAlicloudDnsRecordsDataSource_value_regex (11.44s)
=== RUN   TestAccAlicloudDnsRecordsDataSource_line
--- PASS: TestAccAlicloudDnsRecordsDataSource_line (11.71s)
=== RUN   TestAccAlicloudDnsRecordsDataSource_status
--- PASS: TestAccAlicloudDnsRecordsDataSource_status (11.09s)
=== RUN   TestAccAlicloudDnsRecordsDataSource_is_locked
--- PASS: TestAccAlicloudDnsRecordsDataSource_is_locked (11.21s)
=== RUN   TestAccAlicloudDnsRecord_basic
--- PASS: TestAccAlicloudDnsRecord_basic (13.05s)
=== RUN   TestAccAlicloudDnsRecord_priority
--- PASS: TestAccAlicloudDnsRecord_priority (13.02s)
PASS
ok      github.com/alibaba/terraform-provider/alicloud  94.381s