### PR TITLE
add weight for slb_attachment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,13 +1,14 @@
-## 1.6.0 (Unreleased)
+## 1.6.0 (January 15, 2018)
 
 IMPROVEMENTS:
 
-- *New Resource*: _alicloud_slb_rule_ ([#79](https://github.com/terraform-providers/terraform-provider-alicloud/pull/79))
+- *New Resource*: _alicloud_slb_rule_ ([#80](https://github.com/terraform-providers/terraform-provider-alicloud/pull/80))
 - *New Resource*: _alicloud_slb_rule_ ([#79](https://github.com/terraform-providers/terraform-provider-alicloud/pull/79))
 - *New Resource*: _alicloud_slb_server_group_ ([#78](https://github.com/terraform-providers/terraform-provider-alicloud/pull/78))
 - Support Spot Instance ([#77](https://github.com/terraform-providers/terraform-provider-alicloud/pull/77))
 - Output tip message when international account create SLB failed ([#75](https://github.com/terraform-providers/terraform-provider-alicloud/pull/75))
 - Standardize the order of imports packages ([#74](https://github.com/terraform-providers/terraform-provider-alicloud/pull/74))
+- Add "weight" for slb_attachment to improve the resource ([#81](https://github.com/terraform-providers/terraform-provider-alicloud/pull/81))
 
 BUG FIXES:
 

--- a/alicloud/extension_slb.go
+++ b/alicloud/extension_slb.go
@@ -33,11 +33,11 @@ func (e *ListenerErr) Error() string {
 
 }
 
-func expandBackendServers(list []interface{}) []slb.BackendServerType {
+func expandBackendServers(list []interface{}, weight int) []slb.BackendServerType {
 	result := make([]slb.BackendServerType, 0, len(list))
 	for _, i := range list {
 		if i.(string) != "" {
-			result = append(result, slb.BackendServerType{ServerId: i.(string), Weight: 100})
+			result = append(result, slb.BackendServerType{ServerId: i.(string), Weight: weight})
 		}
 	}
 	return result

--- a/alicloud/import_alicloud_slb_attachment_test.go
+++ b/alicloud/import_alicloud_slb_attachment_test.go
@@ -1,0 +1,28 @@
+package alicloud
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform/helper/resource"
+)
+
+func TestAccAlicloudSlbAttachment_import(t *testing.T) {
+	resourceName := "alicloud_slb_attachment.foo"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckSlbDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccSlbAttachment,
+			},
+
+			resource.TestStep{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}

--- a/alicloud/provider.go
+++ b/alicloud/provider.go
@@ -80,7 +80,7 @@ func Provider() terraform.ResourceProvider {
 			"alicloud_ess_attachment":            resourceAlicloudEssAttachment(),
 			"alicloud_vpc":                       resourceAliyunVpc(),
 			"alicloud_nat_gateway":               resourceAliyunNatGateway(),
-			//both subnet and vswith exists,cause compatible old version, and compatible aws habit.
+			// "alicloud_subnet" aims to match aws usage habit.
 			"alicloud_subnet":              resourceAliyunSubnet(),
 			"alicloud_vswitch":             resourceAliyunSubnet(),
 			"alicloud_route_entry":         resourceAliyunRouteEntry(),

--- a/alicloud/resource_alicloud_slb_attachment.go
+++ b/alicloud/resource_alicloud_slb_attachment.go
@@ -6,7 +6,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/denverdino/aliyungo/slb"
 	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/helper/schema"
 )
@@ -17,10 +16,19 @@ func resourceAliyunSlbAttachment() *schema.Resource {
 		Read:   resourceAliyunSlbAttachmentRead,
 		Update: resourceAliyunSlbAttachmentUpdate,
 		Delete: resourceAliyunSlbAttachmentDelete,
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
 
 		Schema: map[string]*schema.Schema{
 
 			"slb_id": &schema.Schema{
+				Type:       schema.TypeString,
+				Optional:   true,
+				Deprecated: "Field 'instances' has been deprecated from provider version 1.6.0. New field 'load_balancer_id' replaces it.",
+			},
+
+			"load_balancer_id": &schema.Schema{
 				Type:     schema.TypeString,
 				Required: true,
 			},
@@ -28,8 +36,26 @@ func resourceAliyunSlbAttachment() *schema.Resource {
 			"instances": &schema.Schema{
 				Type:     schema.TypeSet,
 				Elem:     &schema.Schema{Type: schema.TypeString},
+				Optional: true,
+				DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
+					return true
+				},
+				Deprecated: "Field 'instances' has been deprecated from provider version 1.6.0. New field 'instance_ids' replaces it.",
+			},
+
+			"instance_ids": &schema.Schema{
+				Type:     schema.TypeSet,
+				Elem:     &schema.Schema{Type: schema.TypeString},
 				Required: true,
-				Set:      schema.HashString,
+				MaxItems: 20,
+				MinItems: 1,
+			},
+
+			"weight": &schema.Schema{
+				Type:         schema.TypeInt,
+				Optional:     true,
+				Default:      100,
+				ValidateFunc: validateIntegerInRange(0, 100),
 			},
 
 			"backend_servers": &schema.Schema{
@@ -43,14 +69,14 @@ func resourceAliyunSlbAttachment() *schema.Resource {
 
 func resourceAliyunSlbAttachmentCreate(d *schema.ResourceData, meta interface{}) error {
 
-	loadBalancer, err := meta.(*AliyunClient).DescribeLoadBalancerAttribute(d.Get("slb_id").(string))
+	loadBalancer, err := meta.(*AliyunClient).DescribeLoadBalancerAttribute(d.Get("load_balancer_id").(string))
 	if err != nil {
 		return err
 	}
 
 	if loadBalancer == nil {
 		d.SetId("")
-		return fmt.Errorf("Special SLB Id %s is not found in %#v.", d.Get("slb_id").(string), getRegion(d, meta))
+		return fmt.Errorf("Specified SLB Id %s is not found in %#v.", d.Get("load_balancer_id").(string), getRegion(d, meta))
 	}
 	d.SetId(loadBalancer.LoadBalancerId)
 
@@ -59,7 +85,7 @@ func resourceAliyunSlbAttachmentCreate(d *schema.ResourceData, meta interface{})
 
 func resourceAliyunSlbAttachmentRead(d *schema.ResourceData, meta interface{}) error {
 
-	loadBalancer, err := meta.(*AliyunClient).DescribeLoadBalancerAttribute(d.Get("slb_id").(string))
+	loadBalancer, err := meta.(*AliyunClient).DescribeLoadBalancerAttribute(d.Id())
 	if err != nil {
 		return err
 	}
@@ -72,7 +98,9 @@ func resourceAliyunSlbAttachmentRead(d *schema.ResourceData, meta interface{}) e
 	backendServerType := loadBalancer.BackendServers
 	servers := backendServerType.BackendServer
 	instanceIds := make([]string, 0, len(servers))
+	var weight int
 	if len(servers) > 0 {
+		weight = servers[0].Weight
 		for _, e := range servers {
 			instanceIds = append(instanceIds, e.ServerId)
 		}
@@ -81,8 +109,9 @@ func resourceAliyunSlbAttachmentRead(d *schema.ResourceData, meta interface{}) e
 		}
 	}
 
-	d.Set("slb_id", d.Id())
-	d.Set("instances", instanceIds)
+	d.Set("load_balancer_id", loadBalancer.LoadBalancerId)
+	d.Set("instance_ids", instanceIds)
+	d.Set("weight", weight)
 	d.Set("backend_servers", strings.Join(instanceIds, ","))
 
 	return nil
@@ -91,12 +120,19 @@ func resourceAliyunSlbAttachmentRead(d *schema.ResourceData, meta interface{}) e
 func resourceAliyunSlbAttachmentUpdate(d *schema.ResourceData, meta interface{}) error {
 
 	slbconn := meta.(*AliyunClient).slbconn
-	if d.HasChange("instances") {
-		o, n := d.GetChange("instances")
+	update := false
+	weight := d.Get("weight").(int)
+
+	if d.HasChange("weight") {
+		update = true
+		d.SetPartial("weight")
+	}
+	if d.HasChange("instance_ids") {
+		o, n := d.GetChange("instance_ids")
 		os := o.(*schema.Set)
 		ns := n.(*schema.Set)
-		remove := expandBackendServers(os.Difference(ns).List())
-		add := expandBackendServers(ns.Difference(os).List())
+		remove := os.Difference(ns).List()
+		add := expandBackendServers(ns.Difference(os).List(), weight)
 
 		if len(add) > 0 {
 			if err := resource.Retry(2*time.Minute, func() *resource.RetryError {
@@ -112,7 +148,28 @@ func resourceAliyunSlbAttachmentUpdate(d *schema.ResourceData, meta interface{})
 				return err
 			}
 		}
-		if err := removeBackendServers(d, meta, remove); err != nil {
+		if len(remove) > 0 {
+			if err := removeBackendServers(d, meta, remove); err != nil {
+				return err
+			}
+		}
+
+		if len(add) < 1 && len(remove) < 1 {
+			update = true
+		}
+		d.SetPartial("instance_ids")
+	}
+
+	if update {
+		if err := resource.Retry(2*time.Minute, func() *resource.RetryError {
+			if _, err := slbconn.SetBackendServers(d.Id(), expandBackendServers(d.Get("instance_ids").(*schema.Set).List(), weight)); err != nil {
+				if IsExceptedError(err, ServiceIsConfiguring) {
+					return resource.RetryableError(fmt.Errorf("Load banalcer sets backend servers timeout and got an error: %#v.", err))
+				}
+				return resource.NonRetryableError(fmt.Errorf("Set backend servers got an error: %#v", err))
+			}
+			return nil
+		}); err != nil {
 			return err
 		}
 	}
@@ -123,27 +180,44 @@ func resourceAliyunSlbAttachmentUpdate(d *schema.ResourceData, meta interface{})
 
 func resourceAliyunSlbAttachmentDelete(d *schema.ResourceData, meta interface{}) error {
 
-	o := d.Get("instances")
-	os := o.(*schema.Set)
-	remove := expandBackendServers(os.List())
-
-	return removeBackendServers(d, meta, remove)
+	return removeBackendServers(d, meta, d.Get("instance_ids").(*schema.Set).List())
 }
 
-func removeBackendServers(d *schema.ResourceData, meta interface{}, servers []slb.BackendServerType) error {
-	slbconn := meta.(*AliyunClient).slbconn
+func removeBackendServers(d *schema.ResourceData, meta interface{}, servers []interface{}) error {
+	client := meta.(*AliyunClient)
+	instanceSet := d.Get("instance_ids").(*schema.Set)
 	if len(servers) > 0 {
-		removeBackendServers := make([]string, 0, len(servers))
-		for _, e := range servers {
-			removeBackendServers = append(removeBackendServers, e.ServerId)
-		}
+
 		return resource.Retry(3*time.Minute, func() *resource.RetryError {
-			_, err := slbconn.RemoveBackendServers(d.Id(), removeBackendServers)
+			_, err := client.slbconn.RemoveBackendServers(d.Id(), convertArrayInterfaceToArrayString(servers))
 			if err != nil {
 				if IsExceptedError(err, BackendServerconfiguring) {
 					return resource.RetryableError(fmt.Errorf("Load balancer removes backend servers timeout and got an error: %#v", err))
 				}
 				return resource.NonRetryableError(fmt.Errorf("Remove backend servers got an error: %#v", err))
+			}
+
+			loadBalancer, err := client.DescribeLoadBalancerAttribute(d.Id())
+			if err != nil {
+				if IsExceptedError(err, LoadBalancerNotFound) {
+					return nil
+				}
+				return resource.NonRetryableError(fmt.Errorf("DescribeLoadBalancerAttribute got an error: %#v", err))
+
+			}
+
+			if loadBalancer == nil {
+				return nil
+			}
+
+			servers := loadBalancer.BackendServers.BackendServer
+
+			if len(servers) > 0 {
+				for _, e := range servers {
+					if instanceSet.Contains(e.ServerId) {
+						return resource.RetryableError(fmt.Errorf("There are still target backend servers in the SLB."))
+					}
+				}
 			}
 			return nil
 		})

--- a/website/alicloud.erb
+++ b/website/alicloud.erb
@@ -106,11 +106,17 @@
                         <li<%= sidebar_current("docs-alicloud-resource-slb") %>>
                             <a href="/docs/providers/alicloud/r/slb.html">alicloud_slb</a>
                         </li>
+                        <li<%= sidebar_current("docs-alicloud-resource-slb-attachment") %>>
+                            <a href="/docs/providers/alicloud/r/slb_attachment.html">alicloud_slb_attachment</a>
+                        </li>
                         <li<%= sidebar_current("docs-alicloud-resource-slb-listener") %>>
                             <a href="/docs/providers/alicloud/r/slb_listener.html">alicloud_slb_listener</a>
                         </li>
-                        <li<%= sidebar_current("docs-alicloud-resource-slb-attachment") %>>
-                            <a href="/docs/providers/alicloud/r/slb_attachment.html">alicloud_slb_attachment</a>
+                        <li<%= sidebar_current("docs-alicloud-resource-slb-rule") %>>
+                            <a href="/docs/providers/alicloud/r/slb_rule.html">alicloud_slb_rule</a>
+                        </li>
+                        <li<%= sidebar_current("docs-alicloud-resource-slb-server-group") %>>
+                            <a href="/docs/providers/alicloud/r/slb_server_group.html">alicloud_slb_server_group</a>
                         </li>
                     </ul>
                 </li>
@@ -169,6 +175,9 @@
                 <li<%= sidebar_current(/^docs-alicloud-resource-ess/) %>>
                     <a href="#">ESS Resources</a>
                     <ul class="nav nav-visible">
+                        <li<%= sidebar_current("docs-alicloud-resource-ess") %>>
+                            <a href="/docs/providers/alicloud/r/ess_attachment.html">alicloud_ess_attachment</a>
+                        </li>
                         <li<%= sidebar_current("docs-alicloud-resource-ess") %>>
                             <a href="/docs/providers/alicloud/r/ess_scaling_group.html">alicloud_ess_scaling_group</a>
                         </li>

--- a/website/docs/r/slb_attachment.html.markdown
+++ b/website/docs/r/slb_attachment.html.markdown
@@ -8,7 +8,7 @@ description: |-
 
 # alicloud\_slb\_attachment
 
-Provides an Application Load Balancer Attachment resource.
+Add a group of backend servers (ECS instance) to the Server Load Balancer or remove them from it.
 
 ## Example Usage
 
@@ -23,7 +23,7 @@ resource "alicloud_instance" "default" {
 }
 
 resource "alicloud_slb_attachment" "default" {
-  slb_id    = "${alicloud_slb.default.id}"
+  load_balancer_id    = "${alicloud_slb.default.id}"
   instances = ["${alicloud_instance.default.id}"]
 }
 ```
@@ -32,11 +32,16 @@ resource "alicloud_slb_attachment" "default" {
 
 The following arguments are supported:
 
-* `slb_id` - (Required) The ID of the SLB..
-* `instances` - (Required) A list of instance ids to added backend server in the SLB. If dettachment instances then this value set [].
-
+* `load_balancer_id` - (Required) ID of the load balancer.
+* `instance_ids` - (Required) A list of instance ids to added backend server in the SLB.
+* `weight` - (Optional) Weight of the instances. Valid value range: [0-100]. Default to 100.
+* `slb_id` - (Deprecated) It has been deprecated from provider version 1.6.0. New field 'load_balancer_id' replaces it.
+* `instances` - (Deprecated) It has been deprecated from provider version 1.6.0. New field 'instance_ids' replaces it.
 ## Attributes Reference
 
 The following attributes are exported:
 
+* `load_balancer_id` - ID of the load balancer.
+* `instance_ids` - A list of instance ids that have been added in the SLB.
+* `weight` - (Optional) Weight of the instances.
 * `backend_servers` - The backend servers of the load balancer.


### PR DESCRIPTION
The PR add a field "weight" for resource alicloud_slb_attachment to improve it.

The running result of test cases as following:

TF_ACC=1 go test ./alicloud -v -run=TestAccAlicloudSlbAttachment -timeout 120m
=== RUN   TestAccAlicloudSlbAttachment_import
--- PASS: TestAccAlicloudSlbAttachment_import (137.53s)
=== RUN   TestAccAlicloudSlbAttachment_basic
--- PASS: TestAccAlicloudSlbAttachment_basic (131.95s)
PASS
ok      github.com/alibaba/terraform-provider/alicloud  269.517s
