### PR TITLE
Prolong waiting time for creating kubernetes cluster to avoid timeout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 IMPROVEMENTS:
 
+- Prolong waiting time for creating kubernetes cluster to avoid timeout ([#158](https://github.com/terraform-providers/terraform-provider-alicloud/pull/158))
 - Update example ([#155](https://github.com/terraform-providers/terraform-provider-alicloud/pull/155))
 - Support load endpoint from environment variable or specified file ([#157](https://github.com/terraform-providers/terraform-provider-alicloud/pull/157))
 

--- a/alicloud/resource_alicloud_cs_kubernetes.go
+++ b/alicloud/resource_alicloud_cs_kubernetes.go
@@ -222,7 +222,7 @@ func resourceAlicloudCSKubernetesCreate(d *schema.ResourceData, meta interface{}
 
 	d.SetId(cluster.ClusterID)
 
-	if err := conn.WaitForClusterAsyn(cluster.ClusterID, cs.Running, 1800); err != nil {
+	if err := conn.WaitForClusterAsyn(cluster.ClusterID, cs.Running, 3600); err != nil {
 		return fmt.Errorf("Waitting for kubernetes cluster %#v got an error: %#v", cs.Running, err)
 	}
 
@@ -242,7 +242,7 @@ func resourceAlicloudCSKubernetesUpdate(d *schema.ResourceData, meta interface{}
 			return fmt.Errorf("Resize Cluster got an error: %#v", err)
 		}
 
-		err = conn.WaitForClusterAsyn(d.Id(), cs.Running, 500)
+		err = conn.WaitForClusterAsyn(d.Id(), cs.Running, 1800)
 
 		if err != nil {
 			return fmt.Errorf("Waitting for container Cluster %#v got an error: %#v", cs.Running, err)

--- a/website/docs/r/cs_kubernetes.html.markdown
+++ b/website/docs/r/cs_kubernetes.html.markdown
@@ -18,6 +18,8 @@ VPC, you can set `new_nat_gateway` to "true" to create one automatically.
 
 -> **NOTE:** Each kubernetes cluster contains 3 master nodes and those number cannot be changed at now.
 
+-> **NOTE:** Creating kubernetes cluster need to install several packages and it will cost more than 30 minutes. Please be patient.
+
 ## Example Usage
 
 Basic Usage


### PR DESCRIPTION
The PR prolongs waiting time while creating kubernetes cluster and  avoids to get timeout error.