### PR TITLE
Data source zones support to retrieve multiple zone

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 IMPROVEMENTS:
 
+- Data source zones support to retrieve multiple zone ([#119](https://github.com/terraform-providers/terraform-provider-alicloud/pull/119))
 - VPC supports alibaba cloud official go sdk ([#118](https://github.com/terraform-providers/terraform-provider-alicloud/pull/118))
 
 ## 1.8.0 (March 02, 2018)

--- a/alicloud/common.go
+++ b/alicloud/common.go
@@ -85,6 +85,7 @@ const (
 	ResourceTypeDisk     = ResourceType("Disk")
 	ResourceTypeVSwitch  = ResourceType("VSwitch")
 	ResourceTypeRds      = ResourceType("Rds")
+	IoOptimized          = ResourceType("IoOptimized")
 )
 
 type InternetChargeType string

--- a/website/docs/d/zones.html.markdown
+++ b/website/docs/d/zones.html.markdown
@@ -36,6 +36,7 @@ The following arguments are supported:
 * `available_instance_type` - (Optional) Limit search to specific instance type.
 * `available_resource_creation` - (Optional) Limit search to specific resource type. The following values are allowed `Instance`, `Disk`, `VSwitch` and `Rds`.
 * `available_disk_category` - (Optional) Limit search to specific disk category. Can be either `cloud`, `cloud_efficiency`, `cloud_ssd`.
+* `multi` - (Optional) Whether to retrieve multiple availability. Default to `false`. Multiple zone usually is used to launch RDS.
 * `output_file` - (Optional) The name of file that can save zones data source after running `terraform plan`.
 
 ~> **NOTE:** Available disk category `cloud` has been outdated and it only can be used none I/O Optimized ECS instances. So many available zones haven't support it. Recommend `cloud_efficiency` and `cloud_ssd`.


### PR DESCRIPTION
The pr support to retrieve multiple zone for launching rds.

The result of running test cases as following:

TF_ACC=1 go test ./alicloud -v -run=TestAccAlicloudZonesDataSource -timeout 120m
=== RUN   TestAccAlicloudZonesDataSource_basic
--- PASS: TestAccAlicloudZonesDataSource_basic (30.76s)
=== RUN   TestAccAlicloudZonesDataSource_filter
--- PASS: TestAccAlicloudZonesDataSource_filter (125.35s)
=== RUN   TestAccAlicloudZonesDataSource_unitRegion
--- PASS: TestAccAlicloudZonesDataSource_unitRegion (44.74s)
=== RUN   TestAccAlicloudZonesDataSource_multiZone
--- PASS: TestAccAlicloudZonesDataSource_multiZone (30.19s)
PASS
ok    github.com/alibaba/terraform-provider/alicloud  231.091s
