### PR TITLE
Fix creating vswitch error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,9 @@
 ## 1.9.2 (Unreleased)
+
+BUG FIXES:
+
+- Fix creating vswitch error ([#149](https://github.com/terraform-providers/terraform-provider-alicloud/pull/149))
+
 ## 1.9.1 (April 13, 2018)
 
 IMPROVEMENTS:

--- a/alicloud/errors.go
+++ b/alicloud/errors.go
@@ -67,9 +67,11 @@ const (
 	InvalidVswitchIDNotFound = "InvalidVswitchID.NotFound"
 	//vroute entry
 	IncorrectRouteEntryStatus     = "IncorrectRouteEntryStatus"
+	InvalidStatusRouteEntry       = "InvalidStatus.RouteEntry"
 	TaskConflict                  = "TaskConflict"
 	RouterEntryForbbiden          = "Forbbiden"
 	RouterEntryConflictDuplicated = "RouterEntryConflict.Duplicated"
+	InvalidCidrBlockOverlapped    = "InvalidCidrBlock.Overlapped"
 
 	InvalidSnatTableIdNotFound = "InvalidSnatTableId.NotFound"
 	// Forward

--- a/alicloud/resource_alicloud_vswitch.go
+++ b/alicloud/resource_alicloud_vswitch.go
@@ -62,7 +62,10 @@ func resourceAliyunSwitchCreate(d *schema.ResourceData, meta interface{}) error 
 		}
 		resp, err := client.vpcconn.CreateVSwitch(args)
 		if err != nil {
-			if IsExceptedError(err, TaskConflict) || IsExceptedError(err, UnknownError) {
+			if IsExceptedError(err, TaskConflict) ||
+				IsExceptedError(err, UnknownError) ||
+				IsExceptedError(err, InvalidStatusRouteEntry) ||
+				IsExceptedError(err, InvalidCidrBlockOverlapped) {
 				return resource.RetryableError(fmt.Errorf("Creating Vswitch got an error: %#v", err))
 			}
 			return resource.NonRetryableError(err)


### PR DESCRIPTION
The PR fixes a error when creating multiple vswitches.

The result of running test case:

TF_ACC=1 go test -v ./alicloud -run=TestAccAlicloudVswitch
=== RUN   TestAccAlicloudVswitch_importBasic
--- PASS: TestAccAlicloudVswitch_importBasic (30.05s)
=== RUN   TestAccAlicloudVswitch_basic
--- PASS: TestAccAlicloudVswitch_basic (28.06s)
=== RUN   TestAccAlicloudVswitch_multi
--- PASS: TestAccAlicloudVswitch_multi (33.84s)
PASS
ok      github.com/alibaba/terraform-provider/alicloud  91.986s
