### PR TITLE
Fix Oss bucket diff error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ IMPROVEMENTS:
 
 - Add method to compare json template is equal ([#187](https://github.com/terraform-providers/terraform-provider-alicloud/pull/187))
 
+BUG FIXES:
+
+- Fix Oss bucket diff error ([#188](https://github.com/terraform-providers/terraform-provider-alicloud/pull/188))
+
 ## 1.9.5 (June 20, 2018)
 
 IMPROVEMENTS:

--- a/alicloud/errors.go
+++ b/alicloud/errors.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/aliyun/alibaba-cloud-sdk-go/sdk/errors"
 	"github.com/aliyun/aliyun-log-go-sdk"
+	"github.com/aliyun/aliyun-oss-go-sdk/oss"
 	"github.com/denverdino/aliyungo/common"
 )
 
@@ -52,6 +53,7 @@ const (
 	VpcQuotaExceeded     = "QuotaExceeded.Vpc"
 	InvalidVpcIDNotFound = "InvalidVpcID.NotFound"
 	ForbiddenVpcNotFound = "Forbidden.VpcNotFound"
+	Throttling           = "Throttling"
 
 	// vswitch
 	VswitcInvalidRegionId    = "InvalidRegionId.NotFound"
@@ -93,8 +95,10 @@ const (
 	ConnectionConflictMessage              = "The requested resource is sold out in the specified zone; try other types of resources or other regions and zones"
 	DBInternalError                        = "InternalError"
 	// oss
-	OssBucketNotFound = "NoSuchBucket"
-	OssBodyNotFound   = "404 Not Found"
+	OssBucketNotFound          = "NoSuchBucket"
+	OssBodyNotFound            = "404 Not Found"
+	NoSuchCORSConfiguration    = "NoSuchCORSConfiguration"
+	NoSuchWebsiteConfiguration = "NoSuchWebsiteConfiguration"
 
 	// RAM Instance Not Found
 	RamInstanceNotFound   = "Forbidden.InstanceNotFound"
@@ -233,6 +237,10 @@ func IsExceptedError(err error, expectCode string) bool {
 	if e, ok := err.(*sls.Error); ok && (e.Code == expectCode || strings.Contains(e.Message, expectCode)) {
 		return true
 	}
+
+	if e, ok := err.(oss.ServiceError); ok && (e.Code == expectCode || strings.Contains(e.Message, expectCode)) {
+		return true
+	}
 	return false
 }
 
@@ -250,6 +258,9 @@ func IsExceptedErrors(err error, expectCodes []string) bool {
 			return true
 		}
 		if e, ok := err.(*sls.Error); ok && (e.Code == code || strings.Contains(e.Message, code)) {
+			return true
+		}
+		if e, ok := err.(oss.ServiceError); ok && (e.Code == code || strings.Contains(e.Message, code)) {
 			return true
 		}
 	}

--- a/alicloud/import_alicloud_oss_bucket_test.go
+++ b/alicloud/import_alicloud_oss_bucket_test.go
@@ -13,7 +13,7 @@ func TestAccAlicloudOssBucket_importBasic(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckInstanceDestroy,
+		CheckDestroy: testAccCheckOssBucketDestroy,
 		Steps: []resource.TestStep{
 			resource.TestStep{
 				Config: testAccAlicloudOssBucketBasicConfig(acctest.RandInt()),
@@ -34,7 +34,7 @@ func TestAccAlicloudOssBucket_importCors(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckInstanceDestroy,
+		CheckDestroy: testAccCheckOssBucketDestroy,
 		Steps: []resource.TestStep{
 			resource.TestStep{
 				Config: testAccAlicloudOssBucketCorsConfig(acctest.RandInt()),
@@ -55,7 +55,7 @@ func TestAccAlicloudOssBucket_importWebsite(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckInstanceDestroy,
+		CheckDestroy: testAccCheckOssBucketDestroy,
 		Steps: []resource.TestStep{
 			resource.TestStep{
 				Config: testAccAlicloudOssBucketWebsiteConfig(acctest.RandInt()),
@@ -75,7 +75,7 @@ func TestAccAlicloudOssBucket_importLogging(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckInstanceDestroy,
+		CheckDestroy: testAccCheckOssBucketDestroy,
 		Steps: []resource.TestStep{
 			resource.TestStep{
 				Config: testAccAlicloudOssBucketLoggingConfig(acctest.RandInt()),
@@ -96,7 +96,7 @@ func TestAccAlicloudOssBucket_importReferer(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckInstanceDestroy,
+		CheckDestroy: testAccCheckOssBucketDestroy,
 		Steps: []resource.TestStep{
 			resource.TestStep{
 				Config: testAccAlicloudOssBucketRefererConfig(acctest.RandInt()),
@@ -116,7 +116,7 @@ func TestAccAlicloudOssBucket_importLifecycle(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckInstanceDestroy,
+		CheckDestroy: testAccCheckOssBucketDestroy,
 		Steps: []resource.TestStep{
 			resource.TestStep{
 				Config: testAccAlicloudOssBucketLifecycleConfig(acctest.RandInt()),


### PR DESCRIPTION
This PR fixes a diff error that while running oss bucket import test cases.

The result of running test cases as follows:

```
TF_ACC=1 go test ./alicloud -v -run=TestAccAlicloudOssBucket -timeout=600m
=== RUN   TestAccAlicloudOssBucket_importBasic
--- PASS: TestAccAlicloudOssBucket_importBasic (6.07s)
=== RUN   TestAccAlicloudOssBucket_importCors
--- PASS: TestAccAlicloudOssBucket_importCors (7.08s)
=== RUN   TestAccAlicloudOssBucket_importWebsite
--- PASS: TestAccAlicloudOssBucket_importWebsite (5.52s)
=== RUN   TestAccAlicloudOssBucket_importLogging
--- PASS: TestAccAlicloudOssBucket_importLogging (8.13s)
=== RUN   TestAccAlicloudOssBucket_importReferer
--- PASS: TestAccAlicloudOssBucket_importReferer (4.90s)
=== RUN   TestAccAlicloudOssBucket_importLifecycle
--- PASS: TestAccAlicloudOssBucket_importLifecycle (6.12s)
=== RUN   TestAccAlicloudOssBucketObject_source
--- PASS: TestAccAlicloudOssBucketObject_source (8.02s)
=== RUN   TestAccAlicloudOssBucketObject_content
--- PASS: TestAccAlicloudOssBucketObject_content (4.71s)
=== RUN   TestAccAlicloudOssBucketObject_acl
--- PASS: TestAccAlicloudOssBucketObject_acl (4.87s)
=== RUN   TestAccAlicloudOssBucketBasic
--- PASS: TestAccAlicloudOssBucketBasic (5.18s)
=== RUN   TestAccAlicloudOssBucketCors
--- PASS: TestAccAlicloudOssBucketCors (4.87s)
=== RUN   TestAccAlicloudOssBucketWebsite
--- PASS: TestAccAlicloudOssBucketWebsite (6.59s)
=== RUN   TestAccAlicloudOssBucketLogging
--- PASS: TestAccAlicloudOssBucketLogging (7.49s)
=== RUN   TestAccAlicloudOssBucketReferer
--- PASS: TestAccAlicloudOssBucketReferer (4.77s)
=== RUN   TestAccAlicloudOssBucketLifecycle
--- PASS: TestAccAlicloudOssBucketLifecycle (5.45s)
PASS
ok  	github.com/alibaba/terraform-provider/alicloud	89.830s
```