### PR TITLE
Deprecate nat gateway fileds spec and bandwidth_paclages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 IMPROVEMENTS:
 
+- Deprecate nat gateway fileds 'spec' and 'bandwidth_packages' ([#100](https://github.com/terraform-providers/terraform-provider-alicloud/pull/100))
 - Support to associate EIP with SLB and Nat Gateway ([#99](https://github.com/terraform-providers/terraform-provider-alicloud/pull/99))
 
 ## 1.7.0 (January 25, 2018)

--- a/alicloud/resource_alicloud_nat_gateway_test.go
+++ b/alicloud/resource_alicloud_nat_gateway_test.go
@@ -18,10 +18,6 @@ func TestAccAlicloudNatGateway_basic(t *testing.T) {
 			return fmt.Errorf("abnormal instance status")
 		}
 
-		if len(nat.BandwidthPackageIds.BandwidthPackageId) == 0 {
-			return fmt.Errorf("no bandwidth package: %#v", nat.BandwidthPackageIds.BandwidthPackageId)
-		}
-
 		return nil
 	}
 
@@ -43,13 +39,12 @@ func TestAccAlicloudNatGateway_basic(t *testing.T) {
 					testCheck,
 					resource.TestCheckResourceAttr(
 						"alicloud_nat_gateway.foo",
-						"spec",
+						"specification",
 						"Small"),
 					resource.TestCheckResourceAttr(
 						"alicloud_nat_gateway.foo",
 						"name",
 						"test_foo"),
-					testAccCheckNatgatewayIpAddress("alicloud_nat_gateway.foo", &nat),
 				),
 			},
 		},
@@ -57,7 +52,7 @@ func TestAccAlicloudNatGateway_basic(t *testing.T) {
 
 }
 
-func TestAccAlicloudNatGateway_spec(t *testing.T) {
+func TestAccAlicloudNatGateway_specification(t *testing.T) {
 	var nat ecs.NatGatewaySetType
 
 	resource.Test(t, resource.TestCase{
@@ -77,7 +72,7 @@ func TestAccAlicloudNatGateway_spec(t *testing.T) {
 						"alicloud_nat_gateway.foo", &nat),
 					resource.TestCheckResourceAttr(
 						"alicloud_nat_gateway.foo",
-						"spec",
+						"specification",
 						"Middle"),
 				),
 			},
@@ -89,38 +84,13 @@ func TestAccAlicloudNatGateway_spec(t *testing.T) {
 						"alicloud_nat_gateway.foo", &nat),
 					resource.TestCheckResourceAttr(
 						"alicloud_nat_gateway.foo",
-						"spec",
+						"specification",
 						"Large"),
 				),
 			},
 		},
 	})
 
