### PR TITLE
New DataSource alicloud_vswitches

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,9 @@
 ## 1.7.2 (Unreleased)
+
+BUG FIXES:
+
+- Fix eip is not exist in nat gateway when creating snat ([#108](https://github.com/terraform-providers/terraform-provider-alicloud/pull/108))
+
 ## 1.7.1 (February 02, 2018)
 
 IMPROVEMENTS:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## 1.7.2 (Unreleased)
 
+IMPROVEMENTS:
+- *New DataSource*: _alicloud_vswitches_ ([#109](https://github.com/terraform-providers/terraform-provider-alicloud/pull/109))
+
 BUG FIXES:
 
 - Fix eip is not exist in nat gateway when creating snat ([#108](https://github.com/terraform-providers/terraform-provider-alicloud/pull/108))

--- a/alicloud/common.go
+++ b/alicloud/common.go
@@ -159,3 +159,8 @@ func userDataHashSum(user_data string) string {
 }
 
 const DBConnectionSuffix = ".mysql.rds.aliyuncs.com"
+
+// Remove useless blank in the string.
+func Trim(v string) string {
+	return strings.Trim(v, " ")
+}

--- a/alicloud/data_source_alicloud_vswitches.go
+++ b/alicloud/data_source_alicloud_vswitches.go
@@ -1,0 +1,203 @@
+package alicloud
+
+import (
+	"fmt"
+	"log"
+	"regexp"
+
+	"github.com/denverdino/aliyungo/ecs"
+	"github.com/hashicorp/terraform/helper/schema"
+)
+
+func dataSourceAlicloudVSwitches() *schema.Resource {
+	return &schema.Resource{
+		Read: dataSourceAlicloudVSwitchesRead,
+
+		Schema: map[string]*schema.Schema{
+			"cidr_block": {
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: true,
+			},
+			"name_regex": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ValidateFunc: validateNameRegex,
+				ForceNew:     true,
+			},
+			"is_default": {
+				Type:     schema.TypeBool,
+				Optional: true,
+				ForceNew: true,
+			},
+			"vpc_id": {
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: true,
+			},
+			"zone_id": {
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: true,
+			},
+			"output_file": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+
+			// Computed values
+			"vswitches": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"vpc_id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"zone_id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"name": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"instance_ids": {
+							Type:     schema.TypeList,
+							Computed: true,
+							Elem:     &schema.Schema{Type: schema.TypeString},
+						},
+						"cidr_block": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"description": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"is_default": {
+							Type:     schema.TypeBool,
+							Computed: true,
+						},
+						"creation_time": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+					},
+				},
+			},
+		},
+	}
+}
+func dataSourceAlicloudVSwitchesRead(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AliyunClient).ecsconn
+
+	args := &ecs.DescribeVSwitchesArgs{
+		RegionId: getRegion(d, meta),
+	}
+	if v, ok := d.GetOk("zone_id"); ok {
+		args.ZoneId = Trim(v.(string))
+	}
+	if v, ok := d.GetOk("vpc_id"); ok {
+		args.VpcId = Trim(v.(string))
+	}
+
+	var allVSwitches []ecs.VSwitchSetType
+	var nameRegex *regexp.Regexp
+	if v, ok := d.GetOk("name_regex"); ok {
+		if r, err := regexp.Compile(Trim(v.(string))); err == nil {
+			nameRegex = r
+		}
+	}
+	for {
+		VSwitches, paginationResult, err := conn.DescribeVSwitches(args)
+		if err != nil {
+			return err
+		}
+
+		for _, vsw := range VSwitches {
+			if v, ok := d.GetOk("cidr_block"); ok && vsw.CidrBlock != Trim(v.(string)) {
+				continue
+			}
+
+			if v, ok := d.GetOk("is_default"); ok && vsw.IsDefault != v.(bool) {
+				continue
+			}
+
+			if nameRegex != nil {
+				if !nameRegex.MatchString(vsw.VSwitchName) {
+					continue
+				}
+			}
+			allVSwitches = append(allVSwitches, vsw)
+		}
+
+		pagination := paginationResult.NextPage()
+		if pagination == nil {
+			break
+		}
+
+		args.Pagination = *pagination
+	}
+
+	if len(allVSwitches) < 1 {
+		return fmt.Errorf("Your query returned no results. Please change your search criteria and try again.")
+	}
+
+	log.Printf("[DEBUG] alicloud_vswitches - VSwitches found: %#v", allVSwitches)
+
+	return VSwitchesDecriptionAttributes(d, allVSwitches, meta)
+}
+
+func VSwitchesDecriptionAttributes(d *schema.ResourceData, VSwitchesetTypes []ecs.VSwitchSetType, meta interface{}) error {
+	var ids []string
+	var s []map[string]interface{}
+	for _, vsw := range VSwitchesetTypes {
+		mapping := map[string]interface{}{
+			"id":            vsw.VSwitchId,
+			"vpc_id":        vsw.VpcId,
+			"zone_id":       vsw.ZoneId,
+			"name":          vsw.VSwitchName,
+			"cidr_block":    vsw.CidrBlock,
+			"description":   vsw.Description,
+			"is_default":    vsw.IsDefault,
+			"creation_time": vsw.CreationTime.String(),
+		}
+		instances, _, err := meta.(*AliyunClient).ecsconn.DescribeInstances(&ecs.DescribeInstancesArgs{
+			RegionId:  getRegion(d, meta),
+			VpcId:     vsw.VpcId,
+			VSwitchId: vsw.VSwitchId,
+			ZoneId:    vsw.ZoneId,
+		})
+		if err != nil {
+			return fmt.Errorf("DescribeInstances got an error: %#v.", err)
+		}
+		instance_ids := make([]string, len(instances))
+		if len(instance_ids) > 0 {
+			for _, inst := range instances {
+				instance_ids = append(instance_ids, inst.InstanceId)
+			}
+		}
+		mapping["instance_ids"] = instance_ids
+
+		log.Printf("[DEBUG] alicloud_vswitches - adding vswitch: %v", mapping)
+		ids = append(ids, vsw.VSwitchId)
+		s = append(s, mapping)
+	}
+
+	d.SetId(dataResourceIdHash(ids))
+	if err := d.Set("vswitches", s); err != nil {
+		return err
+	}
+
+	// create a json file in current directory and write data source to it.
+	if output, ok := d.GetOk("output_file"); ok && output.(string) != "" {
+		writeToFile(output.(string), s)
+	}
+	return nil
+}

--- a/alicloud/data_source_alicloud_vswitches_test.go
+++ b/alicloud/data_source_alicloud_vswitches_test.go
@@ -1,0 +1,52 @@
+package alicloud
+
+import (
+	"testing"
+
+	"regexp"
+
+	"github.com/hashicorp/terraform/helper/resource"
+)
+
+func TestAccAlicloudVSwitchesDataSource(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+		},
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCheckAlicloudVSwitchesDataSourceConfig,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAlicloudDataSourceID("data.alicloud_vswitches.foo"),
+					resource.TestCheckResourceAttr("data.alicloud_vswitches.foo", "vswitches.0.cidr_block", "172.16.0.0/16"),
+					resource.TestMatchResourceAttr("data.alicloud_vswitches.foo", "vswitches.0.name", regexp.MustCompile("^test-for-vswitch-datasourc")),
+					resource.TestCheckResourceAttr("data.alicloud_vswitches.foo", "vswitches.0.is_default", "false"),
+					resource.TestCheckResourceAttr("data.alicloud_vswitches.foo", "vswitches.0.instance_ids.#", "0"),
+				),
+			},
+		},
+	})
+}
+
+const testAccCheckAlicloudVSwitchesDataSourceConfig = `
+data "alicloud_zones" "default" {}
+
+resource "alicloud_vpc" "vpc" {
+  cidr_block = "172.16.0.0/16"
+}
+
+resource "alicloud_vswitch" "vswitch" {
+  name = "test-for-vswitch-datasource"
+  cidr_block = "172.16.0.0/16"
+  vpc_id = "${alicloud_vpc.vpc.id}"
+  availability_zone = "${data.alicloud_zones.default.zones.0.id}"
+}
+
+data "alicloud_vswitches" "foo" {
+  name_regex = "^test-.*-datasource"
+  vpc_id = "${alicloud_vpc.vpc.id}"
+  cidr_block = "${alicloud_vswitch.vswitch.cidr_block}"
+  zone_id = "${data.alicloud_zones.default.zones.0.id}"
+}
+`

