### PR TITLE
Add a new field specification for alicloud_slb

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ IMPROVEMENTS:
 - *New DataSource*: _alicloud_kms_keys_ ([#93](https://github.com/terraform-providers/terraform-provider-alicloud/pull/93))
 - *New DataSource*: _alicloud_instances_ ([#94](https://github.com/terraform-providers/terraform-provider-alicloud/pull/94))
 - Add a new output field "arn" for _alicloud_kms_key_ ([#92](https://github.com/terraform-providers/terraform-provider-alicloud/pull/92))
+- Add a new field "specification" for _alicloud_slb_ ([#95](https://github.com/terraform-providers/terraform-provider-alicloud/pull/95))
 
 ## 1.6.2 (January 22, 2018)
 

--- a/alicloud/diff_suppress_funcs.go
+++ b/alicloud/diff_suppress_funcs.go
@@ -99,6 +99,13 @@ func slbInternetChargeTypeDiffSuppressFunc(k, old, new string, d *schema.Resourc
 	return !slbInternetDiffSuppressFunc(k, old, new, d)
 }
 
+func slbInstanceSpecDiffSuppressFunc(k, old, new string, d *schema.ResourceData) bool {
+	if old != "" && new == "" {
+		return true
+	}
+	return false
+}
+
 func slbBandwidthDiffSuppressFunc(k, old, new string, d *schema.ResourceData) bool {
 	if slbInternetDiffSuppressFunc(k, old, new, d) && slb.InternetChargeType(d.Get("internet_charge_type").(string)) == slb.PayByBandwidth {
 		return false

--- a/alicloud/resource_alicloud_slb_test.go
+++ b/alicloud/resource_alicloud_slb_test.go
@@ -105,6 +105,40 @@ func TestAccAlicloudSlb_vpc(t *testing.T) {
 	})
 }
 
+func TestAccAlicloudSlb_spec(t *testing.T) {
+	var slb slb.LoadBalancerType
+
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+		},
+
+		// module name
+		IDRefreshName: "alicloud_slb.spec",
+
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckSlbDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccSlbBandSpec,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckSlbExists("alicloud_slb.spec", &slb),
+					resource.TestCheckResourceAttr(
+						"alicloud_slb.spec", "specification", ""),
+				),
+			},
+			resource.TestStep{
+				Config: testAccSlbBandSpecUpdate,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckSlbExists("alicloud_slb.spec", &slb),
+					resource.TestCheckResourceAttr(
+						"alicloud_slb.spec", "specification", "slb.s1.small"),
+				),
+			},
+		},
+	})
+}
+
 func testAccCheckSlbExists(n string, slb *slb.LoadBalancerType) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[n]
@@ -191,7 +225,19 @@ resource "alicloud_vswitch" "foo" {
 
 resource "alicloud_slb" "vpc" {
   name = "tf_test_slb_vpc"
-  //internet_charge_type = "paybybandwidth"
+  specification = "slb.s2.small"
   vswitch_id = "${alicloud_vswitch.foo.id}"
+}
+`
+const testAccSlbBandSpec = `
+resource "alicloud_slb" "spec" {
+  name = "tf_test_slb_spec"
+}
+`
+
+const testAccSlbBandSpecUpdate = `
+resource "alicloud_slb" "spec" {
+  name = "tf_test_slb_spec"
+  specification = "slb.s1.small"
 }
 `

--- a/alicloud/validators.go
+++ b/alicloud/validators.go
@@ -361,6 +361,23 @@ func validateSlbInternetChargeType(v interface{}, k string) (ws []string, errors
 	return
 }
 
+func validateSlbInstanceSpecType(v interface{}, k string) (ws []string, errors []error) {
+	if value := v.(string); value != "" {
+		specType := slb.LoadBalancerSpecType(value)
+		validLoadBalancerSpec := []slb.LoadBalancerSpecType{slb.S1Small, slb.S2Small,
+			slb.S2Medium, slb.S3Small, slb.S3Medium, slb.S3Large}
+
+		for _, s := range validLoadBalancerSpec {
+			if s == specType {
+				return
+			}
+		}
+		errors = append(errors, fmt.Errorf("%q must contain a valid LoadBalancerSpecType,"+
+			" expected %#v, got %q", k, validLoadBalancerSpec, value))
+	}
+	return
+}
+
 func validateSlbListenerBandwidth(v interface{}, k string) (ws []string, errors []error) {
 	value := v.(int)
 	if (value < 1 || value > 1000) && value != -1 {

--- a/vendor/github.com/denverdino/aliyungo/slb/loadbalancers.go
+++ b/vendor/github.com/denverdino/aliyungo/slb/loadbalancers.go
@@ -21,6 +21,17 @@ const (
 	PayByTraffic   = InternetChargeType("paybytraffic")
 )
 
+type LoadBalancerSpecType string
+
+const (
+	S1Small = "slb.s1.small"
+	S2Small = "slb.s2.small"
+	S2Medium = "slb.s2.medium"
+	S3Small = "slb.s3.small"
+	S3Medium = "slb.s3.medium"
+	S3Large = "slb.s3.large"
+)
+
 type CreateLoadBalancerArgs struct {
 	RegionId           common.Region
 	LoadBalancerName   string
@@ -31,6 +42,7 @@ type CreateLoadBalancerArgs struct {
 	ClientToken        string
 	MasterZoneId       string
 	SlaveZoneId        string
+	LoadBalancerSpec   LoadBalancerSpecType
 }
 
 type CreateLoadBalancerResponse struct {
@@ -92,6 +104,22 @@ type ModifyLoadBalancerInternetSpecResponse struct {
 func (client *Client) ModifyLoadBalancerInternetSpec(args *ModifyLoadBalancerInternetSpecArgs) (err error) {
 	response := &ModifyLoadBalancerInternetSpecResponse{}
 	err = client.Invoke("ModifyLoadBalancerInternetSpec", args, response)
+	return err
+}
+
+type ModifyLoadBalancerInstanceSpecArgs struct {
+	RegionId common.Region
+	LoadBalancerId     string
+	LoadBalancerSpec   LoadBalancerSpecType
+}
+
+// ModifyLoadBalancerInstanceSpec Modify loadbalancer instance spec
+//
+// You can read doc at https://help.aliyun.com/document_detail/53360.html
+
+func (client *Client) ModifyLoadBalancerInstanceSpec(args *ModifyLoadBalancerInstanceSpecArgs) (err error) {
+	response := &common.Response{}
+	err = client.Invoke("ModifyLoadBalancerInstanceSpec", args, response)
 	return err
 }
 
@@ -194,6 +222,7 @@ type LoadBalancerType struct {
 	BackendServers struct {
 		BackendServer []BackendServerType
 	}
+	LoadBalancerSpec   LoadBalancerSpecType
 }
 
 type DescribeLoadBalancersResponse struct {

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -235,74 +235,74 @@
 		{
 			"checksumSHA1": "9bZS3sdYQuY8j2Fxi9sEoQl2ibQ=",
 			"path": "github.com/denverdino/aliyungo/cdn",
-			"revision": "c0d28eeada35fc1c63b16865b438ee277ca179fb",
-			"revisionTime": "2018-01-19T08:28:08Z"
+			"revision": "43fd660e1e8f277e1bdde03650478aead0d6f582",
+			"revisionTime": "2018-01-25T00:39:10Z"
 		},
 		{
 			"checksumSHA1": "6jhMTB/kEVfbbszOdOyYODYFk5Q=",
 			"path": "github.com/denverdino/aliyungo/common",
-			"revision": "c0d28eeada35fc1c63b16865b438ee277ca179fb",
-			"revisionTime": "2018-01-19T08:28:08Z"
+			"revision": "43fd660e1e8f277e1bdde03650478aead0d6f582",
+			"revisionTime": "2018-01-25T00:39:10Z"
 		},
 		{
 			"checksumSHA1": "JgK7hgdP+yfsRin1lbz0LjBVtic=",
 			"path": "github.com/denverdino/aliyungo/cs",
-			"revision": "c0d28eeada35fc1c63b16865b438ee277ca179fb",
-			"revisionTime": "2018-01-19T08:28:08Z"
+			"revision": "43fd660e1e8f277e1bdde03650478aead0d6f582",
+			"revisionTime": "2018-01-25T00:39:10Z"
 		},
 		{
 			"checksumSHA1": "0y6d3UiB8JckT3YTeXjMbLkSibg=",
 			"path": "github.com/denverdino/aliyungo/dns",
-			"revision": "c0d28eeada35fc1c63b16865b438ee277ca179fb",
-			"revisionTime": "2018-01-19T08:28:08Z"
+			"revision": "43fd660e1e8f277e1bdde03650478aead0d6f582",
+			"revisionTime": "2018-01-25T00:39:10Z"
 		},
 		{
 			"checksumSHA1": "p0MBe0iRbSkAhLFYX7n/+wsfJJY=",
 			"path": "github.com/denverdino/aliyungo/ecs",
-			"revision": "c0d28eeada35fc1c63b16865b438ee277ca179fb",
-			"revisionTime": "2018-01-19T08:28:08Z"
+			"revision": "43fd660e1e8f277e1bdde03650478aead0d6f582",
+			"revisionTime": "2018-01-25T00:39:10Z"
 		},
 		{
 			"checksumSHA1": "ppmAWGfRcffPvGcqpUbxdWwkUbg=",
 			"path": "github.com/denverdino/aliyungo/ess",
-			"revision": "c0d28eeada35fc1c63b16865b438ee277ca179fb",
-			"revisionTime": "2018-01-19T08:28:08Z"
+			"revision": "43fd660e1e8f277e1bdde03650478aead0d6f582",
+			"revisionTime": "2018-01-25T00:39:10Z"
 		},
 		{
 			"checksumSHA1": "rj3YU+oc3pVDG9Rd1zzHtMWsIJg=",
 			"path": "github.com/denverdino/aliyungo/kms",
-			"revision": "c0d28eeada35fc1c63b16865b438ee277ca179fb",
-			"revisionTime": "2018-01-19T08:28:08Z"
+			"revision": "43fd660e1e8f277e1bdde03650478aead0d6f582",
+			"revisionTime": "2018-01-25T00:39:10Z"
 		},
 		{
 			"checksumSHA1": "CPuR3s7LzQkT57Z20zMHXQM2MYQ=",
 			"path": "github.com/denverdino/aliyungo/location",
-			"revision": "c0d28eeada35fc1c63b16865b438ee277ca179fb",
-			"revisionTime": "2018-01-19T08:28:08Z"
+			"revision": "43fd660e1e8f277e1bdde03650478aead0d6f582",
+			"revisionTime": "2018-01-25T00:39:10Z"
 		},
 		{
 			"checksumSHA1": "mkaQUrh01nWescV/Ek7Yv/WwX9Q=",
 			"path": "github.com/denverdino/aliyungo/ram",
-			"revision": "c0d28eeada35fc1c63b16865b438ee277ca179fb",
-			"revisionTime": "2018-01-19T08:28:08Z"
+			"revision": "43fd660e1e8f277e1bdde03650478aead0d6f582",
+			"revisionTime": "2018-01-25T00:39:10Z"
 		},
 		{
 			"checksumSHA1": "D4ugog0rIZolvzyH2Wf/p+eUJOE=",
 			"path": "github.com/denverdino/aliyungo/rds",
-			"revision": "c0d28eeada35fc1c63b16865b438ee277ca179fb",
-			"revisionTime": "2018-01-19T08:28:08Z"
+			"revision": "43fd660e1e8f277e1bdde03650478aead0d6f582",
+			"revisionTime": "2018-01-25T00:39:10Z"
 		},
 		{
-			"checksumSHA1": "vsHDSvuHR3Fce800xGIsMWcEMHc=",
+			"checksumSHA1": "pTmrFsVGJmq42mUzlIhwh72jKbQ=",
 			"path": "github.com/denverdino/aliyungo/slb",
-			"revision": "c0d28eeada35fc1c63b16865b438ee277ca179fb",
-			"revisionTime": "2018-01-19T08:28:08Z"
+			"revision": "43fd660e1e8f277e1bdde03650478aead0d6f582",
+			"revisionTime": "2018-01-25T00:39:10Z"
 		},
 		{
 			"checksumSHA1": "ZSpVJldK4F8joh8pOryB5SaSn8s=",
 			"path": "github.com/denverdino/aliyungo/util",
-			"revision": "c0d28eeada35fc1c63b16865b438ee277ca179fb",
-			"revisionTime": "2018-01-19T08:28:08Z"
+			"revision": "43fd660e1e8f277e1bdde03650478aead0d6f582",
+			"revisionTime": "2018-01-25T00:39:10Z"
 		},
 		{
 			"checksumSHA1": "BCv50o5pDkoSG3vYKOSai1Z8p3w=",

--- a/website/docs/r/slb.html.markdown
+++ b/website/docs/r/slb.html.markdown
@@ -24,6 +24,7 @@ resource "alicloud_slb" "classic" {
   internet             = true
   internet_charge_type = "paybybandwidth"
   bandwidth            = 5
+  specification = "slb.s1.small"
 }
 
 # Create a new load balancer for VPC
@@ -55,6 +56,13 @@ Terraform will autogenerate a name beginning with `tf-lb`.
   value is between 1 and 1000, If argument "internet_charge_type" is "paybytraffic", then this value will be ignore.
 * `listener` - (Deprecated) The field has been deprecated from terraform-alicloud-provider [version 1.3.0](https://github.com/alibaba/terraform-provider/releases/tag/V1.3.0), and use resource `alicloud_slb_listener` to replace.
 * `vswitch_id` - (Required for a VPC SLB, Forces New Resource) The VSwitch ID to launch in.
+* `specification` - (Optional) The specification of the Server Load Balancer instance. Default to empty string indicating it is "Shared-Performance" instance.
+ Launching "[Performance-guaranteed](https://www.alibabacloud.com/help/doc-detail/27657.htm)" instance, it is must be specified and it valid values are: "slb.s1.small", "slb.s2.small", "slb.s2.medium",
+ "slb.s3.small", "slb.s3.medium" and "slb.s3.large".
+
+~> **NOTE:** A "Shared-Performance" instance can be changed to "Performance-guaranteed", but the change is irreversible.
+
+~> **NOTE:** To change a "Shared-Performance" instance to a "Performance-guaranteed" instance, the SLB will have a short probability of business interruption (10 seconds-30 seconds). Advise to change it during the business downturn, or migrate business to other SLB Instances by using GSLB before changing.
 
 ## Attributes Reference
 
@@ -67,6 +75,7 @@ The following attributes are exported:
 * `bandwidth` - The bandwidth of the load balancer.
 * `vswitch_id` - The VSwitch ID of the load balancer. Only available on SLB launched in a VPC.
 * `address` - The IP address of the load balancer.
+* `specification` - The specification of the Server Load Balancer instance.
 
 ## Import
 


### PR DESCRIPTION
The PR adds a new field specification for alicloud_slb resource.

The result of running testcase as follows:

TF_ACC=1 go test ./alicloud -v -run=TestAccAlicloudSlb_spec -timeout 120m 
=== RUN   TestAccAlicloudSlb_spec
--- PASS: TestAccAlicloudSlb_spec (24.53s)
PASS
ok      github.com/alibaba/terraform-provider/alicloud  24.578s

TF_ACC=1 go test ./alicloud -v -run=TestAccAlicloudSlb_import -timeout 120m
=== RUN   TestAccAlicloudSlb_importBandwidth
--- PASS: TestAccAlicloudSlb_importBandwidth (15.40s)
=== RUN   TestAccAlicloudSlb_importTraffic
--- PASS: TestAccAlicloudSlb_importTraffic (14.96s)
=== RUN   TestAccAlicloudSlb_importVpc
--- PASS: TestAccAlicloudSlb_importVpc (34.18s)
PASS
ok      github.com/alibaba/terraform-provider/alicloud  64.588s
