### PR TITLE
Modify EIP default to PayByTraffic for international account

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,8 @@
-## 1.8.0 (Unreleased)
+## 1.7.1 (Unreleased)
 
 IMPROVEMENTS:
 
+- Modify EIP default to PayByTraffic for international account ([#101](https://github.com/terraform-providers/terraform-provider-alicloud/pull/101))
 - Deprecate nat gateway fileds 'spec' and 'bandwidth_packages' ([#100](https://github.com/terraform-providers/terraform-provider-alicloud/pull/100))
 - Support to associate EIP with SLB and Nat Gateway ([#99](https://github.com/terraform-providers/terraform-provider-alicloud/pull/99))
 

--- a/alicloud/errors.go
+++ b/alicloud/errors.go
@@ -23,10 +23,11 @@ const (
 	DiskInternalError         = "InternalError"
 	DiskInvalidOperation      = "InvalidOperation.Conflict"
 	// eip
-	EipIncorrectStatus      = "IncorrectEipStatus"
-	InstanceIncorrectStatus = "IncorrectInstanceStatus"
-	HaVipIncorrectStatus    = "IncorrectHaVipStatus"
-	EipTaskConflict         = "TaskConflict"
+	EipIncorrectStatus         = "IncorrectEipStatus"
+	InstanceIncorrectStatus    = "IncorrectInstanceStatus"
+	HaVipIncorrectStatus       = "IncorrectHaVipStatus"
+	EipTaskConflict            = "TaskConflict"
+	COMMODITYINVALID_COMPONENT = "COMMODITY.INVALID_COMPONENT"
 	// slb
 	LoadBalancerNotFound        = "InvalidLoadBalancerId.NotFound"
 	UnsupportedProtocalPort     = "UnsupportedOperationonfixedprotocalport"

--- a/alicloud/resource_alicloud_eip.go
+++ b/alicloud/resource_alicloud_eip.go
@@ -29,7 +29,7 @@ func resourceAliyunEip() *schema.Resource {
 			},
 			"internet_charge_type": &schema.Schema{
 				Type:         schema.TypeString,
-				Default:      "PayByBandwidth",
+				Default:      "PayByTraffic",
 				Optional:     true,
 				ForceNew:     true,
 				ValidateFunc: validateInternetChargeType,
@@ -64,6 +64,9 @@ func resourceAliyunEipCreate(d *schema.ResourceData, meta interface{}) error {
 
 	_, allocationID, err := conn.AllocateEipAddress(args)
 	if err != nil {
+		if IsExceptedError(err, COMMODITYINVALID_COMPONENT) && args.InternetChargeType == common.PayByBandwidth {
+			return fmt.Errorf("Your account is international and it can only create '%s' elastic IP. Please change it and try again.", common.PayByTraffic)
+		}
 		return err
 	}
 

--- a/website/docs/r/eip.html.markdown
+++ b/website/docs/r/eip.html.markdown
@@ -8,7 +8,10 @@ description: |-
 
 # alicloud\_eip
 
-Provides a ECS EIP resource.
+Provides an elastic IP resource.
+
+~> **NOTE:** The resource only support to create `PayByTraffic` elastic IP for international account. Otherwise, you will happened error `COMMODITY.INVALID_COMPONENT`.
+Your account is international if you can use it to login in [International Web Console](https://account.alibabacloud.com/login/login.htm).
 
 ## Example Usage
 
@@ -24,7 +27,7 @@ resource "alicloud_eip" "example" {
 The following arguments are supported:
 
 * `bandwidth` - (Optional) Maximum bandwidth to the elastic public network, measured in Mbps (Mega bit per second). If this value is not specified, then automatically sets it to 5 Mbps.
-* `internet_charge_type` - (Optional, Forces new resource) Internet charge type of the EIP, Valid values are `PayByBandwidth`, `PayByTraffic`. Default is `PayByBandwidth`.
+* `internet_charge_type` - (Optional, Forces new resource) Internet charge type of the EIP, Valid values are `PayByBandwidth`, `PayByTraffic`. Default is `PayByBandwidth`. From version `1.7.1`, default to `PayByTraffic`.
 
 ## Attributes Reference
 

--- a/website/docs/r/eip_association.html.markdown
+++ b/website/docs/r/eip_association.html.markdown
@@ -13,7 +13,7 @@ Provides an Alicloud EIP Association resource for associating Elastic IP to ECS 
 ~> **NOTE:** `alicloud_eip_association` is useful in scenarios where EIPs are either
  pre-existing or distributed to customers or users and therefore cannot be changed.
 
-~> **NOTE:** From version 1.8.0, the resource support to associate EIP to SLB Instance or Nat Gateway.
+~> **NOTE:** From version 1.7.1, the resource support to associate EIP to SLB Instance or Nat Gateway.
 
 ~> **NOTE:** One EIP can only be associated with ECS or SLB instance which in the VPC.
 


### PR DESCRIPTION
The PR modify EIP default to PayByTraffic for international account results from international account only creates paybytraffic eip.

The result of running test case as following:

TF_ACC=1 go test ./alicloud -v -run=TestAccAlicloudEIP -timeout 120m
=== RUN   TestAccAlicloudEIPAssociation
--- PASS: TestAccAlicloudEIPAssociation (106.07s)
=== RUN   TestAccAlicloudEIPAssociation_natgateway
--- PASS: TestAccAlicloudEIPAssociation_natgateway (41.89s)
=== RUN   TestAccAlicloudEIP_basic
--- PASS: TestAccAlicloudEIP_basic (25.38s)
PASS
ok      github.com/alibaba/terraform-provider/alicloud  173.368s
