### PR TITLE
Support multiple vswitches for ESS scaling group and output slbIds an…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 IMPROVEMENTS:
 
+- Support multiple vswitches for ESS scaling group and output slbIds and dbIds ([#105](https://github.com/terraform-providers/terraform-provider-alicloud/pull/105))
 - Support to set internet_max_bandwidth_out is 0 for ESS configuration ([#103](https://github.com/terraform-providers/terraform-provider-alicloud/pull/103))
 - Modify EIP default to PayByTraffic for international account ([#101](https://github.com/terraform-providers/terraform-provider-alicloud/pull/101))
 - Deprecate nat gateway fileds 'spec' and 'bandwidth_packages' ([#100](https://github.com/terraform-providers/terraform-provider-alicloud/pull/100))

--- a/vendor/github.com/denverdino/aliyungo/ess/group.go
+++ b/vendor/github.com/denverdino/aliyungo/ess/group.go
@@ -28,7 +28,7 @@ type CreateScalingGroupArgs struct {
 	MaxSize         *int
 	DefaultCooldown *int
 	RemovalPolicy   common.FlattenArray
-	DBInstanceId    common.FlattenArray
+	DBInstanceIds   string
 }
 
 type CreateScalingGroupResponse struct {
@@ -111,6 +111,7 @@ type ScalingGroupItemType struct {
 	RemovingCapacity             int
 	RemovalPolicies              RemovalPolicySetType
 	DBInstanceIds                DBInstanceIdSetType
+	LoadBalancerIds              LoadBalancerIdSetType
 }
 
 type VSwitchIdsSetType struct {
@@ -123,6 +124,9 @@ type RemovalPolicySetType struct {
 
 type DBInstanceIdSetType struct {
 	DBInstanceId []string
+}
+type LoadBalancerIdSetType struct {
+	LoadBalancerId []string
 }
 
 // DescribeScalingGroups describes scaling groups

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -235,74 +235,74 @@
 		{
 			"checksumSHA1": "9bZS3sdYQuY8j2Fxi9sEoQl2ibQ=",
 			"path": "github.com/denverdino/aliyungo/cdn",
-			"revision": "dbd400ca5c0b1686bc3321c456755422d58c8f20",
-			"revisionTime": "2018-01-29T01:42:14Z"
+			"revision": "b96fedfcf75e6ed7c6d2e5cdf1d00dec26387816",
+			"revisionTime": "2018-01-31T09:02:44Z"
 		},
 		{
 			"checksumSHA1": "6jhMTB/kEVfbbszOdOyYODYFk5Q=",
 			"path": "github.com/denverdino/aliyungo/common",
-			"revision": "dbd400ca5c0b1686bc3321c456755422d58c8f20",
-			"revisionTime": "2018-01-29T01:42:14Z"
+			"revision": "b96fedfcf75e6ed7c6d2e5cdf1d00dec26387816",
+			"revisionTime": "2018-01-31T09:02:44Z"
 		},
 		{
 			"checksumSHA1": "JgK7hgdP+yfsRin1lbz0LjBVtic=",
 			"path": "github.com/denverdino/aliyungo/cs",
-			"revision": "dbd400ca5c0b1686bc3321c456755422d58c8f20",
-			"revisionTime": "2018-01-29T01:42:14Z"
+			"revision": "b96fedfcf75e6ed7c6d2e5cdf1d00dec26387816",
+			"revisionTime": "2018-01-31T09:02:44Z"
 		},
 		{
 			"checksumSHA1": "0y6d3UiB8JckT3YTeXjMbLkSibg=",
 			"path": "github.com/denverdino/aliyungo/dns",
-			"revision": "dbd400ca5c0b1686bc3321c456755422d58c8f20",
-			"revisionTime": "2018-01-29T01:42:14Z"
+			"revision": "b96fedfcf75e6ed7c6d2e5cdf1d00dec26387816",
+			"revisionTime": "2018-01-31T09:02:44Z"
 		},
 		{
 			"checksumSHA1": "l0Bk07lYC/WR91ljWX+2QylewSo=",
 			"path": "github.com/denverdino/aliyungo/ecs",
-			"revision": "dbd400ca5c0b1686bc3321c456755422d58c8f20",
-			"revisionTime": "2018-01-29T01:42:14Z"
+			"revision": "b96fedfcf75e6ed7c6d2e5cdf1d00dec26387816",
+			"revisionTime": "2018-01-31T09:02:44Z"
 		},
 		{
-			"checksumSHA1": "MbMaaPqEyn/0mBCzAUQsEZkgw0k=",
+			"checksumSHA1": "iGYTQoRVjHR5bdnSuxX6irB4cSg=",
 			"path": "github.com/denverdino/aliyungo/ess",
-			"revision": "dbd400ca5c0b1686bc3321c456755422d58c8f20",
-			"revisionTime": "2018-01-29T01:42:14Z"
+			"revision": "b96fedfcf75e6ed7c6d2e5cdf1d00dec26387816",
+			"revisionTime": "2018-01-31T09:02:44Z"
 		},
 		{
 			"checksumSHA1": "rj3YU+oc3pVDG9Rd1zzHtMWsIJg=",
 			"path": "github.com/denverdino/aliyungo/kms",
-			"revision": "dbd400ca5c0b1686bc3321c456755422d58c8f20",
-			"revisionTime": "2018-01-29T01:42:14Z"
+			"revision": "b96fedfcf75e6ed7c6d2e5cdf1d00dec26387816",
+			"revisionTime": "2018-01-31T09:02:44Z"
 		},
 		{
 			"checksumSHA1": "CPuR3s7LzQkT57Z20zMHXQM2MYQ=",
 			"path": "github.com/denverdino/aliyungo/location",
-			"revision": "dbd400ca5c0b1686bc3321c456755422d58c8f20",
-			"revisionTime": "2018-01-29T01:42:14Z"
+			"revision": "b96fedfcf75e6ed7c6d2e5cdf1d00dec26387816",
+			"revisionTime": "2018-01-31T09:02:44Z"
 		},
 		{
 			"checksumSHA1": "mkaQUrh01nWescV/Ek7Yv/WwX9Q=",
 			"path": "github.com/denverdino/aliyungo/ram",
-			"revision": "dbd400ca5c0b1686bc3321c456755422d58c8f20",
-			"revisionTime": "2018-01-29T01:42:14Z"
+			"revision": "b96fedfcf75e6ed7c6d2e5cdf1d00dec26387816",
+			"revisionTime": "2018-01-31T09:02:44Z"
 		},
 		{
 			"checksumSHA1": "D4ugog0rIZolvzyH2Wf/p+eUJOE=",
 			"path": "github.com/denverdino/aliyungo/rds",
-			"revision": "dbd400ca5c0b1686bc3321c456755422d58c8f20",
-			"revisionTime": "2018-01-29T01:42:14Z"
+			"revision": "b96fedfcf75e6ed7c6d2e5cdf1d00dec26387816",
+			"revisionTime": "2018-01-31T09:02:44Z"
 		},
 		{
 			"checksumSHA1": "pTmrFsVGJmq42mUzlIhwh72jKbQ=",
 			"path": "github.com/denverdino/aliyungo/slb",
-			"revision": "dbd400ca5c0b1686bc3321c456755422d58c8f20",
-			"revisionTime": "2018-01-29T01:42:14Z"
+			"revision": "b96fedfcf75e6ed7c6d2e5cdf1d00dec26387816",
+			"revisionTime": "2018-01-31T09:02:44Z"
 		},
 		{
 			"checksumSHA1": "ZSpVJldK4F8joh8pOryB5SaSn8s=",
 			"path": "github.com/denverdino/aliyungo/util",
-			"revision": "dbd400ca5c0b1686bc3321c456755422d58c8f20",
-			"revisionTime": "2018-01-29T01:42:14Z"
+			"revision": "b96fedfcf75e6ed7c6d2e5cdf1d00dec26387816",
+			"revisionTime": "2018-01-31T09:02:44Z"
 		},
 		{
 			"checksumSHA1": "BCv50o5pDkoSG3vYKOSai1Z8p3w=",

--- a/website/docs/r/ess_scaling_group.html.markdown
+++ b/website/docs/r/ess_scaling_group.html.markdown
@@ -8,9 +8,11 @@ description: |-
 
 # alicloud\_ess\_scaling\_group
 
-Provides a ESS scaling group resource.
+Provides a ESS scaling group resource which is a collection of ECS instances with the same application scenarios.
 
-~> **NOTE:** You can launch an ECS instance for a VPC network via specifying parameter `vswitch_id`. One instance can only belong to one VSwitch.
+It defines the maximum and minimum numbers of ECS instances in the group, and their associated Server Load Balancer instances, RDS instances, and other attributes.
+
+~> **NOTE:** You can launch an ESS scaling group for a VPC network via specifying parameter `vswitch_ids`.
 
 ## Example Usage
 
@@ -30,7 +32,8 @@ The following arguments are supported:
 * `max_size` - (Required) Maximum number of ECS instances in the scaling group. Value range: [0, 100].
 * `scaling_group_name` - (Optional) Name shown for the scaling group, which must contain 2-40 characters (English or Chinese). If this parameter is not specified, the default value is ScalingGroupId.
 * `default_cooldown` - (Optional) Default cool-down time (in seconds) of the scaling group. Value range: [0, 86400]. The default value is 300s.
-* `vswitch_id` - (Optional) The virtual switch ID which the ecs instance to be create in.
+* `vswitch_id` - (Deprecated) It has been deprecated from version 1.7.1 and new field 'vswitch_ids' replaces it.
+* `vswitch_ids` - (Optional) List of virtual switch IDs in which the ecs instances to be launched.
 * `removal_policies` - (Optional) RemovalPolicy is used to select the ECS instances you want to remove from the scaling group when multiple candidates for removal exist. Optional values:
     - OldestInstance: removes the first ECS instance attached to the scaling group.
     - NewestInstance: removes the first ECS instance attached to the scaling group.
@@ -55,8 +58,9 @@ The following attributes are exported:
 * `scaling_group_name` - The name of the scaling group.
 * `default_cooldown` - The default cool-down of the scaling group.
 * `removal_policies` - The removal policy used to select the ECS instance to remove from the scaling group.
-* `db_instance_ids` - The db instance id which the ECS instance attached to.
-* `loadbalancer_ids` - The slb instance id which the ECS instance attached to.
+* `db_instance_ids` - The db instances id which the ECS instance attached to.
+* `loadbalancer_ids` - The slb instances id which the ECS instance attached to.
+* `vswitch_ids` - The vswitches id in which the ECS instance launched.
 
 ## Import
 


### PR DESCRIPTION
The PR supports multiple vswitches for ESS scaling group and outputs slbIds and dbIds.

The result of running test case as follows:

TF_ACC=1 go test ./alicloud -v -run=TestAccAlicloudEssScalingGroup -timeout 120m
=== RUN   TestAccAlicloudEssScalingGroup_importBasic
--- PASS: TestAccAlicloudEssScalingGroup_importBasic (17.54s)
=== RUN   TestAccAlicloudEssScalingGroup_basic
--- PASS: TestAccAlicloudEssScalingGroup_basic (14.67s)
=== RUN   TestAccAlicloudEssScalingGroup_update
--- PASS: TestAccAlicloudEssScalingGroup_update (26.22s)
=== RUN   TestAccAlicloudEssScalingGroup_vpc
--- PASS: TestAccAlicloudEssScalingGroup_vpc (56.14s)
=== RUN   TestAccAlicloudEssScalingGroup_slb
--- PASS: TestAccAlicloudEssScalingGroup_slb (53.85s)
PASS
ok      github.com/alibaba/terraform-provider/alicloud  168.457s
