### PR TITLE
Improve oss resource test case

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 IMPROVEMENTS:
 
+- Improve ots table resource test case ([#196](https://github.com/terraform-providers/terraform-provider-alicloud/pull/196))
 - Improve nat gateway resource test case ([#195](https://github.com/terraform-providers/terraform-provider-alicloud/pull/195))
 - Improve log resource test case ([#194](https://github.com/terraform-providers/terraform-provider-alicloud/pull/194))
 - Support changing ecs charge type from Prepaid to PostPaid ([#192](https://github.com/terraform-providers/terraform-provider-alicloud/pull/192))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 IMPROVEMENTS:
 
+- Improve log resource test case ([#194](https://github.com/terraform-providers/terraform-provider-alicloud/pull/194))
 - Support changing ecs charge type from Prepaid to PostPaid ([#192](https://github.com/terraform-providers/terraform-provider-alicloud/pull/192))
 - Add method to compare json template is equal ([#187](https://github.com/terraform-providers/terraform-provider-alicloud/pull/187))
 - Remove useless file ([#191](https://github.com/terraform-providers/terraform-provider-alicloud/pull/191))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 IMPROVEMENTS:
 
+- Improve oss resource test case ([#197](https://github.com/terraform-providers/terraform-provider-alicloud/pull/197))
 - Improve ots table resource test case ([#196](https://github.com/terraform-providers/terraform-provider-alicloud/pull/196))
 - Improve nat gateway resource test case ([#195](https://github.com/terraform-providers/terraform-provider-alicloud/pull/195))
 - Improve log resource test case ([#194](https://github.com/terraform-providers/terraform-provider-alicloud/pull/194))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 IMPROVEMENTS:
 
+- Improve nat gateway resource test case ([#195](https://github.com/terraform-providers/terraform-provider-alicloud/pull/195))
 - Improve log resource test case ([#194](https://github.com/terraform-providers/terraform-provider-alicloud/pull/194))
 - Support changing ecs charge type from Prepaid to PostPaid ([#192](https://github.com/terraform-providers/terraform-provider-alicloud/pull/192))
 - Add method to compare json template is equal ([#187](https://github.com/terraform-providers/terraform-provider-alicloud/pull/187))

--- a/alicloud/import_alicloud_log_machine_group_test.go
+++ b/alicloud/import_alicloud_log_machine_group_test.go
@@ -12,7 +12,7 @@ func TestAccAlicloudLogMachineGroup_import(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckInstanceDestroy,
+		CheckDestroy: testAccCheckAlicloudLogMachineGroupDestroy,
 		Steps: []resource.TestStep{
 			resource.TestStep{
 				Config: testAlicloudLogMachineGroupIp,

--- a/alicloud/import_alicloud_log_store_index_test.go
+++ b/alicloud/import_alicloud_log_store_index_test.go
@@ -33,7 +33,7 @@ func TestAccAlicloudLogStoreIndex_importField(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckInstanceDestroy,
+		CheckDestroy: testAccCheckAlicloudLogStoreIndexDestroy,
 		Steps: []resource.TestStep{
 			resource.TestStep{
 				Config: testAlicloudLogStoreIndexField,

--- a/alicloud/import_alicloud_nat_gateway_test.go
+++ b/alicloud/import_alicloud_nat_gateway_test.go
@@ -6,34 +6,13 @@ import (
 	"github.com/hashicorp/terraform/helper/resource"
 )
 
-func TestAccAlicloudNatGateway_importBasic(t *testing.T) {
-	resourceName := "alicloud_nat_gateway.foo"
-
-	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckInstanceDestroy,
-		Steps: []resource.TestStep{
-			resource.TestStep{
-				Config: testAccNatGatewayConfig,
-			},
-
-			resource.TestStep{
-				ResourceName:      resourceName,
-				ImportState:       true,
-				ImportStateVerify: true,
-			},
-		},
-	})
-}
-
 func TestAccAlicloudNatGateway_importSpec(t *testing.T) {
 	resourceName := "alicloud_nat_gateway.foo"
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckInstanceDestroy,
+		CheckDestroy: testAccCheckNatGatewayDestroy,
 		Steps: []resource.TestStep{
 			resource.TestStep{
 				Config: testAccNatGatewayConfigSpec,

--- a/alicloud/import_alicloud_ots_table_test.go
+++ b/alicloud/import_alicloud_ots_table_test.go
@@ -6,7 +6,10 @@ import (
 	"github.com/hashicorp/terraform/helper/resource"
 )
 
-func TestAccAlicloudOtsTable_importBasic(t *testing.T) {
+// At present, OTS sdk does not support creating OTS instance and import test case does not support provider config,
+// so this test can not be run successfully.
+
+func SkipTestAccAlicloudOtsTable_importBasic(t *testing.T) {
 	resourceName := "alicloud_ots_table.basic"
 
 	resource.Test(t, resource.TestCase{

--- a/alicloud/resource_alicloud_log_machine_group_test.go
+++ b/alicloud/resource_alicloud_log_machine_group_test.go
@@ -90,17 +90,13 @@ func testAccCheckAlicloudLogMachineGroupDestroy(s *terraform.State) error {
 
 		split := strings.Split(rs.Primary.ID, COLON_SEPARATED)
 
-		group, err := client.DescribeLogMachineGroup(split[0], split[1])
-		if err != nil {
+		if _, err := client.DescribeLogMachineGroup(split[0], split[1]); err != nil {
 			if NotFoundError(err) {
-				return nil
+				continue
 			}
 			return fmt.Errorf("Check log machine group got an error: %#v.", err)
 		}
-
-		if group.Name != "" {
-			return fmt.Errorf("Log machine group %s still exists.", rs.Primary.ID)
-		}
+		return fmt.Errorf("Log machine group %s still exists.", rs.Primary.ID)
 	}
 
 	return nil

--- a/alicloud/resource_alicloud_log_store_index_test.go
+++ b/alicloud/resource_alicloud_log_store_index_test.go
@@ -119,18 +119,18 @@ func testAccCheckAlicloudLogStoreIndexDestroy(s *terraform.State) error {
 		i, err := client.DescribeLogStoreIndex(split[0], split[1])
 		if err != nil {
 			if NotFoundError(err) {
-				return nil
+				continue
 			}
 			return fmt.Errorf("Check log store index got an error: %#v.", err)
 		}
 
 		if len(split) == 2 {
 			if i.Line == nil {
-				return nil
+				continue
 			}
 		} else {
 			if _, ok := i.Keys[split[2]]; !ok {
-				return nil
+				continue
 			}
 		}
 

--- a/alicloud/resource_alicloud_log_store_test.go
+++ b/alicloud/resource_alicloud_log_store_test.go
@@ -70,10 +70,7 @@ func testAccCheckAlicloudLogStoreDestroy(s *terraform.State) error {
 
 		split := strings.Split(rs.Primary.ID, COLON_SEPARATED)
 		store, err := client.DescribeLogStore(split[0], split[1])
-		if err != nil {
-			if NotFoundError(err) {
-				return nil
-			}
+		if err != nil && !NotFoundError(err) {
 			return fmt.Errorf("Check log store got an error: %#v.", err)
 		}
 

--- a/alicloud/resource_alicloud_oss_bucket_object_test.go
+++ b/alicloud/resource_alicloud_oss_bucket_object_test.go
@@ -8,7 +8,6 @@ import (
 	"os"
 	"testing"
 
-	"github.com/aliyun/aliyun-oss-go-sdk/oss"
 	"github.com/hashicorp/terraform/helper/acctest"
 	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/helper/schema"
@@ -184,8 +183,7 @@ func testAccCheckOssBucketObjectDestroyWithProvider(s *terraform.State, provider
 		}
 
 		// Verify the error is what we want
-		e, _ := err.(oss.ServiceError)
-		if e.Code == OssBucketNotFound {
+		if IsExceptedErrors(err, []string{OssBucketNotFound}) {
 			continue
 		}
 

--- a/alicloud/resource_alicloud_oss_bucket_test.go
+++ b/alicloud/resource_alicloud_oss_bucket_test.go
@@ -284,8 +284,7 @@ func testAccCheckOssBucketDestroyWithProvider(s *terraform.State, provider *sche
 		}
 
 		// Verify the error is what we want
-		e, _ := err.(oss.ServiceError)
-		if e.Code == OssBucketNotFound {
+		if IsExceptedErrors(err, []string{OssBucketNotFound}) {
 			continue
 		}
 

--- a/alicloud/resource_alicloud_ots_table_test.go
+++ b/alicloud/resource_alicloud_ots_table_test.go
@@ -10,7 +10,10 @@ import (
 	"github.com/hashicorp/terraform/terraform"
 )
 
-func TestAccAlicloudOtsTable_Basic(t *testing.T) {
+// At present, OTS sdk does not support creating OTS instance, and you should manually create a instance before running the test case.
+// After running the test, you should set it to 'Skip'
+
+func SkipTestAccAlicloudOtsTable_Basic(t *testing.T) {
 	var table tablestore.DescribeTableResponse
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
@@ -86,12 +89,12 @@ func testAccCheckOtsTableDestroy(s *terraform.State) error {
 
 const testAccOtsTable = `
 provider "alicloud" {
-  ots_instance_name = "tf-test"
+  ots_instance_name = "testAccOtsTable"
   region = "cn-hangzhou"
 }
 resource "alicloud_ots_table" "basic" {
   provider = "alicloud"
-  table_name = "ots_table_c"
+  table_name = "testAccOtsTable"
   primary_key = {
     name = "pk1"
     type = "Integer"


### PR DESCRIPTION
```
TF_ACC=1 go test ./alicloud -v -run=TestAccAlicloudOss -timeout=600m
=== RUN   TestAccAlicloudOssBucket_importBasic
--- PASS: TestAccAlicloudOssBucket_importBasic (5.17s)
=== RUN   TestAccAlicloudOssBucket_importCors
--- PASS: TestAccAlicloudOssBucket_importCors (4.59s)
=== RUN   TestAccAlicloudOssBucket_importWebsite
--- PASS: TestAccAlicloudOssBucket_importWebsite (4.63s)
=== RUN   TestAccAlicloudOssBucket_importLogging
--- PASS: TestAccAlicloudOssBucket_importLogging (8.48s)
=== RUN   TestAccAlicloudOssBucket_importReferer
--- PASS: TestAccAlicloudOssBucket_importReferer (4.53s)
=== RUN   TestAccAlicloudOssBucket_importLifecycle
--- PASS: TestAccAlicloudOssBucket_importLifecycle (5.33s)
=== RUN   TestAccAlicloudOssBucketObject_source
--- PASS: TestAccAlicloudOssBucketObject_source (4.31s)
=== RUN   TestAccAlicloudOssBucketObject_content
--- PASS: TestAccAlicloudOssBucketObject_content (4.18s)
=== RUN   TestAccAlicloudOssBucketObject_acl
--- PASS: TestAccAlicloudOssBucketObject_acl (4.30s)
=== RUN   TestAccAlicloudOssBucketBasic
--- PASS: TestAccAlicloudOssBucketBasic (4.72s)
=== RUN   TestAccAlicloudOssBucketCors
--- PASS: TestAccAlicloudOssBucketCors (4.20s)
=== RUN   TestAccAlicloudOssBucketWebsite
--- PASS: TestAccAlicloudOssBucketWebsite (4.23s)
=== RUN   TestAccAlicloudOssBucketLogging
--- PASS: TestAccAlicloudOssBucketLogging (6.72s)
=== RUN   TestAccAlicloudOssBucketReferer
--- PASS: TestAccAlicloudOssBucketReferer (4.09s)
=== RUN   TestAccAlicloudOssBucketLifecycle
--- PASS: TestAccAlicloudOssBucketLifecycle (4.26s)
PASS
ok  	github.com/alibaba/terraform-provider/alicloud	73.767s
```