### PR TITLE
Improve ram resource test case 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 IMPROVEMENTS:
 
+- Improve ram resource test case ([#202](https://github.com/terraform-providers/terraform-provider-alicloud/pull/202))
 - Improve container cluster resource test case ([#201](https://github.com/terraform-providers/terraform-provider-alicloud/pull/201))
 - Improve cloud monitor resource test case ([#200](https://github.com/terraform-providers/terraform-provider-alicloud/pull/200))
 - Improve route and router interface resource test case ([#199](https://github.com/terraform-providers/terraform-provider-alicloud/pull/199))

--- a/alicloud/data_source_alicloud_ram_account_alias_test.go
+++ b/alicloud/data_source_alicloud_ram_account_alias_test.go
@@ -17,7 +17,6 @@ func TestAccAlicloudRamAccountAliasDataSource_basic(t *testing.T) {
 				Config: testAccCheckAlicloudAccountAliasDataSourceBasic,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAlicloudDataSourceID("data.alicloud_ram_account_aliases.alias"),
-					resource.TestCheckResourceAttr("data.alicloud_ram_account_aliases.alias", "account_alias", "1307087942598154"),
 				),
 			},
 		},

--- a/alicloud/data_source_alicloud_ram_groups_test.go
+++ b/alicloud/data_source_alicloud_ram_groups_test.go
@@ -18,8 +18,8 @@ func TestAccAlicloudRamGroupsDataSource_for_user(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAlicloudDataSourceID("data.alicloud_ram_groups.group"),
 					resource.TestCheckResourceAttr("data.alicloud_ram_groups.group", "groups.#", "1"),
-					resource.TestCheckResourceAttr("data.alicloud_ram_groups.group", "groups.0.name", "group3"),
-					resource.TestCheckResourceAttr("data.alicloud_ram_groups.group", "groups.0.comments", "33"),
+					resource.TestCheckResourceAttr("data.alicloud_ram_groups.group", "groups.0.name", "testAccCheckAlicloudRamGroupsDataSourceForUserConfig"),
+					resource.TestCheckResourceAttr("data.alicloud_ram_groups.group", "groups.0.comments", "group comments"),
 				),
 			},
 		},
@@ -38,8 +38,8 @@ func TestAccAlicloudRamGroupsDataSource_for_policy(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAlicloudDataSourceID("data.alicloud_ram_groups.group"),
 					resource.TestCheckResourceAttr("data.alicloud_ram_groups.group", "groups.#", "1"),
-					resource.TestCheckResourceAttr("data.alicloud_ram_groups.group", "groups.0.name", "group1"),
-					resource.TestCheckResourceAttr("data.alicloud_ram_groups.group", "groups.0.comments", "1"),
+					resource.TestCheckResourceAttr("data.alicloud_ram_groups.group", "groups.0.name", "testAccCheckAlicloudRamGroupsDataSourceForPolicyConfig"),
+					resource.TestCheckResourceAttr("data.alicloud_ram_groups.group", "groups.0.comments", "group comments"),
 				),
 			},
 		},
@@ -57,7 +57,6 @@ func TestAccAlicloudRamGroupsDataSource_for_all(t *testing.T) {
 				Config: testAccCheckAlicloudRamGroupsDataSourceForAllConfig,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAlicloudDataSourceID("data.alicloud_ram_groups.group"),
-					resource.TestCheckResourceAttr("data.alicloud_ram_groups.group", "groups.#", "5"),
 				),
 			},
 		},
@@ -75,7 +74,7 @@ func TestAccAlicloudRamGroupsDataSource_group_name_regex(t *testing.T) {
 				Config: testAccCheckAlicloudRamGroupsDataSourceGroupNameRegexConfig,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAlicloudDataSourceID("data.alicloud_ram_groups.group"),
-					resource.TestCheckResourceAttr("data.alicloud_ram_groups.group", "groups.#", "4"),
+					resource.TestCheckResourceAttr("data.alicloud_ram_groups.group", "groups.#", "1"),
 				),
 			},
 		},
