### PR TITLE
new datasource alicloud_eips

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 ## 1.7.2 (Unreleased)
 
 IMPROVEMENTS:
+
+- *New DataSource*: _alicloud_eips_ ([#110](https://github.com/terraform-providers/terraform-provider-alicloud/pull/110))
 - *New DataSource*: _alicloud_vswitches_ ([#109](https://github.com/terraform-providers/terraform-provider-alicloud/pull/109))
 
 BUG FIXES:

--- a/alicloud/data_source_alicloud_eips.go
+++ b/alicloud/data_source_alicloud_eips.go
@@ -1,0 +1,176 @@
+package alicloud
+
+import (
+	"fmt"
+	"log"
+
+	"github.com/denverdino/aliyungo/ecs"
+	"github.com/hashicorp/terraform/helper/schema"
+)
+
+func dataSourceAlicloudEips() *schema.Resource {
+	return &schema.Resource{
+		Read: dataSourceAlicloudEipsRead,
+
+		Schema: map[string]*schema.Schema{
+			"ids": {
+				Type:     schema.TypeList,
+				Optional: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+				ForceNew: true,
+				MinItems: 1,
+			},
+			"in_use": {
+				Type:     schema.TypeBool,
+				Optional: true,
+				Default:  false,
+				ForceNew: true,
+			},
+			"ip_addresses": {
+				Type:     schema.TypeList,
+				Optional: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+				ForceNew: true,
+				MinItems: 1,
+			},
+			"output_file": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+
+			// Computed values
+			"eips": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"ip_address": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"status": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"instance_id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"instance_type": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"bandwidth": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"internet_charge_type": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"creation_time": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+					},
+				},
+			},
+		},
+	}
+}
+func dataSourceAlicloudEipsRead(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AliyunClient).ecsconn
+
+	args := &ecs.DescribeEipAddressesArgs{
+		RegionId: getRegion(d, meta),
+		Status:   ecs.EipStatusAvailable,
+	}
+	if v, ok := d.GetOk("in_use"); ok && v.(bool) {
+		args.Status = ecs.EipStatusInUse
+	}
+	idsMap := make(map[string]string)
+	ipsMap := make(map[string]string)
+	if v, ok := d.GetOk("ids"); ok {
+		for _, vv := range v.([]interface{}) {
+			idsMap[Trim(vv.(string))] = Trim(vv.(string))
+		}
+	}
+	if v, ok := d.GetOk("ip_addresses"); ok {
+		for _, vv := range v.([]interface{}) {
+			ipsMap[Trim(vv.(string))] = Trim(vv.(string))
+		}
+	}
+
+	var allEips []ecs.EipAddressSetType
+
+	for {
+		eips, paginationResult, err := conn.DescribeEipAddresses(args)
+		if err != nil {
+			return err
+		}
+
+		for _, e := range eips {
+			if len(idsMap) > 0 {
+				if _, ok := idsMap[e.AllocationId]; !ok {
+					continue
+				}
+			}
+			if len(ipsMap) > 0 {
+				if _, ok := ipsMap[e.IpAddress]; !ok {
+					continue
+				}
+			}
+			allEips = append(allEips, e)
+		}
+
+		pagination := paginationResult.NextPage()
+		if pagination == nil {
+			break
+		}
+
+		args.Pagination = *pagination
+	}
+
+	if len(allEips) < 1 {
+		return fmt.Errorf("Your query returned no results. Please change your search criteria and try again.")
+	}
+
+	log.Printf("[DEBUG] alicloud_eips - EIPs found: %#v", allEips)
+
+	return eipsDecriptionAttributes(d, allEips, meta)
+}
+
+func eipsDecriptionAttributes(d *schema.ResourceData, eipSetTypes []ecs.EipAddressSetType, meta interface{}) error {
+	var ids []string
+	var s []map[string]interface{}
+	for _, eip := range eipSetTypes {
+		mapping := map[string]interface{}{
+			"id":                   eip.AllocationId,
+			"status":               eip.Status,
+			"ip_address":           eip.IpAddress,
+			"bandwidth":            eip.Bandwidth,
+			"instance_id":          eip.InstanceId,
+			"instance_type":        eip.InstanceType,
+			"internet_charge_type": eip.InternetChargeType,
+			"creation_time":        eip.AllocationTime.String(),
+		}
+		log.Printf("[DEBUG] alicloud_eip - adding eip: %v", mapping)
+		ids = append(ids, eip.AllocationId)
+		s = append(s, mapping)
+	}
+
+	d.SetId(dataResourceIdHash(ids))
+	if err := d.Set("eips", s); err != nil {
+		return err
+	}
+
+	// create a json file in current directory and write data source to it.
+	if output, ok := d.GetOk("output_file"); ok && output.(string) != "" {
+		writeToFile(output.(string), s)
+	}
+	return nil
+}

--- a/alicloud/data_source_alicloud_eips_test.go
+++ b/alicloud/data_source_alicloud_eips_test.go
@@ -1,0 +1,39 @@
+package alicloud
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform/helper/resource"
+)
+
+func TestAccAlicloudEipsDataSource(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+		},
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCheckAlicloudEipsDataSourceConfig,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAlicloudDataSourceID("data.alicloud_eips.foo"),
+					resource.TestCheckResourceAttr("data.alicloud_eips.foo", "eips.#", "2"),
+					resource.TestCheckResourceAttr("data.alicloud_eips.foo", "eips.0.status", "Available"),
+					resource.TestCheckResourceAttr("data.alicloud_eips.foo", "eips.1.bandwidth", "5"),
+				),
+			},
+		},
+	})
+}
+
+const testAccCheckAlicloudEipsDataSourceConfig = `
+resource "alicloud_eip" "eip" {
+  count = 2
+  bandwidth = 5
+}
+
+data "alicloud_eips" "foo" {
+  ids = ["${alicloud_eip.eip.*.id}"]
+  ip_addresses = ["${alicloud_eip.eip.*.ip_address}"]
+}
+`

