### PR TITLE
Add eip unassociation retry times to avoid needless error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ IMPROVEMENTS:
 - Add warning when creating postgresql and ppas database ([#132](https://github.com/terraform-providers/terraform-provider-alicloud/pull/132))
 - Add kubernetes example ([#142](https://github.com/terraform-providers/terraform-provider-alicloud/pull/142))
 - Update sdk to support user-agent ([#143](https://github.com/terraform-providers/terraform-provider-alicloud/pull/143))
+- Add eip unassociation retry times to avoid needless error ([#144](https://github.com/terraform-providers/terraform-provider-alicloud/pull/144))
 
 BUG FIXES:
 

--- a/alicloud/resource_alicloud_eip_association.go
+++ b/alicloud/resource_alicloud_eip_association.go
@@ -124,7 +124,7 @@ func resourceAliyunEipAssociationDelete(d *schema.ResourceData, meta interface{}
 	if strings.HasPrefix(instanceId, "ngw-") {
 		request.InstanceType = Nat
 	}
-	return resource.Retry(3*time.Minute, func() *resource.RetryError {
+	return resource.Retry(5*time.Minute, func() *resource.RetryError {
 		if _, err := client.vpcconn.UnassociateEipAddress(request); err != nil {
 			if IsExceptedError(err, InstanceIncorrectStatus) ||
 				IsExceptedError(err, HaVipIncorrectStatus) ||


### PR DESCRIPTION
This PR add eip unassociation retry times to adapt other resources are destroyed.

The running test case result as follows:

TF_ACC=1 go test ./alicloud -v -run=TestAccAlicloudEIP -timeout=120m
=== RUN   TestAccAlicloudEIPAssociation
--- PASS: TestAccAlicloudEIPAssociation (149.66s)
=== RUN   TestAccAlicloudEIPAssociation_natgateway
--- PASS: TestAccAlicloudEIPAssociation_natgateway (33.43s)
=== RUN   TestAccAlicloudEIP_basic
--- PASS: TestAccAlicloudEIP_basic (22.20s)
PASS
ok    github.com/alibaba/terraform-provider/alicloud  205.332s
