### PR TITLE
Improve security group rule's port range for '-1/-1'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ IMPROVEMENTS:
 - *New DataSource*: _alicloud_instances_ ([#94](https://github.com/terraform-providers/terraform-provider-alicloud/pull/94))
 - Add a new output field "arn" for _alicloud_kms_key_ ([#92](https://github.com/terraform-providers/terraform-provider-alicloud/pull/92))
 - Add a new field "specification" for _alicloud_slb_ ([#95](https://github.com/terraform-providers/terraform-provider-alicloud/pull/95))
+- Improve security group rule's port range for "-1/-1" ([#96](https://github.com/terraform-providers/terraform-provider-alicloud/pull/96))
 
 ## 1.6.2 (January 22, 2018)
 

--- a/alicloud/diff_suppress_funcs.go
+++ b/alicloud/diff_suppress_funcs.go
@@ -193,6 +193,12 @@ func ecsSpotPriceLimitDiffSuppressFunc(k, old, new string, d *schema.ResourceDat
 func ecsSecurityGroupRulePortRangeDiffSuppressFunc(k, old, new string, d *schema.ResourceData) bool {
 	protocol := ecs.IpProtocol(d.Get("ip_protocol").(string))
 	if protocol == ecs.IpProtocolTCP || protocol == ecs.IpProtocolUDP {
+		if new == AllPortRange {
+			return true
+		}
+		return false
+	}
+	if new == AllPortRange {
 		return false
 	}
 	return true

--- a/alicloud/resource_alicloud_security_group_rule.go
+++ b/alicloud/resource_alicloud_security_group_rule.go
@@ -51,8 +51,9 @@ func resourceAliyunSecurityGroupRule() *schema.Resource {
 
 			"port_range": &schema.Schema{
 				Type:             schema.TypeString,
-				Required:         true,
+				Optional:         true,
 				ForceNew:         true,
+				Default:          AllPortRange,
 				DiffSuppressFunc: ecsSecurityGroupRulePortRangeDiffSuppressFunc,
 			},
 
@@ -100,8 +101,8 @@ func resourceAliyunSecurityGroupRuleCreate(d *schema.ResourceData, meta interfac
 	sgId := d.Get("security_group_id").(string)
 	ptl := d.Get("ip_protocol").(string)
 	port := d.Get("port_range").(string)
-	if ecs.IpProtocol(ptl) != ecs.IpProtocolTCP && ecs.IpProtocol(ptl) != ecs.IpProtocolUDP {
-		port = AllPortRange
+	if port == "" {
+		return fmt.Errorf("'port_range': required field is not set or invalid.")
 	}
 	nicType := d.Get("nic_type").(string)
 	policy := d.Get("policy").(string)

--- a/alicloud/resource_alicloud_security_group_rule_test.go
+++ b/alicloud/resource_alicloud_security_group_rule_test.go
@@ -300,14 +300,20 @@ func TestAccAlicloudSecurityGroupRule_MultiAttri(t *testing.T) {
 						"alicloud_security_group_rule.ingress_allow_tcp_22_prior", &pt),
 					testAccCheckSecurityGroupRuleExists(
 						"alicloud_security_group_rule.ingress_deny_tcp_22_prior", &pt),
-					testAccCheckSecurityGroupRuleExists(
-						"alicloud_security_group_rule.all", &pt),
 					resource.TestCheckResourceAttr(
 						"alicloud_security_group_rule.ingress_deny_tcp_22_prior",
 						"port_range",
 						"22/22"),
+					testAccCheckSecurityGroupRuleExists(
+						"alicloud_security_group_rule.all", &pt),
 					resource.TestCheckResourceAttr(
 						"alicloud_security_group_rule.all",
+						"port_range",
+						"-1/-1"),
+					testAccCheckSecurityGroupRuleExists(
+						"alicloud_security_group_rule.gre", &pt),
+					resource.TestCheckResourceAttr(
+						"alicloud_security_group_rule.gre",
 						"port_range",
 						"-1/-1"),
 				),
@@ -638,6 +644,15 @@ resource "alicloud_security_group_rule" "all" {
   priority = 100
   security_group_id = "${alicloud_security_group.main.id}"
   cidr_ip = "0.0.0.0/0"
-  port_range = "22/22"
+  port_range = "-1/-1"
+}
+resource "alicloud_security_group_rule" "gre" {
+  type = "ingress"
+  ip_protocol = "gre"
+  nic_type = "intranet"
+  policy = "accept"
+  priority = 100
+  security_group_id = "${alicloud_security_group.main.id}"
+  cidr_ip = "0.0.0.0/0"
 }
 `

--- a/website/docs/r/security_group_rule.html.markdown
+++ b/website/docs/r/security_group_rule.html.markdown
@@ -41,8 +41,8 @@ The following arguments are supported:
 
 * `type` - (Required) The type of rule being created. Valid options are `ingress` (inbound) or `egress` (outbound).
 * `ip_protocol` - (Required) The protocol. Can be `tcp`, `udp`, `icmp`, `gre` or `all`.
-* `port_range` - (Required) The range of port numbers relevant to the IP protocol. When the protocol is tcp or udp, the default port number range is 1-65535.
-  For example, `1/200` means that the range of the port numbers is 1-200. Other protocols' 'port_range' only is "-1/-1", and other values will be ignored.
+* `port_range` - (Required) The range of port numbers relevant to the IP protocol. Default to "-1/-1". When the protocol is tcp or udp, each side port number range from 1 to 65535 and '-1/-1' will be invalid.
+  For example, `1/200` means that the range of the port numbers is 1-200. Other protocols' 'port_range' can only be "-1/-1", and other values will be invalid.
 * `security_group_id` - (Required) The security group to apply this rule to.
 * `nic_type` - (Optional, Forces new resource) Network type, can be either `internet` or `intranet`, the default value is `internet`.
 * `policy` - (Optional, Forces new resource) Authorization policy, can be either `accept` or `drop`, the default value is `accept`.


### PR DESCRIPTION
The PR improves security group rule's port range for "-1/-1" when ip protocol is "all" or "gre" or "icmp".

The result of running test case as follows:

TF_ACC=1 go test ./alicloud -v -run=TestAccAlicloudSecurityGroupRule -timeout 120m
=== RUN   TestAccAlicloudSecurityGroupRule_Ingress
--- PASS: TestAccAlicloudSecurityGroupRule_Ingress (16.58s)
=== RUN   TestAccAlicloudSecurityGroupRule_Egress
--- PASS: TestAccAlicloudSecurityGroupRule_Egress (14.58s)
=== RUN   TestAccAlicloudSecurityGroupRule_EgressDefaultNicType
--- PASS: TestAccAlicloudSecurityGroupRule_EgressDefaultNicType (23.28s)
=== RUN   TestAccAlicloudSecurityGroupRule_Vpc_Ingress
--- PASS: TestAccAlicloudSecurityGroupRule_Vpc_Ingress (23.70s)
=== RUN   TestAccAlicloudSecurityGroupRule_MissParameterSourceCidrIp
--- PASS: TestAccAlicloudSecurityGroupRule_MissParameterSourceCidrIp (13.38s)
=== RUN   TestAccAlicloudSecurityGroupRule_SourceSecurityGroup
--- PASS: TestAccAlicloudSecurityGroupRule_SourceSecurityGroup (14.48s)
=== RUN   TestAccAlicloudSecurityGroupRule_Multi
--- PASS: TestAccAlicloudSecurityGroupRule_Multi (38.17s)
=== RUN   TestAccAlicloudSecurityGroupRule_MultiAttri
--- PASS: TestAccAlicloudSecurityGroupRule_MultiAttri (23.90s)
PASS
ok      github.com/alibaba/terraform-provider/alicloud  168.110s
