### PR TITLE
Improve security group resource test case

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 IMPROVEMENTS:
 
+- Improve security group resource test case ([#203](https://github.com/terraform-providers/terraform-provider-alicloud/pull/203))
 - Improve ram resource test case ([#202](https://github.com/terraform-providers/terraform-provider-alicloud/pull/202))
 - Improve container cluster resource test case ([#201](https://github.com/terraform-providers/terraform-provider-alicloud/pull/201))
 - Improve cloud monitor resource test case ([#200](https://github.com/terraform-providers/terraform-provider-alicloud/pull/200))

--- a/alicloud/import_alicloud_security_group_test.go
+++ b/alicloud/import_alicloud_security_group_test.go
@@ -12,7 +12,7 @@ func TestAccAlicloudSecurityGroup_importBasic(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckInstanceDestroy,
+		CheckDestroy: testAccCheckSecurityGroupDestroy,
 		Steps: []resource.TestStep{
 			resource.TestStep{
 				Config: testAccSecurityGroupConfig,
@@ -33,7 +33,7 @@ func TestAccAlicloudSecurityGroup_importWithVpc(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckInstanceDestroy,
+		CheckDestroy: testAccCheckSecurityGroupDestroy,
 		Steps: []resource.TestStep{
 			resource.TestStep{
 				Config: testAccSecurityGroupConfig_withVpc,

--- a/alicloud/resource_alicloud_security_group_rule_test.go
+++ b/alicloud/resource_alicloud_security_group_rule_test.go
@@ -367,11 +367,7 @@ func testAccCheckSecurityGroupRuleDestroy(s *terraform.State) error {
 		_, err = client.DescribeSecurityGroupRule(parts[0], parts[1], parts[2], parts[3], parts[4], parts[5], parts[6], prior)
 
 		// Verify the error is what we want
-		if err != nil {
-			// Verify the error is what we want
-			if IsExceptedErrors(err, []string{InvalidSecurityGroupIdNotFound}) {
-				continue
-			}
+		if err != nil && !IsExceptedErrors(err, []string{InvalidSecurityGroupIdNotFound}) {
 			return err
 		}
 	}

--- a/alicloud/resource_alicloud_security_group_test.go
+++ b/alicloud/resource_alicloud_security_group_test.go
@@ -112,7 +112,7 @@ func testAccCheckSecurityGroupDestroy(s *terraform.State) error {
 
 		if err != nil {
 			if NotFoundError(err) || IsExceptedErrors(err, []string{InvalidSecurityGroupIdNotFound}) {
-				return nil
+				continue
 			}
 			return err
 		}


### PR DESCRIPTION
```
TF_ACC=1 go test ./alicloud -v -run=TestAccAlicloudSecurity -timeout=240m
=== RUN   TestAccAlicloudSecurityGroupRulesDataSource
--- PASS: TestAccAlicloudSecurityGroupRulesDataSource (13.80s)
=== RUN   TestAccAlicloudSecurityGroupsDataSource
--- PASS: TestAccAlicloudSecurityGroupsDataSource (7.73s)
=== RUN   TestAccAlicloudSecurityGroup_importBasic
--- PASS: TestAccAlicloudSecurityGroup_importBasic (3.30s)
=== RUN   TestAccAlicloudSecurityGroup_importWithVpc
--- PASS: TestAccAlicloudSecurityGroup_importWithVpc (13.93s)
=== RUN   TestAccAlicloudSecurityGroupRule_Ingress
--- PASS: TestAccAlicloudSecurityGroupRule_Ingress (8.50s)
=== RUN   TestAccAlicloudSecurityGroupRule_Egress
--- PASS: TestAccAlicloudSecurityGroupRule_Egress (4.67s)
=== RUN   TestAccAlicloudSecurityGroupRule_EgressDefaultNicType
--- PASS: TestAccAlicloudSecurityGroupRule_EgressDefaultNicType (6.81s)
=== RUN   TestAccAlicloudSecurityGroupRule_Vpc_Ingress
--- PASS: TestAccAlicloudSecurityGroupRule_Vpc_Ingress (12.39s)
=== RUN   TestAccAlicloudSecurityGroupRule_MissParameterSourceCidrIp
--- PASS: TestAccAlicloudSecurityGroupRule_MissParameterSourceCidrIp (4.33s)
=== RUN   TestAccAlicloudSecurityGroupRule_SourceSecurityGroup
--- PASS: TestAccAlicloudSecurityGroupRule_SourceSecurityGroup (4.75s)
=== RUN   TestAccAlicloudSecurityGroupRule_Multi
--- PASS: TestAccAlicloudSecurityGroupRule_Multi (22.28s)
=== RUN   TestAccAlicloudSecurityGroupRule_MultiAttri
--- PASS: TestAccAlicloudSecurityGroupRule_MultiAttri (15.53s)
=== RUN   TestAccAlicloudSecurityGroup_basic
--- PASS: TestAccAlicloudSecurityGroup_basic (2.78s)
=== RUN   TestAccAlicloudSecurityGroup_withVpc
--- PASS: TestAccAlicloudSecurityGroup_withVpc (10.97s)
PASS
ok  	github.com/alibaba/terraform-provider/alicloud	131.805s
```