### PR TITLE
Fix deleting forward table not found error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 BUG FIXES:
 
+- Fix deleting forward table not found error ([#154](https://github.com/terraform-providers/terraform-provider-alicloud/pull/154))
 - Fix deleting slb listener error ([#150](https://github.com/terraform-providers/terraform-provider-alicloud/pull/150))
 - Fix creating vswitch error ([#149](https://github.com/terraform-providers/terraform-provider-alicloud/pull/149))
 

--- a/alicloud/resource_alicloud_instance.go
+++ b/alicloud/resource_alicloud_instance.go
@@ -191,6 +191,7 @@ func resourceAliyunInstance() *schema.Resource {
 				Type:             schema.TypeString,
 				Optional:         true,
 				ForceNew:         true,
+				Computed:         true,
 				DiffSuppressFunc: vpcTypeResourceDiffSuppressFunc,
 			},
 

--- a/alicloud/service_alicloud_vpc.go
+++ b/alicloud/service_alicloud_vpc.go
@@ -122,7 +122,8 @@ func (client *AliyunClient) DescribeForwardEntry(forwardTableId string, forwardE
 	//this special deal cause the DescribeSnatEntry can't find the records would be throw "cant find the snatTable error"
 	//so judge the snatEntries length priority
 	if err != nil {
-		if IsExceptedError(err, InvalidForwardEntryIdNotFound) {
+		if IsExceptedError(err, InvalidForwardEntryIdNotFound) ||
+			IsExceptedError(err, InvalidForwardTableIdNotFound) {
 			return entry, GetNotFoundErrorFromString(GetNotFoundMessage("Forward Entry", forwardTableId))
 		}
 		return


### PR DESCRIPTION
The result of test case as follows:

TF_ACC=1 go test -v ./alicloud -run=TestAccAlicloudForward
=== RUN   TestAccAlicloudForward_basic
--- PASS: TestAccAlicloudForward_basic (47.23s)
PASS
ok      github.com/alibaba/terraform-provider/alicloud  47.273s
