### PR TITLE
fix slb invalid status error when launching ESS scaling group

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 1.7.0 (Unreleased)
+## 1.7.0 (January 25, 2018)
 
 IMPROVEMENTS:
 
@@ -8,6 +8,10 @@ IMPROVEMENTS:
 - Add a new output field "arn" for _alicloud_kms_key_ ([#92](https://github.com/terraform-providers/terraform-provider-alicloud/pull/92))
 - Add a new field "specification" for _alicloud_slb_ ([#95](https://github.com/terraform-providers/terraform-provider-alicloud/pull/95))
 - Improve security group rule's port range for "-1/-1" ([#96](https://github.com/terraform-providers/terraform-provider-alicloud/pull/96))
+
+BUG FIXES:
+
+- fix slb invalid status error when launching ESS scaling group ([#97](https://github.com/terraform-providers/terraform-provider-alicloud/pull/97))
 
 ## 1.6.2 (January 22, 2018)
 

--- a/alicloud/resource_alicloud_ess_scalinggroup.go
+++ b/alicloud/resource_alicloud_ess_scalinggroup.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 
 	"github.com/denverdino/aliyungo/ess"
+	"github.com/denverdino/aliyungo/slb"
 	"github.com/hashicorp/terraform/helper/schema"
 )
 
@@ -195,7 +196,12 @@ func buildAlicloudEssScalingGroupArgs(d *schema.ResourceData, meta interface{}) 
 	}
 
 	lbs, ok := d.GetOk("loadbalancer_ids")
-	if ok {
+	if ok && len(lbs.([]interface{})) > 0 {
+		for _, lb := range lbs.([]interface{}) {
+			if err := client.slbconn.WaitForLoadBalancerAsyn(lb.(string), slb.ActiveStatus, defaultTimeout); err != nil {
+				return nil, fmt.Errorf("WaitForLoadbalancer %s %s got error: %#v", lb.(string), slb.ActiveStatus, err)
+			}
+		}
 		args.LoadBalancerIds = convertListToJsonString(lbs.([]interface{}))
 	}
 

--- a/alicloud/resource_alicloud_slb.go
+++ b/alicloud/resource_alicloud_slb.go
@@ -256,7 +256,7 @@ func resourceAliyunSlbCreate(d *schema.ResourceData, meta interface{}) error {
 	d.SetId(lb.LoadBalancerId)
 
 	if err := slbconn.WaitForLoadBalancerAsyn(lb.LoadBalancerId, slb.ActiveStatus, defaultTimeout); err != nil {
-		return fmt.Errorf("WaitForListener %s got error: %#v", slb.ActiveStatus, err)
+		return fmt.Errorf("WaitForLoadbalancer %s got error: %#v", slb.ActiveStatus, err)
 	}
 
 	return resourceAliyunSlbUpdate(d, meta)


### PR DESCRIPTION
The PR fixes a error results from slb invalid status when launching ESS scaling group.

The result of running test case as follows:

TF_ACC=1 go test ./alicloud -v -run=TestAccAlicloudEssScalingGroup_slb -timeout 120m
=== RUN   TestAccAlicloudEssScalingGroup_slb
--- PASS: TestAccAlicloudEssScalingGroup_slb (150.28s)
PASS
ok      github.com/alibaba/terraform-provider/alicloud  150.325s