@@ -83,14 +82,65 @@ func TestAccAlicloudRamGroupsDataSource_group_name_regex(t *testing.T) {
 }
 
 const testAccCheckAlicloudRamGroupsDataSourceForUserConfig = `
+variable "name" {
+  default = "testAccCheckAlicloudRamGroupsDataSourceForUserConfig"
+}
+resource "alicloud_ram_user" "user" {
+  name = "${var.name}"
+  display_name = "displayname"
+  mobile = "86-18888888888"
+  email = "hello.uuu@aaa.com"
+  comments = "yoyoyo"
+}
+
+resource "alicloud_ram_group" "group" {
+  name = "${var.name}"
+  comments = "group comments"
+  force=true
+}
+resource "alicloud_ram_group_membership" "membership" {
+  group_name = "${alicloud_ram_group.group.name}"
+  user_names = ["${alicloud_ram_user.user.name}"]
+}
+
 data "alicloud_ram_groups" "group" {
-  user_name = "user1"
+  user_name = "${alicloud_ram_group_membership.membership.user_names[0]}"
 }`
 
 const testAccCheckAlicloudRamGroupsDataSourceForPolicyConfig = `
+variable "name" {
+  default = "testAccCheckAlicloudRamGroupsDataSourceForPolicyConfig"
+}
+resource "alicloud_ram_policy" "policy" {
+  name = "${var.name}"
+  statement = [
+    {
+      effect = "Deny"
+      action = [
+        "oss:ListObjects",
+        "oss:ListObjects"]
+      resource = [
+        "acs:oss:*:*:mybucket",
+        "acs:oss:*:*:mybucket/*"]
+    }]
+  description = "this is a policy test"
+  force = true
+}
+
+resource "alicloud_ram_group" "group" {
+  name = "${var.name}"
+  comments = "group comments"
+  force=true
+}
+
+resource "alicloud_ram_group_policy_attachment" "attach" {
+  policy_name = "${alicloud_ram_policy.policy.name}"
+  group_name = "${alicloud_ram_group.group.name}"
+  policy_type = "${alicloud_ram_policy.policy.type}"
+}
 data "alicloud_ram_groups" "group" {
-  policy_name = "AliyunMobileTestingFullAccess"
-  policy_type = "System"
+  policy_name = "${alicloud_ram_group_policy_attachment.attach.policy_name}"
+  policy_type = "Custom"
 }`
 
 const testAccCheckAlicloudRamGroupsDataSourceForAllConfig = `
@@ -98,6 +148,11 @@ data "alicloud_ram_groups" "group" {
 }`
 
 const testAccCheckAlicloudRamGroupsDataSourceGroupNameRegexConfig = `
+resource "alicloud_ram_group" "group" {
+  name = "testAccCheckAlicloudRamGroupsDataSourceGroupNameRegexConfig"
+  comments = "group comments"
+  force=true
+}
 data "alicloud_ram_groups" "group" {
-  name_regex = "^group"
+  name_regex = "${alicloud_ram_group.group.name}"
 }`

--- a/alicloud/data_source_alicloud_ram_policies_test.go
+++ b/alicloud/data_source_alicloud_ram_policies_test.go
@@ -18,11 +18,8 @@ func TestAccAlicloudRamPoliciesDataSource_for_group(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAlicloudDataSourceID("data.alicloud_ram_policies.policy"),
 					resource.TestCheckResourceAttr("data.alicloud_ram_policies.policy", "policies.#", "1"),
-					resource.TestCheckResourceAttr("data.alicloud_ram_policies.policy", "policies.0.policy_name", "ReadOnlyAccess"),
-					resource.TestCheckResourceAttr("data.alicloud_ram_policies.policy", "policies.0.policy_type", "System"),
-					resource.TestCheckResourceAttr("data.alicloud_ram_policies.policy", "policies.0.description", "只读访问所有阿里云资源的权限"),
-					resource.TestCheckResourceAttr("data.alicloud_ram_policies.policy", "policies.0.default_version", "v2"),
-					resource.TestCheckResourceAttr("data.alicloud_ram_policies.policy", "policies.0.policy_document", "{\n    \"Version\": \"1\", \n    \"Statement\": [\n        {\n            \"Action\": [\n                \"*:Describe*\", \n                \"*:List*\", \n                \"*:Get*\", \n                \"*:BatchGet*\", \n                \"*:Query*\", \n                \"*:BatchQuery*\", \n                \"actiontrail:LookupEvents\", \n                \"dm:Desc*\", \n                \"dm:SenderStatistics*\"\n            ], \n            \"Resource\": \"*\", \n            \"Effect\": \"Allow\"\n        }\n    ]\n}"),
+					resource.TestCheckResourceAttr("data.alicloud_ram_policies.policy", "policies.0.name", "testAccCheckAlicloudRamPoliciessDataSourceForGroupConfig"),
+					resource.TestCheckResourceAttr("data.alicloud_ram_policies.policy", "policies.0.type", "Custom"),
 				),
 			},
 		},
