### PR TITLE
Fix ESS attachs SLB failed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,11 @@
-## 1.1.0 (Unreleased)
+## 1.3.0 (Unreleased)
+
+## 1.2.0 (December 14, 2017)
+
+IMPROVEMENTS:
+
+- resource/dns-record: Fix setting dns priority failed [GH-58]
+
 
 ## 1.0.0 (December 11, 2017)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,11 @@
 
 ## 1.2.0 (December 14, 2017)
 
-IMPROVEMENTS:
+BUG FIXES:
 
 - resource/dns-record: Fix setting dns priority failed [GH-58]
+- resource/dns-record: Fix ESS attachs SLB failed [GH-59]
+- resource/dns-record: Fix security group not found error [GH-59]
 
 
 ## 1.0.0 (December 11, 2017)

--- a/alicloud/data_source_alicloud_dns_domains_test.go
+++ b/alicloud/data_source_alicloud_dns_domains_test.go
@@ -17,8 +17,7 @@ func TestAccAlicloudDnsDomainsDataSource_ali_domain(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAlicloudDataSourceID("data.alicloud_dns_domains.domain"),
 					resource.TestCheckResourceAttr("data.alicloud_dns_domains.domain", "domains.#", "1"),
-					resource.TestCheckResourceAttr("data.alicloud_dns_domains.domain", "domains.0.domain_name", "xiaozhu.top"),
-					resource.TestCheckResourceAttr("data.alicloud_dns_domains.domain", "domains.0.puny_code", "xiaozhu.top"),
+					resource.TestCheckResourceAttr("data.alicloud_dns_domains.domain", "domains.0.ali_domain", "true"),
 				),
 			},
 		},
