### PR TITLE
Add filter parameters for zones data source

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ IMPROVEMENTS:
 
 BUG FIXES:
 
+- Fix getting some instance types failed bug ([#166](https://github.com/terraform-providers/terraform-provider-alicloud/pull/166))
 - Fix kubernetes out range index error ([#164](https://github.com/terraform-providers/terraform-provider-alicloud/pull/164))
 
 ## 1.9.2 (May 09, 2018)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 IMPROVEMENTS:
 
+- Add filter parameters for zones data source. ([#167](https://github.com/terraform-providers/terraform-provider-alicloud/pull/167))
 - Remove kubernetes work_number limitation ([#165](https://github.com/terraform-providers/terraform-provider-alicloud/pull/165))
 - Improve kubernetes examples ([#163](https://github.com/terraform-providers/terraform-provider-alicloud/pull/163))
 

--- a/alicloud/common.go
+++ b/alicloud/common.go
@@ -42,7 +42,7 @@ type NetworkType string
 
 const (
 	Classic = NetworkType("Classic")
-	VPC     = NetworkType("VPC")
+	Vpc     = NetworkType("Vpc")
 )
 
 type TimeType string
@@ -73,6 +73,8 @@ const (
 	Active   = Status("Active")
 	Inactive = Status("Inactive")
 	Idle     = Status("Idle")
+
+	SoldOut = Status("SoldOut")
 )
 
 type IPType string
@@ -207,6 +209,13 @@ func convertListToJsonString(configured []interface{}) string {
 }
 
 const ServerSideEncryptionAes256 = "AES256"
+
+type OptimizedType string
+
+const (
+	IOOptimized   = OptimizedType("optimized")
+	NoneOptimized = OptimizedType("none")
+)
 
 type ResourceKeyType string
 

--- a/alicloud/data_source_alicloud_instance_types.go
+++ b/alicloud/data_source_alicloud_instance_types.go
@@ -2,7 +2,7 @@ package alicloud
 
 import (
 	"fmt"
-	"log"
+	"strings"
 
 	"github.com/denverdino/aliyungo/ecs"
 	"github.com/hashicorp/terraform/helper/schema"
@@ -73,39 +73,44 @@ func dataSourceAlicloudInstanceTypes() *schema.Resource {
 
 func dataSourceAlicloudInstanceTypesRead(d *schema.ResourceData, meta interface{}) error {
 	client := meta.(*AliyunClient)
-	// Ensure instance_type is generation three, and get generation three families
-	validData, err := client.CheckParameterValidity(d, meta)
 
+	zoneId, validZones, err := client.DescribeAvailableResources(d, meta, InstanceTypeResource)
 	if err != nil {
 		return err
+	}
+
+	mapInstanceTypes := make(map[string][]string)
+	for _, zone := range validZones {
+		if zoneId != "" && zoneId != zone.ZoneId {
+			continue
+		}
+		for _, r := range zone.AvailableResources.AvailableResource {
+			if r.Type == string(InstanceTypeResource) {
+				for _, t := range r.SupportedResources.SupportedResource {
+					if t.Status == string(SoldOut) {
+						continue
+					}
+
+					zones, _ := mapInstanceTypes[t.Value]
+					zones = append(zones, zone.ZoneId)
+					mapInstanceTypes[t.Value] = zones
+				}
+			}
+		}
 	}
 
 	cpu := d.Get("cpu_core_count").(int)
 	mem := d.Get("memory_size").(float64)
+	family := strings.TrimSpace(d.Get("instance_type_family").(string))
 
-	args, err := buildAliyunAlicloudInstanceTypesArgs(d, meta)
-
+	resp, err := client.ecsconn.DescribeInstanceTypesNew(&ecs.DescribeInstanceTypesArgs{})
 	if err != nil {
 		return err
-	}
-
-	resp, err := client.ecsconn.DescribeInstanceTypesNew(args)
-	if err != nil {
-		return err
-	}
-
-	validInstanceTypes := make(map[string]string)
-	if val, ok := validData[UpgradedInstanceTypeKey]; ok {
-		validInstanceTypes = val.(map[string]string)
-	}
-	if val, ok := validData[OutdatedInstanceTypeKey]; d.Get("is_outdated").(bool) && ok {
-		validInstanceTypes = val.(map[string]string)
 	}
 
 	var instanceTypes []ecs.InstanceTypeItemType
 	for _, types := range resp {
-		// Only filter series three instance type.
-		if _, ok := validInstanceTypes[types.InstanceTypeId]; !ok {
+		if _, ok := mapInstanceTypes[types.InstanceTypeId]; !ok {
 			continue
 		}
 
@@ -116,6 +121,11 @@ func dataSourceAlicloudInstanceTypesRead(d *schema.ResourceData, meta interface{
 		if mem > 0 && types.MemorySize != mem {
 			continue
 		}
+
+		if family != "" && types.InstanceTypeFamily != family {
+			continue
+		}
+
 		instanceTypes = append(instanceTypes, types)
 	}
 
@@ -123,11 +133,10 @@ func dataSourceAlicloudInstanceTypesRead(d *schema.ResourceData, meta interface{
 		return fmt.Errorf("Your query returned no results. Please change your search criteria and try again.")
 	}
 
-	log.Printf("[DEBUG] alicloud_instance_type - Types found: %#v", instanceTypes)
-	return instanceTypesDescriptionAttributes(d, instanceTypes)
+	return instanceTypesDescriptionAttributes(d, instanceTypes, mapInstanceTypes)
 }
 
-func instanceTypesDescriptionAttributes(d *schema.ResourceData, types []ecs.InstanceTypeItemType) error {
+func instanceTypesDescriptionAttributes(d *schema.ResourceData, types []ecs.InstanceTypeItemType, mapTypes map[string][]string) error {
 	var ids []string
 	var s []map[string]interface{}
 	for _, t := range types {
@@ -138,7 +147,6 @@ func instanceTypesDescriptionAttributes(d *schema.ResourceData, types []ecs.Inst
 			"family":         t.InstanceTypeFamily,
 		}
 
-		log.Printf("[DEBUG] alicloud_instance_type - adding type mapping: %v", mapping)
 		ids = append(ids, t.InstanceTypeId)
 		s = append(s, mapping)
 	}
@@ -153,14 +161,4 @@ func instanceTypesDescriptionAttributes(d *schema.ResourceData, types []ecs.Inst
 		writeToFile(output.(string), s)
 	}
 	return nil
-}
-
-func buildAliyunAlicloudInstanceTypesArgs(d *schema.ResourceData, meta interface{}) (*ecs.DescribeInstanceTypesArgs, error) {
-	args := &ecs.DescribeInstanceTypesArgs{}
-
-	if v := d.Get("instance_type_family").(string); v != "" {
-		args.InstanceTypeFamily = v
-	}
-
-	return args, nil
 }

--- a/alicloud/data_source_alicloud_zones.go
+++ b/alicloud/data_source_alicloud_zones.go
@@ -46,6 +46,26 @@ func dataSourceAlicloudZones() *schema.Resource {
 				Optional: true,
 				Default:  false,
 			},
+			"instance_charge_type": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ForceNew:     true,
+				Default:      PostPaid,
+				ValidateFunc: validateInstanceChargeType,
+			},
+			"network_type": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ForceNew:     true,
+				ValidateFunc: validateAllowedStringValue([]string{string(Vpc), string(Classic)}),
+			},
+			"spot_strategy": &schema.Schema{
+				Type:         schema.TypeString,
+				Optional:     true,
+				ForceNew:     true,
+				Default:      ecs.NoSpot,
+				ValidateFunc: validateInstanceSpotStrategy,
+			},
 
 			"output_file": {
 				Type:     schema.TypeString,

--- a/alicloud/data_source_alicloud_zones_test.go
+++ b/alicloud/data_source_alicloud_zones_test.go
@@ -90,6 +90,23 @@ func TestAccAlicloudZonesDataSource_multiZone(t *testing.T) {
 	})
 }
 
+func TestAccAlicloudZonesDataSource_chargeType(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+		},
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCheckAlicloudZonesDataSource_chargeType,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAlicloudDataSourceID("data.alicloud_zones.default"),
+				),
+			},
+		},
+	})
+}
+
 // the zone length changed occasionally
 // check by range to avoid test case failure
 func testCheckZoneLength(name string) resource.TestCheckFunc {
@@ -147,7 +164,7 @@ data "alicloud_zones" "foo" {
 const testAccCheckAlicloudZonesDataSource_unitRegion = `
 provider "alicloud" {
 	alias = "northeast"
-	region = "ap-northeast-1"
+	region = "ap-southeast-1"
 }
 
 data "alicloud_zones" "foo" {
@@ -162,6 +179,17 @@ provider "alicloud" {
 }
 
 data "alicloud_zones" "default" {
+  available_resource_creation= "Rds"
+  multi = true
+}`
+
+const testAccCheckAlicloudZonesDataSource_chargeType = `
+provider "alicloud" {
+  region = "cn-shanghai"
+}
+
+data "alicloud_zones" "default" {
+  instance_charge_type = "PrePaid"
   available_resource_creation= "Rds"
   multi = true
 }`

--- a/alicloud/extension_ecs.go
+++ b/alicloud/extension_ecs.go
@@ -21,6 +21,17 @@ const (
 	EcsApiVersion20140526 = "2014-05-26"
 )
 
+type DestinationResource string
+
+const (
+	ZoneResource         = DestinationResource("Zone")
+	IoOptimizedResource  = DestinationResource("IoOptimized")
+	InstanceTypeResource = DestinationResource("InstanceType")
+	SystemDiskResource   = DestinationResource("SystemDisk")
+	DataDiskResource     = DestinationResource("DataDisk")
+	NetworkResource      = DestinationResource("Network")
+)
+
 const GenerationOne = "ecs-1"
 const GenerationTwo = "ecs-2"
 const GenerationThree = "ecs-3"
@@ -36,6 +47,7 @@ var OutdatedDiskCategory = map[ecs.DiskCategory]ecs.DiskCategory{
 var SupportedDiskCategory = map[ecs.DiskCategory]ecs.DiskCategory{
 	ecs.DiskCategoryCloudSSD:        ecs.DiskCategoryCloudSSD,
 	ecs.DiskCategoryCloudEfficiency: ecs.DiskCategoryCloudEfficiency,
+	ecs.DiskCategoryEphemeralSSD:    ecs.DiskCategoryEphemeralSSD,
 	ecs.DiskCategoryCloud:           ecs.DiskCategoryCloud}
 
 const AllPortRange = "-1/-1"

--- a/alicloud/resource_alicloud_cs_swarm.go
+++ b/alicloud/resource_alicloud_cs_swarm.go
@@ -152,9 +152,12 @@ func resourceAlicloudCSSwarmCreate(d *schema.ResourceData, meta interface{}) err
 	client := meta.(*AliyunClient)
 	conn := client.csconn
 
-	// Ensure instance_type is generation three
-	_, err := meta.(*AliyunClient).CheckParameterValidity(d, meta)
+	// Ensure instance_type is valid
+	zoneId, validZones, err := meta.(*AliyunClient).DescribeAvailableResources(d, meta, InstanceTypeResource)
 	if err != nil {
+		return err
+	}
+	if err := meta.(*AliyunClient).InstanceTypeValidation(d.Get("instance_type").(string), zoneId, validZones); err != nil {
 		return err
 	}
 
@@ -319,7 +322,6 @@ func resourceAlicloudCSSwarmRead(d *schema.ResourceData, meta interface{}) error
 
 	d.Set("nodes", nodes)
 
-	//d.Set("image_id", oneNode.ImageId)
 	d.Set("instance_type", oneNode.InstanceType)
 	if disks, _, err := client.ecsconn.DescribeDisks(&ecs.DescribeDisksArgs{
 		RegionId:   getRegion(d, meta),

--- a/alicloud/resource_alicloud_db_instance.go
+++ b/alicloud/resource_alicloud_db_instance.go
@@ -409,7 +409,7 @@ func buildDBCreateRequest(d *schema.ResourceData, meta interface{}) (*rds.Create
 
 	if vswitchId != "" {
 		request.VSwitchId = vswitchId
-		request.InstanceNetworkType = string(VPC)
+		request.InstanceNetworkType = strings.ToUpper(string(Vpc))
 
 		// check vswitchId in zone
 		vsw, err := client.DescribeVswitch(vswitchId)

--- a/alicloud/resource_alicloud_ess_scalingconfiguration.go
+++ b/alicloud/resource_alicloud_ess_scalingconfiguration.go
@@ -176,8 +176,11 @@ func resourceAlicloudEssScalingConfiguration() *schema.Resource {
 func resourceAliyunEssScalingConfigurationCreate(d *schema.ResourceData, meta interface{}) error {
 
 	// Ensure instance_type is generation three
-	validData, err := meta.(*AliyunClient).CheckParameterValidity(d, meta)
+	zoneId, validZones, err := meta.(*AliyunClient).DescribeAvailableResources(d, meta, InstanceTypeResource)
 	if err != nil {
+		return err
+	}
+	if err := meta.(*AliyunClient).InstanceTypeValidation(d.Get("instance_type").(string), zoneId, validZones); err != nil {
 		return err
 	}
 
@@ -186,8 +189,9 @@ func resourceAliyunEssScalingConfigurationCreate(d *schema.ResourceData, meta in
 		return err
 	}
 
-	if validData[IoOptimizedKey].(ecs.IoOptimized) == ecs.IoOptimizedOptimized {
-		args.IoOptimized = ecs.IoOptimizedOptimized
+	args.IoOptimized = ecs.IoOptimizedOptimized
+	if d.Get("is_outdated").(bool) == true {
+		args.IoOptimized = ecs.IoOptimizedNone
 	}
 
 	essconn := meta.(*AliyunClient).essconn

--- a/alicloud/resource_alicloud_slb.go
+++ b/alicloud/resource_alicloud_slb.go
@@ -265,6 +265,10 @@ func resourceAliyunSlbCreate(d *schema.ResourceData, meta interface{}) error {
 func resourceAliyunSlbRead(d *schema.ResourceData, meta interface{}) error {
 	loadBalancer, err := meta.(*AliyunClient).DescribeLoadBalancerAttribute(d.Id())
 	if err != nil {
+		if IsExceptedErrors(err, []string{LoadBalancerNotFound}) {
+			d.SetId("")
+			return nil
+		}
 		return err
 	}
 

--- a/alicloud/service_alicloud_ecs.go
+++ b/alicloud/service_alicloud_ecs.go
@@ -3,7 +3,6 @@ package alicloud
 import (
 	"encoding/json"
 	"fmt"
-	"log"
 	"strings"
 
 	"github.com/denverdino/aliyungo/common"
@@ -250,352 +249,107 @@ func (client *AliyunClient) RevokeSecurityGroupEgress(args *ecs.RevokeSecurityGr
 	return client.ecsconn.RevokeSecurityGroupEgress(args)
 }
 
-func (client *AliyunClient) CheckParameterValidity(d *schema.ResourceData, meta interface{}) (map[ResourceKeyType]interface{}, error) {
+func (client *AliyunClient) DescribeAvailableResources(d *schema.ResourceData, meta interface{}, destination DestinationResource) (zoneId string, validZones []ecs.AvailableZoneType, err error) {
 	// Before creating resources, check input parameters validity according available zone.
 	// If availability zone is nil, it will return all of supported resources in the current.
 	conn := meta.(*AliyunClient).ecsconn
-	zones, err := conn.DescribeZones(getRegion(d, meta))
-	if err != nil {
-		return nil, fmt.Errorf("Error DescribeZone: %#v", err)
+	args := ecs.DescribeAvailableResourceArgs{
+		RegionId:            getRegionId(d, meta),
+		DestinationResource: string(destination),
+		IoOptimized:         string(IOOptimized),
+	}
+	if v, ok := d.GetOk("availability_zone"); ok && strings.TrimSpace(v.(string)) != "" {
+		zoneId = strings.TrimSpace(v.(string))
+	} else if v, ok := d.GetOk("vswitch_id"); ok && strings.TrimSpace(v.(string)) != "" {
+		if vsw, err := meta.(*AliyunClient).DescribeVswitch(strings.TrimSpace(v.(string))); err == nil {
+			zoneId = vsw.ZoneId
+		}
 	}
 
-	if zones == nil || len(zones) < 1 {
-		return nil, fmt.Errorf("There are no availability zones in the region: %#v.", getRegion(d, meta))
+	if v, ok := d.GetOk("instance_charge_type"); ok && strings.TrimSpace(v.(string)) != "" {
+		args.InstanceChargeType = strings.TrimSpace(v.(string))
 	}
 
-	zoneId := ""
-	if val, ok := d.GetOk("availability_zone"); ok {
-		zoneId = val.(string)
+	if v, ok := d.GetOk("spot_strategy"); ok && strings.TrimSpace(v.(string)) != "" {
+		args.SpotStrategy = strings.TrimSpace(v.(string))
+	}
+
+	if v, ok := d.GetOk("network_type"); ok && strings.TrimSpace(v.(string)) != "" {
+		args.NetworkCategory = strings.TrimSpace(v.(string))
+	}
+
+	if v, ok := d.GetOk("is_outdated"); ok && v.(bool) == true {
+		args.IoOptimized = string(NoneOptimized)
+	}
+
+	resources, e := conn.DescribeAvailableResource(&args)
+	if e != nil {
+		return "", nil, fmt.Errorf("Error DescribeAvailableResource: %#v", e)
+	}
+
+	if resources == nil || len(resources.AvailableZones.AvailableZone) < 1 {
+		err = fmt.Errorf("There are no availability resources in the region: %s.", getRegionId(d, meta))
+		return
 	}
 
 	valid := false
-	var validZones []string
-	for _, zone := range zones {
+	var expectedZones []string
+	for _, zone := range resources.AvailableZones.AvailableZone {
+		if zone.Status == string(SoldOut) {
+			continue
+		}
 		if zoneId != "" && zone.ZoneId == zoneId {
 			valid = true
-			zones = append(make([]ecs.ZoneType, 1), zone)
+			validZones = append(make([]ecs.AvailableZoneType, 1), zone)
 			break
 		}
-		validZones = append(validZones, zone.ZoneId)
+		expectedZones = append(expectedZones, zone.ZoneId)
+		validZones = append(validZones, zone)
 	}
 	if zoneId != "" && !valid {
-		return nil, fmt.Errorf("Availability zone %s is not supported in the region %s. Expected availability zones: %s.",
-			zoneId, getRegion(d, meta), strings.Join(validZones, ", "))
+		err = fmt.Errorf("Availability zone %s status is sold out in the region %s. Expected availability zones: %s.",
+			zoneId, getRegionId(d, meta), strings.Join(expectedZones, ", "))
+		return
 	}
 
-	// Retrieve series instance type family
-	ioOptimized := ecs.IoOptimizedOptimized
-	var expectedFamilies []string
-	mapOutdatedInstanceFamilies, mapUpgradedInstanceFamilies, err := client.FetchSpecifiedInstanceTypeFamily(getRegion(d, meta), zoneId, []string{GenerationOne, GenerationTwo}, zones)
-	if err != nil {
-		return nil, err
-	}
-	for key := range mapUpgradedInstanceFamilies {
-		expectedFamilies = append(expectedFamilies, key)
+	if len(validZones) <= 0 {
+		err = fmt.Errorf("There is no availability resources in the region %s. Please choose another region.", getRegionId(d, meta))
+		return
 	}
 
-	validData := make(map[ResourceKeyType]interface{})
-	mapZones := make(map[string]ecs.ZoneType)
-	mapSupportedInstanceTypes := make(map[string]string)
-	mapUpgradedInstanceTypes := make(map[string]string)
-	mapOutdatedInstanceTypes := make(map[string]string)
-	mapOutdatedDiskCategories := make(map[ecs.DiskCategory]ecs.DiskCategory)
-	mapDiskCategories := make(map[ecs.DiskCategory]ecs.DiskCategory)
-	for _, zone := range zones {
-		//Filter and get all instance types in the zones
-		for _, insType := range zone.AvailableInstanceTypes.InstanceTypes {
-			if _, ok := mapSupportedInstanceTypes[insType]; !ok {
-				insTypeSplit := strings.Split(insType, DOT_SEPARATED)
-				mapSupportedInstanceTypes[insType] = string(insTypeSplit[0] + DOT_SEPARATED + insTypeSplit[1])
-			}
-		}
-		if len(zone.AvailableDiskCategories.DiskCategories) < 1 {
-			continue
-		}
-		//Filter and get all instance types in the zones
-		for _, category := range zone.AvailableDiskCategories.DiskCategories {
-			if _, ok := SupportedDiskCategory[category]; ok {
-				mapDiskCategories[category] = category
-			}
-			if _, ok := OutdatedDiskCategory[category]; ok {
-				mapOutdatedDiskCategories[category] = category
-			}
-		}
-		resources := zone.AvailableResources.ResourcesInfo
-		if len(resources) < 1 {
-			continue
-		}
-		mapZones[zone.ZoneId] = zone
-	}
-	//separate all instance types according generation 3 in the zones
-	for key, _ := range mapSupportedInstanceTypes {
-		find := false
-		for out, _ := range mapOutdatedInstanceFamilies {
-			if strings.HasPrefix(key, out) {
-				mapOutdatedInstanceTypes[key] = out
-				mapSupportedInstanceTypes[key] = out
-				find = true
-				break
-			}
-		}
-		if find {
-			continue
-		}
-		for upgrade, _ := range mapUpgradedInstanceFamilies {
-			if strings.HasPrefix(key, upgrade) {
-				mapUpgradedInstanceTypes[key] = upgrade
-				mapSupportedInstanceTypes[key] = upgrade
-				break
-			}
-		}
-	}
-
-	instanceTypeSchemas := []string{"available_instance_type", "instance_type", "master_instance_type", "worker_instance_type"}
-	var instanceTypes []string
-	for _, iType := range instanceTypeSchemas {
-		if insType, ok := d.GetOk(iType); ok {
-			instanceTypes = append(instanceTypes, insType.(string))
-		}
-	}
-
-	if len(instanceTypes) > 0 {
-		for _, instanceType := range instanceTypes {
-			if !strings.HasPrefix(instanceType, "ecs.") {
-				return nil, fmt.Errorf("Invalid instance_type: %s. Please modify it and try again.", instanceType)
-			}
-			var instanceTypeObject ecs.InstanceTypeItemType
-			targetFamily, ok := mapSupportedInstanceTypes[instanceType]
-			if ok {
-				mapInstanceTypes, err := client.FetchSpecifiedInstanceTypesByFamily(zoneId, targetFamily, zones)
-				if err != nil {
-					return nil, err
-				}
-
-				var validInstanceTypes []string
-				for key, value := range mapInstanceTypes {
-					if instanceType == key {
-						instanceTypeObject = mapInstanceTypes[key]
-						break
-					}
-					core := "Core"
-					if value.CpuCoreCount > 1 {
-						core = "Cores"
-					}
-					validInstanceTypes = append(validInstanceTypes, fmt.Sprintf("%s(%d%s,%.0fGB)", key, value.CpuCoreCount, core, value.MemorySize))
-				}
-				if instanceTypeObject.InstanceTypeId == "" {
-					if zoneId == "" {
-						return nil, fmt.Errorf("Instance type %s is not supported in the region %s. Expected instance types of family %s: %s.",
-							instanceType, getRegion(d, meta), targetFamily, strings.Join(validInstanceTypes, ", "))
-					}
-					return nil, fmt.Errorf("Instance type %s is not supported in the availability zone %s. Expected instance types of family %s: %s.",
-						instanceType, zoneId, targetFamily, strings.Join(validInstanceTypes, ", "))
-				}
-
-				outDisk := false
-				if disk, ok := d.GetOk("system_disk_category"); ok {
-					_, outDisk = OutdatedDiskCategory[ecs.DiskCategory(disk.(string))]
-				}
-
-				_, outdatedOk := mapOutdatedInstanceTypes[instanceType]
-				_, expectedOk := mapUpgradedInstanceTypes[instanceType]
-
-				if expectedOk && outDisk {
-					return nil, fmt.Errorf("Instance type %s can't support 'cloud' as instance system disk. "+
-						"Please change your disk category to efficient disk '%s' or '%s'.", instanceType, ecs.DiskCategoryCloudSSD, ecs.DiskCategoryCloudEfficiency)
-				}
-				if outdatedOk {
-					var expectedEqualCpus []string
-					var expectedEqualMoreCpus []string
-					for _, fam := range mapUpgradedInstanceTypes {
-						mapInstanceTypes, err := client.FetchSpecifiedInstanceTypesByFamily(zoneId, fam, zones)
-						if err != nil {
-							return nil, err
-						}
-						for _, value := range mapInstanceTypes {
-							core := "Core"
-							if value.CpuCoreCount > 1 {
-								core = "Cores"
-							}
-							if instanceTypeObject.CpuCoreCount == value.CpuCoreCount {
-								expectedEqualCpus = append(expectedEqualCpus, fmt.Sprintf("%s(%d%s,%.0fGB)", value.InstanceTypeId, value.CpuCoreCount, core, value.MemorySize))
-							} else if instanceTypeObject.CpuCoreCount*2 == value.CpuCoreCount {
-								expectedEqualMoreCpus = append(expectedEqualMoreCpus, fmt.Sprintf("%s(%d%s,%.0fGB)", value.InstanceTypeId, value.CpuCoreCount, core, value.MemorySize))
-							}
-						}
-					}
-					expectedInstanceTypes := expectedEqualMoreCpus
-					if len(expectedEqualCpus) > 0 {
-						expectedInstanceTypes = expectedEqualCpus
-					}
-
-					if out, ok := d.GetOk("is_outdated"); !(ok && out.(bool)) {
-						core := "Core"
-						if instanceTypeObject.CpuCoreCount > 1 {
-							core = "Cores"
-						}
-						return nil, fmt.Errorf("The current instance type %s(%d%s,%.0fGB) has been outdated. Expect to use the upgraded instance types: %s. You can keep the instance type %s by setting 'is_outdated' to true.",
-							instanceType, instanceTypeObject.CpuCoreCount, core, instanceTypeObject.MemorySize, strings.Join(expectedInstanceTypes, ", "), instanceType)
-					} else {
-						// Check none io optimized and cloud
-						_, typeOk := NoneIoOptimizedInstanceType[instanceType]
-						_, famOk := NoneIoOptimizedFamily[targetFamily]
-						_, halfOk := HalfIoOptimizedFamily[targetFamily]
-						if typeOk || famOk {
-							if outDisk {
-								ioOptimized = ecs.IoOptimizedNone
-							} else {
-								return nil, fmt.Errorf("The current instance type %s is no I/O optimized, and it only supports 'cloud' as instance system disk. "+
-									"Suggest to upgrade instance type and use efficient disk. Expected instance types: %s.", instanceType, strings.Join(expectedInstanceTypes, ", "))
-							}
-						} else if outDisk {
-							if halfOk {
-								ioOptimized = ecs.IoOptimizedNone
-							} else {
-								return nil, fmt.Errorf("The current instance type %s is I/O optimized, and it can't support 'cloud' as instance system disk. "+
-									"Suggest to upgrade instance type and use efficient disk. Expectd instance types: %s.", instanceType, strings.Join(expectedInstanceTypes, ", "))
-							}
-						}
-					}
-				}
-
-			} else if err := getExpectInstanceTypesAndFormatOut(zoneId, targetFamily, getRegion(d, meta), mapUpgradedInstanceFamilies); err != nil {
-				return nil, err
-			}
-		}
-	}
-
-	if instanceTypeFamily, ok := d.GetOk("instance_type_family"); ok {
-
-		if !strings.HasPrefix(instanceTypeFamily.(string), "ecs.") {
-			return nil, fmt.Errorf("Invalid instance_type_family: %s. Please modify it and try again.", instanceTypeFamily.(string))
-		}
-
-		_, outdatedOk := mapOutdatedInstanceFamilies[instanceTypeFamily.(string)]
-		_, expectedOk := mapUpgradedInstanceFamilies[instanceTypeFamily.(string)]
-		if outdatedOk || !expectedOk {
-			if err := getExpectInstanceTypesAndFormatOut(zoneId, instanceTypeFamily.(string), getRegion(d, meta), mapUpgradedInstanceFamilies); err != nil {
-				return nil, err
-			}
-		}
-	}
-
-	validData[ZoneKey] = mapZones
-	validData[InstanceTypeKey] = mapSupportedInstanceTypes
-	validData[UpgradedInstanceTypeKey] = mapUpgradedInstanceTypes
-	validData[OutdatedInstanceTypeKey] = mapOutdatedInstanceTypes
-	validData[UpgradedInstanceTypeFamilyKey] = mapUpgradedInstanceFamilies
-	validData[OutdatedInstanceTypeFamilyKey] = mapOutdatedInstanceFamilies
-	validData[OutdatedDiskCategoryKey] = mapOutdatedDiskCategories
-	validData[DiskCategoryKey] = mapDiskCategories
-	validData[IoOptimizedKey] = ioOptimized
-
-	return validData, nil
+	return
 }
 
-func (client *AliyunClient) FetchSpecifiedInstanceTypeFamily(regionId common.Region, zoneId string, generations []string, all_zones []ecs.ZoneType) (map[string]ecs.InstanceTypeFamily, map[string]ecs.InstanceTypeFamily, error) {
-	// Describe specified series instance type families
-	mapOutdatedInstanceFamilies := make(map[string]ecs.InstanceTypeFamily)
-	mapUpgradedInstanceFamilies := make(map[string]ecs.InstanceTypeFamily)
-	response, err := client.ecsconn.DescribeInstanceTypeFamilies(&ecs.DescribeInstanceTypeFamiliesArgs{
-		RegionId: regionId,
-	})
-	if err != nil {
-		return nil, nil, fmt.Errorf("Error DescribeInstanceTypeFamilies: %#v.", err)
-	}
-	log.Printf("All the instance families in the region %s: %#v", regionId, response)
+func (client *AliyunClient) InstanceTypeValidation(targetType, zoneId string, validZones []ecs.AvailableZoneType) error {
 
-	tempOutdatedMap := make(map[string]string)
-	for _, gen := range generations {
-		tempOutdatedMap[gen] = gen
-	}
-
-	for _, family := range response.InstanceTypeFamilies.InstanceTypeFamily {
-		if _, ok := tempOutdatedMap[family.Generation]; ok {
-			mapOutdatedInstanceFamilies[family.InstanceTypeFamilyId] = family
+	mapInstanceTypeToZones := make(map[string]string)
+	var expectedInstanceTypes []string
+	for _, zone := range validZones {
+		if zoneId != "" && zoneId != zone.ZoneId {
 			continue
 		}
-		mapUpgradedInstanceFamilies[family.InstanceTypeFamilyId] = family
-	}
+		for _, r := range zone.AvailableResources.AvailableResource {
+			if r.Type == string(InstanceTypeResource) {
+				for _, t := range r.SupportedResources.SupportedResource {
+					if t.Status == string(SoldOut) {
+						continue
+					}
+					if targetType == t.Value {
+						return nil
+					}
 
-	// Filter specified zone's instance type families, and make them fit for specified generation
+					if _, ok := mapInstanceTypeToZones[t.Value]; !ok {
+						expectedInstanceTypes = append(expectedInstanceTypes, t.Value)
+						mapInstanceTypeToZones[t.Value] = t.Value
+					}
+				}
+			}
+		}
+	}
 	if zoneId != "" {
-		outdatedValidFamilies := make(map[string]ecs.InstanceTypeFamily)
-		upgradedValidFamilies := make(map[string]ecs.InstanceTypeFamily)
-		for _, zone := range all_zones {
-			if zone.ZoneId == zoneId {
-				for _, resource := range zone.AvailableResources.ResourcesInfo {
-					families := resource.InstanceTypeFamilies[ecs.SupportedInstanceTypeFamily]
-					for _, familyId := range families {
-						if val, ok := mapOutdatedInstanceFamilies[familyId]; ok {
-							outdatedValidFamilies[familyId] = val
-						}
-						if val, ok := mapUpgradedInstanceFamilies[familyId]; ok {
-							upgradedValidFamilies[familyId] = val
-						}
-					}
-
-				}
-				return outdatedValidFamilies, upgradedValidFamilies, nil
-			}
-		}
+		return fmt.Errorf("The instance type %s is solded out or is not supported in the zone %s. Expected instance types: %s", targetType, zoneId, strings.Join(expectedInstanceTypes, ", "))
 	}
-	log.Printf("New generation instance families: %#v.\n Outdated instance families: %#v.",
-		mapUpgradedInstanceFamilies, mapOutdatedInstanceFamilies)
-	return mapOutdatedInstanceFamilies, mapUpgradedInstanceFamilies, nil
-}
-
-func (client *AliyunClient) FetchSpecifiedInstanceTypesByFamily(zoneId, instanceTypeFamily string, all_zones []ecs.ZoneType) (map[string]ecs.InstanceTypeItemType, error) {
-	// Describe all instance types of specified families
-	types, err := client.ecsconn.DescribeInstanceTypesNew(&ecs.DescribeInstanceTypesArgs{
-		InstanceTypeFamily: instanceTypeFamily,
-	})
-	if err != nil {
-		return nil, fmt.Errorf("Error DescribeInstanceTypes: %#v.", err)
-	}
-	log.Printf("All the instance types of family %s: %#v", instanceTypeFamily, types)
-	instanceTypes := make(map[string]ecs.InstanceTypeItemType)
-	for _, ty := range types {
-		instanceTypes[ty.InstanceTypeId] = ty
-	}
-
-	// Filter specified zone's instance types, and make them fit for specified families
-	if zoneId != "" {
-		validInstanceTypes := make(map[string]ecs.InstanceTypeItemType)
-		for _, zone := range all_zones {
-			if zone.ZoneId == zoneId {
-				for _, resource := range zone.AvailableResources.ResourcesInfo {
-					types := resource.InstanceTypes[ecs.SupportedInstanceType]
-					for _, ty := range types {
-						if val, ok := instanceTypes[ty]; ok {
-							validInstanceTypes[ty] = val
-						}
-					}
-
-				}
-				return validInstanceTypes, nil
-			}
-		}
-	}
-	return instanceTypes, nil
-}
-
-func getExpectInstanceTypesAndFormatOut(zoneId, instanceTypeFamily string, regionId common.Region, mapInstanceFamilies map[string]ecs.InstanceTypeFamily) error {
-	var validFamilies []string
-
-	for key := range mapInstanceFamilies {
-		validFamilies = append(validFamilies, key)
-	}
-	if len(validFamilies) < 1 {
-		return fmt.Errorf("There is no available instance type family in the current availability zone." +
-			"Please change availability zone or region and try again.")
-	}
-	if zoneId == "" {
-		return fmt.Errorf("Instance type family %s is not supported in the region %s. Expected instance type families: %s.",
-			instanceTypeFamily, regionId, strings.Join(validFamilies, ", "))
-	}
-	return fmt.Errorf("Instance type family %s is not supported in the availability zone %s. Expected instance type families: %s.",
-		instanceTypeFamily, zoneId, strings.Join(validFamilies, ", "))
+	return fmt.Errorf("The instance type %s is solded out or is not supported in the region %s. Expected instance types: %s", targetType, client.RegionId, strings.Join(expectedInstanceTypes, ", "))
 }
 
 func (client *AliyunClient) QueryInstancesWithKeyPair(region common.Region, instanceIds, keypair string) ([]interface{}, []ecs.InstanceAttributesType, error) {

--- a/alicloud/validators_test.go
+++ b/alicloud/validators_test.go
@@ -47,7 +47,7 @@ func TestValidateInstanceDiskCategory(t *testing.T) {
 		}
 	}
 
-	invalidDiskCategory := []string{"all", "ephemeral", "ephemeral_ssd", "ALL", "efficiency"}
+	invalidDiskCategory := []string{"all", "ephemeral", "ALL", "efficiency"}
 	for _, v := range invalidDiskCategory {
 		_, errors := validateDiskCategory(v, "instance_disk_category")
 		if len(errors) == 0 {

--- a/vendor/github.com/denverdino/aliyungo/ecs/instance_types.go
+++ b/vendor/github.com/denverdino/aliyungo/ecs/instance_types.go
@@ -9,10 +9,18 @@ type DescribeInstanceTypesArgs struct {
 //
 // You can read doc at http://docs.aliyun.com/#/pub/ecs/open-api/datatype&instancetypeitemtype
 type InstanceTypeItemType struct {
-	InstanceTypeId     string
-	CpuCoreCount       int
-	MemorySize         float64
-	InstanceTypeFamily string
+	InstanceTypeId       string
+	CpuCoreCount         int
+	MemorySize           float64
+	InstanceTypeFamily   string
+	GPUAmount            int
+	GPUSpec              string
+	InitialCredit        int
+	BaselineCredit       int
+	EniQuantity          int
+	LocalStorageCapacity int
+	LocalStorageAmount   int
+	LocalStorageCategory string
 }
 
 type DescribeInstanceTypesResponse struct {

--- a/vendor/github.com/denverdino/aliyungo/ecs/zones.go
+++ b/vendor/github.com/denverdino/aliyungo/ecs/zones.go
@@ -1,6 +1,8 @@
 package ecs
 
-import "github.com/denverdino/aliyungo/common"
+import (
+	"github.com/denverdino/aliyungo/common"
+)
 
 type ResourceType string
 
@@ -101,4 +103,56 @@ func (client *Client) DescribeZonesWithRaw(regionId common.Region) (response *De
 	}
 
 	return nil, err
+}
+
+type DescribeAvailableResourceArgs struct {
+	RegionId            string
+	DestinationResource string
+	ZoneId              string
+	InstanceChargeType  string
+	SpotStrategy        string
+	IoOptimized         string
+	InstanceType        string
+	SystemDiskCategory  string
+	DataDiskCategory    string
+	NetworkCategory     string
+}
+
+type DescribeAvailableResourceResponse struct {
+	common.Response
+	AvailableZones struct {
+		AvailableZone []AvailableZoneType
+	}
+}
+
+type AvailableZoneType struct {
+	RegionId           string
+	ZoneId             string
+	Status             string
+	AvailableResources struct {
+		AvailableResource []NewAvailableResourcesType
+	}
+}
+
+type NewAvailableResourcesType struct {
+	Type               string
+	SupportedResources struct {
+		SupportedResource []SupportedResourcesType
+	}
+}
+
+type SupportedResourcesType struct {
+	Value  string
+	Status string
+	Min    string
+	Max    string
+	Unit   string
+}
+
+// https://www.alibabacloud.com/help/doc-detail/66186.htm
+func (client *Client) DescribeAvailableResource(args *DescribeAvailableResourceArgs) (response *DescribeAvailableResourceResponse, err error) {
+
+	response = &DescribeAvailableResourceResponse{}
+	err = client.Invoke("DescribeAvailableResource", args, response)
+	return response, err
 }

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -353,10 +353,10 @@
 			"revisionTime": "2018-03-30T09:12:25Z"
 		},
 		{
-			"checksumSHA1": "iCz6Eg/bwlA6KtxUgSehZsQ3cHA=",
+			"checksumSHA1": "kopZshfphnegdwQyPge+bnqQzwg=",
 			"path": "github.com/denverdino/aliyungo/ecs",
-			"revision": "39745192ce9045d198ca2003b493ea29b3f7d9d3",
-			"revisionTime": "2018-03-30T09:12:25Z"
+			"revision": "63ba2cd70c5aed58c3b7bd6dfe95ffd4a8187c97",
+			"revisionTime": "2018-05-21T07:44:21Z"
 		},
 		{
 			"checksumSHA1": "HoHraolKNPZUPxCbKvkbXTJnkWA=",

--- a/website/docs/d/security_group_rules.html.markdown
+++ b/website/docs/d/security_group_rules.html.markdown
@@ -14,6 +14,7 @@ The id of the security group can be provided via variable or filtered by another
 
 ## Example Usage
 The following example shows how to obtain details of the security group rule and passing the data to the instance at launch.
+
 ```
 # accept a security group id as a variable
 

--- a/website/docs/d/zones.html.markdown
+++ b/website/docs/d/zones.html.markdown
@@ -10,6 +10,8 @@ description: |-
 
 The Zones data source allows access to the list of Alicloud Zones which can be accessed by an Alicloud account within the region configured in the provider.
 
+~> **NOTE:** If one zone is sold out, it will not be outputted.
+
 ## Example Usage
 
 ```
@@ -37,6 +39,9 @@ The following arguments are supported:
 * `available_resource_creation` - (Optional) Limit search to specific resource type. The following values are allowed `Instance`, `Disk`, `VSwitch` and `Rds`.
 * `available_disk_category` - (Optional) Limit search to specific disk category. Can be either `cloud`, `cloud_efficiency`, `cloud_ssd`.
 * `multi` - (Optional) Whether to retrieve multiple availability. Default to `false`. Multiple zone usually is used to launch RDS.
+* `instance_charge_type` - (Optional) According to ECS instance charge type to filter all availability zones. Valid values: `PrePaid` and `PostPaid`. Default to `PostPaid`.
+* `network_type` - (Optional) According to network type to filter all availability zones. Valid values: `Classic` and `Vpc`.
+* `spot_strategy` - - (Optional) According to ECS spot type to filter all availability zones. Valid values: `NoSpot`, `SpotWithPriceLimit` and `SpotAsPriceGo`. Default to `NoSpot`.
 * `output_file` - (Optional) The name of file that can save zones data source after running `terraform plan`.
 
 ~> **NOTE:** Available disk category `cloud` has been outdated and it only can be used none I/O Optimized ECS instances. So many available zones haven't support it. Recommend `cloud_efficiency` and `cloud_ssd`.


### PR DESCRIPTION
The PR adds three filter parameter to got specified availability zone.

The result of running test case as follows:

TF_ACC=1 go test -v ./alicloud -run=TestAccAlicloudZones
=== RUN   TestAccAlicloudZonesDataSource_basic
--- PASS: TestAccAlicloudZonesDataSource_basic (8.07s)
=== RUN   TestAccAlicloudZonesDataSource_filter
--- PASS: TestAccAlicloudZonesDataSource_filter (7.72s)
=== RUN   TestAccAlicloudZonesDataSource_unitRegion
--- PASS: TestAccAlicloudZonesDataSource_unitRegion (4.97s)
=== RUN   TestAccAlicloudZonesDataSource_multiZone
--- PASS: TestAccAlicloudZonesDataSource_multiZone (6.30s)
=== RUN   TestAccAlicloudZonesDataSource_chargeType
--- PASS: TestAccAlicloudZonesDataSource_chargeType (3.64s)
PASS
ok      github.com/alibaba/terraform-provider/alicloud  30.751s