@@ -58,25 +55,7 @@ func TestAccAlicloudRamPoliciesDataSource_for_user(t *testing.T) {
 				Config: testAccCheckAlicloudRamPoliciessDataSourceForUserConfig,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAlicloudDataSourceID("data.alicloud_ram_policies.policy"),
-					resource.TestCheckResourceAttr("data.alicloud_ram_policies.policy", "policies.#", "2"),
-				),
-			},
-		},
-	})
-}
-
-func TestAccAlicloudRamPoliciesDataSource_for_all(t *testing.T) {
-	resource.Test(t, resource.TestCase{
-		PreCheck: func() {
-			testAccPreCheck(t)
-		},
-		Providers: testAccProviders,
-		Steps: []resource.TestStep{
-			{
-				Config: testAccCheckAlicloudRamPoliciessDataSourceForAllConfig,
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAlicloudDataSourceID("data.alicloud_ram_policies.policy"),
-					resource.TestCheckResourceAttr("data.alicloud_ram_policies.policy", "policies.#", "131"),
+					resource.TestCheckResourceAttr("data.alicloud_ram_policies.policy", "policies.#", "1"),
 				),
 			},
 		},
@@ -94,7 +73,7 @@ func TestAccAlicloudRamPoliciesDataSource_policy_name_regex(t *testing.T) {
 				Config: testAccCheckAlicloudRamPoliciessDataSourcePolicyNameRegexConfig,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAlicloudDataSourceID("data.alicloud_ram_policies.policy"),
-					resource.TestCheckResourceAttr("data.alicloud_ram_policies.policy", "policies.#", "74"),
+					resource.TestCheckResourceAttr("data.alicloud_ram_policies.policy", "policies.#", "1"),
 				),
 			},
 		},
