### PR TITLE
fix a bug that can't create multiple VPC, vswitch and nat gateway at …

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ IMPROVEMENTS:
 - Deprecate nat gateway fileds 'spec' and 'bandwidth_packages' ([#100](https://github.com/terraform-providers/terraform-provider-alicloud/pull/100))
 - Support to associate EIP with SLB and Nat Gateway ([#99](https://github.com/terraform-providers/terraform-provider-alicloud/pull/99))
 
+BUG FIXES:
+
+- fix a bug that can't create multiple VPC, vswitch and nat gateway at one time ([#102](https://github.com/terraform-providers/terraform-provider-alicloud/pull/102))
+
 ## 1.7.0 (January 25, 2018)
 
 IMPROVEMENTS:

--- a/alicloud/errors.go
+++ b/alicloud/errors.go
@@ -26,7 +26,6 @@ const (
 	EipIncorrectStatus         = "IncorrectEipStatus"
 	InstanceIncorrectStatus    = "IncorrectInstanceStatus"
 	HaVipIncorrectStatus       = "IncorrectHaVipStatus"
-	EipTaskConflict            = "TaskConflict"
 	COMMODITYINVALID_COMPONENT = "COMMODITY.INVALID_COMPONENT"
 	// slb
 	LoadBalancerNotFound        = "InvalidLoadBalancerId.NotFound"

--- a/alicloud/resource_alicloud_nat_gateway.go
+++ b/alicloud/resource_alicloud_nat_gateway.go
@@ -31,7 +31,7 @@ func resourceAliyunNatGateway() *schema.Resource {
 			"spec": &schema.Schema{
 				Type:       schema.TypeString,
 				Optional:   true,
-				Deprecated: "Field 'spec' has been deprecated from provider version 1.8.0, and new field 'specification' can replace it.",
+				Deprecated: "Field 'spec' has been deprecated from provider version 1.7.1, and new field 'specification' can replace it.",
 			},
 			"specification": &schema.Schema{
 				Type:         schema.TypeString,
@@ -88,7 +88,7 @@ func resourceAliyunNatGateway() *schema.Resource {
 					},
 				},
 				Optional:   true,
-				Deprecated: "Field 'bandwidth_packages' has been deprecated from provider version 1.8.0. Resource 'alicloud_eip_association' can bind several elastic IPs for one Nat Gateway.",
+				Deprecated: "Field 'bandwidth_packages' has been deprecated from provider version 1.7.1. Resource 'alicloud_eip_association' can bind several elastic IPs for one Nat Gateway.",
 				DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
 					return true
 				},
@@ -118,7 +118,7 @@ func resourceAliyunNatGatewayCreate(d *schema.ResourceData, meta interface{}) er
 		ar := args
 		resp, err := conn.CreateNatGateway(&ar)
 		if err != nil {
-			if IsExceptedError(err, VswitchStatusError) {
+			if IsExceptedError(err, VswitchStatusError) || IsExceptedError(err, TaskConflict) {
 				return resource.RetryableError(fmt.Errorf("CreateNatGateway got error: %#v", err))
 			}
 			return resource.NonRetryableError(fmt.Errorf("CreateNatGateway got error: %#v", err))

--- a/alicloud/resource_alicloud_slb_attachment.go
+++ b/alicloud/resource_alicloud_slb_attachment.go
@@ -25,7 +25,7 @@ func resourceAliyunSlbAttachment() *schema.Resource {
 			"slb_id": &schema.Schema{
 				Type:       schema.TypeString,
 				Optional:   true,
-				Deprecated: "Field 'instances' has been deprecated from provider version 1.6.0. New field 'load_balancer_id' replaces it.",
+				Deprecated: "Field 'slb_id' has been deprecated from provider version 1.6.0. New field 'load_balancer_id' replaces it.",
 			},
 
 			"load_balancer_id": &schema.Schema{

--- a/alicloud/resource_alicloud_vpc.go
+++ b/alicloud/resource_alicloud_vpc.go
@@ -87,7 +87,7 @@ func resourceAliyunVpcCreate(d *schema.ResourceData, meta interface{}) error {
 			if IsExceptedError(err, VpcQuotaExceeded) {
 				return resource.NonRetryableError(fmt.Errorf("The number of VPC has quota has reached the quota limit in your account, and please use existing VPCs or remove some of them."))
 			}
-			if IsExceptedError(err, UnknownError) {
+			if IsExceptedError(err, TaskConflict) || IsExceptedError(err, UnknownError) {
 				return resource.RetryableError(fmt.Errorf("Create vpc timeout and got an error: %#v.", err))
 			}
 			return resource.NonRetryableError(err)

--- a/alicloud/resource_alicloud_vswitch.go
+++ b/alicloud/resource_alicloud_vswitch.go
@@ -62,7 +62,7 @@ func resourceAliyunSwitchCreate(d *schema.ResourceData, meta interface{}) error 
 		}
 		vswId, err := conn.CreateVSwitch(args)
 		if err != nil {
-			if IsExceptedError(err, UnknownError) {
+			if IsExceptedError(err, TaskConflict) || IsExceptedError(err, UnknownError) {
 				return resource.RetryableError(fmt.Errorf("Creating Vswitch got an error: %#v", err))
 			}
 			return resource.NonRetryableError(err)

--- a/website/docs/r/nat_gateway.html.markdown
+++ b/website/docs/r/nat_gateway.html.markdown
@@ -10,7 +10,7 @@ description: |-
 
 Provides a resource to create a VPC NAT Gateway.
 
-~> **NOTE:** From version 1.8.0, the resource deprecates bandwidth packages.
+~> **NOTE:** From version 1.7.1, the resource deprecates bandwidth packages.
 And if you want to add public IP, you can use resource 'alicloud_eip_association' to bind several elastic IPs for one Nat Gateway.
 
 ~> **NOTE:** Resource bandwidth packages will not be supported since 00:00 on November 4, 2017, and public IP can be replaced be elastic IPs.
@@ -45,11 +45,11 @@ resource "alicloud_nat_gateway" "nat_gateway" {
 The following arguments are supported:
 
 * `vpc_id` - (Required, Forces New Resorce) The VPC ID.
-* `spec` - (Deprecated) It has been deprecated from provider version 1.8.0, and new field 'specification' can replace it.
+* `spec` - (Deprecated) It has been deprecated from provider version 1.7.1, and new field 'specification' can replace it.
 * `specification` - (Optional) The specification of the nat gateway. Valid values are `Small`, `Middle` and `Large`. Default to `Small`. Details refer to [Nat Gateway Specification](https://www.alibabacloud.com/help/doc-detail/42757.htm).
 * `name` - (Optional) Name of the nat gateway. The value can have a string of 2 to 128 characters, must contain only alphanumeric characters or hyphens, such as "-",".","_", and must not begin or end with a hyphen, and must not begin with http:// or https://. Defaults to null.
 * `description` - (Optional) Description of the nat gateway, This description can have a string of 2 to 256 characters, It cannot begin with http:// or https://. Defaults to null.
-* `bandwidth_packages` - (Deprecated) It has been deprecated from provider version 1.8.0. Resource 'alicloud_eip_association' can bind several elastic IPs for one Nat Gateway.
+* `bandwidth_packages` - (Deprecated) It has been deprecated from provider version 1.7.1. Resource 'alicloud_eip_association' can bind several elastic IPs for one Nat Gateway.
 
 
 ## Attributes Reference
@@ -59,7 +59,7 @@ The following attributes are exported:
 * `id` - The ID of the nat gateway.
 * `name` - The name of the nat gateway.
 * `description` - The description of the nat gateway.
-* `spec` - It has been deprecated from provider version 1.8.0.
+* `spec` - It has been deprecated from provider version 1.7.1.
 * `specification` - The specification of the nat gateway.
 * `vpc_id` - The VPC ID for the nat gateway.
 * `bandwidth_package_ids` - A list ID of the bandwidth packages, and split them with commas


### PR DESCRIPTION
The PR fixes a bug that can't create multiple VPC, vswitch and nat gateway at one time.

The result of running test case as follows:

$ TF_ACC=1 go test ./alicloud -v -run=TestAccAlicloudVpc -timeout 120m
=== RUN   TestAccAlicloudVpcsDataSource_cidr_block
--- PASS: TestAccAlicloudVpcsDataSource_cidr_block (13.58s)
=== RUN   TestAccAlicloudVpc_importBasic
--- PASS: TestAccAlicloudVpc_importBasic (20.83s)
=== RUN   TestAccAlicloudVpc_basic
--- PASS: TestAccAlicloudVpc_basic (18.57s)
=== RUN   TestAccAlicloudVpc_update
--- PASS: TestAccAlicloudVpc_update (30.30s)
=== RUN   TestAccAlicloudVpc_multi
--- PASS: TestAccAlicloudVpc_multi (18.87s)
PASS
ok      github.com/alibaba/terraform-provider/alicloud  102.184s

$ TF_ACC=1 go test ./alicloud -v -run=TestAccAlicloudVswitch -timeout 120m
=== RUN   TestAccAlicloudVswitch_importBasic
--- PASS: TestAccAlicloudVswitch_importBasic (35.50s)
=== RUN   TestAccAlicloudVswitch_basic
--- PASS: TestAccAlicloudVswitch_basic (29.39s)
=== RUN   TestAccAlicloudVswitch_multi
--- PASS: TestAccAlicloudVswitch_multi (34.12s)
PASS
ok      github.com/alibaba/terraform-provider/alicloud  99.045s
