### PR TITLE
Improve dns resource test case

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 IMPROVEMENTS:
 
+- Improve ots table resource test case ([#196](https://github.com/terraform-providers/terraform-provider-alicloud/pull/196))
 - Improve nat gateway resource test case ([#195](https://github.com/terraform-providers/terraform-provider-alicloud/pull/195))
 - Improve log resource test case ([#194](https://github.com/terraform-providers/terraform-provider-alicloud/pull/194))
 - Support changing ecs charge type from Prepaid to PostPaid ([#192](https://github.com/terraform-providers/terraform-provider-alicloud/pull/192))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 IMPROVEMENTS:
 
+- Improve dns resource test case ([#198](https://github.com/terraform-providers/terraform-provider-alicloud/pull/198))
 - Improve oss resource test case ([#197](https://github.com/terraform-providers/terraform-provider-alicloud/pull/197))
 - Improve ots table resource test case ([#196](https://github.com/terraform-providers/terraform-provider-alicloud/pull/196))
 - Improve nat gateway resource test case ([#195](https://github.com/terraform-providers/terraform-provider-alicloud/pull/195))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 IMPROVEMENTS:
 
+- Improve log resource test case ([#194](https://github.com/terraform-providers/terraform-provider-alicloud/pull/194))
 - Support changing ecs charge type from Prepaid to PostPaid ([#192](https://github.com/terraform-providers/terraform-provider-alicloud/pull/192))
 - Add method to compare json template is equal ([#187](https://github.com/terraform-providers/terraform-provider-alicloud/pull/187))
 - Remove useless file ([#191](https://github.com/terraform-providers/terraform-provider-alicloud/pull/191))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 IMPROVEMENTS:
 
+- Improve oss resource test case ([#197](https://github.com/terraform-providers/terraform-provider-alicloud/pull/197))
 - Improve ots table resource test case ([#196](https://github.com/terraform-providers/terraform-provider-alicloud/pull/196))
 - Improve nat gateway resource test case ([#195](https://github.com/terraform-providers/terraform-provider-alicloud/pull/195))
 - Improve log resource test case ([#194](https://github.com/terraform-providers/terraform-provider-alicloud/pull/194))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 IMPROVEMENTS:
 
+- Improve nat gateway resource test case ([#195](https://github.com/terraform-providers/terraform-provider-alicloud/pull/195))
 - Improve log resource test case ([#194](https://github.com/terraform-providers/terraform-provider-alicloud/pull/194))
 - Support changing ecs charge type from Prepaid to PostPaid ([#192](https://github.com/terraform-providers/terraform-provider-alicloud/pull/192))
 - Add method to compare json template is equal ([#187](https://github.com/terraform-providers/terraform-provider-alicloud/pull/187))

--- a/alicloud/data_source_alicloud_dns_domains_test.go
+++ b/alicloud/data_source_alicloud_dns_domains_test.go
@@ -25,24 +25,6 @@ func TestAccAlicloudDnsDomainsDataSource_ali_domain(t *testing.T) {
 	})
 }
 
-func TestAccAlicloudDnsDomainsDataSource_version_code(t *testing.T) {
-	resource.Test(t, resource.TestCase{
-		PreCheck: func() {
-			testAccPreCheck(t)
-		},
-		Providers: testAccProviders,
-		Steps: []resource.TestStep{
-			{
-				Config: testAccCheckAlicloudDomainsDataSourceVersionCodeConfig,
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAlicloudDataSourceID("data.alicloud_dns_domains.domain"),
-					resource.TestCheckResourceAttr("data.alicloud_dns_domains.domain", "domains.#", "1"),
-				),
-			},
-		},
-	})
-}
-
 func TestAccAlicloudDnsDomainsDataSource_name_regex(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
@@ -61,40 +43,15 @@ func TestAccAlicloudDnsDomainsDataSource_name_regex(t *testing.T) {
 	})
 }
 
-func TestAccAlicloudDnsDomainsDataSource_group_name_regex(t *testing.T) {
-	resource.Test(t, resource.TestCase{
-		PreCheck: func() {
-			testAccPreCheck(t)
-		},
-		Providers: testAccProviders,
-		Steps: []resource.TestStep{
-			{
-				Config: testAccCheckAlicloudDomainsDataSourceGroupNameRegexConfig,
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAlicloudDataSourceID("data.alicloud_dns_domains.domain"),
-					resource.TestCheckResourceAttr("data.alicloud_dns_domains.domain", "domains.#", "2"),
-				),
-			},
-		},
-	})
-}
-
 const testAccCheckAlicloudDomainsDataSourceAliDomainConfig = `
 data "alicloud_dns_domains" "domain" {
   ali_domain = true
 }`
 
-const testAccCheckAlicloudDomainsDataSourceVersionCodeConfig = `
-data "alicloud_dns_domains" "domain" {
-  version_code = "mianfei"
-}`
-
 const testAccCheckAlicloudDomainsDataSourceNameRegexConfig = `
+resource "alicloud_dns" "dns" {
+  name = "yufish.com"
+}
 data "alicloud_dns_domains" "domain" {
-  domain_name_regex = ".*"
-}`
-
-const testAccCheckAlicloudDomainsDataSourceGroupNameRegexConfig = `
-data "alicloud_dns_domains" "domain" {
-  group_name_regex = ".*"
+  domain_name_regex = "${alicloud_dns.dns.name}"
 }`

--- a/alicloud/data_source_alicloud_dns_groups_test.go
+++ b/alicloud/data_source_alicloud_dns_groups_test.go
@@ -18,7 +18,7 @@ func TestAccAlicloudDnsGroupsDataSource_name_regex(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAlicloudDataSourceID("data.alicloud_dns_groups.group"),
 					resource.TestCheckResourceAttr("data.alicloud_dns_groups.group", "groups.#", "1"),
-					resource.TestCheckResourceAttr("data.alicloud_dns_groups.group", "groups.0.group_name", "ALL\n"),
+					resource.TestCheckResourceAttr("data.alicloud_dns_groups.group", "groups.0.group_name", "ALL"),
 				),
 			},
 		},

--- a/alicloud/errors.go
+++ b/alicloud/errors.go
@@ -108,6 +108,8 @@ const (
 	RecordForbiddenDNSChange    = "RecordForbidden.DNSChange"
 	FobiddenNotEmptyGroup       = "Fobidden.NotEmptyGroup"
 	DomainRecordNotBelongToUser = "DomainRecordNotBelongToUser"
+	InvalidDomainNotFound       = "InvalidDomain.NotFound"
+	InvalidDomainNameNoExist    = "InvalidDomainName.NoExist"
 
 	// ram user
 	DeleteConflictUserGroup        = "DeleteConflict.User.Group"

--- a/alicloud/import_alicloud_log_machine_group_test.go
+++ b/alicloud/import_alicloud_log_machine_group_test.go
@@ -12,7 +12,7 @@ func TestAccAlicloudLogMachineGroup_import(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckInstanceDestroy,
+		CheckDestroy: testAccCheckAlicloudLogMachineGroupDestroy,
 		Steps: []resource.TestStep{
 			resource.TestStep{
 				Config: testAlicloudLogMachineGroupIp,

--- a/alicloud/import_alicloud_log_store_index_test.go
+++ b/alicloud/import_alicloud_log_store_index_test.go
@@ -33,7 +33,7 @@ func TestAccAlicloudLogStoreIndex_importField(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckInstanceDestroy,
+		CheckDestroy: testAccCheckAlicloudLogStoreIndexDestroy,
 		Steps: []resource.TestStep{
 			resource.TestStep{
 				Config: testAlicloudLogStoreIndexField,

--- a/alicloud/import_alicloud_nat_gateway_test.go
+++ b/alicloud/import_alicloud_nat_gateway_test.go
@@ -6,34 +6,13 @@ import (
 	"github.com/hashicorp/terraform/helper/resource"
 )
 
-func TestAccAlicloudNatGateway_importBasic(t *testing.T) {
-	resourceName := "alicloud_nat_gateway.foo"
-
-	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckInstanceDestroy,
-		Steps: []resource.TestStep{
-			resource.TestStep{
-				Config: testAccNatGatewayConfig,
-			},
-
-			resource.TestStep{
-				ResourceName:      resourceName,
-				ImportState:       true,
-				ImportStateVerify: true,
-			},
-		},
-	})
-}
-
 func TestAccAlicloudNatGateway_importSpec(t *testing.T) {
 	resourceName := "alicloud_nat_gateway.foo"
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckInstanceDestroy,
+		CheckDestroy: testAccCheckNatGatewayDestroy,
 		Steps: []resource.TestStep{
 			resource.TestStep{
 				Config: testAccNatGatewayConfigSpec,

--- a/alicloud/import_alicloud_ots_table_test.go
+++ b/alicloud/import_alicloud_ots_table_test.go
@@ -6,7 +6,10 @@ import (
 	"github.com/hashicorp/terraform/helper/resource"
 )
 
-func TestAccAlicloudOtsTable_importBasic(t *testing.T) {
+// At present, OTS sdk does not support creating OTS instance and import test case does not support provider config,
+// so this test can not be run successfully.
+
+func SkipTestAccAlicloudOtsTable_importBasic(t *testing.T) {
 	resourceName := "alicloud_ots_table.basic"
 
 	resource.Test(t, resource.TestCase{

--- a/alicloud/resource_alicloud_dns_record_test.go
+++ b/alicloud/resource_alicloud_dns_record_test.go
@@ -115,8 +115,10 @@ func testAccCheckDnsRecordDestroy(s *terraform.State) error {
 		}
 
 		response, err := conn.DescribeDomainRecordInfoNew(request)
-
-		if response.RecordId != "" || err != nil {
+		if err != nil {
+			return err
+		}
+		if response.RecordId != "" {
 			return fmt.Errorf("Error Domain record still exist.")
 		}
 	}

--- a/alicloud/resource_alicloud_dns_test.go
+++ b/alicloud/resource_alicloud_dns_test.go
@@ -5,7 +5,6 @@ import (
 	"log"
 	"testing"
 
-	"github.com/denverdino/aliyungo/common"
 	"github.com/denverdino/aliyungo/dns"
 	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/terraform"
@@ -33,7 +32,7 @@ func TestAccAlicloudDns_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(
 						"alicloud_dns.dns",
 						"name",
-						"starmove.com"),
+						"yufish.com"),
 				),
 			},
 		},
@@ -87,13 +86,8 @@ func testAccCheckDnsDestroy(s *terraform.State) error {
 
 		_, err := conn.DescribeDomainInfo(request)
 
-		if err != nil {
-			e, _ := err.(*common.Error)
-			if e.ErrorResponse.Code == "InvalidDomainName.NoExist" {
-				return nil
-			} else {
-				return fmt.Errorf("Error Domain still exist.")
-			}
+		if err != nil && !IsExceptedErrors(err, []string{InvalidDomainNameNoExist}) {
+			return fmt.Errorf("Error Domain still exist.")
 		}
 	}
 
@@ -102,6 +96,6 @@ func testAccCheckDnsDestroy(s *terraform.State) error {
 
 const testAccDnsConfig = `
 resource "alicloud_dns" "dns" {
-  name = "starmove.com"
+  name = "yufish.com"
 }
 `

--- a/alicloud/resource_alicloud_log_machine_group_test.go
+++ b/alicloud/resource_alicloud_log_machine_group_test.go
@@ -90,17 +90,13 @@ func testAccCheckAlicloudLogMachineGroupDestroy(s *terraform.State) error {
 
 		split := strings.Split(rs.Primary.ID, COLON_SEPARATED)
 
-		group, err := client.DescribeLogMachineGroup(split[0], split[1])
-		if err != nil {
+		if _, err := client.DescribeLogMachineGroup(split[0], split[1]); err != nil {
 			if NotFoundError(err) {
-				return nil
+				continue
 			}
 			return fmt.Errorf("Check log machine group got an error: %#v.", err)
 		}
-
-		if group.Name != "" {
-			return fmt.Errorf("Log machine group %s still exists.", rs.Primary.ID)
-		}
+		return fmt.Errorf("Log machine group %s still exists.", rs.Primary.ID)
 	}
 
 	return nil

--- a/alicloud/resource_alicloud_log_store_index_test.go
+++ b/alicloud/resource_alicloud_log_store_index_test.go
@@ -119,18 +119,18 @@ func testAccCheckAlicloudLogStoreIndexDestroy(s *terraform.State) error {
 		i, err := client.DescribeLogStoreIndex(split[0], split[1])
 		if err != nil {
 			if NotFoundError(err) {
-				return nil
+				continue
 			}
 			return fmt.Errorf("Check log store index got an error: %#v.", err)
 		}
 
 		if len(split) == 2 {
 			if i.Line == nil {
-				return nil
+				continue
 			}
 		} else {
 			if _, ok := i.Keys[split[2]]; !ok {
-				return nil
+				continue
 			}
 		}
 

--- a/alicloud/resource_alicloud_log_store_test.go
+++ b/alicloud/resource_alicloud_log_store_test.go
@@ -70,10 +70,7 @@ func testAccCheckAlicloudLogStoreDestroy(s *terraform.State) error {
 
 		split := strings.Split(rs.Primary.ID, COLON_SEPARATED)
 		store, err := client.DescribeLogStore(split[0], split[1])
-		if err != nil {
-			if NotFoundError(err) {
-				return nil
-			}
+		if err != nil && !NotFoundError(err) {
 			return fmt.Errorf("Check log store got an error: %#v.", err)
 		}
 

--- a/alicloud/resource_alicloud_oss_bucket_object_test.go
+++ b/alicloud/resource_alicloud_oss_bucket_object_test.go
@@ -8,7 +8,6 @@ import (
 	"os"
 	"testing"
 
-	"github.com/aliyun/aliyun-oss-go-sdk/oss"
 	"github.com/hashicorp/terraform/helper/acctest"
 	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/helper/schema"
@@ -184,8 +183,7 @@ func testAccCheckOssBucketObjectDestroyWithProvider(s *terraform.State, provider
 		}
 
 		// Verify the error is what we want
-		e, _ := err.(oss.ServiceError)
-		if e.Code == OssBucketNotFound {
+		if IsExceptedErrors(err, []string{OssBucketNotFound}) {
 			continue
 		}
 

--- a/alicloud/resource_alicloud_oss_bucket_test.go
+++ b/alicloud/resource_alicloud_oss_bucket_test.go
@@ -284,8 +284,7 @@ func testAccCheckOssBucketDestroyWithProvider(s *terraform.State, provider *sche
 		}
 
 		// Verify the error is what we want
-		e, _ := err.(oss.ServiceError)
-		if e.Code == OssBucketNotFound {
+		if IsExceptedErrors(err, []string{OssBucketNotFound}) {
 			continue
 		}
 

--- a/alicloud/resource_alicloud_ots_table_test.go
+++ b/alicloud/resource_alicloud_ots_table_test.go
@@ -10,7 +10,10 @@ import (
 	"github.com/hashicorp/terraform/terraform"
 )
 
-func TestAccAlicloudOtsTable_Basic(t *testing.T) {
+// At present, OTS sdk does not support creating OTS instance, and you should manually create a instance before running the test case.
+// After running the test, you should set it to 'Skip'
+
+func SkipTestAccAlicloudOtsTable_Basic(t *testing.T) {
 	var table tablestore.DescribeTableResponse
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
@@ -86,12 +89,12 @@ func testAccCheckOtsTableDestroy(s *terraform.State) error {
 
 const testAccOtsTable = `
 provider "alicloud" {
-  ots_instance_name = "tf-test"
+  ots_instance_name = "testAccOtsTable"
   region = "cn-hangzhou"
 }
 resource "alicloud_ots_table" "basic" {
   provider = "alicloud"
-  table_name = "ots_table_c"
+  table_name = "testAccOtsTable"
   primary_key = {
     name = "pk1"
     type = "Integer"


### PR DESCRIPTION
```
TF_ACC=1 go test ./alicloud -v -run=TestAccAlicloudDns -timeout=240m
=== RUN   TestAccAlicloudDnsDomainsDataSource_ali_domain
--- PASS: TestAccAlicloudDnsDomainsDataSource_ali_domain (2.59s)
=== RUN   TestAccAlicloudDnsDomainsDataSource_name_regex
--- PASS: TestAccAlicloudDnsDomainsDataSource_name_regex (3.61s)
=== RUN   TestAccAlicloudDnsGroupsDataSource_name_regex
--- PASS: TestAccAlicloudDnsGroupsDataSource_name_regex (2.87s)
=== RUN   TestAccAlicloudDnsRecordsDataSource_host_record_regex
--- PASS: TestAccAlicloudDnsRecordsDataSource_host_record_regex (3.46s)
=== RUN   TestAccAlicloudDnsRecordsDataSource_type
--- PASS: TestAccAlicloudDnsRecordsDataSource_type (2.90s)
=== RUN   TestAccAlicloudDnsRecordsDataSource_value_regex
--- PASS: TestAccAlicloudDnsRecordsDataSource_value_regex (5.14s)
=== RUN   TestAccAlicloudDnsRecordsDataSource_line
--- PASS: TestAccAlicloudDnsRecordsDataSource_line (2.81s)
=== RUN   TestAccAlicloudDnsRecordsDataSource_status
--- PASS: TestAccAlicloudDnsRecordsDataSource_status (3.07s)
=== RUN   TestAccAlicloudDnsRecordsDataSource_is_locked
--- PASS: TestAccAlicloudDnsRecordsDataSource_is_locked (2.82s)
=== RUN   TestAccAlicloudDnsDomainRecord_importBasic
--- PASS: TestAccAlicloudDnsDomainRecord_importBasic (3.58s)
=== RUN   TestAccAlicloudDnsDomain_importBasic
--- PASS: TestAccAlicloudDnsDomain_importBasic (3.03s)
=== RUN   TestAccAlicloudDnsGroup_basic
--- PASS: TestAccAlicloudDnsGroup_basic (2.59s)
=== RUN   TestAccAlicloudDnsRecord_basic
--- PASS: TestAccAlicloudDnsRecord_basic (3.93s)
=== RUN   TestAccAlicloudDnsRecord_priority
--- PASS: TestAccAlicloudDnsRecord_priority (4.26s)
=== RUN   TestAccAlicloudDns_basic
--- PASS: TestAccAlicloudDns_basic (3.01s)
PASS
ok  	github.com/alibaba/terraform-provider/alicloud	49.715s

```