@@ -120,31 +99,148 @@ func TestAccAlicloudRamPoliciesDataSource_policy_type(t *testing.T) {
 }
 
 const testAccCheckAlicloudRamPoliciessDataSourceForGroupConfig = `
+variable "name" {
+  default = "testAccCheckAlicloudRamPoliciessDataSourceForGroupConfig"
+}
+resource "alicloud_ram_policy" "policy" {
+  name = "${var.name}"
+  statement = [
+    {
+      effect = "Deny"
+      action = [
+        "oss:ListObjects",
+        "oss:ListObjects"]
+      resource = [
+        "acs:oss:*:*:mybucket",
+        "acs:oss:*:*:mybucket/*"]
+    }]
+  description = "this is a policy test"
+  force = true
+}
+
+resource "alicloud_ram_group" "group" {
+  name = "${var.name}"
+  comments = "group comments"
+  force=true
+}
+
+resource "alicloud_ram_group_policy_attachment" "attach" {
+  policy_name = "${alicloud_ram_policy.policy.name}"
+  group_name = "${alicloud_ram_group.group.name}"
+  policy_type = "${alicloud_ram_policy.policy.type}"
+}
 data "alicloud_ram_policies" "policy" {
-  group_name = "group2"
+  group_name = "${alicloud_ram_group_policy_attachment.attach.group_name}"
 }`
 
 const testAccCheckAlicloudRamPoliciessDataSourceForRoleConfig = `
+variable "name" {
+  default = "testAccCheckAlicloudRamPoliciessDataSourceForRoleConfig"
+}
+resource "alicloud_ram_policy" "policy" {
+  name = "${var.name}"
+  statement = [
+    {
+      effect = "Deny"
+      action = [
+        "oss:ListObjects",
+        "oss:ListObjects"]
+      resource = [
+        "acs:oss:*:*:mybucket",
+        "acs:oss:*:*:mybucket/*"]
+    }]
+  description = "this is a policy test"
+  force = true
+}
+
+resource "alicloud_ram_role" "role" {
+  name = "${var.name}"
+  services = ["apigateway.aliyuncs.com", "ecs.aliyuncs.com"]
+  description = "this is a test"
+  force = true
+}
+
+resource "alicloud_ram_role_policy_attachment" "attach" {
+  policy_name = "${alicloud_ram_policy.policy.name}"
+  role_name = "${alicloud_ram_role.role.name}"
+  policy_type = "${alicloud_ram_policy.policy.type}"
+}
 data "alicloud_ram_policies" "policy" {
-  role_name = "testrole"
+  role_name = "${alicloud_ram_role_policy_attachment.attach.role_name}"
   type = "Custom"
 }`
 
 const testAccCheckAlicloudRamPoliciessDataSourceForUserConfig = `
-data "alicloud_ram_policies" "policy" {
-  user_name = "user1"
-}`
+variable "name" {
+  default = "testAccCheckAlicloudRamPoliciessDataSourceForUserConfig"
+}
+resource "alicloud_ram_policy" "policy" {
+  name = "${var.name}"
+  statement = [
+    {
+      effect = "Deny"
+      action = [
+        "oss:ListObjects",
+        "oss:ListObjects"]
+      resource = [
+        "acs:oss:*:*:mybucket",
+        "acs:oss:*:*:mybucket/*"]
+    }]
+  description = "this is a policy test"
+  force = true
+}
 
-const testAccCheckAlicloudRamPoliciessDataSourceForAllConfig = `
+resource "alicloud_ram_user" "user" {
+  name = "${var.name}"
+  display_name = "displayname"
+  mobile = "86-18888888888"
+  email = "hello.uuu@aaa.com"
+  comments = "yoyoyo"
+}
+
+resource "alicloud_ram_user_policy_attachment" "attach" {
+  policy_name = "${alicloud_ram_policy.policy.name}"
+  user_name = "${alicloud_ram_user.user.name}"
+  policy_type = "${alicloud_ram_policy.policy.type}"
+}
+
 data "alicloud_ram_policies" "policy" {
+  user_name = "${alicloud_ram_user_policy_attachment.attach.user_name}"
 }`
 
 const testAccCheckAlicloudRamPoliciessDataSourcePolicyNameRegexConfig = `
+resource "alicloud_ram_policy" "policy" {
+  name = "testAccCheckAlicloudRamPoliciessDataSourcePolicyNameRegexConfig"
+  statement = [
+    {
+      effect = "Deny"
+      action = [
+        "oss:ListObjects"]
+      resource = [
+        "acs:oss:*:*:mybucket"]
+    }]
+  description = "this is a policy test"
+  force = true
+}
 data "alicloud_ram_policies" "policy" {
-  name_regex = ".*Full.*"
+  name_regex = "${alicloud_ram_policy.policy.name}"
 }`
 
 const testAccCheckAlicloudRamPoliciessDataSourcePolicyTypeConfig = `
+resource "alicloud_ram_policy" "policy" {
+  name = "testAccCheckAlicloudRamPoliciessDataSourcePolicyNameRegexConfig"
+  statement = [
+    {
+      effect = "Deny"
+      action = [
+        "oss:ListObjects"]
+      resource = [
+        "acs:oss:*:*:mybucket"]
+    }]
+  description = "this is a policy test"
+  force = true
+}
 data "alicloud_ram_policies" "policy" {
+  name_regex = "${alicloud_ram_policy.policy.name}"
   type = "Custom"
 }`

--- a/alicloud/resource_alicloud_ram_access_key_test.go
+++ b/alicloud/resource_alicloud_ram_access_key_test.go
@@ -101,10 +101,7 @@ func testAccCheckRamAccessKeyDestroy(s *terraform.State) error {
 				}
 			}
 		}
