### PR TITLE
fix a bug that creating ESS scaling group and configuration results f…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ BUG FIXES:
 
 - fix a bug that can't create multiple VPC, vswitch and nat gateway at one time ([#102](https://github.com/terraform-providers/terraform-provider-alicloud/pull/102))
 - fix a bug that can't import instance 'role_name' ([#104](https://github.com/terraform-providers/terraform-provider-alicloud/pull/104))
+- fix a bug that creating ESS scaling group and configuration results from 'Throttling' ([#106](https://github.com/terraform-providers/terraform-provider-alicloud/pull/106))
 
 ## 1.7.0 (January 25, 2018)
 

--- a/alicloud/errors.go
+++ b/alicloud/errors.go
@@ -70,7 +70,7 @@ const (
 	IncorrectCapacityMaxSize                    = "IncorrectCapacity.MaxSize"
 	IncorrectCapacityMinSize                    = "IncorrectCapacity.MinSize"
 	ScalingActivityInProgress                   = "ScalingActivityInProgress"
-
+	EssThrottling                               = "Throttling"
 	// rds
 	InvalidDBInstanceIdNotFound            = "InvalidDBInstanceId.NotFound"
 	InvalidDBNameNotFound                  = "InvalidDBName.NotFound"

--- a/alicloud/resource_alicloud_ess_scalingconfiguration_test.go
+++ b/alicloud/resource_alicloud_ess_scalingconfiguration_test.go
@@ -377,7 +377,7 @@ resource "alicloud_ess_scaling_group" "foo" {
 	max_size = 1
 	scaling_group_name = "test-scaling-configuration-multi"
 	removal_policies = ["OldestInstance", "NewestInstance"]
-	vswitch_id = "${alicloud_vswitch.vswitch.id}"
+	vswitch_ids = ["${alicloud_vswitch.vswitch.id}"]
 
 }
 

--- a/website/docs/r/ess_scaling_configuration.html.markdown
+++ b/website/docs/r/ess_scaling_configuration.html.markdown
@@ -45,7 +45,7 @@ The following arguments are supported:
 * `is_outdated` - (Optional) Whether to use outdated instance type. Default to false.
 * `security_group_id` - (Required) ID of the security group to which a newly created instance belongs.
 * `scaling_configuration_name` - (Optional) Name shown for the scheduled task. If this parameter value is not specified, the default value is ScalingConfigurationId.
-* `internet_charge_type` - (Optional) Network billing type, Values: PayByBandwidth or PayByTraffic. If this parameter value is not specified, the default value is PayByBandwidth.
+* `internet_charge_type` - (Optional) Network billing type, Values: PayByBandwidth or PayByTraffic. Default to `PayByBandwidth`.
 * `internet_max_bandwidth_in` - (Optional) Maximum incoming bandwidth from the public network, measured in Mbps (Mega bit per second). The value range is [1,200].
 * `internet_max_bandwidth_out` - (Optional) Maximum outgoing bandwidth from the public network, measured in Mbps (Mega bit per second). The value range for PayByBandwidth is [0,100].
 * `system_disk_category` - (Optional) Category of the system disk. The parameter value options are `cloud_efficiency`, `cloud_ssd` and `cloud`. `cloud` only is used to some no I/O optimized instance. Default to `cloud_efficiency`.


### PR DESCRIPTION
The PR fixes a bug that creating ESS scaling group and configuration results from 'Throttling'.

The result of running test cases as follows:

TF_ACC=1 go test ./alicloud -v -run=TestAccAlicloudEssScalingConfiguration -timeout 120m
=== RUN   TestAccAlicloudEssScalingConfiguration_basic
--- PASS: TestAccAlicloudEssScalingConfiguration_basic (34.55s)
=== RUN   TestAccAlicloudEssScalingConfiguration_multiConfig
--- PASS: TestAccAlicloudEssScalingConfiguration_multiConfig (49.38s)
=== RUN   TestAccAlicloudEssScalingConfiguration_active
--- PASS: TestAccAlicloudEssScalingConfiguration_active (36.69s)
=== RUN   TestAccAlicloudEssScalingConfiguration_inactive
--- PASS: TestAccAlicloudEssScalingConfiguration_inactive (39.98s)
=== RUN   TestAccAlicloudEssScalingConfiguration_enable
--- PASS: TestAccAlicloudEssScalingConfiguration_enable (36.31s)
=== RUN   TestAccAlicloudEssScalingConfiguration_disable
--- PASS: TestAccAlicloudEssScalingConfiguration_disable (30.23s)
PASS
ok      github.com/alibaba/terraform-provider/alicloud  227.181s
