### PR TITLE
fix several bugs about db result from its status and id not found

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,13 +1,17 @@
-## 1.6.2 (Unreleased)
+## 1.6.2 (January 22, 2018)
 
 IMPROVEMENTS:
 
-- Support to set instnace name for RDS ([#89](https://github.com/terraform-providers/terraform-provider-alicloud/pull/89))
+- Modify db_connection prefix default value to "instance_id + 'tf'"([#90](https://github.com/terraform-providers/terraform-provider-alicloud/pull/90))
+- Modify db_connection ID to make it more simple while importing it([#90](https://github.com/terraform-providers/terraform-provider-alicloud/pull/90))
+- Add wait method to avoid useless status error while creating/modifying account or privilege or connection or database([#90](https://github.com/terraform-providers/terraform-provider-alicloud/pull/90))
+- Support to set instnace name for RDS ([#88](https://github.com/terraform-providers/terraform-provider-alicloud/pull/88))
 - Avoid container cluster cidr block conflicts with vswitch's ([#88](https://github.com/terraform-providers/terraform-provider-alicloud/pull/88))
 - Output resource import information ([#87](https://github.com/terraform-providers/terraform-provider-alicloud/pull/87))
 
 BUG FIXES:
 
+- fix instance id not found and instane status not supported bug([#90](https://github.com/terraform-providers/terraform-provider-alicloud/pull/90))
 - fix deleting slb_attachment resource failed bug ([#86](https://github.com/terraform-providers/terraform-provider-alicloud/pull/86))
 
 

--- a/alicloud/common.go
+++ b/alicloud/common.go
@@ -157,3 +157,5 @@ func userDataHashSum(user_data string) string {
 	}
 	return string(v)
 }
+
+const DBConnectionSuffix = ".mysql.rds.aliyuncs.com"

--- a/alicloud/resource_alicloud_db_account_privilege_test.go
+++ b/alicloud/resource_alicloud_db_account_privilege_test.go
@@ -81,8 +81,8 @@ func testAccCheckDBAccountPrivilegeDestroy(s *terraform.State) error {
 
 		// Verify the error is what we want
 		if err != nil {
-			if NotFoundError(err) || IsExceptedError(err, InvalidAccountNameNotFound) {
-				continue
+			if NotFoundError(err) || IsExceptedError(err, InvalidDBInstanceIdNotFound) || IsExceptedError(err, InvalidAccountNameNotFound) {
+				return nil
 			}
 			return err
 		}

--- a/alicloud/resource_alicloud_db_account_test.go
+++ b/alicloud/resource_alicloud_db_account_test.go
@@ -29,7 +29,7 @@ func TestAccAlicloudDBAccount_basic(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckDBAccountExists(
 						"alicloud_db_account.account", &account),
-					resource.TestCheckResourceAttr("alicloud_db_instance.account", "name", "tf_db"),
+					resource.TestCheckResourceAttr("alicloud_db_account.account", "name", "tf_db"),
 				),
 			},
 		},
@@ -79,8 +79,8 @@ func testAccCheckDBAccountDestroy(s *terraform.State) error {
 
 		// Verify the error is what we want
 		if err != nil {
-			if NotFoundError(err) || IsExceptedError(err, InvalidAccountNameNotFound) {
-				continue
+			if NotFoundError(err) || IsExceptedError(err, InvalidDBInstanceIdNotFound) || IsExceptedError(err, InvalidAccountNameNotFound) {
+				return nil
 			}
 			return err
 		}

--- a/alicloud/resource_alicloud_db_backup_policy_test.go
+++ b/alicloud/resource_alicloud_db_backup_policy_test.go
@@ -78,8 +78,8 @@ func testAccCheckDBBackupPolicyDestroy(s *terraform.State) error {
 			DBInstanceId: rs.Primary.ID,
 		})
 		if err != nil {
-			if NotFoundError(err) || IsExceptedError(err, InvalidDBInstanceNameNotFound) {
-				continue
+			if IsExceptedError(err, InvalidDBInstanceIdNotFound) || IsExceptedError(err, InvalidDBInstanceNameNotFound) {
+				return nil
 			}
 			return fmt.Errorf("Error Describe DB backup policy: %#v", err)
 		}

--- a/alicloud/resource_alicloud_db_connection.go
+++ b/alicloud/resource_alicloud_db_connection.go
@@ -27,9 +27,11 @@ func resourceAlicloudDBConnection() *schema.Resource {
 				Required: true,
 			},
 			"connection_prefix": &schema.Schema{
-				Type:     schema.TypeString,
-				Optional: true,
-				Computed: true,
+				Type:         schema.TypeString,
+				Optional:     true,
+				Computed:     true,
+				ForceNew:     true,
+				ValidateFunc: validateDBConnectionPrefix,
 			},
 			"port": &schema.Schema{
 				Type:         schema.TypeString,
@@ -53,32 +55,30 @@ func resourceAlicloudDBConnectionCreate(d *schema.ResourceData, meta interface{}
 	client := meta.(*AliyunClient)
 	instance_id := d.Get("instance_id").(string)
 	prefix, ok := d.GetOk("connection_prefix")
-	if !ok || prefix == "" {
-		prefix = fmt.Sprintf("%s0o", instance_id)
+	if !ok || prefix.(string) == "" {
+		prefix = fmt.Sprintf("%stf", instance_id)
 	}
 
 	if err := client.AllocateDBPublicConnection(instance_id, prefix.(string), d.Get("port").(string)); err != nil {
 		return fmt.Errorf("AllocateInstancePublicConnection got an error: %#v", err)
 	}
 
-	connection, err := client.DescribeDBInstanceNetInfoByIpType(instance_id, rds.Public)
-	if err != nil {
-		return err
-	}
-
-	d.SetId(fmt.Sprintf("%s:%s", instance_id, connection.ConnectionString))
+	d.SetId(fmt.Sprintf("%s%s%s", instance_id, COLON_SEPARATED, prefix.(string)))
 
 	return resourceAlicloudDBConnectionUpdate(d, meta)
 }
 
 func resourceAlicloudDBConnectionRead(d *schema.ResourceData, meta interface{}) error {
+	if strings.HasSuffix(d.Id(), DBConnectionSuffix) {
+		d.SetId(strings.Replace(d.Id(), DBConnectionSuffix, "", -1))
+	}
 
 	parts := strings.Split(d.Id(), COLON_SEPARATED)
 
 	conn, err := meta.(*AliyunClient).DescribeDBInstanceNetInfoByIpType(parts[0], rds.Public)
 
 	if err != nil {
-		if NotFoundError(err) || IsExceptedError(err, InvalidCurrentConnectionStringNotFound) {
+		if IsExceptedError(err, InvalidDBInstanceIdNotFound) || IsExceptedError(err, InvalidCurrentConnectionStringNotFound) {
 			d.SetId("")
 			return nil
 		}
@@ -86,7 +86,7 @@ func resourceAlicloudDBConnectionRead(d *schema.ResourceData, meta interface{}) 
 	}
 
 	d.Set("instance_id", parts[0])
-	d.Set("connection_prefix", strings.Split(conn.ConnectionString, DOT_SEPARATED)[0])
+	d.Set("connection_prefix", parts[1])
 	d.Set("port", conn.Port)
 	d.Set("connection_string", conn.ConnectionString)
 	d.Set("ip_address", conn.IPAddress)
@@ -95,37 +95,47 @@ func resourceAlicloudDBConnectionRead(d *schema.ResourceData, meta interface{}) 
 }
 
 func resourceAlicloudDBConnectionUpdate(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AliyunClient).rdsconn
 	d.Partial(true)
+
+	if strings.HasSuffix(d.Id(), DBConnectionSuffix) {
+		d.SetId(strings.Replace(d.Id(), DBConnectionSuffix, "", -1))
+	}
 
 	parts := strings.Split(d.Id(), COLON_SEPARATED)
 
-	update := false
-	args := &rds.ModifyDBInstanceConnectionStringArgs{
-		DBInstanceId:            parts[0],
-		CurrentConnectionString: parts[1],
-		ConnectionStringPrefix:  strings.Split(parts[1], DOT_SEPARATED)[0],
-		Port: d.Get("port").(string),
-	}
-	if d.HasChange("connection_prefix") && !d.IsNewResource() {
-		args.ConnectionStringPrefix = d.Get("connection_prefix").(string)
-		update = true
-		d.SetPartial("connection_prefix")
-	}
-
 	if d.HasChange("port") && !d.IsNewResource() {
-		update = true
-		d.SetPartial("port")
-	}
-
-	if update {
-		if err := meta.(*AliyunClient).rdsconn.ModifyDBInstanceConnectionString(args); err != nil {
-			return fmt.Errorf("ModifyDBInstanceConnectionString got an error: %#v", err)
+		args := &rds.ModifyDBInstanceConnectionStringArgs{
+			DBInstanceId:            parts[0],
+			CurrentConnectionString: fmt.Sprintf("%s%s", parts[1], DBConnectionSuffix),
+			ConnectionStringPrefix:  parts[1],
+			Port: d.Get("port").(string),
 		}
-		connection, err := meta.(*AliyunClient).DescribeDBInstanceNetInfoByIpType(args.DBInstanceId, rds.Public)
-		if err != nil {
+
+		// wait instance running before modifying
+		if err := conn.WaitForInstanceAsyn(args.DBInstanceId, rds.Running, 500); err != nil {
+			return fmt.Errorf("WaitForInstance %s got error: %#v", rds.Running, err)
+		}
+
+		if err := resource.Retry(3*time.Minute, func() *resource.RetryError {
+			if err := conn.ModifyDBInstanceConnectionString(args); err != nil {
+				if IsExceptedError(err, OperationDeniedDBInstanceStatus) || IsExceptedError(err, DBInternalError) {
+					return resource.RetryableError(fmt.Errorf("Modify DBInstance Connection Port got an error: %#v.", err))
+				}
+				return resource.NonRetryableError(fmt.Errorf("Modify DBInstance Connection Port got an error: %#v.", err))
+			}
+			return nil
+		}); err != nil {
 			return err
 		}
-		d.SetId(fmt.Sprintf("%s:%s", args.DBInstanceId, connection.ConnectionString))
+
+		// wait instance running after modifying
+		if err := conn.WaitForInstanceAsyn(args.DBInstanceId, rds.Running, 500); err != nil {
+			return fmt.Errorf("WaitForInstance %s got error: %#v", rds.Running, err)
+		}
+
+		d.SetPartial("port")
+
 	}
 
 	d.Partial(false)
@@ -134,10 +144,14 @@ func resourceAlicloudDBConnectionUpdate(d *schema.ResourceData, meta interface{}
 
 func resourceAlicloudDBConnectionDelete(d *schema.ResourceData, meta interface{}) error {
 	client := meta.(*AliyunClient)
+	if strings.HasSuffix(d.Id(), DBConnectionSuffix) {
+		d.SetId(strings.Replace(d.Id(), DBConnectionSuffix, "", -1))
+	}
+
 	parts := strings.Split(d.Id(), COLON_SEPARATED)
 
 	return resource.Retry(3*time.Minute, func() *resource.RetryError {
-		err := client.ReleaseDBPublicConnection(parts[0], parts[1])
+		err := client.ReleaseDBPublicConnection(parts[0], fmt.Sprintf("%s%s", parts[1], DBConnectionSuffix))
 
 		if err != nil {
 			if IsExceptedError(err, InvalidCurrentConnectionStringNotFound) || IsExceptedError(err, AtLeastOneNetTypeExists) {
@@ -148,7 +162,7 @@ func resourceAlicloudDBConnectionDelete(d *schema.ResourceData, meta interface{}
 		conn, err := meta.(*AliyunClient).DescribeDBInstanceNetInfoByIpType(parts[0], rds.Public)
 
 		if err != nil {
-			if NotFoundError(err) || IsExceptedError(err, InvalidCurrentConnectionStringNotFound) {
+			if IsExceptedError(err, InvalidDBInstanceIdNotFound) || IsExceptedError(err, InvalidCurrentConnectionStringNotFound) {
 				return nil
 			}
 			return resource.NonRetryableError(fmt.Errorf("Release DB connection got an error: %#v.", err))
@@ -159,6 +173,6 @@ func resourceAlicloudDBConnectionDelete(d *schema.ResourceData, meta interface{}
 			return nil
 		}
 
-		return resource.RetryableError(fmt.Errorf("DB in use - trying again while it is deleted."))
+		return resource.RetryableError(fmt.Errorf("Release DB connection timeout."))
 	})
 }

--- a/alicloud/resource_alicloud_db_database.go
+++ b/alicloud/resource_alicloud_db_database.go
@@ -85,11 +85,12 @@ func resourceAlicloudDBDatabaseRead(d *schema.ResourceData, meta interface{}) er
 	parts := strings.Split(d.Id(), COLON_SEPARATED)
 	db, err := meta.(*AliyunClient).DescribeDatabaseByName(parts[0], parts[1])
 	if err != nil {
-		if NotFoundError(err) || IsExceptedError(err, InvalidDBNameNotFound) {
-			d.SetId("")
-			return nil
-		}
 		return fmt.Errorf("Error Describe DB InstanceAttribute: %#v", err)
+	}
+
+	if db == nil {
+		d.SetId("")
+		return nil
 	}
 
 	d.Set("instance_id", db.DBInstanceId)
@@ -135,9 +136,6 @@ func resourceAlicloudDBDatabaseDelete(d *schema.ResourceData, meta interface{}) 
 
 		db, err := meta.(*AliyunClient).DescribeDatabaseByName(parts[0], parts[1])
 		if err != nil {
-			if NotFoundError(err) || IsExceptedError(err, InvalidDBNameNotFound) {
-				return nil
-			}
 			return resource.NonRetryableError(fmt.Errorf("Error Describe DB InstanceAttribute: %#v", err))
 		}
 		if db == nil {

--- a/alicloud/resource_alicloud_db_database_test.go
+++ b/alicloud/resource_alicloud_db_database_test.go
@@ -79,10 +79,6 @@ func testAccCheckDBDatabaseDestroy(s *terraform.State) error {
 
 		// Verify the error is what we want
 		if err != nil {
-			// Verify the error is what we want
-			if NotFoundError(err) || IsExceptedError(err, InvalidDBNameNotFound) {
-				continue
-			}
 			return err
 		}
 

--- a/alicloud/resource_alicloud_db_instance.go
+++ b/alicloud/resource_alicloud_db_instance.go
@@ -75,11 +75,11 @@ func resourceAlicloudDBInstance() *schema.Resource {
 			},
 
 			"zone_id": &schema.Schema{
-				Type:             schema.TypeString,
-				Optional:         true,
-				ForceNew:         true,
-				Computed:         true,
-				DiffSuppressFunc: zoneIdDiffSuppressFunc,
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: true,
+				Computed: true,
+				//DiffSuppressFunc: zoneIdDiffSuppressFunc,
 			},
 
 			"multi_az": &schema.Schema{

--- a/website/docs/r/db_connection.html.markdown
+++ b/website/docs/r/db_connection.html.markdown
@@ -28,14 +28,14 @@ resource "alicloud_db_connection" "default" {
 The following arguments are supported:
 
 * `instance_id` - (Required) The Id of instance that can run database.
-* `connection_prefix` - (Optional) Prefix of an Internet connection string. Default to <instance_id> + '0o'.
+* `connection_prefix` - (Optional) Prefix of an Internet connection string. It must be checked for uniqueness. It may consist of lowercase letters, numbers, and underlines, and must start with a letter and have no more than 30 characters. Default to <instance_id> + 'tf'.
 * `port` - (Optional) Internet connection port. Valid value: [3001-3999]. Default to 3306.
 
 ## Attributes Reference
 
 The following attributes are exported:
 
-* `id` - The current instance connection resource ID. Composed of instance ID and connection string with format "<instance_id>:<connection_string>".
+* `id` - The current instance connection resource ID. Composed of instance ID and connection string with format "<instance_id>:<connection_prefix>".
 * `connection_prefix` - Prefix of a connection string.
 * `port` - Connection instance port.
 * `connection_string` - Connection instance string.
@@ -46,5 +46,5 @@ The following attributes are exported:
 RDS connection can be imported using the id, e.g.
 
 ```
-$ terraform import alicloud_db_connection.example "rm-1234512345:terraform.mysql.rds.aliyuncs.com"
+$ terraform import alicloud_db_connection.example abc12345678
 ```


### PR DESCRIPTION
The PR fixes several rds bugs result from its id not found and its status is not correct.

The result of running test cases as follows:

TF_ACC=1 go test ./alicloud -v -run=TestAclicloudDB -timeout 120m
=== RUN   TestAccAlicloudDBAccountPrivilege_import
--- PASS: TestAccAlicloudDBAccountPrivilege_import (711.62s)
=== RUN   TestAccAlicloudDBAccount_import
--- PASS: TestAccAlicloudDBAccount_import (621.34s)
=== RUN   TestAccAlicloudDBBackupPolicy_import
--- PASS: TestAccAlicloudDBBackupPolicy_import (541.98s)
=== RUN   TestAccAlicloudDBConnection_import
--- PASS: TestAccAlicloudDBConnection_import (517.14s)
=== RUN   TestAccAlicloudDBDatabase_import
--- PASS: TestAccAlicloudDBDatabase_import (550.41s)
=== RUN   TestAccAlicloudDBInstance_import
 the result is &{Response:{RequestId:547266C6-53A1-4861-BE00-75A82AC4C42B} Items:0xc4203101e0} the args is &{DBInstanceId:rm-2zee435167m2r234d SecurityIps:10.168.1.12,100.69.7.112 DBInstanceIPArrayName: DBInstanceIPArrayAttribute:}--- PASS: TestAccAlicloudDBInstance_import (372.67s)
=== RUN   TestAccAlicloudDBAccountPrivilege_basic
--- PASS: TestAccAlicloudDBAccountPrivilege_basic (626.73s)
=== RUN   TestAccAlicloudDBAccount_basic
--- PASS: TestAccAlicloudDBAccount_basic (496.80s)
=== RUN   TestAccAlicloudDBBackupPolicy_basic
--- PASS: TestAccAlicloudDBBackupPolicy_basic (542.31s)
=== RUN   TestAccAlicloudDBConnection_basic
--- PASS: TestAccAlicloudDBConnection_basic (541.00s)
=== RUN   TestAccAlicloudDBDatabase_basic
--- PASS: TestAccAlicloudDBDatabase_basic (603.54s)
=== RUN   TestAccAlicloudDBInstance_basic
--- PASS: TestAccAlicloudDBInstance_basic (329.42s)
=== RUN   TestAccAlicloudDBInstance_vpc
 the result is &{Response:{RequestId:FCA2DE91-7566-4E69-A4FF-07977E0CE587} Items:0xc4203f06e0} the args is &{DBInstanceId:rm-2zel43e90wbv7732n SecurityIps:10.168.1.12,100.69.7.112 DBInstanceIPArrayName: DBInstanceIPArrayAttribute:}--- PASS: TestAccAlicloudDBInstance_vpc (331.58s)
=== RUN   TestAccAlicloudDBInstance_multiAZ
--- PASS: TestAccAlicloudDBInstance_multiAZ (370.55s)
PASS
ok github.com/alibaba/terraform-provider/alicloud 7180.103s