--- a/alicloud/errors.go
+++ b/alicloud/errors.go
@@ -53,6 +53,7 @@ const (
 	NotFindSnatEntryBySnatId             = "NotFindSnatEntryBySnatId"
 	NotFindForwardEntryByForwardId       = "NotFindForwardEntryByForwardId"
 	VswitchStatusError                   = "VswitchStatusError"
+	EIP_NOT_IN_GATEWAY                   = "EIP_NOT_IN_GATEWAY"
 	// vpc
 	VpcQuotaExceeded = "QuotaExceeded.Vpc"
 	// vswitch

--- a/alicloud/provider.go
+++ b/alicloud/provider.go
@@ -46,6 +46,7 @@ func Provider() terraform.ResourceProvider {
 			"alicloud_instance_types": dataSourceAlicloudInstanceTypes(),
 			"alicloud_instances":      dataSourceAlicloudInstances(),
 			"alicloud_vpcs":           dataSourceAlicloudVpcs(),
+			"alicloud_vswitches":      dataSourceAlicloudVSwitches(),
 			"alicloud_key_pairs":      dataSourceAlicloudKeyPairs(),
 			"alicloud_kms_keys":       dataSourceAlicloudKmsKeys(),
 			"alicloud_dns_domains":    dataSourceAlicloudDnsDomains(),

--- a/website/alicloud.erb
+++ b/website/alicloud.erb
@@ -37,6 +37,9 @@
                         <li<%= sidebar_current("docs-alicloud-datasource-vpcs") %>>
                             <a href="/docs/providers/alicloud/d/vpcs.html">alicloud_vpcs</a>
                         </li>
+                        <li<%= sidebar_current("docs-alicloud-datasource-vswitches") %>>
+                            <a href="/docs/providers/alicloud/d/vswitches.html">alicloud_vswitches</a>
+                        </li>
                         <li<%= sidebar_current("docs-alicloud-datasource-dns-domain-groups") %>>
                             <a href="/docs/providers/alicloud/d/dns_domain_groups.html">alicloud_dns_domain_groups</a>
                         </li>

--- a/website/docs/d/instances.html.markdown
+++ b/website/docs/d/instances.html.markdown
@@ -36,6 +36,8 @@ The following arguments are supported:
 
 ## Attributes Reference
 
+The following argument are exported:
+
 * `instances` A list of instnaces. It contains several attributes to `Block Instances`.
 
 ### Block Instances

--- a/website/docs/d/vswitches.html.markdown
+++ b/website/docs/d/vswitches.html.markdown
@@ -1,0 +1,60 @@
+---
+layout: "alicloud"
+page_title: "Alicloud: alicloud_vswitches"
+sidebar_current: "docs-alicloud-datasource-vswitches"
+description: |-
+    Provides a list of VSwitch which owned by an Alicloud account.
+---
+
+# alicloud\_vswitches
+
+The Virtual sunbet data source lists a list of vswitches resource information owned by an Alicloud account,
+and each vswitch including its basic attribution, VPC ID and containing ECS instance IDs.
+
+## Example Usage
+
+```
+data "alicloud_vswitches" "subnets"{
+    cidr_block="172.16.0.0/12"
+    name_regex="^foo"
+}
+
+resource "alicloud_instance" "foo" {
+    ...
+    instance_name =  "in-the-vpc"
+    vswitch_id = "${data.alicloud_vswitches.subnets.vswitches.0.id}"
+    ...
+}
+
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `cidr_block` - (Optional) Limit search to specific cidr block,like "172.16.0.0/12".
+* `zone_id` - (Optional) The availability zone for one vswitch.
+* `name_regex` - (Optional) A regex string of VSwitch name.
+* `is_default` - (Optional) Whether the Vswitch is created by system - valid value is true or false.
+* `vpc_id` - (Optional) VPC ID in which vswitch belongs.
+* `output_file` - (Optional) The name of file that can save vswitches data source after running `terraform plan`.
+
+## Attributes Reference
+
+The following attributes are exported:
+
+* `vswitches` A list of vswitches. It contains several attributes to `Block VSwitches`.
+
+### Block VSwitches
+
+Attributes for vswitches:
+
+* `id` - ID of the VSwitch.
+* `zone_id` - ID of the availability zone where VSwitch belongs.
+* `vpc_id` - ID of the VPC where VSwitch belongs.
+* `name` - Name of the VSwitch.
+* `instance_ids` - List of ECS instance IDs in the specified VSwitch.
+* `cidr_block` - CIDR block of the VSwitch.
+* `description` - Description of the VSwitch
+* `is_default` - Whether the VSwitch is the default VSwitch in the belonging region.
+* `creation_time` - Time of creation.


### PR DESCRIPTION
The PR support new dataSource alicloud_vswitches.

The PR has a pre-PR: #108 

The result of running test case as follows:

TF_ACC=1 go test ./alicloud -v -run=TestAccAlicloudVSwitchesDataSource -timeout 120m
=== RUN   TestAccAlicloudVSwitchesDataSource
--- PASS: TestAccAlicloudVSwitchesDataSource (38.61s)
PASS
ok      github.com/alibaba/terraform-provider/alicloud  38.649s