### PR TITLE
Fix vpc not found when vpc has been deleted

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,10 @@
 ## 1.9.1 (Unreleased)
+
+BUG FIXES:
+
+- Fix vpc not found when vpc has been deleted ([#131](https://github.com/terraform-providers/terraform-provider-alicloud/pull/131))
+
+
 ## 1.9.0 (March 19, 2018)
 
 IMPROVEMENTS:

--- a/alicloud/errors.go
+++ b/alicloud/errors.go
@@ -60,6 +60,8 @@ const (
 	// vpc
 	VpcQuotaExceeded     = "QuotaExceeded.Vpc"
 	InvalidVpcIDNotFound = "InvalidVpcID.NotFound"
+	ForbiddenVpcNotFound = "Forbidden.VpcNotFound"
+
 	// vswitch
 	VswitcInvalidRegionId    = "InvalidRegionId.NotFound"
 	InvalidVswitchIDNotFound = "InvalidVswitchID.NotFound"

--- a/alicloud/resource_alicloud_vpc.go
+++ b/alicloud/resource_alicloud_vpc.go
@@ -178,7 +178,7 @@ func resourceAliyunVpcDelete(d *schema.ResourceData, meta interface{}) error {
 		_, err := client.vpcconn.DeleteVpc(request)
 
 		if err != nil {
-			if IsExceptedError(err, InvalidVpcIDNotFound) {
+			if IsExceptedError(err, InvalidVpcIDNotFound) || IsExceptedError(err, ForbiddenVpcNotFound) {
 				return nil
 			}
 			return resource.RetryableError(fmt.Errorf("Delete VPC timeout and got an error: %#v.", err))

--- a/alicloud/service_alicloud_vpc.go
+++ b/alicloud/service_alicloud_vpc.go
@@ -53,7 +53,7 @@ func (client *AliyunClient) DescribeVpc(vpcId string) (v vpc.DescribeVpcAttribut
 
 	resp, err := client.vpcconn.DescribeVpcAttribute(request)
 	if err != nil {
-		if IsExceptedError(err, InvalidVpcIDNotFound) {
+		if IsExceptedError(err, InvalidVpcIDNotFound) || IsExceptedError(err, ForbiddenVpcNotFound) {
 			return v, GetNotFoundErrorFromString(GetNotFoundMessage("VPC", vpcId))
 		}
 		return


### PR DESCRIPTION
This PR add one error code to fix vpc not found bug.

The result of running test case as follows:

TF_ACC=1 go test ./alicloud -v -run=TestAccAlicloudVpc -timeout=120m
=== RUN   TestAccAlicloudVpcsDataSource_cidr_block
--- PASS: TestAccAlicloudVpcsDataSource_cidr_block (21.92s)
=== RUN   TestAccAlicloudVpc_importBasic
--- PASS: TestAccAlicloudVpc_importBasic (18.51s)
=== RUN   TestAccAlicloudVpc_basic
--- PASS: TestAccAlicloudVpc_basic (17.39s)
=== RUN   TestAccAlicloudVpc_update
--- PASS: TestAccAlicloudVpc_update (27.34s)
=== RUN   TestAccAlicloudVpc_multi
--- PASS: TestAccAlicloudVpc_multi (12.50s)
PASS
ok    github.com/alibaba/terraform-provider/alicloud  97.703s