### PR TITLE
Fix creating Classic instance failed result in role_name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ IMPROVEMENTS:
 
 BUG FIXES:
 
+- Fix creating Classic instance failed result in role_name ([#111](https://github.com/terraform-providers/terraform-provider-alicloud/pull/111))
 - Fix eip is not exist in nat gateway when creating snat ([#108](https://github.com/terraform-providers/terraform-provider-alicloud/pull/108))
 
 ## 1.7.1 (February 02, 2018)

--- a/alicloud/diff_suppress_funcs.go
+++ b/alicloud/diff_suppress_funcs.go
@@ -203,3 +203,10 @@ func ecsSecurityGroupRulePortRangeDiffSuppressFunc(k, old, new string, d *schema
 	}
 	return true
 }
+
+func vpcTypeResourceDiffSuppressFunc(k, old, new string, d *schema.ResourceData) bool {
+	if len(Trim(d.Get("vswitch_id").(string))) > 0 {
+		return false
+	}
+	return true
+}


### PR DESCRIPTION
The PR fixes an error that creating Classic instance failed result in role_name.

The result of running test case as follows:

TF_ACC=1 go test ./alicloud -v -run=TestAccAlicloudInstance_ramrole -timeout 120m
=== RUN   TestAccAlicloudInstance_ramrole
--- PASS: TestAccAlicloudInstance_ramrole (178.55s)
PASS
ok      github.com/alibaba/terraform-provider/alicloud  178.591s