### PR TITLE
fix several bugs about db result from its status and id not found

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 IMPROVEMENTS:
 
+- Avoid container cluster cidr block conflicts with vswitch's ([#88](https://github.com/terraform-providers/terraform-provider-alicloud/pull/88))
 - Output resource import information ([#87](https://github.com/terraform-providers/terraform-provider-alicloud/pull/87))
 
 BUG FIXES:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 IMPROVEMENTS:
 
+- Support to set instnace name for RDS ([#89](https://github.com/terraform-providers/terraform-provider-alicloud/pull/89))
 - Avoid container cluster cidr block conflicts with vswitch's ([#88](https://github.com/terraform-providers/terraform-provider-alicloud/pull/88))
 - Output resource import information ([#87](https://github.com/terraform-providers/terraform-provider-alicloud/pull/87))
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,13 +1,14 @@
-## 1.6.2 (Unreleased)
+## 1.6.2 (January 22, 2018)
 
 IMPROVEMENTS:
 
-- Support to set instnace name for RDS ([#89](https://github.com/terraform-providers/terraform-provider-alicloud/pull/89))
+- Support to set instnace name for RDS ([#88](https://github.com/terraform-providers/terraform-provider-alicloud/pull/88))
 - Avoid container cluster cidr block conflicts with vswitch's ([#88](https://github.com/terraform-providers/terraform-provider-alicloud/pull/88))
 - Output resource import information ([#87](https://github.com/terraform-providers/terraform-provider-alicloud/pull/87))
 
 BUG FIXES:
 
+- fix several bugs about db result from its status and id not found ([#89](https://github.com/terraform-providers/terraform-provider-alicloud/pull/89))
 - fix deleting slb_attachment resource failed bug ([#86](https://github.com/terraform-providers/terraform-provider-alicloud/pull/86))
 
 

--- a/alicloud/common.go
+++ b/alicloud/common.go
@@ -157,3 +157,5 @@ func userDataHashSum(user_data string) string {
 	}
 	return string(v)
 }
+
+const DBConnectionSuffix = ".mysql.rds.aliyuncs.com"

--- a/alicloud/diff_suppress_funcs.go
+++ b/alicloud/diff_suppress_funcs.go
@@ -143,8 +143,6 @@ func ecsChargeTypeSuppressFunc(k, old, new string, d *schema.ResourceData) bool 
 func zoneIdDiffSuppressFunc(k, old, new string, d *schema.ResourceData) bool {
 	if vsw, ok := d.GetOk("vswitch_id"); ok && vsw.(string) != "" {
 		return true
-	} else if vsw, ok := d.GetOk("subnet_id"); ok && vsw.(string) != "" {
-		return true
 	} else if multi, ok := d.GetOk("multi_az"); ok && multi.(bool) {
 		return true
 	}

--- a/alicloud/errors.go
+++ b/alicloud/errors.go
@@ -71,6 +71,7 @@ const (
 	ScalingActivityInProgress                   = "ScalingActivityInProgress"
 
 	// rds
+	InvalidDBInstanceIdNotFound            = "InvalidDBInstanceId.NotFound"
 	InvalidDBNameNotFound                  = "InvalidDBName.NotFound"
 	InvalidDBInstanceNameNotFound          = "InvalidDBInstanceName.NotFound"
 	InvalidCurrentConnectionStringNotFound = "InvalidCurrentConnectionString.NotFound"
@@ -80,6 +81,9 @@ const (
 	OperationDeniedDBInstanceStatus        = "OperationDenied.DBInstanceStatus"
 	InvalidConnectionStringDuplicate       = "InvalidConnectionString.Duplicate"
 	AtLeastOneNetTypeExists                = "AtLeastOneNetTypeExists"
+	ConnectionOperationDenied              = "OperationDenied"
+	ConnectionConflictMessage              = "The requested resource is sold out in the specified zone; try other types of resources or other regions and zones"
+	DBInternalError                        = "InternalError"
 	// oss
 	OssBucketNotFound = "NoSuchBucket"
 	OssBodyNotFound   = "404 Not Found"

--- a/alicloud/resource_alicloud_container_cluster.go
+++ b/alicloud/resource_alicloud_container_cluster.go
@@ -126,7 +126,6 @@ func resourceAlicloudContainerClusterCreate(d *schema.ResourceData, meta interfa
 		}
 		args.NetworkMode = cs.VPCNetwork
 		args.VSwitchID = v.(string)
-		args.SubnetCIDR = cidr.(string)
 
 		vswInfo, _, err := client.vpcconn.DescribeVSwitches(&ecs.DescribeVSwitchesArgs{
 			RegionId:  getRegion(d, meta),
@@ -138,6 +137,11 @@ func resourceAlicloudContainerClusterCreate(d *schema.ResourceData, meta interfa
 		if len(vswInfo) < 1 {
 			return fmt.Errorf("There is not found specified vswitch: %s, please check and try again.", v.(string))
 		}
+		if vswInfo[0].CidrBlock == cidr.(string) {
+			return fmt.Errorf("Container cluster's cidr_block only accepts 192.168.X.0/24 or 172.18.X.0/24 ~ 172.31.X.0/24. " +
+				"And it cannot be equal to vswitch's cidr_block and sub cidr block.")
+		}
+		args.SubnetCIDR = cidr.(string)
 		args.VPCID = vswInfo[0].VpcId
 	} else {
 		args.NetworkMode = cs.ClassicNetwork

--- a/alicloud/resource_alicloud_db_account_privilege_test.go
+++ b/alicloud/resource_alicloud_db_account_privilege_test.go
@@ -81,8 +81,8 @@ func testAccCheckDBAccountPrivilegeDestroy(s *terraform.State) error {
 
 		// Verify the error is what we want
 		if err != nil {
-			if NotFoundError(err) || IsExceptedError(err, InvalidAccountNameNotFound) {
-				continue
+			if NotFoundError(err) || IsExceptedError(err, InvalidDBInstanceIdNotFound) || IsExceptedError(err, InvalidAccountNameNotFound) {
+				return nil
 			}
 			return err
 		}

--- a/alicloud/resource_alicloud_db_account_test.go
+++ b/alicloud/resource_alicloud_db_account_test.go
@@ -29,7 +29,7 @@ func TestAccAlicloudDBAccount_basic(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckDBAccountExists(
 						"alicloud_db_account.account", &account),
-					resource.TestCheckResourceAttr("alicloud_db_instance.account", "name", "tf_db"),
+					resource.TestCheckResourceAttr("alicloud_db_account.account", "name", "tf_db"),
 				),
 			},
 		},
@@ -79,8 +79,8 @@ func testAccCheckDBAccountDestroy(s *terraform.State) error {
 
 		// Verify the error is what we want
 		if err != nil {
-			if NotFoundError(err) || IsExceptedError(err, InvalidAccountNameNotFound) {
-				continue
+			if NotFoundError(err) || IsExceptedError(err, InvalidDBInstanceIdNotFound) || IsExceptedError(err, InvalidAccountNameNotFound) {
+				return nil
 			}
 			return err
 		}

--- a/alicloud/resource_alicloud_db_backup_policy_test.go
+++ b/alicloud/resource_alicloud_db_backup_policy_test.go
@@ -78,8 +78,8 @@ func testAccCheckDBBackupPolicyDestroy(s *terraform.State) error {
 			DBInstanceId: rs.Primary.ID,
 		})
 		if err != nil {
-			if NotFoundError(err) || IsExceptedError(err, InvalidDBInstanceNameNotFound) {
-				continue
+			if IsExceptedError(err, InvalidDBInstanceIdNotFound) || IsExceptedError(err, InvalidDBInstanceNameNotFound) {
+				return nil
 			}
 			return fmt.Errorf("Error Describe DB backup policy: %#v", err)
 		}

--- a/alicloud/resource_alicloud_db_connection.go
+++ b/alicloud/resource_alicloud_db_connection.go
@@ -27,9 +27,11 @@ func resourceAlicloudDBConnection() *schema.Resource {
 				Required: true,
 			},
 			"connection_prefix": &schema.Schema{
-				Type:     schema.TypeString,
-				Optional: true,
-				Computed: true,
+				Type:         schema.TypeString,
+				Optional:     true,
+				Computed:     true,
+				ForceNew:     true,
+				ValidateFunc: validateDBConnectionPrefix,
 			},
 			"port": &schema.Schema{
 				Type:         schema.TypeString,
@@ -53,32 +55,30 @@ func resourceAlicloudDBConnectionCreate(d *schema.ResourceData, meta interface{}
 	client := meta.(*AliyunClient)
 	instance_id := d.Get("instance_id").(string)
 	prefix, ok := d.GetOk("connection_prefix")
-	if !ok || prefix == "" {
-		prefix = fmt.Sprintf("%s0o", instance_id)
+	if !ok || prefix.(string) == "" {
+		prefix = fmt.Sprintf("%stf", instance_id)
 	}
 
 	if err := client.AllocateDBPublicConnection(instance_id, prefix.(string), d.Get("port").(string)); err != nil {
 		return fmt.Errorf("AllocateInstancePublicConnection got an error: %#v", err)
 	}
 
-	connection, err := client.DescribeDBInstanceNetInfoByIpType(instance_id, rds.Public)
-	if err != nil {
-		return err
-	}
-
-	d.SetId(fmt.Sprintf("%s:%s", instance_id, connection.ConnectionString))
+	d.SetId(fmt.Sprintf("%s%s%s", instance_id, COLON_SEPARATED, prefix.(string)))
 
 	return resourceAlicloudDBConnectionUpdate(d, meta)
 }
 
 func resourceAlicloudDBConnectionRead(d *schema.ResourceData, meta interface{}) error {
+	if strings.HasSuffix(d.Id(), DBConnectionSuffix) {
+		d.SetId(strings.Replace(d.Id(), DBConnectionSuffix, "", -1))
+	}
 
 	parts := strings.Split(d.Id(), COLON_SEPARATED)
 
 	conn, err := meta.(*AliyunClient).DescribeDBInstanceNetInfoByIpType(parts[0], rds.Public)
 
 	if err != nil {
-		if NotFoundError(err) || IsExceptedError(err, InvalidCurrentConnectionStringNotFound) {
+		if IsExceptedError(err, InvalidDBInstanceIdNotFound) || IsExceptedError(err, InvalidCurrentConnectionStringNotFound) {
 			d.SetId("")
 			return nil
 		}
@@ -86,7 +86,7 @@ func resourceAlicloudDBConnectionRead(d *schema.ResourceData, meta interface{}) 
 	}
 
 	d.Set("instance_id", parts[0])
-	d.Set("connection_prefix", strings.Split(conn.ConnectionString, DOT_SEPARATED)[0])
+	d.Set("connection_prefix", parts[1])
 	d.Set("port", conn.Port)
 	d.Set("connection_string", conn.ConnectionString)
 	d.Set("ip_address", conn.IPAddress)
@@ -95,37 +95,47 @@ func resourceAlicloudDBConnectionRead(d *schema.ResourceData, meta interface{}) 
 }
 
 func resourceAlicloudDBConnectionUpdate(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AliyunClient).rdsconn
 	d.Partial(true)
+
+	if strings.HasSuffix(d.Id(), DBConnectionSuffix) {
+		d.SetId(strings.Replace(d.Id(), DBConnectionSuffix, "", -1))
+	}
 
 	parts := strings.Split(d.Id(), COLON_SEPARATED)
 
-	update := false
-	args := &rds.ModifyDBInstanceConnectionStringArgs{
-		DBInstanceId:            parts[0],
-		CurrentConnectionString: parts[1],
-		ConnectionStringPrefix:  strings.Split(parts[1], DOT_SEPARATED)[0],
-		Port: d.Get("port").(string),
-	}
-	if d.HasChange("connection_prefix") && !d.IsNewResource() {
-		args.ConnectionStringPrefix = d.Get("connection_prefix").(string)
-		update = true
-		d.SetPartial("connection_prefix")
-	}
-
 	if d.HasChange("port") && !d.IsNewResource() {
-		update = true
-		d.SetPartial("port")
-	}
-
-	if update {
-		if err := meta.(*AliyunClient).rdsconn.ModifyDBInstanceConnectionString(args); err != nil {
-			return fmt.Errorf("ModifyDBInstanceConnectionString got an error: %#v", err)
+		args := &rds.ModifyDBInstanceConnectionStringArgs{
+			DBInstanceId:            parts[0],
+			CurrentConnectionString: fmt.Sprintf("%s%s", parts[1], DBConnectionSuffix),
+			ConnectionStringPrefix:  parts[1],
+			Port: d.Get("port").(string),
 		}
-		connection, err := meta.(*AliyunClient).DescribeDBInstanceNetInfoByIpType(args.DBInstanceId, rds.Public)
-		if err != nil {
+
+		// wait instance running before modifying
+		if err := conn.WaitForInstanceAsyn(args.DBInstanceId, rds.Running, 500); err != nil {
+			return fmt.Errorf("WaitForInstance %s got error: %#v", rds.Running, err)
+		}
+
+		if err := resource.Retry(3*time.Minute, func() *resource.RetryError {
+			if err := conn.ModifyDBInstanceConnectionString(args); err != nil {
+				if IsExceptedError(err, OperationDeniedDBInstanceStatus) || IsExceptedError(err, DBInternalError) {
+					return resource.RetryableError(fmt.Errorf("Modify DBInstance Connection Port got an error: %#v.", err))
+				}
+				return resource.NonRetryableError(fmt.Errorf("Modify DBInstance Connection Port got an error: %#v.", err))
+			}
+			return nil
+		}); err != nil {
 			return err
 		}
-		d.SetId(fmt.Sprintf("%s:%s", args.DBInstanceId, connection.ConnectionString))
+
+		// wait instance running after modifying
+		if err := conn.WaitForInstanceAsyn(args.DBInstanceId, rds.Running, 500); err != nil {
+			return fmt.Errorf("WaitForInstance %s got error: %#v", rds.Running, err)
+		}
+
+		d.SetPartial("port")
+
 	}
 
 	d.Partial(false)
@@ -134,10 +144,14 @@ func resourceAlicloudDBConnectionUpdate(d *schema.ResourceData, meta interface{}
 
 func resourceAlicloudDBConnectionDelete(d *schema.ResourceData, meta interface{}) error {
 	client := meta.(*AliyunClient)
+	if strings.HasSuffix(d.Id(), DBConnectionSuffix) {
+		d.SetId(strings.Replace(d.Id(), DBConnectionSuffix, "", -1))
+	}
+
 	parts := strings.Split(d.Id(), COLON_SEPARATED)
 
 	return resource.Retry(3*time.Minute, func() *resource.RetryError {
-		err := client.ReleaseDBPublicConnection(parts[0], parts[1])
+		err := client.ReleaseDBPublicConnection(parts[0], fmt.Sprintf("%s%s", parts[1], DBConnectionSuffix))
 
 		if err != nil {
 			if IsExceptedError(err, InvalidCurrentConnectionStringNotFound) || IsExceptedError(err, AtLeastOneNetTypeExists) {
@@ -148,7 +162,7 @@ func resourceAlicloudDBConnectionDelete(d *schema.ResourceData, meta interface{}
 		conn, err := meta.(*AliyunClient).DescribeDBInstanceNetInfoByIpType(parts[0], rds.Public)
 
 		if err != nil {
-			if NotFoundError(err) || IsExceptedError(err, InvalidCurrentConnectionStringNotFound) {
+			if IsExceptedError(err, InvalidDBInstanceIdNotFound) || IsExceptedError(err, InvalidCurrentConnectionStringNotFound) {
 				return nil
 			}
 			return resource.NonRetryableError(fmt.Errorf("Release DB connection got an error: %#v.", err))
@@ -159,6 +173,6 @@ func resourceAlicloudDBConnectionDelete(d *schema.ResourceData, meta interface{}
 			return nil
 		}
 
-		return resource.RetryableError(fmt.Errorf("DB in use - trying again while it is deleted."))
+		return resource.RetryableError(fmt.Errorf("Release DB connection timeout."))
 	})
 }

--- a/alicloud/resource_alicloud_db_database.go
+++ b/alicloud/resource_alicloud_db_database.go
@@ -85,11 +85,12 @@ func resourceAlicloudDBDatabaseRead(d *schema.ResourceData, meta interface{}) er
 	parts := strings.Split(d.Id(), COLON_SEPARATED)
 	db, err := meta.(*AliyunClient).DescribeDatabaseByName(parts[0], parts[1])
 	if err != nil {
-		if NotFoundError(err) || IsExceptedError(err, InvalidDBNameNotFound) {
-			d.SetId("")
-			return nil
-		}
 		return fmt.Errorf("Error Describe DB InstanceAttribute: %#v", err)
+	}
+
+	if db == nil {
+		d.SetId("")
+		return nil
 	}
 
 	d.Set("instance_id", db.DBInstanceId)
@@ -135,9 +136,6 @@ func resourceAlicloudDBDatabaseDelete(d *schema.ResourceData, meta interface{}) 
 
 		db, err := meta.(*AliyunClient).DescribeDatabaseByName(parts[0], parts[1])
 		if err != nil {
-			if NotFoundError(err) || IsExceptedError(err, InvalidDBNameNotFound) {
-				return nil
-			}
 			return resource.NonRetryableError(fmt.Errorf("Error Describe DB InstanceAttribute: %#v", err))
 		}
 		if db == nil {

--- a/alicloud/resource_alicloud_db_database_test.go
+++ b/alicloud/resource_alicloud_db_database_test.go
@@ -79,10 +79,6 @@ func testAccCheckDBDatabaseDestroy(s *terraform.State) error {
 
 		// Verify the error is what we want
 		if err != nil {
-			// Verify the error is what we want
-			if NotFoundError(err) || IsExceptedError(err, InvalidDBNameNotFound) {
-				continue
-			}
 			return err
 		}
 

--- a/alicloud/resource_alicloud_db_instance.go
+++ b/alicloud/resource_alicloud_db_instance.go
@@ -75,11 +75,11 @@ func resourceAlicloudDBInstance() *schema.Resource {
 			},
 
 			"zone_id": &schema.Schema{
-				Type:             schema.TypeString,
-				Optional:         true,
-				ForceNew:         true,
-				Computed:         true,
-				DiffSuppressFunc: zoneIdDiffSuppressFunc,
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: true,
+				Computed: true,
+				//DiffSuppressFunc: zoneIdDiffSuppressFunc,
 			},
 
 			"multi_az": &schema.Schema{

--- a/alicloud/resource_alicloud_db_instance_test.go
+++ b/alicloud/resource_alicloud_db_instance_test.go
@@ -42,6 +42,10 @@ func TestAccAlicloudDBInstance_basic(t *testing.T) {
 						"alicloud_db_instance.foo",
 						"engine",
 						"MySQL"),
+					resource.TestCheckResourceAttr(
+						"alicloud_db_instance.foo",
+						"instance_name",
+						"test-instance"),
 				),
 			},
 		},
@@ -284,7 +288,7 @@ func testAccCheckDBInstanceDestroy(s *terraform.State) error {
 
 		// Verify the error is what we want
 		if err != nil {
-			if NotFoundError(err) || IsExceptedError(err, InvalidDBInstanceNameNotFound) {
+			if NotFoundError(err) || IsExceptedError(err, InvalidDBInstanceIdNotFound) || IsExceptedError(err, InvalidDBInstanceNameNotFound) {
 				continue
 			}
 			return err
@@ -301,6 +305,7 @@ resource "alicloud_db_instance" "foo" {
 	instance_type = "rds.mysql.t1.small"
 	instance_storage = "10"
 	instance_charge_type = "Postpaid"
+	instance_name = "test-instance"
 }
 `
 

--- a/alicloud/validators.go
+++ b/alicloud/validators.go
@@ -1079,3 +1079,21 @@ func validateInstanceSpotStrategy(v interface{}, k string) (ws []string, errors 
 	}
 	return
 }
+
+func validateDBConnectionPrefix(v interface{}, k string) (ws []string, errors []error) {
+	if value := v.(string); value != "" {
+		if len(value) < 1 || len(value) > 31 {
+			errors = append(errors, fmt.Errorf("%q cannot be less than 1 and larger than 30.", k))
+		}
+	}
+	return
+}
+
+func validateDBInstanceName(v interface{}, k string) (ws []string, errors []error) {
+	if value := v.(string); value != "" {
+		if len(value) < 2 || len(value) > 256 {
+			errors = append(errors, fmt.Errorf("%q cannot be less than 1 and larger than 30.", k))
+		}
+	}
+	return
+}

--- a/vendor/github.com/denverdino/aliyungo/rds/instances.go
+++ b/vendor/github.com/denverdino/aliyungo/rds/instances.go
@@ -5,6 +5,7 @@ import (
 	"time"
 
 	"github.com/denverdino/aliyungo/common"
+	"log"
 )
 
 type DBInstanceIPArray struct {
@@ -539,6 +540,7 @@ func (client *Client) WaitForAccount(instanceId string, accountName string, stat
 		}
 
 		accs := resp.Accounts.DBInstanceAccount
+		log.Printf("**********acc: %#v", accs)
 
 		if timeout <= 0 {
 			return common.GetClientErrorFromString("Timeout")
@@ -1078,6 +1080,19 @@ type ModifyDBInstanceConnectionStringArgs struct {
 func (client *Client) ModifyDBInstanceConnectionString(args *ModifyDBInstanceConnectionStringArgs) error {
 	response := common.Response{}
 	return client.Invoke("ModifyDBInstanceConnectionString", args, &response)
+}
+
+type ModifyDBInstanceDescriptionArgs struct {
+	DBInstanceId            string
+	DBInstanceDescription string
+}
+
+// ModifyDBInstanceDescription modify rds instance name
+//
+// You can read doc at https://help.aliyun.com/document_detail/26248.html
+func (client *Client) ModifyDBInstanceDescription(args *ModifyDBInstanceDescriptionArgs) error {
+	response := common.Response{}
+	return client.Invoke("ModifyDBInstanceDescription", args, &response)
 }
 
 type BackupPolicy struct {

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -235,68 +235,68 @@
 		{
 			"checksumSHA1": "9bZS3sdYQuY8j2Fxi9sEoQl2ibQ=",
 			"path": "github.com/denverdino/aliyungo/cdn",
-			"revision": "f6ec6f26ec42e39b07c75c738eb30c869d305ce5",
-			"revisionTime": "2018-01-18T01:34:02Z"
+			"revision": "c0d28eeada35fc1c63b16865b438ee277ca179fb",
+			"revisionTime": "2018-01-19T08:28:08Z"
 		},
 		{
 			"checksumSHA1": "6jhMTB/kEVfbbszOdOyYODYFk5Q=",
 			"path": "github.com/denverdino/aliyungo/common",
-			"revision": "f6ec6f26ec42e39b07c75c738eb30c869d305ce5",
-			"revisionTime": "2018-01-18T01:34:02Z"
+			"revision": "c0d28eeada35fc1c63b16865b438ee277ca179fb",
+			"revisionTime": "2018-01-19T08:28:08Z"
 		},
 		{
 			"checksumSHA1": "JgK7hgdP+yfsRin1lbz0LjBVtic=",
 			"path": "github.com/denverdino/aliyungo/cs",
-			"revision": "f6ec6f26ec42e39b07c75c738eb30c869d305ce5",
-			"revisionTime": "2018-01-18T01:34:02Z"
+			"revision": "c0d28eeada35fc1c63b16865b438ee277ca179fb",
+			"revisionTime": "2018-01-19T08:28:08Z"
 		},
 		{
 			"checksumSHA1": "0y6d3UiB8JckT3YTeXjMbLkSibg=",
 			"path": "github.com/denverdino/aliyungo/dns",
-			"revision": "f6ec6f26ec42e39b07c75c738eb30c869d305ce5",
-			"revisionTime": "2018-01-18T01:34:02Z"
+			"revision": "c0d28eeada35fc1c63b16865b438ee277ca179fb",
+			"revisionTime": "2018-01-19T08:28:08Z"
 		},
 		{
 			"checksumSHA1": "p0MBe0iRbSkAhLFYX7n/+wsfJJY=",
 			"path": "github.com/denverdino/aliyungo/ecs",
-			"revision": "f6ec6f26ec42e39b07c75c738eb30c869d305ce5",
-			"revisionTime": "2018-01-18T01:34:02Z"
+			"revision": "c0d28eeada35fc1c63b16865b438ee277ca179fb",
+			"revisionTime": "2018-01-19T08:28:08Z"
 		},
 		{
 			"checksumSHA1": "ppmAWGfRcffPvGcqpUbxdWwkUbg=",
 			"path": "github.com/denverdino/aliyungo/ess",
-			"revision": "f6ec6f26ec42e39b07c75c738eb30c869d305ce5",
-			"revisionTime": "2018-01-18T01:34:02Z"
+			"revision": "c0d28eeada35fc1c63b16865b438ee277ca179fb",
+			"revisionTime": "2018-01-19T08:28:08Z"
 		},
 		{
 			"checksumSHA1": "CPuR3s7LzQkT57Z20zMHXQM2MYQ=",
 			"path": "github.com/denverdino/aliyungo/location",
-			"revision": "f6ec6f26ec42e39b07c75c738eb30c869d305ce5",
-			"revisionTime": "2018-01-18T01:34:02Z"
+			"revision": "c0d28eeada35fc1c63b16865b438ee277ca179fb",
+			"revisionTime": "2018-01-19T08:28:08Z"
 		},
 		{
 			"checksumSHA1": "mkaQUrh01nWescV/Ek7Yv/WwX9Q=",
 			"path": "github.com/denverdino/aliyungo/ram",
-			"revision": "f6ec6f26ec42e39b07c75c738eb30c869d305ce5",
-			"revisionTime": "2018-01-18T01:34:02Z"
+			"revision": "c0d28eeada35fc1c63b16865b438ee277ca179fb",
+			"revisionTime": "2018-01-19T08:28:08Z"
 		},
 		{
-			"checksumSHA1": "EVzLqNTiuKKF5Ay5Cy5+TETjpvk=",
+			"checksumSHA1": "D4ugog0rIZolvzyH2Wf/p+eUJOE=",
 			"path": "github.com/denverdino/aliyungo/rds",
-			"revision": "f6ec6f26ec42e39b07c75c738eb30c869d305ce5",
-			"revisionTime": "2018-01-18T01:34:02Z"
+			"revision": "c0d28eeada35fc1c63b16865b438ee277ca179fb",
+			"revisionTime": "2018-01-19T08:28:08Z"
 		},
 		{
 			"checksumSHA1": "vsHDSvuHR3Fce800xGIsMWcEMHc=",
 			"path": "github.com/denverdino/aliyungo/slb",
-			"revision": "f6ec6f26ec42e39b07c75c738eb30c869d305ce5",
-			"revisionTime": "2018-01-18T01:34:02Z"
+			"revision": "c0d28eeada35fc1c63b16865b438ee277ca179fb",
+			"revisionTime": "2018-01-19T08:28:08Z"
 		},
 		{
 			"checksumSHA1": "ZSpVJldK4F8joh8pOryB5SaSn8s=",
 			"path": "github.com/denverdino/aliyungo/util",
-			"revision": "f6ec6f26ec42e39b07c75c738eb30c869d305ce5",
-			"revisionTime": "2018-01-18T01:34:02Z"
+			"revision": "c0d28eeada35fc1c63b16865b438ee277ca179fb",
+			"revisionTime": "2018-01-19T08:28:08Z"
 		},
 		{
 			"checksumSHA1": "BCv50o5pDkoSG3vYKOSai1Z8p3w=",
@@ -694,6 +694,11 @@
 			"path": "golang.org/x/net/html/atom",
 			"revision": "1c05540f6879653db88113bc4a2b70aec4bd491f",
 			"revisionTime": "2017-08-04T00:04:37Z"
+		},
+		{
+			"origin": "https:/github.com/denverdino/aliyungo",
+			"path": "https://github.com/denverdino/aliyungo",
+			"revision": ""
 		},
 		{
 			"checksumSHA1": "wICWAGQfZcHD2y0dHesz9R2YSiw=",

--- a/website/docs/r/container_cluster.html.markdown
+++ b/website/docs/r/container_cluster.html.markdown
@@ -34,7 +34,7 @@ The following arguments are supported:
 * `name` - (Force new resource) The container cluster's name. It is the only in one Alicloud account.
 * `name_prefix` - (Force new resource) The container cluster name's prefix. It is conflict with `name`. If it is specified, terraform will using it to build the only cluster name.
 * `size` - The ECS node number of the container cluster. Its value choices are 1~20, and default to 1.
-* `cidr_block` - (Required, Force new resource) The CIDR block for the Container. Its valid value are `192.168.X.0/24` or `172.16.X.0/24` ~ `172.31.X.0/24`, and it can't be conflict with VSwitch's.
+* `cidr_block` - (Required, Force new resource) The CIDR block for the Container. Its valid value are `192.168.X.0/24` or `172.18.X.0/24` ~ `172.31.X.0/24`. And it cannot be equal to vswitch's cidr_block and sub cidr block.
 * `image_id` - (Force new resource) The image ID of ECS instance node used. Default to System automate allocated.
 * `instance_type` - (Required, Force new resource) The type of ECS instance node.
 * `password` - (Required, Force new resource) The password of ECS instance node.

--- a/website/docs/r/db_connection.html.markdown
+++ b/website/docs/r/db_connection.html.markdown
@@ -28,14 +28,14 @@ resource "alicloud_db_connection" "default" {
 The following arguments are supported:
 
 * `instance_id` - (Required) The Id of instance that can run database.
-* `connection_prefix` - (Optional) Prefix of an Internet connection string. Default to <instance_id> + '0o'.
+* `connection_prefix` - (Optional) Prefix of an Internet connection string. It must be checked for uniqueness. It may consist of lowercase letters, numbers, and underlines, and must start with a letter and have no more than 30 characters. Default to <instance_id> + 'tf'.
 * `port` - (Optional) Internet connection port. Valid value: [3001-3999]. Default to 3306.
 
 ## Attributes Reference
 
 The following attributes are exported:
 
-* `id` - The current instance connection resource ID. Composed of instance ID and connection string with format "<instance_id>:<connection_string>".
+* `id` - The current instance connection resource ID. Composed of instance ID and connection string with format "<instance_id>:<connection_prefix>".
 * `connection_prefix` - Prefix of a connection string.
 * `port` - Connection instance port.
 * `connection_string` - Connection instance string.
@@ -46,5 +46,5 @@ The following attributes are exported:
 RDS connection can be imported using the id, e.g.
 
 ```
-$ terraform import alicloud_db_connection.example "rm-1234512345:terraform.mysql.rds.aliyuncs.com"
+$ terraform import alicloud_db_connection.example abc12345678
 ```

--- a/website/docs/r/db_instance.html.markdown
+++ b/website/docs/r/db_instance.html.markdown
@@ -43,6 +43,7 @@ The following arguments are supported:
     - [20,2000] for SQL Server 2012 basic single node edition
     Increase progressively at a rate of 5 GB. For details, see [Instance type table](https://www.alibabacloud.com/help/doc-detail/26312.htm).
 
+* `instance_name` - (Optional) The name of DB instance. It a string of 2 to 256 characters.
 * `instance_charge_type` - (Optional) Valid values are `Prepaid`, `Postpaid`, Default to `Postpaid`.
 * `period` - (Optional) The duration that you will buy DB instance (in month). It is valid when instance_charge_type is `PrePaid`. Valid values: [1~9], 12, 24, 36. Default to 1.
 * `zone_id` - (Optional) The Zone to launch the DB instance. It is ignored and will be computed when set `vswitch_id`. It conflict with `multi_az`.
@@ -74,6 +75,7 @@ The following attributes are exported:
 * `instance_type` - The RDS instance type.
 * `db_instance_storage` - (Deprecated from version 1.5.0)
 * `instance_storage` - The RDS instance storage space.
+* `instance_name` - The name of DB instance.
 * `port` - RDS database connection port.
 * `connection_string` - RDS database connection string.
 * `zone_id` - The zone ID of the RDS instance.


### PR DESCRIPTION
The PR fixes several rds bugs result from its id not found and its status is not correct.

The pr has a pre pr #88 

The result of running test cases as follows:

TF_ACC=1 go test ./alicloud -v -run=TestAclicloudDB -timeout 120m
=== RUN   TestAccAlicloudDBAccountPrivilege_import
--- PASS: TestAccAlicloudDBAccountPrivilege_import (711.62s)
=== RUN   TestAccAlicloudDBAccount_import
--- PASS: TestAccAlicloudDBAccount_import (621.34s)
=== RUN   TestAccAlicloudDBBackupPolicy_import
--- PASS: TestAccAlicloudDBBackupPolicy_import (541.98s)
=== RUN   TestAccAlicloudDBConnection_import
--- PASS: TestAccAlicloudDBConnection_import (517.14s)
=== RUN   TestAccAlicloudDBDatabase_import
--- PASS: TestAccAlicloudDBDatabase_import (550.41s)
=== RUN   TestAccAlicloudDBInstance_import
 the result is &{Response:{RequestId:547266C6-53A1-4861-BE00-75A82AC4C42B} Items:0xc4203101e0} the args is &{DBInstanceId:rm-2zee435167m2r234d SecurityIps:10.168.1.12,100.69.7.112 DBInstanceIPArrayName: DBInstanceIPArrayAttribute:}--- PASS: TestAccAlicloudDBInstance_import (372.67s)
=== RUN   TestAccAlicloudDBAccountPrivilege_basic
--- PASS: TestAccAlicloudDBAccountPrivilege_basic (626.73s)
=== RUN   TestAccAlicloudDBAccount_basic
--- PASS: TestAccAlicloudDBAccount_basic (496.80s)
=== RUN   TestAccAlicloudDBBackupPolicy_basic
--- PASS: TestAccAlicloudDBBackupPolicy_basic (542.31s)
=== RUN   TestAccAlicloudDBConnection_basic
--- PASS: TestAccAlicloudDBConnection_basic (541.00s)
=== RUN   TestAccAlicloudDBDatabase_basic
--- PASS: TestAccAlicloudDBDatabase_basic (603.54s)
=== RUN   TestAccAlicloudDBInstance_basic
--- PASS: TestAccAlicloudDBInstance_basic (329.42s)
=== RUN   TestAccAlicloudDBInstance_vpc
 the result is &{Response:{RequestId:FCA2DE91-7566-4E69-A4FF-07977E0CE587} Items:0xc4203f06e0} the args is &{DBInstanceId:rm-2zel43e90wbv7732n SecurityIps:10.168.1.12,100.69.7.112 DBInstanceIPArrayName: DBInstanceIPArrayAttribute:}--- PASS: TestAccAlicloudDBInstance_vpc (331.58s)
=== RUN   TestAccAlicloudDBInstance_multiAZ
--- PASS: TestAccAlicloudDBInstance_multiAZ (370.55s)
PASS
ok github.com/alibaba/terraform-provider/alicloud 7180.103s