@@ -91,7 +90,7 @@ data "alicloud_dns_domains" "domain" {
 
 const testAccCheckAlicloudDomainsDataSourceNameRegexConfig = `
 data "alicloud_dns_domains" "domain" {
-  domain_name_regex = "cloud*"
+  domain_name_regex = ".*"
 }`
 
 const testAccCheckAlicloudDomainsDataSourceGroupNameRegexConfig = `

--- a/alicloud/data_source_alicloud_dns_groups_test.go
+++ b/alicloud/data_source_alicloud_dns_groups_test.go
@@ -17,8 +17,7 @@ func TestAccAlicloudDnsGroupsDataSource_name_regex(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAlicloudDataSourceID("data.alicloud_dns_groups.group"),
 					resource.TestCheckResourceAttr("data.alicloud_dns_groups.group", "groups.#", "1"),
-					resource.TestCheckResourceAttr("data.alicloud_dns_groups.group", "groups.0.group_id", "520fa32a-076b-4f80-854d-987046e223fe"),
-					resource.TestCheckResourceAttr("data.alicloud_dns_groups.group", "groups.0.group_name", "yuy"),
+					resource.TestCheckResourceAttr("data.alicloud_dns_groups.group", "groups.0.group_name", "ALL\n"),
 				),
 			},
 		},
@@ -27,5 +26,5 @@ func TestAccAlicloudDnsGroupsDataSource_name_regex(t *testing.T) {
 
 const testAccCheckAlicloudDnsGroupsDataSourceNameRegexConfig = `
 data "alicloud_dns_groups" "group" {
-  name_regex = "^yu"
+  name_regex = "^ALL"
 }`

--- a/alicloud/data_source_alicloud_dns_records.go
+++ b/alicloud/data_source_alicloud_dns_records.go
@@ -95,7 +95,7 @@ func dataSourceAlicloudDnsRecords() *schema.Resource {
 							Computed: true,
 						},
 						"priority": {
-							Type:     schema.TypeString,
+							Type:     schema.TypeInt,
 							Computed: true,
 						},
 						"line": {
@@ -196,7 +196,7 @@ func recordsDecriptionAttributes(d *schema.ResourceData, recordTypes []dns.Recor
 			"host_record": record.RR,
 			"type":        record.Type,
 			"value":       record.Value,
-			"status":      record.Status,
+			"status":      strings.ToLower(record.Status),
 			"locked":      record.Locked,
 			"ttl":         record.TTL,
 			"priority":    record.Priority,

--- a/alicloud/data_source_alicloud_dns_records_test.go
+++ b/alicloud/data_source_alicloud_dns_records_test.go
@@ -17,14 +17,8 @@ func TestAccAlicloudDnsRecordsDataSource_host_record_regex(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAlicloudDataSourceID("data.alicloud_dns_records.record"),
 					resource.TestCheckResourceAttr("data.alicloud_dns_records.record", "records.#", "1"),
-					resource.TestCheckResourceAttr("data.alicloud_dns_records.record", "records.0.record_id", "3438492787133440"),
-					resource.TestCheckResourceAttr("data.alicloud_dns_records.record", "records.0.domain_name", "heguimin.top"),
 					resource.TestCheckResourceAttr("data.alicloud_dns_records.record", "records.0.host_record", "smtp"),
-					resource.TestCheckResourceAttr("data.alicloud_dns_records.record", "records.0.status", "ENABLE"),
-					resource.TestCheckResourceAttr("data.alicloud_dns_records.record", "records.0.ttl", "600"),
 					resource.TestCheckResourceAttr("data.alicloud_dns_records.record", "records.0.type", "CNAME"),
-					resource.TestCheckResourceAttr("data.alicloud_dns_records.record", "records.0.value", "smtp.mxhichina.com"),
-					resource.TestCheckResourceAttr("data.alicloud_dns_records.record", "records.0.line", "default"),
 				),
 			},
 		},
@@ -42,7 +36,7 @@ func TestAccAlicloudDnsRecordsDataSource_type(t *testing.T) {
 				Config: testAccCheckAlicloudDnsRecordsDataSourceTypeConfig,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAlicloudDataSourceID("data.alicloud_dns_records.record"),
-					resource.TestCheckResourceAttr("data.alicloud_dns_records.record", "records.#", "7"),
+					resource.TestCheckResourceAttr("data.alicloud_dns_records.record", "records.0.type", "CNAME"),
 				),
 			},
 		},
@@ -60,7 +54,7 @@ func TestAccAlicloudDnsRecordsDataSource_value_regex(t *testing.T) {
 				Config: testAccCheckAlicloudDnsRecordsDataSourceValueRegexConfig,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAlicloudDataSourceID("data.alicloud_dns_records.record"),
-					resource.TestCheckResourceAttr("data.alicloud_dns_records.record", "records.#", "3"),
+					resource.TestCheckResourceAttr("data.alicloud_dns_records.record", "records.0.value", "mail.mxhichina.com"),
 				),
 			},
 		},
@@ -78,7 +72,7 @@ func TestAccAlicloudDnsRecordsDataSource_line(t *testing.T) {
 				Config: testAccCheckAlicloudDnsRecordsDataSourceLineConfig,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAlicloudDataSourceID("data.alicloud_dns_records.record"),
-					resource.TestCheckResourceAttr("data.alicloud_dns_records.record", "records.#", "17"),
+					resource.TestCheckResourceAttr("data.alicloud_dns_records.record", "records.0.line", "default"),
 				),
 			},
 		},
@@ -96,7 +90,7 @@ func TestAccAlicloudDnsRecordsDataSource_status(t *testing.T) {
 				Config: testAccCheckAlicloudDnsRecordsDataSourceStatusConfig,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAlicloudDataSourceID("data.alicloud_dns_records.record"),
-					resource.TestCheckResourceAttr("data.alicloud_dns_records.record", "records.#", "17"),
+					resource.TestCheckResourceAttr("data.alicloud_dns_records.record", "records.0.status", "enable"),
 				),
 			},
 		},
@@ -114,7 +108,7 @@ func TestAccAlicloudDnsRecordsDataSource_is_locked(t *testing.T) {
 				Config: testAccCheckAlicloudDnsRecordsDataSourceIsLockedConfig,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAlicloudDataSourceID("data.alicloud_dns_records.record"),
-					resource.TestCheckResourceAttr("data.alicloud_dns_records.record", "records.#", "17"),
+					resource.TestCheckResourceAttr("data.alicloud_dns_records.record", "records.0.locked", "false"),
 				),
 			},
 		},
@@ -122,37 +116,49 @@ func TestAccAlicloudDnsRecordsDataSource_is_locked(t *testing.T) {
 }
 
 const testAccCheckAlicloudDnsRecordsDataSourceHostRecordRegexConfig = `
+data "alicloud_dns_domains" "domains" {}
+
 data "alicloud_dns_records" "record" {
-  domain_name = "heguimin.top"
-  host_record_regex = ".*smtp.*"
+  domain_name = "${data.alicloud_dns_domains.domains.domains.0.domain_name}"
+  host_record_regex = "^smtp"
 }`
 
 const testAccCheckAlicloudDnsRecordsDataSourceTypeConfig = `
+data "alicloud_dns_domains" "domains" {}
+
 data "alicloud_dns_records" "record" {
-  domain_name = "heguimin.top"
+  domain_name = "${data.alicloud_dns_domains.domains.domains.0.domain_name}"
   type = "CNAME"
 }`
 
 const testAccCheckAlicloudDnsRecordsDataSourceValueRegexConfig = `
+data "alicloud_dns_domains" "domains" {}
+
 data "alicloud_dns_records" "record" {
-  domain_name = "heguimin.top"
-  value_regex = "^mail.mxhichina"
+  domain_name = "${data.alicloud_dns_domains.domains.domains.0.domain_name}"
+  value_regex = "^mail"
 }`
 
 const testAccCheckAlicloudDnsRecordsDataSourceStatusConfig = `
+data "alicloud_dns_domains" "domains" {}
+
 data "alicloud_dns_records" "record" {
-  domain_name = "heguimin.top"
+  domain_name = "${data.alicloud_dns_domains.domains.domains.0.domain_name}"
   status = "enable"
 }`
 
 const testAccCheckAlicloudDnsRecordsDataSourceIsLockedConfig = `
+data "alicloud_dns_domains" "domains" {}
+
 data "alicloud_dns_records" "record" {
-  domain_name = "heguimin.top"
+  domain_name = "${data.alicloud_dns_domains.domains.domains.0.domain_name}"
   is_locked = false
 }`
 
 const testAccCheckAlicloudDnsRecordsDataSourceLineConfig = `
+data "alicloud_dns_domains" "domains" {}
+
 data "alicloud_dns_records" "record" {
-  domain_name = "heguimin.top"
+  domain_name = "${data.alicloud_dns_domains.domains.domains.0.domain_name}"
   line = "default"
 }`

--- a/alicloud/diff_suppress_funcs.go
+++ b/alicloud/diff_suppress_funcs.go
@@ -1,6 +1,7 @@
 package alicloud
 
 import (
+	"github.com/denverdino/aliyungo/dns"
 	"github.com/denverdino/aliyungo/slb"
 	"github.com/hashicorp/terraform/helper/schema"
 )
@@ -70,6 +71,13 @@ func httpHttpsTcpDiffSuppressFunc(k, old, new string, d *schema.ResourceData) bo
 }
 func sslCertificateIdDiffSuppressFunc(k, old, new string, d *schema.ResourceData) bool {
 	if protocol, ok := d.GetOk("protocol"); ok && Protocol(protocol.(string)) == Https {
+		return false
+	}
+	return true
+}
+
+func dnsPriorityDiffSuppressFunc(k, old, new string, d *schema.ResourceData) bool {
+	if recordType, ok := d.GetOk("type"); ok && recordType.(string) == dns.MXRecord {
 		return false
 	}
 	return true

--- a/alicloud/resource_alicloud_db_instance.go
+++ b/alicloud/resource_alicloud_db_instance.go
@@ -33,10 +33,10 @@ func resourceAlicloudDBInstance() *schema.Resource {
 				Required:     true,
 			},
 			"engine_version": &schema.Schema{
-				Type: schema.TypeString,
-				//ValidateFunc: validateAllowedStringValue([]string{"5.5", "5.6", "5.7", "2008r2", "2012", "9.4", "9.3"}),
-				ForceNew: true,
-				Required: true,
+				Type:         schema.TypeString,
+				ValidateFunc: validateAllowedStringValue([]string{"5.5", "5.6", "5.7", "2008r2", "2012", "9.4", "9.3"}),
+				ForceNew:     true,
+				Required:     true,
 			},
 			"db_instance_class": &schema.Schema{
 				Type:     schema.TypeString,

--- a/alicloud/resource_alicloud_dns_record_test.go
+++ b/alicloud/resource_alicloud_dns_record_test.go
@@ -31,10 +31,6 @@ func TestAccAlicloudDnsRecord_basic(t *testing.T) {
 						"alicloud_dns_record.record", &v),
 					resource.TestCheckResourceAttr(
 						"alicloud_dns_record.record",
-						"name",
-						"heguimin.top"),
-					resource.TestCheckResourceAttr(
-						"alicloud_dns_record.record",
 						"type",
 						"CNAME"),
 				),
@@ -73,6 +69,36 @@ func testAccCheckDnsRecordExists(n string, record *dns.RecordTypeNew) resource.T
 	}
 }
 
+func TestAccAlicloudDnsRecord_priority(t *testing.T) {
+	var v dns.RecordTypeNew
+
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+		},
+
+		// module name
+		IDRefreshName: "alicloud_dns_record.record",
+
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckDnsRecordDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccDnsRecordPriority,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckDnsRecordExists(
+						"alicloud_dns_record.record", &v),
+					resource.TestCheckResourceAttr(
+						"alicloud_dns_record.record", "type", "MX"),
+					resource.TestCheckResourceAttr(
+						"alicloud_dns_record.record", "priority", "10"),
+				),
+			},
+		},
+	})
+
+}
+
 func testAccCheckDnsRecordDestroy(s *terraform.State) error {
 
 	for _, rs := range s.RootModule().Resources {
@@ -99,11 +125,25 @@ func testAccCheckDnsRecordDestroy(s *terraform.State) error {
 }
 
 const testAccDnsRecordConfig = `
+data "alicloud_dns_domains" "domains" {}
+
 resource "alicloud_dns_record" "record" {
-  name = "heguimin.top"
-  host_record = "alimailskajdh"
+  name = "${data.alicloud_dns_domains.domains.domains.0.domain_name}"
+  host_record = "alimail"
   type = "CNAME"
   value = "mail.mxhichin.com"
   count = 1
+}
+`
+const testAccDnsRecordPriority = `
+data "alicloud_dns_domains" "domains" {}
+
+resource "alicloud_dns_record" "record" {
+  name = "${data.alicloud_dns_domains.domains.domains.0.domain_name}"
+  host_record = "alipriority"
+  type = "MX"
+  value = "www.aliyun.com"
+  count = 1
+  priority = 10
 }
 `

--- a/alicloud/resource_alicloud_ess_scalinggroup.go
+++ b/alicloud/resource_alicloud_ess_scalinggroup.go
@@ -197,7 +197,7 @@ func buildAlicloudEssScalingGroupArgs(d *schema.ResourceData, meta interface{}) 
 	lbs, ok := d.GetOk("loadbalancer_ids")
 	if ok {
 		lbsStrings := lbs.([]interface{})
-		args.LoadBalancerId = strings.Join(expandStringList(lbsStrings), COMMA_SEPARATED)
+		args.LoadBalancerIds = strings.Join(expandStringList(lbsStrings), COMMA_SEPARATED)
 	}
 
 	return args, nil

--- a/alicloud/resource_alicloud_ess_scalinggroup.go
+++ b/alicloud/resource_alicloud_ess_scalinggroup.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"github.com/denverdino/aliyungo/ess"
 	"github.com/hashicorp/terraform/helper/schema"
-	"strings"
 )
 
 func resourceAlicloudEssScalingGroup() *schema.Resource {
@@ -196,8 +195,8 @@ func buildAlicloudEssScalingGroupArgs(d *schema.ResourceData, meta interface{}) 
 
 	lbs, ok := d.GetOk("loadbalancer_ids")
 	if ok {
-		lbsStrings := lbs.([]interface{})
-		args.LoadBalancerIds = strings.Join(expandStringList(lbsStrings), COMMA_SEPARATED)
+		//lbsStrings := lbs.([]interface{})
+		args.LoadBalancerIds = convertListToJsonString(lbs.([]interface{}))
 	}
 
 	return args, nil

--- a/alicloud/resource_alicloud_ess_scalinggroup_test.go
+++ b/alicloud/resource_alicloud_ess_scalinggroup_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"github.com/denverdino/aliyungo/common"
 	"github.com/denverdino/aliyungo/ess"
+	"github.com/denverdino/aliyungo/slb"
 	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/terraform"
 	"log"
@@ -30,27 +31,17 @@ func TestAccAlicloudEssScalingGroup_basic(t *testing.T) {
 					testAccCheckEssScalingGroupExists(
 						"alicloud_ess_scaling_group.foo", &sg),
 					resource.TestCheckResourceAttr(
-						"alicloud_ess_scaling_group.foo",
-						"min_size",
-						"1"),
+						"alicloud_ess_scaling_group.foo", "min_size", "1"),
 					resource.TestCheckResourceAttr(
-						"alicloud_ess_scaling_group.foo",
-						"max_size",
-						"1"),
+						"alicloud_ess_scaling_group.foo", "max_size", "1"),
 					resource.TestCheckResourceAttr(
-						"alicloud_ess_scaling_group.foo",
-						"scaling_group_name",
-						"foo"),
+						"alicloud_ess_scaling_group.foo", "scaling_group_name", "sg-for-test-config"),
 					resource.TestCheckResourceAttr(
-						"alicloud_ess_scaling_group.foo",
-						"removal_policies.#",
-						"2",
-					),
+						"alicloud_ess_scaling_group.foo", "removal_policies.#", "2"),
 				),
 			},
 		},
 	})
-
 }
 
 func TestAccAlicloudEssScalingGroup_update(t *testing.T) {
@@ -73,22 +64,13 @@ func TestAccAlicloudEssScalingGroup_update(t *testing.T) {
 					testAccCheckEssScalingGroupExists(
 						"alicloud_ess_scaling_group.foo", &sg),
 					resource.TestCheckResourceAttr(
-						"alicloud_ess_scaling_group.foo",
-						"min_size",
-						"1"),
+						"alicloud_ess_scaling_group.foo", "min_size", "1"),
 					resource.TestCheckResourceAttr(
-						"alicloud_ess_scaling_group.foo",
-						"max_size",
-						"1"),
+						"alicloud_ess_scaling_group.foo", "max_size", "1"),
 					resource.TestCheckResourceAttr(
-						"alicloud_ess_scaling_group.foo",
-						"scaling_group_name",
-						"foo"),
+						"alicloud_ess_scaling_group.foo", "scaling_group_name", "sg-for-test"),
 					resource.TestCheckResourceAttr(
-						"alicloud_ess_scaling_group.foo",
-						"removal_policies.#",
-						"2",
-					),
+						"alicloud_ess_scaling_group.foo", "removal_policies.#", "2"),
 				),
 			},
 
@@ -98,22 +80,13 @@ func TestAccAlicloudEssScalingGroup_update(t *testing.T) {
 					testAccCheckEssScalingGroupExists(
 						"alicloud_ess_scaling_group.foo", &sg),
 					resource.TestCheckResourceAttr(
-						"alicloud_ess_scaling_group.foo",
-						"min_size",
-						"2"),
+						"alicloud_ess_scaling_group.foo", "min_size", "2"),
 					resource.TestCheckResourceAttr(
-						"alicloud_ess_scaling_group.foo",
-						"max_size",
-						"2"),
+						"alicloud_ess_scaling_group.foo", "max_size", "2"),
 					resource.TestCheckResourceAttr(
-						"alicloud_ess_scaling_group.foo",
-						"scaling_group_name",
-						"update"),
+						"alicloud_ess_scaling_group.foo", "scaling_group_name", "update"),
 					resource.TestCheckResourceAttr(
-						"alicloud_ess_scaling_group.foo",
-						"removal_policies.#",
-						"1",
-					),
+						"alicloud_ess_scaling_group.foo", "removal_policies.#", "1"),
 				),
 			},
 		},
@@ -121,7 +94,7 @@ func TestAccAlicloudEssScalingGroup_update(t *testing.T) {
 
 }
 
-func SkipTestAccAlicloudEssScalingGroup_vpc(t *testing.T) {
+func TestAccAlicloudEssScalingGroup_vpc(t *testing.T) {
 	var sg ess.ScalingGroupItemType
 
 	resource.Test(t, resource.TestCase{
@@ -141,22 +114,48 @@ func SkipTestAccAlicloudEssScalingGroup_vpc(t *testing.T) {
 					testAccCheckEssScalingGroupExists(
 						"alicloud_ess_scaling_group.foo", &sg),
 					resource.TestCheckResourceAttr(
-						"alicloud_ess_scaling_group.foo",
-						"min_size",
-						"1"),
+						"alicloud_ess_scaling_group.foo", "min_size", "1"),
 					resource.TestCheckResourceAttr(
-						"alicloud_ess_scaling_group.foo",
-						"max_size",
-						"1"),
+						"alicloud_ess_scaling_group.foo", "max_size", "1"),
 					resource.TestCheckResourceAttr(
-						"alicloud_ess_scaling_group.foo",
-						"scaling_group_name",
-						"foo"),
+						"alicloud_ess_scaling_group.foo", "scaling_group_name", "sg-for-test-vpc"),
 					resource.TestCheckResourceAttr(
-						"alicloud_ess_scaling_group.foo",
-						"removal_policies.#",
-						"2",
-					),
+						"alicloud_ess_scaling_group.foo", "removal_policies.#", "2"),
+				),
+			},
+		},
+	})
+
+}
+
+func TestAccAlicloudEssScalingGroup_slb(t *testing.T) {
+	var sg ess.ScalingGroupItemType
+	var slb slb.LoadBalancerType
+
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+		},
+
+		// module name
+		IDRefreshName: "alicloud_ess_scaling_group.scaling",
+
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckEssScalingGroupDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccEssScalingGroup_slb,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckEssScalingGroupExists(
+						"alicloud_ess_scaling_group.scaling", &sg),
+					testAccCheckSlbExists(
+						"alicloud_slb.instance.0", &slb),
+					testAccCheckSlbExists(
+						"alicloud_slb.instance.1", &slb),
+					resource.TestCheckResourceAttr(
+						"alicloud_ess_scaling_group.scaling", "min_size", "1"),
+					resource.TestCheckResourceAttr(
+						"alicloud_ess_scaling_group.scaling", "max_size", "1"),
 				),
 			},
 		},
@@ -224,7 +223,7 @@ const testAccEssScalingGroupConfig = `
 resource "alicloud_ess_scaling_group" "foo" {
 	min_size = 1
 	max_size = 1
-	scaling_group_name = "foo"
+	scaling_group_name = "sg-for-test-config"
 	removal_policies = ["OldestInstance", "NewestInstance"]
 }
 `
@@ -233,7 +232,7 @@ const testAccEssScalingGroup = `
 resource "alicloud_ess_scaling_group" "foo" {
 	min_size = 1
 	max_size = 1
-	scaling_group_name = "foo"
+	scaling_group_name = "sg-for-test"
 	removal_policies = ["OldestInstance", "NewestInstance"]
 }
 `
@@ -276,7 +275,7 @@ resource "alicloud_security_group" "tf_test_foo" {
 resource "alicloud_ess_scaling_group" "foo" {
 	min_size = 1
 	max_size = 1
-	scaling_group_name = "foo"
+	scaling_group_name = "sg-for-test-vpc"
 	default_cooldown = 20
 	vswitch_id = "${alicloud_vswitch.foo.id}"
 	removal_policies = ["OldestInstance", "NewestInstance"]
@@ -285,12 +284,75 @@ resource "alicloud_ess_scaling_group" "foo" {
 resource "alicloud_ess_scaling_configuration" "foo" {
 	scaling_group_id = "${alicloud_ess_scaling_group.foo.id}"
 	enable = true
-
+	active = true
 	image_id = "${data.alicloud_images.ecs_image.images.0.id}"
 	instance_type = "ecs.n4.large"
 	system_disk_category = "cloud_efficiency"
 	internet_charge_type = "PayByTraffic"
 	internet_max_bandwidth_out = 10
 	security_group_id = "${alicloud_security_group.tf_test_foo.id}"
+	force_delete = "true"
+}
+`
+
+const testAccEssScalingGroup_slb = `
+data "alicloud_images" "ecs_image" {
+  most_recent = true
+  name_regex =  "^centos_6\\w{1,5}[64].*"
+}
+// Zones data source for availability_zone
+data "alicloud_zones" "default" {
+  available_resource_creation = "VSwitch"
+}
+
+// If there is not specifying vpc_id, the module will launch a new vpc
+resource "alicloud_vpc" "vpc" {
+  cidr_block = "172.16.0.0/12"
+}
+
+// According to the vswitch cidr blocks to launch several vswitches
+resource "alicloud_vswitch" "vswitch" {
+  vpc_id = "${alicloud_vpc.vpc.id}"
+  cidr_block = "172.16.0.0/16"
+  availability_zone = "${data.alicloud_zones.default.zones.0.id}"
+}
+
+resource "alicloud_security_group" "sg" {
+  vpc_id = "${alicloud_vpc.vpc.id}"
+}
+
+resource "alicloud_ess_scaling_group" "scaling" {
+  min_size = "1"
+  max_size = "1"
+  scaling_group_name = "sg-for-test-slb"
+  removal_policies = ["OldestInstance", "NewestInstance"]
+  vswitch_id = "${alicloud_vswitch.vswitch.id}"
+  loadbalancer_ids = ["${alicloud_slb.instance.0.id}","${alicloud_slb.instance.1.id}"]
+}
+
+resource "alicloud_ess_scaling_configuration" "config" {
+  scaling_group_id = "${alicloud_ess_scaling_group.scaling.id}"
+  active = true
+  enable = true
+  image_id = "${data.alicloud_images.ecs_image.images.0.id}"
+  instance_type = "ecs.n4.small"
+  security_group_id = "${alicloud_security_group.sg.id}"
+  force_delete = "true"
+}
+
+resource "alicloud_slb" "instance" {
+  count=2
+  name = "slb-for-ess"
+  internet_charge_type = "paybytraffic"
+  internet = false
+}
+resource "alicloud_slb_listener" "tcp" {
+  count = 2
+  load_balancer_id = "${element(alicloud_slb.instance.*.id, count.index)}"
+  backend_port = "22"
+  frontend_port = "22"
+  protocol = "tcp"
+  bandwidth = "10"
+  health_check_type = "tcp"
 }
 `

--- a/alicloud/resource_alicloud_security_group_rule.go
+++ b/alicloud/resource_alicloud_security_group_rule.go
@@ -165,11 +165,11 @@ func resourceAliyunSecurityGroupRuleRead(d *schema.ResourceData, meta interface{
 
 	rule, err := client.DescribeSecurityGroupRule(sgId, direction, parts[2], parts[3], parts[4], parts[5], policy, priority)
 	if err != nil {
-		if NotFoundError(err) {
+		if IsExceptedError(err, InvalidSecurityGroupIdNotFound) {
 			d.SetId("")
 			return nil
 		}
-		return fmt.Errorf("Error SecurityGroup rule: %#v", err)
+		return fmt.Errorf("Error describing security group rule: %#v", err)
 	}
 
 	d.Set("type", rule.Direction)
@@ -245,7 +245,7 @@ func resourceAliyunSecurityGroupRuleDelete(d *schema.ResourceData, meta interfac
 
 		_, err = client.DescribeSecurityGroupRule(parts[0], parts[1], parts[2], parts[3], parts[4], parts[5], policy, priority)
 		if err != nil {
-			if NotFoundError(err) {
+			if IsExceptedError(err, InvalidSecurityGroupIdNotFound) {
 				return nil
 			}
 			return resource.NonRetryableError(err)

--- a/alicloud/resource_alicloud_vroute_entry.go
+++ b/alicloud/resource_alicloud_vroute_entry.go
@@ -78,7 +78,6 @@ func resourceAliyunRouteEntryCreate(d *schema.ResourceData, meta interface{}) er
 		if err != nil {
 			return resource.NonRetryableError(fmt.Errorf("Building CreateRouteEntryArgs got an error: %#v", err))
 		}
-		//args.ClientToken = fmt.Sprintf("%s-%d", args.ClientToken, timeNow)
 
 		if err := conn.CreateRouteEntry(args); err != nil {
 			// Route Entry does not support concurrence when creating or deleting it;

--- a/vendor/github.com/denverdino/aliyungo/dns/AddDomainRecord.go
+++ b/vendor/github.com/denverdino/aliyungo/dns/AddDomainRecord.go
@@ -14,7 +14,7 @@ type AddDomainRecordArgs struct {
 
 	//optional
 	TTL      int32
-	Priority int
+	Priority int32
 	Line     string
 }
 

--- a/vendor/github.com/denverdino/aliyungo/dns/DescribeDomainRecordInfoNew.go
+++ b/vendor/github.com/denverdino/aliyungo/dns/DescribeDomainRecordInfoNew.go
@@ -10,7 +10,7 @@ type RecordTypeNew struct {
 	Type       string
 	Value      string
 	TTL        float64
-	Priority   string
+	Priority   int32
 	Line       string
 	Status     string
 	Locked     bool

--- a/vendor/github.com/denverdino/aliyungo/ess/group.go
+++ b/vendor/github.com/denverdino/aliyungo/ess/group.go
@@ -16,7 +16,7 @@ const (
 type CreateScalingGroupArgs struct {
 	RegionId         common.Region
 	ScalingGroupName string
-	LoadBalancerId   string
+	LoadBalancerIds   string
 	VpcId            string
 	VSwitchId        string
 	// NOTE: Set MinSize, MaxSize and DefaultCooldown type to int pointer to distinguish zero value from unset value.

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -235,68 +235,68 @@
 		{
 			"checksumSHA1": "9JK6TQ6tSG68roB1KWs3NIxw6zY=",
 			"path": "github.com/denverdino/aliyungo/cdn",
-			"revision": "d7c7e038ca2b9ffd3c2b5525d9eae4a31b0704c7",
-			"revisionTime": "2017-12-07T06:26:40Z"
+			"revision": "4bae75444be7f963b8e8b707611f552c9352d098",
+			"revisionTime": "2017-12-13T12:38:21Z"
 		},
 		{
 			"checksumSHA1": "qvFutFkayxTxJN3E1AENo4kHEzA=",
 			"path": "github.com/denverdino/aliyungo/common",
-			"revision": "d7c7e038ca2b9ffd3c2b5525d9eae4a31b0704c7",
-			"revisionTime": "2017-12-07T06:26:40Z"
+			"revision": "4bae75444be7f963b8e8b707611f552c9352d098",
+			"revisionTime": "2017-12-13T12:38:21Z"
 		},
 		{
 			"checksumSHA1": "iINyIl3tdnJ1149OjjDIYM8o7gk=",
 			"path": "github.com/denverdino/aliyungo/cs",
-			"revision": "d7c7e038ca2b9ffd3c2b5525d9eae4a31b0704c7",
-			"revisionTime": "2017-12-07T06:26:40Z"
+			"revision": "4bae75444be7f963b8e8b707611f552c9352d098",
+			"revisionTime": "2017-12-13T12:38:21Z"
 		},
 		{
-			"checksumSHA1": "zHBzMaiaG1TbhrU15Wp/7Rbl4ZY=",
+			"checksumSHA1": "r3LvtjLkVZzM8X1HKSOznMs2FSA=",
 			"path": "github.com/denverdino/aliyungo/dns",
-			"revision": "d7c7e038ca2b9ffd3c2b5525d9eae4a31b0704c7",
-			"revisionTime": "2017-12-07T06:26:40Z"
+			"revision": "4bae75444be7f963b8e8b707611f552c9352d098",
+			"revisionTime": "2017-12-13T12:38:21Z"
 		},
 		{
 			"checksumSHA1": "dRCnl3Jccqs69IUO8s90ZUez/Vc=",
 			"path": "github.com/denverdino/aliyungo/ecs",
-			"revision": "d7c7e038ca2b9ffd3c2b5525d9eae4a31b0704c7",
-			"revisionTime": "2017-12-07T06:26:40Z"
+			"revision": "4bae75444be7f963b8e8b707611f552c9352d098",
+			"revisionTime": "2017-12-13T12:38:21Z"
 		},
 		{
-			"checksumSHA1": "0qcm0qCFWDyeYjG+y596rgwEcQ4=",
+			"checksumSHA1": "VH9KnFDd2UcZcldPHlOmMM8kNJ4=",
 			"path": "github.com/denverdino/aliyungo/ess",
-			"revision": "d7c7e038ca2b9ffd3c2b5525d9eae4a31b0704c7",
-			"revisionTime": "2017-12-07T06:26:40Z"
+			"revision": "4bae75444be7f963b8e8b707611f552c9352d098",
+			"revisionTime": "2017-12-13T12:38:21Z"
 		},
 		{
 			"checksumSHA1": "CPuR3s7LzQkT57Z20zMHXQM2MYQ=",
 			"path": "github.com/denverdino/aliyungo/location",
-			"revision": "d7c7e038ca2b9ffd3c2b5525d9eae4a31b0704c7",
-			"revisionTime": "2017-12-07T06:26:40Z"
+			"revision": "4bae75444be7f963b8e8b707611f552c9352d098",
+			"revisionTime": "2017-12-13T12:38:21Z"
 		},
 		{
 			"checksumSHA1": "sievsBvgtVF2iZ2FjmDZppH3+Ro=",
 			"path": "github.com/denverdino/aliyungo/ram",
-			"revision": "d7c7e038ca2b9ffd3c2b5525d9eae4a31b0704c7",
-			"revisionTime": "2017-12-07T06:26:40Z"
+			"revision": "4bae75444be7f963b8e8b707611f552c9352d098",
+			"revisionTime": "2017-12-13T12:38:21Z"
 		},
 		{
 			"checksumSHA1": "5muc4YGlXvIK6BwWNXQppIEcEkg=",
 			"path": "github.com/denverdino/aliyungo/rds",
-			"revision": "d7c7e038ca2b9ffd3c2b5525d9eae4a31b0704c7",
-			"revisionTime": "2017-12-07T06:26:40Z"
+			"revision": "4bae75444be7f963b8e8b707611f552c9352d098",
+			"revisionTime": "2017-12-13T12:38:21Z"
 		},
 		{
 			"checksumSHA1": "lCoboKg3pzrdnhtP+mcu6F48+UY=",
 			"path": "github.com/denverdino/aliyungo/slb",
-			"revision": "d7c7e038ca2b9ffd3c2b5525d9eae4a31b0704c7",
-			"revisionTime": "2017-12-07T06:26:40Z"
+			"revision": "4bae75444be7f963b8e8b707611f552c9352d098",
+			"revisionTime": "2017-12-13T12:38:21Z"
 		},
 		{
 			"checksumSHA1": "cKVBRn7GKT+0IqfGUc/NnKDWzCw=",
 			"path": "github.com/denverdino/aliyungo/util",
-			"revision": "d7c7e038ca2b9ffd3c2b5525d9eae4a31b0704c7",
-			"revisionTime": "2017-12-07T06:26:40Z"
+			"revision": "4bae75444be7f963b8e8b707611f552c9352d098",
+			"revisionTime": "2017-12-13T12:38:21Z"
 		},
 		{
 			"checksumSHA1": "BCv50o5pDkoSG3vYKOSai1Z8p3w=",

--- a/website/docs/r/ess_scaling_group.html.markdown
+++ b/website/docs/r/ess_scaling_group.html.markdown
@@ -41,7 +41,7 @@ The following arguments are supported:
     - The specified RDS instance’s whitelist must have room for more IP addresses.
 * `loadbalancer_ids` - (Optional) If a Server Load Balancer instance is specified in the scaling group, the scaling group automatically attaches its ECS instances to the Server Load Balancer instance.
     - The Server Load Balancer instance must be enabled.
-    - Health check must be enabled for all listener ports configured for the Server Load Balancer instance; otherwise, creation fails.
+    - At least one listener must be configured for each Server Load Balancer and it HealthCheck must be on. Otherwise, creation will failed.
     - The Server Load Balancer instance attached with VPC-type ECS instances cannot be attached to the scaling group.
     - The default weight of an ECS instance attached to the Server Load Balancer instance is 50.
 


### PR DESCRIPTION
The PR fixed ESS attachs SLB failed and security group not found error.

The result of running test cases as follows:

$ TF_ACC=1 go test -v ./alicloud -run=TestAccAlicloudEss -timeout 120m=== RUN   TestAccAlicloudEssScalingGroup_importBasic
--- PASS: TestAccAlicloudEssScalingGroup_importBasic (22.25s)
=== RUN   TestAccAlicloudEssSchedule_importBasic
--- PASS: TestAccAlicloudEssSchedule_importBasic (12.28s)
=== RUN   TestAccAlicloudEssScalingConfiguration_basic
--- PASS: TestAccAlicloudEssScalingConfiguration_basic (30.41s)
=== RUN   TestAccAlicloudEssScalingConfiguration_multiConfig
--- PASS: TestAccAlicloudEssScalingConfiguration_multiConfig (40.18s)
=== RUN   TestAccAlicloudEssScalingConfiguration_active
--- PASS: TestAccAlicloudEssScalingConfiguration_active (25.83s)
=== RUN   TestAccAlicloudEssScalingConfiguration_inactive
--- PASS: TestAccAlicloudEssScalingConfiguration_inactive (25.44s)
=== RUN   TestAccAlicloudEssScalingConfiguration_enable
--- PASS: TestAccAlicloudEssScalingConfiguration_enable (26.08s)
=== RUN   TestAccAlicloudEssScalingConfiguration_disable
--- PASS: TestAccAlicloudEssScalingConfiguration_disable (24.85s)
=== RUN   TestAccAlicloudEssScalingGroup_basic
--- PASS: TestAccAlicloudEssScalingGroup_basic (19.99s)
=== RUN   TestAccAlicloudEssScalingGroup_update
--- PASS: TestAccAlicloudEssScalingGroup_update (23.09s)
=== RUN   TestAccAlicloudEssScalingGroup_vpc
--- PASS: TestAccAlicloudEssScalingGroup_vpc (155.85s)
=== RUN   TestAccAlicloudEssScalingGroup_slb
--- PASS: TestAccAlicloudEssScalingGroup_slb (46.53s)
=== RUN   TestAccAlicloudEssScalingRule_basic
--- PASS: TestAccAlicloudEssScalingRule_basic (12.77s)
=== RUN   TestAccAlicloudEssScalingRule_update
--- PASS: TestAccAlicloudEssScalingRule_update (12.36s)
=== RUN   TestAccAlicloudEssSchedule_basic
--- PASS: TestAccAlicloudEssSchedule_basic (13.12s)
PASS
ok    github.com/alibaba/terraform-provider/alicloud  491.388s

