### PR TITLE
fix a bug that can't import instance 'role_name'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ IMPROVEMENTS:
 BUG FIXES:
 
 - fix a bug that can't create multiple VPC, vswitch and nat gateway at one time ([#102](https://github.com/terraform-providers/terraform-provider-alicloud/pull/102))
+- fix a bug that can't import instance 'role_name' ([#104](https://github.com/terraform-providers/terraform-provider-alicloud/pull/104))
 
 ## 1.7.0 (January 25, 2018)
 


### PR DESCRIPTION
The PR fixes a bug that can't import instance 'role_name'.

The result of running test case as follows:

TF_ACC=1 go test ./alicloud -v -run=TestAccAlicloudInstance_ramrole -timeout 120m
=== RUN   TestAccAlicloudInstance_ramrole
--- PASS: TestAccAlicloudInstance_ramrole (139.66s)
PASS
ok      github.com/alibaba/terraform-provider/alicloud  139.703s