-}
-
-func testAccCheckNatgatewayIpAddress(n string, nat *ecs.NatGatewaySetType) resource.TestCheckFunc {
-	return func(s *terraform.State) error {
-		rs, ok := s.RootModule().Resources[n]
-		if !ok {
-			return fmt.Errorf("Not found: %s", n)
-		}
-
-		if rs.Primary.ID == "" {
-			return fmt.Errorf("No NatGateway ID is set")
-		}
-
-		client := testAccProvider.Meta().(*AliyunClient)
-		natGateway, err := client.DescribeNatGateway(rs.Primary.ID)
-
-		if err != nil {
-			return err
-		}
-		if natGateway == nil {
-			return fmt.Errorf("Natgateway not found")
-		}
-
-		return nil
-	}
 }
 
 func testAccCheckNatGatewayExists(n string, nat *ecs.NatGatewaySetType) resource.TestCheckFunc {
@@ -194,27 +164,8 @@ resource "alicloud_vswitch" "foo" {
 
 resource "alicloud_nat_gateway" "foo" {
 	vpc_id = "${alicloud_vpc.foo.id}"
-	spec = "Small"
+	specification = "Small"
 	name = "test_foo"
-	bandwidth_packages = [{
-	  ip_count = 1
-	  bandwidth = 5
-	  zone = "${data.alicloud_zones.default.zones.0.id}"
-	}, {
-	  ip_count = 2
-	  bandwidth = 6
-	  zone = "${data.alicloud_zones.default.zones.0.id}"
-	}, {
-	  ip_count = 3
-	  bandwidth = 7
-	  zone = "${data.alicloud_zones.default.zones.0.id}"
-	}, {
-	  ip_count = 1
-	  bandwidth = 8
-	  zone = "${data.alicloud_zones.default.zones.0.id}"
-	}]
-	depends_on = [
-    	"alicloud_vswitch.foo"]
 }
 `
 
@@ -236,19 +187,8 @@ resource "alicloud_vswitch" "foo" {
 
 resource "alicloud_nat_gateway" "foo" {
 	vpc_id = "${alicloud_vpc.foo.id}"
-	spec = "Middle"
+	specification = "Middle"
 	name = "test_foo"
-	bandwidth_packages = [{
-	  ip_count = 1
-	  bandwidth = 5
-	  zone = "${data.alicloud_zones.default.zones.0.id}"
-	}, {
-	  ip_count = 2
-	  bandwidth = 10
-	  zone = "${data.alicloud_zones.default.zones.0.id}"
-	}]
-	depends_on = [
-    	"alicloud_vswitch.foo"]
 }
 `
 
@@ -270,18 +210,7 @@ resource "alicloud_vswitch" "foo" {
 
 resource "alicloud_nat_gateway" "foo" {
 	vpc_id = "${alicloud_vpc.foo.id}"
-	spec = "Large"
+	specification = "Large"
 	name = "test_foo"
-	bandwidth_packages = [{
-	  ip_count = 1
-	  bandwidth = 5
-	  zone = "${data.alicloud_zones.default.zones.0.id}"
-	}, {
-	  ip_count = 2
-	  bandwidth = 10
-	  zone = "${data.alicloud_zones.default.zones.0.id}"
-	}]
-	depends_on = [
-    	"alicloud_vswitch.foo"]
 }
 `

--- a/alicloud/validators.go
+++ b/alicloud/validators.go
@@ -1142,3 +1142,13 @@ func validateKmsKeyStatus(v interface{}, k string) (ws []string, errors []error)
 	}
 	return
 }
+
+func validateNatGatewaySpec(v interface{}, k string) (ws []string, errors []error) {
+	spec := ecs.NatGatewaySpec(v.(string))
+	if spec != ecs.NatGatewaySmallSpec && spec != ecs.NatGatewayMiddleSpec && spec != ecs.NatGatewayLargeSpec {
+		errors = append(errors, fmt.Errorf(
+			"%q must contain a valid specification, expected %s or %s or %s, got %s.",
+			k, ecs.NatGatewaySmallSpec, ecs.NatGatewayMiddleSpec, ecs.NatGatewayLargeSpec, spec))
+	}
+	return
+}

--- a/website/docs/r/nat_gateway.html.markdown
+++ b/website/docs/r/nat_gateway.html.markdown
@@ -10,7 +10,11 @@ description: |-
 
 Provides a resource to create a VPC NAT Gateway.
 
-~> **NOTE:** alicloud_nat_gateway must depends on alicloud_vswitch.
+~> **NOTE:** From version 1.8.0, the resource deprecates bandwidth packages.
+And if you want to add public IP, you can use resource 'alicloud_eip_association' to bind several elastic IPs for one Nat Gateway.
+
+~> **NOTE:** Resource bandwidth packages will not be supported since 00:00 on November 4, 2017, and public IP can be replaced be elastic IPs.
+If a Nat Gateway has already bought some bandwidth packages, it can not bind elastic IP and you have to submit the [work order](https://selfservice.console.aliyun.com/ticket/createIndex) to solve.
 
 
 ## Example Usage
@@ -33,22 +37,6 @@ resource "alicloud_nat_gateway" "nat_gateway" {
   vpc_id = "${alicloud_vpc.vpc.id}"
   spec   = "Small"
   name   = "test_foo"
-
-  bandwidth_packages = [{
-    ip_count  = 1
-    bandwidth = 5
-    zone      = "cn-beijing-b"
-  },
-    {
-      ip_count  = 2
-      bandwidth = 10
-      zone      = "cn-beijing-b"
-    },
-  ]
-
-  depends_on = [
-    "alicloud_vswitch.vsw",
-  ]
 }
 ```
 
@@ -57,19 +45,12 @@ resource "alicloud_nat_gateway" "nat_gateway" {
 The following arguments are supported:
 
 * `vpc_id` - (Required, Forces New Resorce) The VPC ID.
-* `spec` - (Required, Forces New Resorce) The specification of the nat gateway. Valid values are `Small`, `Middle` and `Large`. Details refer to [Nat Gateway Specification](https://help.aliyun.com/document_detail/42757.html?spm=5176.doc32322.6.559.kFNBzv)
+* `spec` - (Deprecated) It has been deprecated from provider version 1.8.0, and new field 'specification' can replace it.
+* `specification` - (Optional) The specification of the nat gateway. Valid values are `Small`, `Middle` and `Large`. Default to `Small`. Details refer to [Nat Gateway Specification](https://www.alibabacloud.com/help/doc-detail/42757.htm).
 * `name` - (Optional) Name of the nat gateway. The value can have a string of 2 to 128 characters, must contain only alphanumeric characters or hyphens, such as "-",".","_", and must not begin or end with a hyphen, and must not begin with http:// or https://. Defaults to null.
 * `description` - (Optional) Description of the nat gateway, This description can have a string of 2 to 256 characters, It cannot begin with http:// or https://. Defaults to null.
-* `bandwidth_packages` - (Required) A list of bandwidth packages for the nat gatway.
+* `bandwidth_packages` - (Deprecated) It has been deprecated from provider version 1.8.0. Resource 'alicloud_eip_association' can bind several elastic IPs for one Nat Gateway.
 
-## Block bandwidth package
-
-The bandwidth package mapping supports the following:
-
-* `ip_count` - (Required) The IP number of the current bandwidth package. Its value range from 1 to 50.
-* `bandwidth` - (Required) The bandwidth value of the current bandwidth package. Its value range from 5 to 5000.
-* `zone` - (Optional) The AZ for the current bandwidth. If this value is not specified, Terraform will set a random AZ.
-* `public_ip_addresses` - (Computer) The public ip for bandwidth package. the public ip count equal `ip_count`, multi ip would complex with ",", such as "10.0.0.1,10.0.0.2".
 
 ## Attributes Reference
 
@@ -78,7 +59,8 @@ The following attributes are exported:
 * `id` - The ID of the nat gateway.
 * `name` - The name of the nat gateway.
 * `description` - The description of the nat gateway.
-* `spec` - The specification of the nat gateway.
+* `spec` - It has been deprecated from provider version 1.8.0.
+* `specification` - The specification of the nat gateway.
 * `vpc_id` - The VPC ID for the nat gateway.
 * `bandwidth_package_ids` - A list ID of the bandwidth packages, and split them with commas
 * `snat_table_ids` - The nat gateway will auto create a snap and forward item, the `snat_table_ids` is the created one.


### PR DESCRIPTION
The PR deprecates nat gateway two fileds 'spec' and 'bandwidth_paclages'. 

The result of running test cases as follows:

TF_ACC=1 go test ./alicloud -v -run=TestAccAlicloudNatGateway -timeout 120m
=== RUN   TestAccAlicloudNatGateway_importBasic
--- PASS: TestAccAlicloudNatGateway_importBasic (38.63s)
=== RUN   TestAccAlicloudNatGateway_importSpec
--- PASS: TestAccAlicloudNatGateway_importSpec (38.73s)
=== RUN   TestAccAlicloudNatGateway_basic
--- PASS: TestAccAlicloudNatGateway_basic (38.92s)
=== RUN   TestAccAlicloudNatGateway_specification
--- PASS: TestAccAlicloudNatGateway_specification (51.41s)
PASS
ok      github.com/alibaba/terraform-provider/alicloud  167.736s