-		if err != nil {
-			if RamEntityNotExist(err) {
-				return nil
-			}
+		if err != nil && !RamEntityNotExist(err) {
 			return err
 		}
 	}

--- a/alicloud/resource_alicloud_ram_account_alias_test.go
+++ b/alicloud/resource_alicloud_ram_account_alias_test.go
@@ -30,7 +30,7 @@ func TestAccAlicloudRamAccountAlias_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(
 						"alicloud_ram_account_alias.alias",
 						"account_alias",
-						"hallo"),
+						"testaccramaccountaliasconfig"),
 				),
 			},
 		},
@@ -75,10 +75,7 @@ func testAccCheckRamAccountAliasDestroy(s *terraform.State) error {
 
 		_, err := conn.GetAccountAlias()
 
-		if err != nil {
-			if RamEntityNotExist(err) {
-				return nil
-			}
+		if err != nil && !RamEntityNotExist(err) {
 			return err
 		}
 	}
@@ -87,5 +84,5 @@ func testAccCheckRamAccountAliasDestroy(s *terraform.State) error {
 
 const testAccRamAccountAliasConfig = `
 resource "alicloud_ram_account_alias" "alias" {
-  account_alias = "hallo"
+  account_alias = "testaccramaccountaliasconfig"
 }`

--- a/alicloud/resource_alicloud_ram_group_policy_attachment_test.go
+++ b/alicloud/resource_alicloud_ram_group_policy_attachment_test.go
@@ -90,10 +90,7 @@ func testAccCheckRamGroupPolicyAttachmentDestroy(s *terraform.State) error {
 
 		response, err := conn.ListPoliciesForGroup(request)
 
-		if err != nil {
-			if RamEntityNotExist(err) {
-				return nil
-			}
+		if err != nil && !RamEntityNotExist(err) {
 			return err
 		}
 

--- a/alicloud/resource_alicloud_ram_group_test.go
+++ b/alicloud/resource_alicloud_ram_group_test.go
@@ -2,7 +2,6 @@ package alicloud
 
 import (
 	"fmt"
-	"log"
 	"testing"
 
 	"github.com/denverdino/aliyungo/ram"
@@ -58,18 +57,15 @@ func testAccCheckRamGroupExists(n string, group *ram.Group) resource.TestCheckFu
 		client := testAccProvider.Meta().(*AliyunClient)
 		conn := client.ramconn
 
-		request := ram.GroupQueryRequest{
-			GroupName: rs.Primary.Attributes["name"],
-		}
-
-		response, err := conn.GetGroup(request)
-		log.Printf("[WARN] Group id %#v", rs.Primary.ID)
+		response, err := conn.GetGroup(ram.GroupQueryRequest{
+			GroupName: rs.Primary.ID,
+		})
 
 		if err == nil {
 			*group = response.Group
 			return nil
 		}
-		return fmt.Errorf("Error finding group %#v", rs.Primary.ID)
+		return fmt.Errorf("Error finding group %#v", err)
 	}
 }
 
@@ -85,15 +81,12 @@ func testAccCheckRamGroupDestroy(s *terraform.State) error {
 		conn := client.ramconn
 
 		request := ram.GroupQueryRequest{
-			GroupName: rs.Primary.Attributes["name"],
+			GroupName: rs.Primary.ID,
 		}
 
 		_, err := conn.GetGroup(request)
 
-		if err != nil {
-			if RamEntityNotExist(err) {
-				return nil
-			}
+		if err != nil && !RamEntityNotExist(err) {
 			return err
 		}
 	}

--- a/alicloud/resource_alicloud_ram_login_profile_test.go
+++ b/alicloud/resource_alicloud_ram_login_profile_test.go
@@ -83,10 +83,7 @@ func testAccCheckRamLoginProfileDestroy(s *terraform.State) error {
 
 		_, err := conn.GetLoginProfile(request)
 
-		if err != nil {
-			if RamEntityNotExist(err) {
-				return nil
-			}
+		if err != nil && !RamEntityNotExist(err) {
 			return err
 		}
 	}

--- a/alicloud/resource_alicloud_ram_policy_test.go
+++ b/alicloud/resource_alicloud_ram_policy_test.go
@@ -92,10 +92,7 @@ func testAccCheckRamPolicyDestroy(s *terraform.State) error {
 
 		_, err := conn.GetPolicy(request)
 
-		if err != nil {
-			if RamEntityNotExist(err) {
-				return nil
-			}
+		if err != nil && !RamEntityNotExist(err) {
 			return err
 		}
 	}

--- a/alicloud/resource_alicloud_ram_role_policy_attachment_test.go
+++ b/alicloud/resource_alicloud_ram_role_policy_attachment_test.go
@@ -90,10 +90,7 @@ func testAccCheckRamRolePolicyAttachmentDestroy(s *terraform.State) error {
 
 		response, err := conn.ListPoliciesForRole(request)
 
-		if err != nil {
-			if RamEntityNotExist(err) {
-				return nil
-			}
+		if err != nil && !RamEntityNotExist(err) {
 			return err
 		}
 
@@ -128,7 +125,6 @@ resource "alicloud_ram_policy" "policy" {
 resource "alicloud_ram_role" "role" {
   name = "rolename"
   services = ["apigateway.aliyuncs.com", "ecs.aliyuncs.com"]
-  ram_users = ["acs:ram::123456789:root", "acs:ram::1234567890:user/username"]
   description = "this is a test"
   force = true
 }

--- a/alicloud/resource_alicloud_ram_role_test.go
+++ b/alicloud/resource_alicloud_ram_role_test.go
@@ -90,10 +90,7 @@ func testAccCheckRamRoleDestroy(s *terraform.State) error {
 
 		_, err := conn.GetRole(request)
 
-		if err != nil {
-			if RamEntityNotExist(err) {
-				return nil
-			}
+		if err != nil && !RamEntityNotExist(err) {
 			return err
 		}
 	}
@@ -104,7 +101,6 @@ const testAccRamRoleConfig = `
 resource "alicloud_ram_role" "role" {
   name = "rolename"
   services = ["apigateway.aliyuncs.com", "ecs.aliyuncs.com"]
-  ram_users = ["acs:ram::123456789:root", "acs:ram::1234567890:user/username"]
   description = "this is a test"
   force = true
 }`

--- a/alicloud/resource_alicloud_ram_user_test.go
+++ b/alicloud/resource_alicloud_ram_user_test.go
@@ -94,10 +94,7 @@ func testAccCheckRamUserDestroy(s *terraform.State) error {
 
 		_, err := conn.GetUser(request)
 
-		if err != nil {
-			if RamEntityNotExist(err) {
-				return nil
-			}
+		if err != nil && !RamEntityNotExist(err) {
 			return err
 		}
 	}


### PR DESCRIPTION
```
TF_ACC=1 go test ./alicloud -v -run=TestAccAlicloudRam -timeout=240m
=== RUN   TestAccAlicloudRamAccountAliasDataSource_basic
--- PASS: TestAccAlicloudRamAccountAliasDataSource_basic (2.70s)
=== RUN   TestAccAlicloudRamGroupsDataSource_for_user
--- PASS: TestAccAlicloudRamGroupsDataSource_for_user (6.27s)
=== RUN   TestAccAlicloudRamGroupsDataSource_for_policy
--- PASS: TestAccAlicloudRamGroupsDataSource_for_policy (5.61s)
=== RUN   TestAccAlicloudRamGroupsDataSource_for_all
--- PASS: TestAccAlicloudRamGroupsDataSource_for_all (2.43s)
=== RUN   TestAccAlicloudRamGroupsDataSource_group_name_regex
--- PASS: TestAccAlicloudRamGroupsDataSource_group_name_regex (3.71s)
=== RUN   TestAccAlicloudRamPoliciesDataSource_for_group
--- PASS: TestAccAlicloudRamPoliciesDataSource_for_group (8.31s)
=== RUN   TestAccAlicloudRamPoliciesDataSource_for_role
--- PASS: TestAccAlicloudRamPoliciesDataSource_for_role (7.14s)
=== RUN   TestAccAlicloudRamPoliciesDataSource_for_user
--- PASS: TestAccAlicloudRamPoliciesDataSource_for_user (7.32s)
=== RUN   TestAccAlicloudRamPoliciesDataSource_policy_name_regex
--- PASS: TestAccAlicloudRamPoliciesDataSource_policy_name_regex (6.35s)
=== RUN   TestAccAlicloudRamPoliciesDataSource_policy_type
--- PASS: TestAccAlicloudRamPoliciesDataSource_policy_type (5.74s)
=== RUN   TestAccAlicloudRamRolesDataSource_for_policy
--- PASS: TestAccAlicloudRamRolesDataSource_for_policy (6.04s)
=== RUN   TestAccAlicloudRamRolesDataSource_for_all
--- PASS: TestAccAlicloudRamRolesDataSource_for_all (30.15s)
=== RUN   TestAccAlicloudRamRolesDataSource_role_name_regex
--- PASS: TestAccAlicloudRamRolesDataSource_role_name_regex (4.21s)
=== RUN   TestAccAlicloudRamUsersDataSource_for_group
--- PASS: TestAccAlicloudRamUsersDataSource_for_group (5.78s)
=== RUN   TestAccAlicloudRamUsersDataSource_for_policy
--- PASS: TestAccAlicloudRamUsersDataSource_for_policy (5.86s)
=== RUN   TestAccAlicloudRamUsersDataSource_for_all
--- PASS: TestAccAlicloudRamUsersDataSource_for_all (2.47s)
=== RUN   TestAccAlicloudRamUsersDataSource_user_name_regex
--- PASS: TestAccAlicloudRamUsersDataSource_user_name_regex (3.91s)
=== RUN   TestAccAlicloudRamLoginProfile_importBasic
--- PASS: TestAccAlicloudRamLoginProfile_importBasic (4.67s)
=== RUN   TestAccAlicloudRamPolicy_importBasic
--- PASS: TestAccAlicloudRamPolicy_importBasic (3.72s)
=== RUN   TestAccAlicloudRamRole_importBasic
--- PASS: TestAccAlicloudRamRole_importBasic (3.47s)
=== RUN   TestAccAlicloudRamUser_importBasic
--- PASS: TestAccAlicloudRamUser_importBasic (3.18s)
=== RUN   TestAccAlicloudRamAccessKey_basic
--- PASS: TestAccAlicloudRamAccessKey_basic (4.70s)
=== RUN   TestAccAlicloudRamAccountAlias_basic
--- PASS: TestAccAlicloudRamAccountAlias_basic (2.60s)
=== RUN   TestAccAlicloudRamGroupMembership_basic
--- PASS: TestAccAlicloudRamGroupMembership_basic (4.98s)
=== RUN   TestAccAlicloudRamGroupPolicyAttachment_basic
--- PASS: TestAccAlicloudRamGroupPolicyAttachment_basic (4.66s)
=== RUN   TestAccAlicloudRamGroup_basic
--- PASS: TestAccAlicloudRamGroup_basic (3.17s)
=== RUN   TestAccAlicloudRamLoginProfile_basic
--- PASS: TestAccAlicloudRamLoginProfile_basic (4.14s)
=== RUN   TestAccAlicloudRamPolicy_basic
--- PASS: TestAccAlicloudRamPolicy_basic (3.37s)
=== RUN   TestAccAlicloudRamRoleAttachment_basic
--- PASS: TestAccAlicloudRamRoleAttachment_basic (117.58s)
=== RUN   TestAccAlicloudRamRolePolicyAttachment_basic
--- PASS: TestAccAlicloudRamRolePolicyAttachment_basic (4.69s)
=== RUN   TestAccAlicloudRamRole_basic
--- PASS: TestAccAlicloudRamRole_basic (3.23s)
=== RUN   TestAccAlicloudRamUserPolicyAttachment_basic
--- PASS: TestAccAlicloudRamUserPolicyAttachment_basic (5.33s)
=== RUN   TestAccAlicloudRamUser_basic
--- PASS: TestAccAlicloudRamUser_basic (2.90s)
PASS
ok  	github.com/alibaba/terraform-provider/alicloud	290.457s
```