### PR TITLE
fix deleting slb_attachment resource failed bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 1.6.2 (Unreleased)
+
+BUG FIXES:
+
+- fix deleting slb_attachment resource failed bug ([#86](https://github.com/terraform-providers/terraform-provider-alicloud/pull/86))
+
+
 ## 1.6.1 (January 18, 2018)
 
 IMPROVEMENTS:

--- a/alicloud/errors.go
+++ b/alicloud/errors.go
@@ -32,6 +32,7 @@ const (
 	ListenerNotFound            = "The specified resource does not exist"
 	ListenerAlreadyExists       = "ListenerAlreadyExists"
 	ServiceIsConfiguring        = "ServiceIsConfiguring"
+	ServiceIsStopping           = "ServiceIsStopping"
 	BackendServerconfiguring    = "BackendServer.configuring"
 	SystemBusy                  = "SystemBusy"
 	SlbOrderFailed              = "OrderFailed"

--- a/alicloud/resource_alicloud_slb_attachment.go
+++ b/alicloud/resource_alicloud_slb_attachment.go
@@ -195,7 +195,7 @@ func removeBackendServers(d *schema.ResourceData, meta interface{}, servers []in
 		return resource.Retry(3*time.Minute, func() *resource.RetryError {
 			_, err := client.slbconn.RemoveBackendServers(d.Id(), convertArrayInterfaceToArrayString(servers))
 			if err != nil {
-				if IsExceptedError(err, BackendServerconfiguring) {
+				if IsExceptedError(err, BackendServerconfiguring) || IsExceptedError(err, ServiceIsStopping) {
 					return resource.RetryableError(fmt.Errorf("Load balancer removes backend servers timeout and got an error: %#v", err))
 				}
 				return resource.NonRetryableError(fmt.Errorf("Remove backend servers got an error: %#v", err))


### PR DESCRIPTION
The PR fixes a bug that deleting slb_attachment resource failed results from slb is stopping.

The result of running test case as follows:

TF_ACC=1 go test ./alicloud -v -run=TestAccAlicloudSlbAttachment -timeout 120m
=== RUN   TestAccAlicloudSlbAttachment_import
--- PASS: TestAccAlicloudSlbAttachment_import (137.44s)
=== RUN   TestAccAlicloudSlbAttachment_basic
--- PASS: TestAccAlicloudSlbAttachment_basic (144.63s)
PASS
ok      github.com/alibaba/terraform-provider/alicloud  282.103s
