### PR TITLE
Support inner network segregation in one security group

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ IMPROVEMENTS:
 
 - *New DataSource*: _alicloud_eips_ ([#110](https://github.com/terraform-providers/terraform-provider-alicloud/pull/110))
 - *New DataSource*: _alicloud_vswitches_ ([#109](https://github.com/terraform-providers/terraform-provider-alicloud/pull/109))
+- Support inner network segregation in one security group ([#112](https://github.com/terraform-providers/terraform-provider-alicloud/pull/112))
 
 BUG FIXES:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ IMPROVEMENTS:
 
 BUG FIXES:
 
+- Fix creating Classic instance failed result in role_name ([#111](https://github.com/terraform-providers/terraform-provider-alicloud/pull/111))
 - Fix eip is not exist in nat gateway when creating snat ([#108](https://github.com/terraform-providers/terraform-provider-alicloud/pull/108))
 
 ## 1.7.1 (February 02, 2018)

--- a/alicloud/diff_suppress_funcs.go
+++ b/alicloud/diff_suppress_funcs.go
@@ -203,3 +203,10 @@ func ecsSecurityGroupRulePortRangeDiffSuppressFunc(k, old, new string, d *schema
 	}
 	return true
 }
+
+func vpcTypeResourceDiffSuppressFunc(k, old, new string, d *schema.ResourceData) bool {
+	if len(Trim(d.Get("vswitch_id").(string))) > 0 {
+		return false
+	}
+	return true
+}

--- a/alicloud/resource_alicloud_security_group_test.go
+++ b/alicloud/resource_alicloud_security_group_test.go
@@ -62,6 +62,10 @@ func TestAccAlicloudSecurityGroup_withVpc(t *testing.T) {
 						"alicloud_security_group.foo", &sg),
 					testAccCheckVpcExists(
 						"alicloud_vpc.vpc", &vpc),
+					resource.TestCheckResourceAttr(
+						"alicloud_security_group.foo",
+						"inner_access",
+						"true"),
 				),
 			},
 		},

--- a/vendor/github.com/denverdino/aliyungo/ecs/networks.go
+++ b/vendor/github.com/denverdino/aliyungo/ecs/networks.go
@@ -38,7 +38,7 @@ type ModifyInstanceNetworkSpec struct {
 	InstanceId              string
 	InternetMaxBandwidthOut *int
 	InternetMaxBandwidthIn  *int
-	NetworkChargeType common.InternetChargeType
+	NetworkChargeType       common.InternetChargeType
 }
 
 type ModifyInstanceNetworkSpecResponse struct {
@@ -88,9 +88,10 @@ type EipInstanceType string
 const (
 	EcsInstance = "EcsInstance"
 	SlbInstance = "SlbInstance"
-	Nat = "Nat"
-	HaVip = "HaVip"
+	Nat         = "Nat"
+	HaVip       = "HaVip"
 )
+
 type AssociateEipAddressArgs struct {
 	AllocationId string
 	InstanceId   string

--- a/vendor/github.com/denverdino/aliyungo/ecs/security_groups.go
+++ b/vendor/github.com/denverdino/aliyungo/ecs/security_groups.go
@@ -34,6 +34,13 @@ const (
 	PermissionPolicyDrop   = PermissionPolicy("drop")
 )
 
+type GroupInnerAccessPolicy string
+
+const (
+	GroupInnerAccept = GroupInnerAccessPolicy("Accept")
+	GroupInnerDrop   = GroupInnerAccessPolicy("Drop")
+)
+
 type DescribeSecurityGroupAttributeArgs struct {
 	SecurityGroupId string
 	RegionId        common.Region
@@ -70,6 +77,7 @@ type DescribeSecurityGroupAttributeResponse struct {
 		Permission []PermissionType
 	}
 	VpcId string
+	InnerAccessPolicy GroupInnerAccessPolicy
 }
 
 //
@@ -199,6 +207,21 @@ type ModifySecurityGroupAttributeResponse struct {
 func (client *Client) ModifySecurityGroupAttribute(args *ModifySecurityGroupAttributeArgs) error {
 	response := ModifySecurityGroupAttributeResponse{}
 	err := client.Invoke("ModifySecurityGroupAttribute", args, &response)
+	return err
+}
+
+type ModifySecurityGroupPolicyArgs struct {
+	RegionId          common.Region
+	SecurityGroupId   string
+	InnerAccessPolicy GroupInnerAccessPolicy
+}
+
+// ModifySecurityGroupPolicy modifies inner access policy of security group
+//
+// You can read doc at https://www.alibabacloud.com/help/doc-detail/57315.htm
+func (client *Client) ModifySecurityGroupPolicy(args *ModifySecurityGroupPolicyArgs) error {
+	response := common.Response{}
+	err := client.Invoke("ModifySecurityGroupPolicy", args, &response)
 	return err
 }
 

--- a/vendor/github.com/denverdino/aliyungo/ess/group.go
+++ b/vendor/github.com/denverdino/aliyungo/ess/group.go
@@ -307,7 +307,7 @@ const DefaultWaitTimeout = 120
 const DefaultWaitForInterval = 5
 
 // WaitForScalingGroup waits for group to given status
-func (client *Client) WaitForScalingGroup (regionId common.Region, groupId string, status LifecycleState, timeout int) error {
+func (client *Client) WaitForScalingGroup(regionId common.Region, groupId string, status LifecycleState, timeout int) error {
 	if timeout <= 0 {
 		timeout = DefaultWaitTimeout
 	}

--- a/vendor/github.com/denverdino/aliyungo/rds/instances.go
+++ b/vendor/github.com/denverdino/aliyungo/rds/instances.go
@@ -1083,7 +1083,7 @@ func (client *Client) ModifyDBInstanceConnectionString(args *ModifyDBInstanceCon
 }
 
 type ModifyDBInstanceDescriptionArgs struct {
-	DBInstanceId            string
+	DBInstanceId          string
 	DBInstanceDescription string
 }
 
@@ -1165,6 +1165,31 @@ func (client *Client) ModifyDBInstanceSpec(args *ModifyDBInstanceSpecArgs) (resp
 	response := ModifyDBInstanceSpecResponse{}
 	err = client.Invoke("ModifyDBInstanceSpec", args, &response)
 
+	if err != nil {
+		return nil, err
+	}
+	return &response, nil
+}
+
+type ModifyDBInstancePayTypeArgs struct {
+	DBInstanceId string
+	PayType      DBPayType
+	Period       common.TimeType
+	UsedTime     string
+	AutoPay      string
+}
+
+type ModifyDBInstancePayTypeResponse struct {
+	common.Response
+	OrderId int
+}
+
+// ModifyDBInstancePayType modify db charge type
+//
+// You can read doc at https://help.aliyun.com/document_detail/26247.html
+func (client *Client) ModifyDBInstancePayType(args *ModifyDBInstancePayTypeArgs) (resp *ModifyDBInstancePayTypeResponse, err error) {
+	response := ModifyDBInstancePayTypeResponse{}
+	err = client.Invoke("ModifyDBInstancePayType", args, &response)
 	if err != nil {
 		return nil, err
 	}

--- a/vendor/github.com/denverdino/aliyungo/slb/listeners.go
+++ b/vendor/github.com/denverdino/aliyungo/slb/listeners.go
@@ -103,6 +103,9 @@ type HTTPListenerType struct {
 	VServerGroup           FlagType
 	VServerGroupId         string
 	Gzip                   FlagType
+	XForwardedFor_SLBID    FlagType
+	XForwardedFor_SLBIP    FlagType
+	XForwardedFor_proto    FlagType
 }
 type CreateLoadBalancerHTTPListenerArgs HTTPListenerType
 

--- a/vendor/github.com/denverdino/aliyungo/slb/loadbalancers.go
+++ b/vendor/github.com/denverdino/aliyungo/slb/loadbalancers.go
@@ -24,12 +24,12 @@ const (
 type LoadBalancerSpecType string
 
 const (
-	S1Small = "slb.s1.small"
-	S2Small = "slb.s2.small"
+	S1Small  = "slb.s1.small"
+	S2Small  = "slb.s2.small"
 	S2Medium = "slb.s2.medium"
-	S3Small = "slb.s3.small"
+	S3Small  = "slb.s3.small"
 	S3Medium = "slb.s3.medium"
-	S3Large = "slb.s3.large"
+	S3Large  = "slb.s3.large"
 )
 
 type CreateLoadBalancerArgs struct {
@@ -108,9 +108,9 @@ func (client *Client) ModifyLoadBalancerInternetSpec(args *ModifyLoadBalancerInt
 }
 
 type ModifyLoadBalancerInstanceSpecArgs struct {
-	RegionId common.Region
-	LoadBalancerId     string
-	LoadBalancerSpec   LoadBalancerSpecType
+	RegionId         common.Region
+	LoadBalancerId   string
+	LoadBalancerSpec LoadBalancerSpecType
 }
 
 // ModifyLoadBalancerInstanceSpec Modify loadbalancer instance spec
@@ -222,7 +222,7 @@ type LoadBalancerType struct {
 	BackendServers struct {
 		BackendServer []BackendServerType
 	}
-	LoadBalancerSpec   LoadBalancerSpecType
+	LoadBalancerSpec LoadBalancerSpecType
 }
 
 type DescribeLoadBalancersResponse struct {

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -235,74 +235,74 @@
 		{
 			"checksumSHA1": "9bZS3sdYQuY8j2Fxi9sEoQl2ibQ=",
 			"path": "github.com/denverdino/aliyungo/cdn",
-			"revision": "f974a5515be2328f9028603308418b56d5e84844",
-			"revisionTime": "2018-02-02T02:50:02Z"
+			"revision": "4d25ef3f0b2972d770a545bf568aea4b4d3314b3",
+			"revisionTime": "2018-02-07T01:39:38Z"
 		},
 		{
 			"checksumSHA1": "6jhMTB/kEVfbbszOdOyYODYFk5Q=",
 			"path": "github.com/denverdino/aliyungo/common",
-			"revision": "f974a5515be2328f9028603308418b56d5e84844",
-			"revisionTime": "2018-02-02T02:50:02Z"
+			"revision": "4d25ef3f0b2972d770a545bf568aea4b4d3314b3",
+			"revisionTime": "2018-02-07T01:39:38Z"
 		},
 		{
 			"checksumSHA1": "JgK7hgdP+yfsRin1lbz0LjBVtic=",
 			"path": "github.com/denverdino/aliyungo/cs",
-			"revision": "f974a5515be2328f9028603308418b56d5e84844",
-			"revisionTime": "2018-02-02T02:50:02Z"
+			"revision": "4d25ef3f0b2972d770a545bf568aea4b4d3314b3",
+			"revisionTime": "2018-02-07T01:39:38Z"
 		},
 		{
 			"checksumSHA1": "0y6d3UiB8JckT3YTeXjMbLkSibg=",
 			"path": "github.com/denverdino/aliyungo/dns",
-			"revision": "f974a5515be2328f9028603308418b56d5e84844",
-			"revisionTime": "2018-02-02T02:50:02Z"
+			"revision": "4d25ef3f0b2972d770a545bf568aea4b4d3314b3",
+			"revisionTime": "2018-02-07T01:39:38Z"
 		},
 		{
-			"checksumSHA1": "l0Bk07lYC/WR91ljWX+2QylewSo=",
+			"checksumSHA1": "bXwG0DJI1Zpdaoctht4rTx7tDnQ=",
 			"path": "github.com/denverdino/aliyungo/ecs",
-			"revision": "f974a5515be2328f9028603308418b56d5e84844",
-			"revisionTime": "2018-02-02T02:50:02Z"
+			"revision": "4d25ef3f0b2972d770a545bf568aea4b4d3314b3",
+			"revisionTime": "2018-02-07T01:39:38Z"
 		},
 		{
-			"checksumSHA1": "egdeptetSfA/kCVWQNuC7eKMI+o=",
+			"checksumSHA1": "VOqJAC5GCE7xGdb1PWrYHkiH62Q=",
 			"path": "github.com/denverdino/aliyungo/ess",
-			"revision": "f974a5515be2328f9028603308418b56d5e84844",
-			"revisionTime": "2018-02-02T02:50:02Z"
+			"revision": "4d25ef3f0b2972d770a545bf568aea4b4d3314b3",
+			"revisionTime": "2018-02-07T01:39:38Z"
 		},
 		{
 			"checksumSHA1": "rj3YU+oc3pVDG9Rd1zzHtMWsIJg=",
 			"path": "github.com/denverdino/aliyungo/kms",
-			"revision": "f974a5515be2328f9028603308418b56d5e84844",
-			"revisionTime": "2018-02-02T02:50:02Z"
+			"revision": "4d25ef3f0b2972d770a545bf568aea4b4d3314b3",
+			"revisionTime": "2018-02-07T01:39:38Z"
 		},
 		{
 			"checksumSHA1": "CPuR3s7LzQkT57Z20zMHXQM2MYQ=",
 			"path": "github.com/denverdino/aliyungo/location",
-			"revision": "f974a5515be2328f9028603308418b56d5e84844",
-			"revisionTime": "2018-02-02T02:50:02Z"
+			"revision": "4d25ef3f0b2972d770a545bf568aea4b4d3314b3",
+			"revisionTime": "2018-02-07T01:39:38Z"
 		},
 		{
 			"checksumSHA1": "mkaQUrh01nWescV/Ek7Yv/WwX9Q=",
 			"path": "github.com/denverdino/aliyungo/ram",
-			"revision": "f974a5515be2328f9028603308418b56d5e84844",
-			"revisionTime": "2018-02-02T02:50:02Z"
+			"revision": "4d25ef3f0b2972d770a545bf568aea4b4d3314b3",
+			"revisionTime": "2018-02-07T01:39:38Z"
 		},
 		{
-			"checksumSHA1": "D4ugog0rIZolvzyH2Wf/p+eUJOE=",
+			"checksumSHA1": "BZOpoyXwLnP+JHjR1lhSe8LahEk=",
 			"path": "github.com/denverdino/aliyungo/rds",
-			"revision": "f974a5515be2328f9028603308418b56d5e84844",
-			"revisionTime": "2018-02-02T02:50:02Z"
+			"revision": "4d25ef3f0b2972d770a545bf568aea4b4d3314b3",
+			"revisionTime": "2018-02-07T01:39:38Z"
 		},
 		{
-			"checksumSHA1": "pTmrFsVGJmq42mUzlIhwh72jKbQ=",
+			"checksumSHA1": "tz60kzMq3ub8Q/KbiHXwWxn4QO8=",
 			"path": "github.com/denverdino/aliyungo/slb",
-			"revision": "f974a5515be2328f9028603308418b56d5e84844",
-			"revisionTime": "2018-02-02T02:50:02Z"
+			"revision": "4d25ef3f0b2972d770a545bf568aea4b4d3314b3",
+			"revisionTime": "2018-02-07T01:39:38Z"
 		},
 		{
 			"checksumSHA1": "ZSpVJldK4F8joh8pOryB5SaSn8s=",
 			"path": "github.com/denverdino/aliyungo/util",
-			"revision": "f974a5515be2328f9028603308418b56d5e84844",
-			"revisionTime": "2018-02-02T02:50:02Z"
+			"revision": "4d25ef3f0b2972d770a545bf568aea4b4d3314b3",
+			"revisionTime": "2018-02-07T01:39:38Z"
 		},
 		{
 			"checksumSHA1": "BCv50o5pDkoSG3vYKOSai1Z8p3w=",

--- a/website/docs/r/security_group.html.markdown
+++ b/website/docs/r/security_group.html.markdown
@@ -12,6 +12,8 @@ Provides a security group resource.
 
 ~> **NOTE:** `alicloud_security_group` is used to build and manage a security group, and `alicloud_security_group_rule` can define ingress or egress rules for it.
 
+~> **NOTE:** From version 1.7.2, `alicloud_security_group` has supported to segregate different ECS instance in which the same security group.
+
 ## Example Usage
 
 Basic Usage
@@ -42,6 +44,8 @@ The following arguments are supported:
 * `name` - (Optional) The name of the security group. Defaults to null.
 * `description` - (Optional, Forces new resource) The security group description. Defaults to null.
 * `vpc_id` - (Optional, Forces new resource) The VPC ID.
+* `inner_access` - (Optional) Whether to allow both machines to access each other on all ports in the same security group.
+Combining security group rules, the policy can define multiple application scenario. Default to true. It is valid from verison `1.7.2`.
 
 ## Attributes Reference
 
@@ -51,6 +55,7 @@ The following attributes are exported:
 * `vpc_id` - The VPC ID.
 * `name` - The name of the security group
 * `description` - The description of the security group
+* `inner_access` - Whether to allow inner network access.
 
 ## Import
 


### PR DESCRIPTION
The PR supports to segregate different ECS instance in which the same security group.

The PR has a pre-pr #111 .

The result of running test case as follows:

TF_ACC=1 go test ./alicloud -v -run=TestAccAlicloudSecurityGroup -timeout 120m
=== RUN   TestAccAlicloudSecurityGroup_importBasic
--- PASS: TestAccAlicloudSecurityGroup_importBasic (33.26s)
=== RUN   TestAccAlicloudSecurityGroup_importWithVpc
--- PASS: TestAccAlicloudSecurityGroup_importWithVpc (43.95s)
=== RUN   TestAccAlicloudSecurityGroupRule_Ingress
--- PASS: TestAccAlicloudSecurityGroupRule_Ingress (36.68s)
=== RUN   TestAccAlicloudSecurityGroupRule_Egress
--- PASS: TestAccAlicloudSecurityGroupRule_Egress (35.32s)
=== RUN   TestAccAlicloudSecurityGroupRule_EgressDefaultNicType
--- PASS: TestAccAlicloudSecurityGroupRule_EgressDefaultNicType (33.80s)
=== RUN   TestAccAlicloudSecurityGroupRule_Vpc_Ingress
--- PASS: TestAccAlicloudSecurityGroupRule_Vpc_Ingress (43.24s)
=== RUN   TestAccAlicloudSecurityGroupRule_MissParameterSourceCidrIp
--- PASS: TestAccAlicloudSecurityGroupRule_MissParameterSourceCidrIp (31.92s)
=== RUN   TestAccAlicloudSecurityGroupRule_SourceSecurityGroup
--- PASS: TestAccAlicloudSecurityGroupRule_SourceSecurityGroup (34.82s)
=== RUN   TestAccAlicloudSecurityGroupRule_Multi
--- PASS: TestAccAlicloudSecurityGroupRule_Multi (74.08s)
=== RUN   TestAccAlicloudSecurityGroupRule_MultiAttri
--- PASS: TestAccAlicloudSecurityGroupRule_MultiAttri (48.98s)
=== RUN   TestAccAlicloudSecurityGroup_basic
--- PASS: TestAccAlicloudSecurityGroup_basic (30.35s)
=== RUN   TestAccAlicloudSecurityGroup_withVpc
--- PASS: TestAccAlicloudSecurityGroup_withVpc (38.06s)
PASS
ok      github.com/alibaba/terraform-provider/alicloud  484.497s
