### PR TITLE
Avoid needless error when creating security group rule

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,15 @@
+## 1.7.0 (unreleased)
+
+IMPROVEMENTS:
+
+- Avoid needless error when creating security group rule ([#83](https://github.com/terraform-providers/terraform-provider-alicloud/pull/83))
+
+
 ## 1.6.0 (January 15, 2018)
 
 IMPROVEMENTS:
 
-- *New Resource*: _alicloud_slb_rule_ ([#80](https://github.com/terraform-providers/terraform-provider-alicloud/pull/80))
+- *New Resource*: _alicloud_ess_attachment_ ([#80](https://github.com/terraform-providers/terraform-provider-alicloud/pull/80))
 - *New Resource*: _alicloud_slb_rule_ ([#79](https://github.com/terraform-providers/terraform-provider-alicloud/pull/79))
 - *New Resource*: _alicloud_slb_server_group_ ([#78](https://github.com/terraform-providers/terraform-provider-alicloud/pull/78))
 - Support Spot Instance ([#77](https://github.com/terraform-providers/terraform-provider-alicloud/pull/77))

--- a/alicloud/diff_suppress_funcs.go
+++ b/alicloud/diff_suppress_funcs.go
@@ -120,7 +120,7 @@ func ecsPrivateIpDiffSuppressFunc(k, old, new string, d *schema.ResourceData) bo
 	return true
 }
 func ecsInternetDiffSuppressFunc(k, old, new string, d *schema.ResourceData) bool {
-	if allocate, ok := d.GetOk("allocate_public_ip"); ok && allocate.(bool) {
+	if max, ok := d.GetOk("internet_max_bandwidth_out"); ok && max.(int) > 0 {
 		return false
 	}
 	return true
@@ -180,6 +180,14 @@ func ecsSpotStrategyDiffSuppressFunc(k, old, new string, d *schema.ResourceData)
 func ecsSpotPriceLimitDiffSuppressFunc(k, old, new string, d *schema.ResourceData) bool {
 	if common.InstanceChargeType(d.Get("instance_charge_type").(string)) == common.PostPaid &&
 		ecs.SpotStrategyType(d.Get("spot_strategy").(string)) == ecs.SpotWithPriceLimit {
+		return false
+	}
+	return true
+}
+
+func ecsSecurityGroupRulePortRangeDiffSuppressFunc(k, old, new string, d *schema.ResourceData) bool {
+	protocol := ecs.IpProtocol(d.Get("ip_protocol").(string))
+	if protocol == ecs.IpProtocolTCP || protocol == ecs.IpProtocolUDP {
 		return false
 	}
 	return true

--- a/alicloud/extension_ecs.go
+++ b/alicloud/extension_ecs.go
@@ -2,16 +2,6 @@ package alicloud
 
 import "github.com/denverdino/aliyungo/ecs"
 
-type GroupRuleIpProtocol string
-
-const (
-	GroupRuleTcp  = GroupRuleIpProtocol("tcp")
-	GroupRuleUdp  = GroupRuleIpProtocol("udp")
-	GroupRuleIcmp = GroupRuleIpProtocol("icmp")
-	GroupRuleGre  = GroupRuleIpProtocol("gre")
-	GroupRuleAll  = GroupRuleIpProtocol("all")
-)
-
 type GroupRuleNicType string
 
 const (
@@ -47,3 +37,5 @@ var SupportedDiskCategory = map[ecs.DiskCategory]ecs.DiskCategory{
 	ecs.DiskCategoryCloudSSD:        ecs.DiskCategoryCloudSSD,
 	ecs.DiskCategoryCloudEfficiency: ecs.DiskCategoryCloudEfficiency,
 	ecs.DiskCategoryCloud:           ecs.DiskCategoryCloud}
+
+const AllPortRange = "-1/-1"

--- a/alicloud/resource_alicloud_security_group_rule_test.go
+++ b/alicloud/resource_alicloud_security_group_rule_test.go
@@ -300,10 +300,16 @@ func TestAccAlicloudSecurityGroupRule_MultiAttri(t *testing.T) {
 						"alicloud_security_group_rule.ingress_allow_tcp_22_prior", &pt),
 					testAccCheckSecurityGroupRuleExists(
 						"alicloud_security_group_rule.ingress_deny_tcp_22_prior", &pt),
+					testAccCheckSecurityGroupRuleExists(
+						"alicloud_security_group_rule.all", &pt),
 					resource.TestCheckResourceAttr(
 						"alicloud_security_group_rule.ingress_deny_tcp_22_prior",
 						"port_range",
 						"22/22"),
+					resource.TestCheckResourceAttr(
+						"alicloud_security_group_rule.all",
+						"port_range",
+						"-1/-1"),
 				),
 			},
 		},
@@ -623,5 +629,15 @@ resource "alicloud_security_group_rule" "ingress_deny_tcp_22_prior" {
   priority = 100
   security_group_id = "${alicloud_security_group.main.id}"
   cidr_ip = "0.0.0.0/0"
+}
+resource "alicloud_security_group_rule" "all" {
+  type = "ingress"
+  ip_protocol = "all"
+  nic_type = "intranet"
+  policy = "accept"
+  priority = 100
+  security_group_id = "${alicloud_security_group.main.id}"
+  cidr_ip = "0.0.0.0/0"
+  port_range = "22/22"
 }
 `

--- a/alicloud/validators.go
+++ b/alicloud/validators.go
@@ -138,10 +138,11 @@ func validateSecurityRuleType(v interface{}, k string) (ws []string, errors []er
 }
 
 func validateSecurityRuleIpProtocol(v interface{}, k string) (ws []string, errors []error) {
-	pt := GroupRuleIpProtocol(v.(string))
-	if pt != GroupRuleTcp && pt != GroupRuleUdp && pt != GroupRuleIcmp && pt != GroupRuleGre && pt != GroupRuleAll {
+	pt := ecs.IpProtocol(v.(string))
+	if pt != ecs.IpProtocolTCP && pt != ecs.IpProtocolUDP && pt != ecs.IpProtocolICMP &&
+		pt != ecs.IpProtocolGRE && pt != ecs.IpProtocolAll {
 		errors = append(errors, fmt.Errorf("%s must be one of %s, %s, %s, %s and %s", k,
-			GroupRuleTcp, GroupRuleUdp, GroupRuleIcmp, GroupRuleGre, GroupRuleAll))
+			ecs.IpProtocolTCP, ecs.IpProtocolUDP, ecs.IpProtocolICMP, ecs.IpProtocolGRE, ecs.IpProtocolAll))
 	}
 
 	return

--- a/website/docs/r/security_group_rule.html.markdown
+++ b/website/docs/r/security_group_rule.html.markdown
@@ -41,7 +41,8 @@ The following arguments are supported:
 
 * `type` - (Required) The type of rule being created. Valid options are `ingress` (inbound) or `egress` (outbound).
 * `ip_protocol` - (Required) The protocol. Can be `tcp`, `udp`, `icmp`, `gre` or `all`.
-* `port_range` - (Required) The range of port numbers relevant to the IP protocol. When the protocol is tcp or udp, the default port number range is 1-65535. For example, `1/200` means that the range of the port numbers is 1-200.
+* `port_range` - (Required) The range of port numbers relevant to the IP protocol. When the protocol is tcp or udp, the default port number range is 1-65535.
+  For example, `1/200` means that the range of the port numbers is 1-200. Other protocols' 'port_range' only is "-1/-1", and other values will be ignored.
 * `security_group_id` - (Required) The security group to apply this rule to.
 * `nic_type` - (Optional, Forces new resource) Network type, can be either `internet` or `intranet`, the default value is `internet`.
 * `policy` - (Optional, Forces new resource) Authorization policy, can be either `accept` or `drop`, the default value is `accept`.


### PR DESCRIPTION
The PR improves resource alicloud_secuity_group_rule to avoid needless error when creating security group rule.

The result of running test cases as follows:

TF_ACC=1 go test ./alicloud -v -run=TestAccAlicloudSecurityGroupRule -timeout 120m
=== RUN   TestAccAlicloudSecurityGroupRule_Ingress
--- PASS: TestAccAlicloudSecurityGroupRule_Ingress (18.25s)
=== RUN   TestAccAlicloudSecurityGroupRule_Egress
--- PASS: TestAccAlicloudSecurityGroupRule_Egress (18.50s)
=== RUN   TestAccAlicloudSecurityGroupRule_EgressDefaultNicType
--- PASS: TestAccAlicloudSecurityGroupRule_EgressDefaultNicType (17.78s)
=== RUN   TestAccAlicloudSecurityGroupRule_Vpc_Ingress
--- PASS: TestAccAlicloudSecurityGroupRule_Vpc_Ingress (25.76s)
=== RUN   TestAccAlicloudSecurityGroupRule_MissParameterSourceCidrIp
--- PASS: TestAccAlicloudSecurityGroupRule_MissParameterSourceCidrIp (17.58s)
=== RUN   TestAccAlicloudSecurityGroupRule_SourceSecurityGroup
--- PASS: TestAccAlicloudSecurityGroupRule_SourceSecurityGroup (18.93s)
=== RUN   TestAccAlicloudSecurityGroupRule_Multi
--- PASS: TestAccAlicloudSecurityGroupRule_Multi (45.67s)
=== RUN   TestAccAlicloudSecurityGroupRule_MultiAttri
--- PASS: TestAccAlicloudSecurityGroupRule_MultiAttri (28.75s)
PASS
ok      github.com/alibaba/terraform-provider/alicloud  191.254s

