### PR TITLE
 add new datasource alicloud_instances

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ IMPROVEMENTS:
 
 - *New Resource*: _alicloud_kms_key_ ([#91](https://github.com/terraform-providers/terraform-provider-alicloud/pull/91))
 - *New DataSource*: _alicloud_kms_keys_ ([#93](https://github.com/terraform-providers/terraform-provider-alicloud/pull/93))
+- *New DataSource*: _alicloud_instances_ ([#94](https://github.com/terraform-providers/terraform-provider-alicloud/pull/94))
 - Add a new output field "arn" for _alicloud_kms_key_ ([#92](https://github.com/terraform-providers/terraform-provider-alicloud/pull/92))
 
 ## 1.6.2 (January 22, 2018)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 IMPROVEMENTS:
 
 - *New Resource*: _alicloud_kms_key_ ([#91](https://github.com/terraform-providers/terraform-provider-alicloud/pull/91))
+- Add a new output field "arn" for _alicloud_kms_key_ ([#92](https://github.com/terraform-providers/terraform-provider-alicloud/pull/92))
 
 ## 1.6.2 (January 22, 2018)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 IMPROVEMENTS:
 
 - *New Resource*: _alicloud_kms_key_ ([#91](https://github.com/terraform-providers/terraform-provider-alicloud/pull/91))
+- *New DataSource*: _alicloud_kms_keys_ ([#93](https://github.com/terraform-providers/terraform-provider-alicloud/pull/93))
 - Add a new output field "arn" for _alicloud_kms_key_ ([#92](https://github.com/terraform-providers/terraform-provider-alicloud/pull/92))
 
 ## 1.6.2 (January 22, 2018)

--- a/alicloud/data_source_alicloud_instances.go
+++ b/alicloud/data_source_alicloud_instances.go
@@ -1,0 +1,345 @@
+package alicloud
+
+import (
+	"fmt"
+	"log"
+	"regexp"
+
+	"github.com/denverdino/aliyungo/ecs"
+	"github.com/hashicorp/terraform/helper/schema"
+)
+
+func dataSourceAlicloudInstances() *schema.Resource {
+	return &schema.Resource{
+		Read: dataSourceAlicloudInstancesRead,
+
+		Schema: map[string]*schema.Schema{
+			"ids": {
+				Type:     schema.TypeList,
+				Optional: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+				ForceNew: true,
+				MinItems: 1,
+			},
+			"name_regex": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ValidateFunc: validateNameRegex,
+				ForceNew:     true,
+			},
+			"image_id": {
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: true,
+			},
+			"status": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ValidateFunc: validateInstanceStatus,
+				ForceNew:     true,
+			},
+			"vpc_id": {
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: true,
+			},
+			"vswitch_id": {
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: true,
+			},
+			"availability_zone": &schema.Schema{
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: true,
+			},
+
+			"tags": tagsSchema(),
+
+			"output_file": {
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: true,
+			},
+
+			// Computed values
+			"instances": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"region_id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"availability_zone": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"status": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"name": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"instance_type": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"vpc_id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"vswitch_id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"image_id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"private_ip": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"public_ip": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"eip": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"description": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"security_groups": {
+							Type:     schema.TypeList,
+							Computed: true,
+							Elem:     &schema.Schema{Type: schema.TypeString},
+						},
+						"key_name": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"creation_time": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"instance_charge_type": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"internet_charge_type": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"internet_max_bandwidth_out": {
+							Type:     schema.TypeInt,
+							Computed: true,
+						},
+						"spot_strategy": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"disk_device_mappings": {
+							Type:     schema.TypeList,
+							Computed: true,
+							//Set:      imageDiskDeviceMappingHash,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"device": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+									"size": {
+										Type:     schema.TypeInt,
+										Computed: true,
+									},
+									"category": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+									"type": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+								},
+							},
+						},
+						"tags": tagsSchema(),
+					},
+				},
+			},
+		},
+	}
+}
+func dataSourceAlicloudInstancesRead(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AliyunClient).ecsconn
+
+	args := &ecs.DescribeInstancesArgs{
+		RegionId: getRegion(d, meta),
+		Status:   ecs.InstanceStatus(d.Get("status").(string)),
+	}
+
+	if v, ok := d.GetOk("ids"); ok && len(v.([]interface{})) > 0 {
+		args.InstanceIds = convertListToJsonString(v.([]interface{}))
+	}
+	if v, ok := d.GetOk("vpc_id"); ok && v != "" {
+		args.VpcId = v.(string)
+	}
+	if v, ok := d.GetOk("vswitch_id"); ok && v != "" {
+		args.VSwitchId = v.(string)
+	}
+	if v, ok := d.GetOk("availability_zone"); ok && v != "" {
+		args.ZoneId = v.(string)
+	}
+	if v, ok := d.GetOk("tags"); ok {
+		mapping := make(map[string]string)
+		for key, value := range v.(map[string]interface{}) {
+			mapping[key] = value.(string)
+		}
+		args.Tag = mapping
+	}
+
+	var allInstances []ecs.InstanceAttributesType
+
+	for {
+		instances, paginationResult, err := conn.DescribeInstances(args)
+		if err != nil {
+			return err
+		}
+
+		allInstances = append(allInstances, instances...)
+
+		pagination := paginationResult.NextPage()
+		if pagination == nil {
+			break
+		}
+
+		args.Pagination = *pagination
+	}
+
+	var filteredInstancesTemp []ecs.InstanceAttributesType
+
+	nameRegex, ok := d.GetOk("name_regex")
+	imageId, okImg := d.GetOk("image_id")
+	if (ok && nameRegex.(string) != "") || (okImg && imageId.(string) != "") {
+		var r *regexp.Regexp
+		if nameRegex != "" {
+			r = regexp.MustCompile(nameRegex.(string))
+		}
+		for _, inst := range allInstances {
+			if r != nil && !r.MatchString(inst.InstanceName) {
+				continue
+			}
+			if imageId.(string) != "" && inst.ImageId != imageId.(string) {
+				continue
+			}
+			filteredInstancesTemp = append(filteredInstancesTemp, inst)
+		}
+	} else {
+		filteredInstancesTemp = allInstances
+	}
+
+	if len(filteredInstancesTemp) < 1 {
+		return fmt.Errorf("Your query returned no results. Please change your search criteria and try again.")
+	}
+
+	log.Printf("[DEBUG] alicloud_instances - Instances found: %#v", filteredInstancesTemp)
+
+	return instancessDescriptionAttributes(d, filteredInstancesTemp, meta)
+}
+
+// populate the numerous fields that the instance description returns.
+func instancessDescriptionAttributes(d *schema.ResourceData, instances []ecs.InstanceAttributesType, meta interface{}) error {
+	var ids []string
+	var s []map[string]interface{}
+	for _, inst := range instances {
+		mapping := map[string]interface{}{
+			"id":                         inst.InstanceId,
+			"region_id":                  inst.RegionId,
+			"availability_zone":          inst.ZoneId,
+			"status":                     inst.Status,
+			"name":                       inst.InstanceName,
+			"instance_type":              inst.InstanceType,
+			"vpc_id":                     inst.VpcAttributes.VpcId,
+			"vswitch_id":                 inst.VpcAttributes.VSwitchId,
+			"image_id":                   inst.ImageId,
+			"description":                inst.Description,
+			"security_groups":            inst.SecurityGroupIds.SecurityGroupId,
+			"eip":                        inst.EipAddress.IpAddress,
+			"key_name":                   inst.KeyPairName,
+			"spot_strategy":              inst.SpotStrategy,
+			"creation_time":              inst.CreationTime.String(),
+			"instance_charge_type":       inst.InstanceChargeType,
+			"internet_charge_type":       inst.InternetChargeType,
+			"internet_max_bandwidth_out": inst.InternetMaxBandwidthOut,
+			// Complex types get their own functions
+			"disk_device_mappings": instanceDisksMappings(d, inst.InstanceId, meta),
+			"tags":                 tagsToMap(inst.Tags.Tag),
+		}
+		if len(inst.InnerIpAddress.IpAddress) > 0 {
+			mapping["private_ip"] = inst.InnerIpAddress.IpAddress[0]
+		} else {
+			mapping["private_ip"] = inst.VpcAttributes.PrivateIpAddress.IpAddress[0]
+		}
+		if len(inst.PublicIpAddress.IpAddress) > 0 {
+			mapping["public_ip"] = inst.PublicIpAddress.IpAddress[0]
+		} else {
+			mapping["public_ip"] = inst.VpcAttributes.NatIpAddress
+		}
+
+		log.Printf("[DEBUG] alicloud_instance - adding instance mapping: %v", mapping)
+		ids = append(ids, inst.InstanceId)
+		s = append(s, mapping)
+	}
+
+	d.SetId(dataResourceIdHash(ids))
+	if err := d.Set("instances", s); err != nil {
+		return err
+	}
+
+	// create a json file in current directory and write data source to it.
+	if output, ok := d.GetOk("output_file"); ok && output.(string) != "" {
+		writeToFile(output.(string), s)
+	}
+	return nil
+}
+
+//Returns a mapping of instance disks
+func instanceDisksMappings(d *schema.ResourceData, instanceId string, meta interface{}) []map[string]interface{} {
+
+	disks, _, err := meta.(*AliyunClient).ecsconn.DescribeDisks(&ecs.DescribeDisksArgs{
+		RegionId:   getRegion(d, meta),
+		InstanceId: instanceId,
+	})
+
+	if err != nil {
+		log.Printf("[ERROR] DescribeDisks for instance got error: %#v", err)
+		return nil
+	}
+
+	var s []map[string]interface{}
+
+	for _, v := range disks {
+		mapping := map[string]interface{}{
+			"device":   v.Device,
+			"size":     v.Size,
+			"category": v.Category,
+			"type":     v.Type,
+		}
+
+		log.Printf("[DEBUG] alicloud_instances - adding disk device mapping: %v", mapping)
+		s = append(s, mapping)
+	}
+
+	return s
+}

--- a/alicloud/data_source_alicloud_instances_test.go
+++ b/alicloud/data_source_alicloud_instances_test.go
@@ -1,0 +1,207 @@
+package alicloud
+
+import (
+	//"regexp"
+	"testing"
+
+	"github.com/hashicorp/terraform/helper/resource"
+)
+
+func TestAccAlicloudInstancesDataSource_nameRegex(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCheckAlicloudInstancesDataSourceNameRegex,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAlicloudDataSourceID("data.alicloud_instances.inst"),
+					resource.TestCheckResourceAttr("data.alicloud_instances.inst", "instances.#", "1"),
+					resource.TestCheckResourceAttr("data.alicloud_instances.inst", "instances.0.name", "test_datasource_name_regex"),
+					resource.TestCheckResourceAttr("data.alicloud_instances.inst", "instances.0.status", "Running"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAlicloudInstancesDataSource_image(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCheckAlicloudInstancesDataSourceImageId,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAlicloudDataSourceID("data.alicloud_instances.inst"),
+					resource.TestCheckResourceAttr("data.alicloud_instances.inst", "instances.#", "1"),
+					resource.TestCheckResourceAttr("data.alicloud_instances.inst", "instances.0.name", "test_datasource_imageId"),
+					resource.TestCheckResourceAttr("data.alicloud_instances.inst", "instances.0.status", "Running"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAlicloudInstancesDataSource_vpcId(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCheckAlicloudInstancesDataSourceVpcId,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAlicloudDataSourceID("data.alicloud_instances.inst"),
+					resource.TestCheckResourceAttr("data.alicloud_instances.inst", "instances.#", "1"),
+					resource.TestCheckResourceAttr("data.alicloud_instances.inst", "instances.0.private_ip", "172.16.10.10"),
+					resource.TestCheckResourceAttr("data.alicloud_instances.inst", "instances.0.status", "Running"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAlicloudInstancesDataSource_tags(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCheckAlicloudImagesDataSourceTags,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAlicloudDataSourceID("data.alicloud_instances.inst"),
+					resource.TestCheckResourceAttr("data.alicloud_instances.inst", "instances.#", "1"),
+					resource.TestCheckResourceAttr("data.alicloud_instances.inst", "instances.0.tags.from", "datasource"),
+					resource.TestCheckResourceAttr("data.alicloud_instances.inst", "instances.0.tags.usage", "test"),
+				),
+			},
+		},
+	})
+}
+
+const testAccCheckAlicloudInstancesDataSourceNameRegex = `
+data "alicloud_images" "images" {
+	name_regex = "ubuntu*"
+}
+resource "alicloud_security_group" "tf_test_foo" {}
+
+resource "alicloud_instance" "foo" {
+	image_id = "${data.alicloud_images.images.images.0.id}"
+	instance_type = "ecs.mn4.small"
+	security_groups = ["${alicloud_security_group.tf_test_foo.*.id}"]
+	instance_name = "test_datasource_name_regex"
+}
+
+data "alicloud_instances" "inst" {
+	name_regex = "test_datasource*"
+	availability_zone = "${alicloud_instance.foo.availability_zone}"
+}
+`
+
+const testAccCheckAlicloudInstancesDataSourceImageId = `
+data "alicloud_images" "images" {
+	name_regex = "ubuntu*"
+}
+resource "alicloud_security_group" "tf_test_foo" {}
+
+resource "alicloud_instance" "foo" {
+	image_id = "${data.alicloud_images.images.images.0.id}"
+
+	instance_type = "ecs.mn4.small"
+	security_groups = ["${alicloud_security_group.tf_test_foo.*.id}"]
+	instance_name = "test_datasource_imageId"
+}
+
+data "alicloud_instances" "inst" {
+	image_id = "${alicloud_instance.foo.image_id}"
+}
+`
+
+const testAccCheckAlicloudInstancesDataSourceVpcId = `
+data "alicloud_images" "images" {
+	name_regex = "ubuntu*"
+}
+data "alicloud_zones" "default" {
+	"available_disk_category"= "cloud_efficiency"
+	"available_resource_creation"= "VSwitch"
+}
+
+resource "alicloud_vpc" "foo" {
+  	cidr_block = "172.16.0.0/12"
+}
+
+resource "alicloud_vswitch" "foo" {
+  	vpc_id = "${alicloud_vpc.foo.id}"
+  	cidr_block = "172.16.0.0/16"
+  	availability_zone = "${data.alicloud_zones.default.zones.0.id}"
+}
+
+resource "alicloud_security_group" "tf_test_foo" {
+	vpc_id = "${alicloud_vpc.foo.id}"
+}
+
+resource "alicloud_instance" "foo" {
+	# cn-beijing
+	vswitch_id = "${alicloud_vswitch.foo.id}"
+	private_ip = "172.16.10.10"
+	image_id = "${data.alicloud_images.images.images.0.id}"
+
+	# series III
+	instance_type = "ecs.n4.large"
+	system_disk_category = "cloud_efficiency"
+
+	security_groups = ["${alicloud_security_group.tf_test_foo.id}"]
+}
+
+data "alicloud_instances" "inst" {
+	vpc_id = "${alicloud_vpc.foo.id}"
+	status = "Running"
+}
+`
+
+const testAccCheckAlicloudImagesDataSourceTags = `
+data "alicloud_images" "images" {
+	name_regex = "ubuntu*"
+}
+data "alicloud_zones" "default" {
+	"available_disk_category"= "cloud_efficiency"
+	"available_resource_creation"= "VSwitch"
+}
+
+resource "alicloud_vpc" "foo" {
+  	cidr_block = "172.16.0.0/12"
+}
+
+resource "alicloud_vswitch" "foo" {
+  	vpc_id = "${alicloud_vpc.foo.id}"
+  	cidr_block = "172.16.0.0/21"
+  	availability_zone = "${data.alicloud_zones.default.zones.0.id}"
+}
+
+resource "alicloud_security_group" "tf_test_foo" {
+	vpc_id = "${alicloud_vpc.foo.id}"
+}
+
+resource "alicloud_instance" "foo" {
+	# cn-beijing
+	vswitch_id = "${alicloud_vswitch.foo.id}"
+	image_id = "${data.alicloud_images.images.images.0.id}"
+
+	# series III
+	instance_type = "ecs.n4.large"
+	system_disk_category = "cloud_efficiency"
+
+	security_groups = ["${alicloud_security_group.tf_test_foo.id}"]
+	tags {
+		from = "datasource"
+		usage = "test"
+	}
+}
+
+data "alicloud_instances" "inst" {
+	tags {
+		from = "datasource"
+	}
+	ids = ["${alicloud_instance.foo.id}"]
+}
+`

--- a/alicloud/data_source_alicloud_kms_keys.go
+++ b/alicloud/data_source_alicloud_kms_keys.go
@@ -1,0 +1,167 @@
+package alicloud
+
+import (
+	"fmt"
+	"regexp"
+
+	"github.com/denverdino/aliyungo/kms"
+	"github.com/hashicorp/terraform/helper/schema"
+)
+
+func dataSourceAlicloudKmsKeys() *schema.Resource {
+	return &schema.Resource{
+		Read: dataSourceAlicloudKmsKeysRead,
+
+		Schema: map[string]*schema.Schema{
+			"ids": &schema.Schema{
+				Type:     schema.TypeList,
+				Optional: true,
+				ForceNew: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+				MinItems: 1,
+			},
+
+			"description_regex": &schema.Schema{
+				Type:         schema.TypeString,
+				Optional:     true,
+				ForceNew:     true,
+				ValidateFunc: validateNameRegex,
+			},
+
+			"status": &schema.Schema{
+				Type:         schema.TypeString,
+				Optional:     true,
+				ForceNew:     true,
+				ValidateFunc: validateKmsKeyStatus,
+			},
+
+			"output_file": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+
+			//Computed value
+			"keys": &schema.Schema{
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"arn": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"description": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"status": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"creation_date": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"delete_date": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"creator": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func dataSourceAlicloudKmsKeysRead(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AliyunClient).kmsconn
+
+	args := &kms.ListKeysArgs{}
+
+	idsMap := make(map[string]string)
+	if v, ok := d.GetOk("ids"); ok && len(v.([]interface{})) > 0 {
+		for _, i := range v.([]interface{}) {
+			idsMap[i.(string)] = i.(string)
+		}
+	}
+
+	var keyIds []string
+	pagination := getPagination(1, 50)
+	for true {
+		args.Pagination = pagination
+		results, err := conn.ListKeys(args)
+		if err != nil {
+			return fmt.Errorf("Error ListKeys: %#v", err)
+		}
+		for _, key := range results.Keys.Key {
+			if idsMap != nil {
+				if _, ok := idsMap[key.KeyId]; ok {
+					keyIds = append(keyIds, key.KeyId)
+					continue
+				}
+			}
+			keyIds = append(keyIds, key.KeyId)
+		}
+		if len(results.Keys.Key) < pagination.PageSize {
+			break
+		}
+		pagination.PageNumber += 1
+	}
+
+	if len(keyIds) < 1 {
+		return fmt.Errorf("Your query kms keys returned no results. Please change your search criteria and try again.")
+	}
+
+	var s []map[string]interface{}
+	var ids []string
+	descriptionRegex, ok := d.GetOk("description_regex")
+	var r *regexp.Regexp
+	if ok && descriptionRegex.(string) != "" {
+		r = regexp.MustCompile(descriptionRegex.(string))
+	}
+	status, statusOk := d.GetOk("status")
+
+	for _, k := range keyIds {
+		key, err := conn.DescribeKey(k)
+		if err != nil {
+			return fmt.Errorf("DescribeKey got an error: %#v", err)
+		}
+
+		if r != nil && !r.MatchString(key.KeyMetadata.Description) {
+			continue
+		}
+		if statusOk && status != "" && status != key.KeyMetadata.KeyState {
+			continue
+		}
+		mapping := map[string]interface{}{
+			"id":            key.KeyMetadata.KeyId,
+			"arn":           key.KeyMetadata.Arn,
+			"description":   key.KeyMetadata.Description,
+			"status":        key.KeyMetadata.KeyState,
+			"creation_date": key.KeyMetadata.CreationDate,
+			"delete_date":   key.KeyMetadata.DeleteDate,
+			"creator":       key.KeyMetadata.Creator,
+		}
+		s = append(s, mapping)
+		ids = append(ids, key.KeyMetadata.KeyId)
+	}
+
+	d.SetId(dataResourceIdHash(ids))
+	if err := d.Set("keys", s); err != nil {
+		return err
+	}
+
+	// create a json file in current directory and write data source to it.
+	if output, ok := d.GetOk("output_file"); ok && output.(string) != "" {
+		writeToFile(output.(string), s)
+	}
+	return nil
+}

--- a/alicloud/data_source_alicloud_kms_keys_test.go
+++ b/alicloud/data_source_alicloud_kms_keys_test.go
@@ -1,0 +1,39 @@
+package alicloud
+
+import (
+	//"regexp"
+	"testing"
+
+	"github.com/hashicorp/terraform/helper/resource"
+)
+
+func TestAccAlicloudKmsKeyDataSource_basic(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCheckAlicloudKmsKeyDataSourceBasic,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAlicloudDataSourceID("data.alicloud_kms_keys.keys"),
+					resource.TestCheckResourceAttr("data.alicloud_kms_keys.keys", "keys.#", "1"),
+					resource.TestCheckResourceAttr("data.alicloud_kms_keys.keys", "keys.0.description", "Terraform acc test datasource"),
+					resource.TestCheckResourceAttr("data.alicloud_kms_keys.keys", "keys.0.status", "Enabled"),
+				),
+			},
+		},
+	})
+}
+
+const testAccCheckAlicloudKmsKeyDataSourceBasic = `
+resource "alicloud_kms_key" "key" {
+    description = "Terraform acc test datasource"
+    deletion_window_in_days = 7
+}
+
+data "alicloud_kms_keys" "keys" {
+	description_regex = "Terraform*"
+	ids = ["${alicloud_kms_key.key.id}"]
+	status = "Enabled"
+}
+`

--- a/alicloud/provider.go
+++ b/alicloud/provider.go
@@ -44,6 +44,7 @@ func Provider() terraform.ResourceProvider {
 			"alicloud_regions":        dataSourceAlicloudRegions(),
 			"alicloud_zones":          dataSourceAlicloudZones(),
 			"alicloud_instance_types": dataSourceAlicloudInstanceTypes(),
+			"alicloud_instances":      dataSourceAlicloudInstances(),
 			"alicloud_vpcs":           dataSourceAlicloudVpcs(),
 			"alicloud_key_pairs":      dataSourceAlicloudKeyPairs(),
 			"alicloud_kms_keys":       dataSourceAlicloudKmsKeys(),

--- a/alicloud/provider.go
+++ b/alicloud/provider.go
@@ -46,6 +46,7 @@ func Provider() terraform.ResourceProvider {
 			"alicloud_instance_types": dataSourceAlicloudInstanceTypes(),
 			"alicloud_vpcs":           dataSourceAlicloudVpcs(),
 			"alicloud_key_pairs":      dataSourceAlicloudKeyPairs(),
+			"alicloud_kms_keys":       dataSourceAlicloudKmsKeys(),
 			"alicloud_dns_domains":    dataSourceAlicloudDnsDomains(),
 			"alicloud_dns_groups":     dataSourceAlicloudDnsGroups(),
 			"alicloud_dns_records":    dataSourceAlicloudDnsRecords(),

--- a/alicloud/resource_alicloud_kms_key.go
+++ b/alicloud/resource_alicloud_kms_key.go
@@ -53,6 +53,10 @@ func resourceAlicloudKmsKey() *schema.Resource {
 				ValidateFunc: validateIntegerInRange(7, 30),
 				Default:      30,
 			},
+			"arn": &schema.Schema{
+				Type:     schema.TypeString,
+				Computed: true,
+			},
 		},
 	}
 }
@@ -98,6 +102,7 @@ func resourceAlicloudKmsKeyRead(d *schema.ResourceData, meta interface{}) error 
 	d.Set("key_usage", key.KeyMetadata.KeyUsage)
 	d.Set("is_enabled", KeyState(key.KeyMetadata.KeyState) == Enabled)
 	d.Set("deletion_window_in_days", d.Get("deletion_window_in_days").(int))
+	d.Set("arn", key.KeyMetadata.Arn)
 
 	return nil
 }

--- a/alicloud/validators.go
+++ b/alicloud/validators.go
@@ -321,6 +321,17 @@ func validateInstanceChargeTypePeriodUnit(v interface{}, k string) (ws []string,
 	return
 }
 
+func validateInstanceStatus(v interface{}, k string) (ws []string, errors []error) {
+	status := ecs.InstanceStatus(v.(string))
+	if status != ecs.Running && status != ecs.Stopped && status != ecs.Creating &&
+		status != ecs.Starting && status != ecs.Stopping {
+		errors = append(errors, fmt.Errorf(
+			"%q must contain a valid status, expected %s or %s or %s or %s or %s, got %s.",
+			k, ecs.Creating, ecs.Starting, ecs.Running, ecs.Stopping, ecs.Stopped, status))
+	}
+	return
+}
+
 // SLB
 func validateSlbName(v interface{}, k string) (ws []string, errors []error) {
 	if value := v.(string); value != "" {
@@ -1101,6 +1112,16 @@ func validateDBInstanceName(v interface{}, k string) (ws []string, errors []erro
 		if len(value) < 2 || len(value) > 256 {
 			errors = append(errors, fmt.Errorf("%q cannot be less than 1 and larger than 30.", k))
 		}
+	}
+	return
+}
+
+func validateKmsKeyStatus(v interface{}, k string) (ws []string, errors []error) {
+	status := KeyState(v.(string))
+	if status != Enabled && status != Disabled && status != PendingDeletion {
+		errors = append(errors, fmt.Errorf(
+			"%q must contain a valid status, expected %s or %s or %s, got %s.",
+			k, Enabled, Disabled, PendingDeletion, status))
 	}
 	return
 }

--- a/website/alicloud.erb
+++ b/website/alicloud.erb
@@ -28,6 +28,9 @@
                         <li<%= sidebar_current("docs-alicloud-datasource-key-pairs") %>>
                             <a href="/docs/providers/alicloud/d/key_pairs.html">alicloud_key_pairs</a>
                         </li>
+                        <li<%= sidebar_current("docs-alicloud-datasource-kms-keys") %>>
+                            <a href="/docs/providers/alicloud/d/kms_keys.html">alicloud_kms_keys</a>
+                        </li>
                         <li<%= sidebar_current("docs-alicloud-datasource-vpcs") %>>
                             <a href="/docs/providers/alicloud/d/vpcs.html">alicloud_vpcs</a>
                         </li>

--- a/website/alicloud.erb
+++ b/website/alicloud.erb
@@ -31,6 +31,9 @@
                         <li<%= sidebar_current("docs-alicloud-datasource-kms-keys") %>>
                             <a href="/docs/providers/alicloud/d/kms_keys.html">alicloud_kms_keys</a>
                         </li>
+                        <li<%= sidebar_current("docs-alicloud-datasource-instances") %>>
+                            <a href="/docs/providers/alicloud/d/instances.html">alicloud_instances</a>
+                        </li>
                         <li<%= sidebar_current("docs-alicloud-datasource-vpcs") %>>
                             <a href="/docs/providers/alicloud/d/vpcs.html">alicloud_vpcs</a>
                         </li>

--- a/website/docs/d/dns_domain_groups.html.markdown
+++ b/website/docs/d/dns_domain_groups.html.markdown
@@ -8,4 +8,4 @@ description: |-
 
 # alicloud\_dns\_domain\_groups
 
-~> **NOTE:** This datasource has been deprecated from [v1.5.0](https://github.com/alibaba/terraform-provider/releases/tag/V1.5.0). New datasource `alicloud_dns_groups` will replace.
+~> **NOTE:** This datasource has been deprecated from [v1.3.2](https://github.com/alibaba/terraform-provider/releases/tag/V1.3.2). New datasource `alicloud_dns_groups` will replace.

--- a/website/docs/d/dns_domain_records.html.markdown
+++ b/website/docs/d/dns_domain_records.html.markdown
@@ -8,4 +8,4 @@ description: |-
 
 # alicloud\_dns\_domain\_records
 
-~> **NOTE:** This resource has been deprecated from [v1.5.0](https://github.com/alibaba/terraform-provider/releases/tag/V1.5.0). New datasource `alicloud_dns_records` will replace.
+~> **NOTE:** This resource has been deprecated from [v1.3.2](https://github.com/alibaba/terraform-provider/releases/tag/V1.3.2). New datasource `alicloud_dns_records` will replace.

--- a/website/docs/d/instances.html.markdown
+++ b/website/docs/d/instances.html.markdown
@@ -1,0 +1,70 @@
+---
+layout: "alicloud"
+page_title: "Alicloud: alicloud_instances"
+sidebar_current: "docs-alicloud-datasource-instances"
+description: |-
+    Provides a list of ECS instances to the user.
+---
+
+# alicloud\_instances
+
+The Instances data source list ECS instance resource accoring to its ID, name regex, image id, status and other fields.
+
+## Example Usage
+
+```
+data "alicloud_instances" "instances" {
+	name_regex = "web_server"
+	status = "Running"
+}
+
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `ids` - (Optional) A list of ECS instance ID.
+* `name_regex` - (Optional) A regex string to apply to the instance list returned by Alicloud.
+* `image_id` - (Optional) The image ID of some ECS instance used.
+* `status` - (Optional) List specified status instances. Valid values: "Creating", "Starting", "Running", "Stopping" and "Stopped". Default to list all status.
+* `vpc_id` - (Optional) List several instances in the specified VPC.
+* `vswitch_id` - (Optional) List several instances in the specified VSwitch.
+* `availability_zone` - (Optional) List several instances in the specified availability zone.
+* `tags` - (Optional) A mapping of tags marked ECS instanes.
+* `output_file` - (Optional) The name of file that can save instances data source after running `terraform plan`.
+
+## Attributes Reference
+
+* `instances` A list of instnaces. It contains several attributes to `Block Instances`.
+
+### Block Instances
+
+Attributes for instanes:
+
+* `id` - ID of the instance.
+* `region_id` - Region Id the instance belongs.
+* `availability_zone` - Availability zone the instance belongs.
+* `status` - Instance current status.
+* `name` - Instance name.
+* `description` - Instance description.
+* `instance_type` - Instance type.
+* `vpc_id` - VPC ID the instance belongs.
+* `vswitch_id` - VSwitch ID the instance belongs.
+* `image_id` - Image id the instance used.
+* `private_ip` - Instance private IP address.
+* `public_ip` - Instance public IP address.
+* `eip` - EIP address the VPC instance used.
+* `security_groups` - List security group ID the instance belongs.
+* `key_name` - Key pair the instance used.
+* `creation_time` - Instance creation time.
+* `instance_charge_type` - Instance charge type.
+* `internet_charge_type` - Instance network charge type.
+* `internet_max_bandwidth_out` - Instance internet out max bandwidth
+* `spot_strategy` - Spot strategy the instance used.
+* `disk_device_mappings` - Description of the disk the instance attached.
+  * `device` - Device information of the created disk: such as /dev/xvdb.
+  * `size` - Size of the created disk.
+  * `category` - Cloud disk category.
+  * `type` - Cloud disk type. System disk or data disk.
+* `tags` - A mapping of tags marked ECS instanes.

--- a/website/docs/d/kms_keys.html.markdown
+++ b/website/docs/d/kms_keys.html.markdown
@@ -1,0 +1,43 @@
+---
+layout: "alicloud"
+page_title: "Alicloud: alicloud_kms_keys"
+sidebar_current: "docs-alicloud-datasource-kms-keys"
+description: |-
+    Provides a list of Availability KMS Keys.
+---
+
+# alicloud\_kms\_keys
+
+The KMS keys data source provides a list of Alicloud KMS keys in an Alicloud account according to the specified filters.
+
+## Example Usage
+
+```
+# Declare the data source
+data "alicloud_kms_keys" "keys" {
+	description_regex = "Hello KMS"
+	output_file = "kms_keys.json"
+}
+
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `ids` - (Optional) A list of KMS key ID.
+* `description_regex` - (Optional) A regex string of the KMS key description.
+* `status` - (Optional) The status of KMS key. Valid values: "Enabled", "Disabled", "PendingDeletion". Default to nil to get all keys.
+* `output_file` - (Optional) The name of file that can save KMS keys data source after running `terraform plan`.
+
+## Attributes Reference
+
+A list of KMS keys will be exported and its every element contains the following attributes:
+
+* `id` - ID of the key.
+* `arn` - The Alicloud Resource Name (ARN) of the key.
+* `description` - Description of the key.
+* `status` - Status of the key, with possible values: "Enabled", "Disabled", "PendingDeletion".
+* `creation_date` - Creation date of key.
+* `delete_date` - Delete date of key.
+* `creator` - The createor to key belongs.

--- a/website/docs/d/ram_alias.html.markdown
+++ b/website/docs/d/ram_alias.html.markdown
@@ -1,0 +1,11 @@
+---
+layout: "alicloud"
+page_title: "Alicloud: alicloud_ram_account_alias"
+sidebar_current: "docs-alicloud-datasource-ram-account-alias"
+description: |-
+    Provides an alias of the cloud account.
+---
+
+# alicloud\_ram\_account\_alias
+
+~> **NOTE:** This datasource has been deprecated from [v1.3.2](https://github.com/alibaba/terraform-provider/releases/tag/V1.3.2). New datasource `alicloud_ram_account_aliases` will replace.

--- a/website/docs/r/kms_key.html.markdown
+++ b/website/docs/r/kms_key.html.markdown
@@ -39,6 +39,7 @@ The following arguments are supported:
 ## Attributes Reference
 
 * `id` - The ID of the key.
+* `arn` - The Alicloud Resource Name (ARN) of the key.
 * `description` - The description of the key.
 * `key_usage` - Specifies the usage of CMK.
 * `deletion_window_in_days` - During pre-deletion days.


### PR DESCRIPTION
The PR adds a new datasource alicloud_instances.

The PR has a pre-pr #93 

The result of running test case as follows:

TF_ACC=1 go test ./alicloud -v -run=TestAccAlicloudInstancesDataSource -timeout 120m
=== RUN   TestAccAlicloudInstancesDataSource_nameRegex
--- PASS: TestAccAlicloudInstancesDataSource_nameRegex (137.39s)
=== RUN   TestAccAlicloudInstancesDataSource_image
--- PASS: TestAccAlicloudInstancesDataSource_image (137.99s)
=== RUN   TestAccAlicloudInstancesDataSource_vpcId
--- PASS: TestAccAlicloudInstancesDataSource_vpcId (157.24s)
=== RUN   TestAccAlicloudInstancesDataSource_tags
--- PASS: TestAccAlicloudInstancesDataSource_tags (172.14s)
PASS
ok    github.com/alibaba/terraform-provider/alicloud  604.800s
