### PR TITLE
Fix SLB listener "OperationBusy" error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 IMPROVEMENTS:
 
+- Fix SLB listener "OperationBusy" error ([#159](https://github.com/terraform-providers/terraform-provider-alicloud/pull/159))
 - Prolong waiting time for creating kubernetes cluster to avoid timeout ([#158](https://github.com/terraform-providers/terraform-provider-alicloud/pull/158))
 - Update example ([#155](https://github.com/terraform-providers/terraform-provider-alicloud/pull/155))
 - Support load endpoint from environment variable or specified file ([#157](https://github.com/terraform-providers/terraform-provider-alicloud/pull/157))

--- a/alicloud/errors.go
+++ b/alicloud/errors.go
@@ -36,10 +36,6 @@ const (
 	UnsupportedProtocalPort     = "UnsupportedOperationonfixedprotocalport"
 	ListenerNotFound            = "The specified resource does not exist"
 	ListenerAlreadyExists       = "ListenerAlreadyExists"
-	ServiceIsConfiguring        = "ServiceIsConfiguring"
-	ServiceIsStopping           = "ServiceIsStopping"
-	BackendServerconfiguring    = "BackendServer.configuring"
-	SystemBusy                  = "SystemBusy"
 	SlbOrderFailed              = "OrderFailed"
 	VServerGroupNotFoundMessage = "The specified VServerGroupId does not exist"
 	RspoolVipExist              = "RspoolVipExist"
@@ -166,6 +162,8 @@ const (
 	ApplicationConfirmConflict   = "Conflicts with unconfirmed updates for operation"
 )
 
+var SlbIsBusy = []string{"SystemBusy", "OperationBusy", "ServiceIsStopping", "BackendServer.configuring", "ServiceIsConfiguring"}
+
 // An Error represents a custom error for Terraform failure response
 type ProviderError struct {
 	errorCode string
@@ -224,6 +222,23 @@ func IsExceptedError(err error, expectCode string) bool {
 
 	if e, ok := err.(*ProviderError); ok && (e.ErrorCode() == expectCode || strings.Contains(e.Message(), expectCode)) {
 		return true
+	}
+	return false
+}
+
+func IsExceptedErrors(err error, expectCodes []string) bool {
+	for _, code := range expectCodes {
+		if e, ok := err.(*common.Error); ok && (e.Code == code || strings.Contains(e.Message, code)) {
+			return true
+		}
+
+		if e, ok := err.(*errors.ServerError); ok && (e.ErrorCode() == code || strings.Contains(e.Message(), code)) {
+			return true
+		}
+
+		if e, ok := err.(*ProviderError); ok && (e.ErrorCode() == code || strings.Contains(e.Message(), code)) {
+			return true
+		}
 	}
 	return false
 }

--- a/alicloud/resource_alicloud_slb_attachment.go
+++ b/alicloud/resource_alicloud_slb_attachment.go
@@ -142,7 +142,7 @@ func resourceAliyunSlbAttachmentUpdate(d *schema.ResourceData, meta interface{})
 			if err := resource.Retry(2*time.Minute, func() *resource.RetryError {
 				_, err := slbconn.AddBackendServers(d.Id(), add)
 				if err != nil {
-					if IsExceptedError(err, ServiceIsConfiguring) {
+					if IsExceptedErrors(err, SlbIsBusy) {
 						return resource.RetryableError(fmt.Errorf("Load banalcer adds backend servers timeout and got an error: %#v.", err))
 					}
 					return resource.NonRetryableError(fmt.Errorf("Add backend servers got an error: %#v", err))
@@ -167,7 +167,7 @@ func resourceAliyunSlbAttachmentUpdate(d *schema.ResourceData, meta interface{})
 	if update {
 		if err := resource.Retry(2*time.Minute, func() *resource.RetryError {
 			if _, err := slbconn.SetBackendServers(d.Id(), expandBackendServers(d.Get("instance_ids").(*schema.Set).List(), weight)); err != nil {
-				if IsExceptedError(err, ServiceIsConfiguring) {
+				if IsExceptedErrors(err, SlbIsBusy) {
 					return resource.RetryableError(fmt.Errorf("Load banalcer sets backend servers timeout and got an error: %#v.", err))
 				}
 				return resource.NonRetryableError(fmt.Errorf("Set backend servers got an error: %#v", err))
@@ -195,7 +195,7 @@ func removeBackendServers(d *schema.ResourceData, meta interface{}, servers []in
 		return resource.Retry(3*time.Minute, func() *resource.RetryError {
 			_, err := client.slbconn.RemoveBackendServers(d.Id(), convertArrayInterfaceToArrayString(servers))
 			if err != nil {
-				if IsExceptedError(err, BackendServerconfiguring) || IsExceptedError(err, ServiceIsStopping) {
+				if IsExceptedErrors(err, SlbIsBusy) {
 					return resource.RetryableError(fmt.Errorf("Load balancer removes backend servers timeout and got an error: %#v", err))
 				}
 				return resource.NonRetryableError(fmt.Errorf("Remove backend servers got an error: %#v", err))


### PR DESCRIPTION
This PR aims to fix  "OperationBusy" error while describe slb listener.

The result of test cases as follows:

TF_ACC=1 go test -v ./alicloud -run=TestAccAlicloudSlbListener 
=== RUN   TestAccAlicloudSlbListener_importHttp
--- PASS: TestAccAlicloudSlbListener_importHttp (14.87s)
=== RUN   TestAccAlicloudSlbListener_importTcp
--- PASS: TestAccAlicloudSlbListener_importTcp (15.96s)
=== RUN   TestAccAlicloudSlbListener_importUdp
--- PASS: TestAccAlicloudSlbListener_importUdp (18.79s)
=== RUN   TestAccAlicloudSlbListener_http
--- PASS: TestAccAlicloudSlbListener_http (14.53s)
=== RUN   TestAccAlicloudSlbListener_tcp
--- PASS: TestAccAlicloudSlbListener_tcp (15.73s)
=== RUN   TestAccAlicloudSlbListener_udp
--- PASS: TestAccAlicloudSlbListener_udp (17.20s)
PASS
ok      github.com/alibaba/terraform-provider/alicloud  97.119s

TF_ACC=1 go test -v ./alicloud -run=TestAccAlicloudSlbAttachment
=== RUN   TestAccAlicloudSlbAttachment_import
--- PASS: TestAccAlicloudSlbAttachment_import (117.60s)
=== RUN   TestAccAlicloudSlbAttachment_basic
--- PASS: TestAccAlicloudSlbAttachment_basic (106.28s)
PASS
ok      github.com/alibaba/terraform-provider/alicloud  223.924s
