### PR TITLE
Fix deleting slb listener error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,9 @@
 ## 1.9.2 (Unreleased)
+
+BUG FIXES:
+
+- Fix creating vswitch error ([#149](https://github.com/terraform-providers/terraform-provider-alicloud/pull/149))
+
 ## 1.9.1 (April 13, 2018)
 
 IMPROVEMENTS:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 BUG FIXES:
 
+- Fix deleting slb listener error ([#150](https://github.com/terraform-providers/terraform-provider-alicloud/pull/150))
 - Fix creating vswitch error ([#149](https://github.com/terraform-providers/terraform-provider-alicloud/pull/149))
 
 ## 1.9.1 (April 13, 2018)

--- a/alicloud/errors.go
+++ b/alicloud/errors.go
@@ -67,9 +67,11 @@ const (
 	InvalidVswitchIDNotFound = "InvalidVswitchID.NotFound"
 	//vroute entry
 	IncorrectRouteEntryStatus     = "IncorrectRouteEntryStatus"
+	InvalidStatusRouteEntry       = "InvalidStatus.RouteEntry"
 	TaskConflict                  = "TaskConflict"
 	RouterEntryForbbiden          = "Forbbiden"
 	RouterEntryConflictDuplicated = "RouterEntryConflict.Duplicated"
+	InvalidCidrBlockOverlapped    = "InvalidCidrBlock.Overlapped"
 
 	InvalidSnatTableIdNotFound = "InvalidSnatTableId.NotFound"
 	// Forward

--- a/alicloud/resource_alicloud_slb_listener.go
+++ b/alicloud/resource_alicloud_slb_listener.go
@@ -496,8 +496,9 @@ func resourceAliyunSlbListenerDelete(d *schema.ResourceData, meta interface{}) e
 		err := slbconn.DeleteLoadBalancerListener(lb_id, port)
 
 		if err != nil {
-			if IsExceptedError(err, SystemBusy) {
-				resource.RetryableError(fmt.Errorf("Delete load balancer listener timeout and got an error: %#v.", err))
+			if IsExceptedError(err, SystemBusy) ||
+				IsExceptedError(err, BackendServerconfiguring) {
+				return resource.RetryableError(fmt.Errorf("Delete load balancer listener timeout and got an error: %#v.", err))
 			}
 			return resource.NonRetryableError(err)
 		}

--- a/alicloud/resource_alicloud_vswitch.go
+++ b/alicloud/resource_alicloud_vswitch.go
@@ -62,7 +62,10 @@ func resourceAliyunSwitchCreate(d *schema.ResourceData, meta interface{}) error 
 		}
 		resp, err := client.vpcconn.CreateVSwitch(args)
 		if err != nil {
-			if IsExceptedError(err, TaskConflict) || IsExceptedError(err, UnknownError) {
+			if IsExceptedError(err, TaskConflict) ||
+				IsExceptedError(err, UnknownError) ||
+				IsExceptedError(err, InvalidStatusRouteEntry) ||
+				IsExceptedError(err, InvalidCidrBlockOverlapped) {
 				return resource.RetryableError(fmt.Errorf("Creating Vswitch got an error: %#v", err))
 			}
 			return resource.NonRetryableError(err)


### PR DESCRIPTION
The PR fixes a bug that deleting a listener when there is backend server.

The result of running test cases:

TF_ACC=1 go test -v ./alicloud -run=TestAccAlicloudSlbListener
=== RUN   TestAccAlicloudSlbListener_importHttp
--- PASS: TestAccAlicloudSlbListener_importHttp (21.60s)
=== RUN   TestAccAlicloudSlbListener_importTcp
--- PASS: TestAccAlicloudSlbListener_importTcp (21.30s)
=== RUN   TestAccAlicloudSlbListener_importUdp
--- PASS: TestAccAlicloudSlbListener_importUdp (19.77s)
=== RUN   TestAccAlicloudSlbListener_http
--- PASS: TestAccAlicloudSlbListener_http (18.97s)
=== RUN   TestAccAlicloudSlbListener_tcp
--- PASS: TestAccAlicloudSlbListener_tcp (19.19s)
=== RUN   TestAccAlicloudSlbListener_udp
--- PASS: TestAccAlicloudSlbListener_udp (21.06s)
PASS
ok      github.com/alibaba/terraform-provider/alicloud  121.933s