--- a/alicloud/provider.go
+++ b/alicloud/provider.go
@@ -47,6 +47,7 @@ func Provider() terraform.ResourceProvider {
 			"alicloud_instances":      dataSourceAlicloudInstances(),
 			"alicloud_vpcs":           dataSourceAlicloudVpcs(),
 			"alicloud_vswitches":      dataSourceAlicloudVSwitches(),
+			"alicloud_eips":           dataSourceAlicloudEips(),
 			"alicloud_key_pairs":      dataSourceAlicloudKeyPairs(),
 			"alicloud_kms_keys":       dataSourceAlicloudKmsKeys(),
 			"alicloud_dns_domains":    dataSourceAlicloudDnsDomains(),

--- a/website/alicloud.erb
+++ b/website/alicloud.erb
@@ -40,6 +40,9 @@
                         <li<%= sidebar_current("docs-alicloud-datasource-vswitches") %>>
                             <a href="/docs/providers/alicloud/d/vswitches.html">alicloud_vswitches</a>
                         </li>
+                        <li<%= sidebar_current("docs-alicloud-datasource-eips") %>>
+                            <a href="/docs/providers/alicloud/d/eips.html">alicloud_eips</a>
+                        </li>
                         <li<%= sidebar_current("docs-alicloud-datasource-dns-domain-groups") %>>
                             <a href="/docs/providers/alicloud/d/dns_domain_groups.html">alicloud_dns_domain_groups</a>
                         </li>

--- a/website/docs/d/eips.html.markdown
+++ b/website/docs/d/eips.html.markdown
@@ -1,0 +1,62 @@
+---
+layout: "alicloud"
+page_title: "Alicloud: alicloud_eips"
+sidebar_current: "docs-alicloud-datasource-eips"
+description: |-
+    Provides a list of EIP which owned by an Alicloud account.
+---
+
+# alicloud\_eips
+
+The elastic ip address data source lists a list of eips resource information owned by an Alicloud account,
+and each EIP including its basic attribution and association instance.
+
+## Example Usage
+
+```
+data "alicloud_eips" "eips"{
+    cidr_block="172.16.0.0/12"
+    name_regex="^foo"
+}
+
+resource "alicloud_instance" "foo" {
+    ...
+    instance_name =  "in-the-eip"
+    vswitch_id = "vsw-abc123456"
+    ...
+}
+
+resource "alicloud_eip_association" "asso" {
+    instance_id = "${alicloud_instance.foo.id}"
+    allocation_id = "${data.alicloud_eips.eips.eips.0.id}"
+}
+
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `ids` - (Optional) A list of EIP allocation ID.
+* `ip_addresses` - (Optional) A list of EIP ip address ID.
+* `in_use` - (Optional) Whether the EIP is in use. Default to "false" indicates the EIP is available.
+* `output_file` - (Optional) The name of file that can save eips data source after running `terraform plan`.
+
+## Attributes Reference
+
+The following attributes are exported:
+
+* `eips` A list of eips. It contains several attributes to `Block EIPs`.
+
+### Block EIPs
+
+Attributes for eips:
+
+* `id` - ID of the EIP.
+* `status` - EIP status.
+* `ip_address` - Address of the the EIP.
+* `bandwidth` - EIP internat max bandwidth.
+* `internet_charge_type` - EIP internet charge type.
+* `instance_id` - ID of the instance with which EIP association.
+* `instance_id` - Type of the instance with which EIP association.
+* `creation_time` - Time of creation.


### PR DESCRIPTION
The PR adds a new datasource alicloud_eips.

The result of running test case as follows:

TF_ACC=1 go test ./alicloud -v -run=TestAccAlicloudEipsDataSource -timeout 120m
=== RUN   TestAccAlicloudEipsDataSource
--- PASS: TestAccAlicloudEipsDataSource (18.89s)
PASS
ok      github.com/alibaba/terraform-provider/alicloud  18.928s
