### PR TITLE
Improve vpc and vswitch resource test case

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 IMPROVEMENTS:
 
+- Improve vpc and vswitch resource test case ([#205](https://github.com/terraform-providers/terraform-provider-alicloud/pull/205))
 - Improve slb resource test case ([#204](https://github.com/terraform-providers/terraform-provider-alicloud/pull/204))
 - Improve security group resource test case ([#203](https://github.com/terraform-providers/terraform-provider-alicloud/pull/203))
 - Improve ram resource test case ([#202](https://github.com/terraform-providers/terraform-provider-alicloud/pull/202))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 IMPROVEMENTS:
 
+- Improve slb resource test case ([#204](https://github.com/terraform-providers/terraform-provider-alicloud/pull/204))
 - Improve security group resource test case ([#203](https://github.com/terraform-providers/terraform-provider-alicloud/pull/203))
 - Improve ram resource test case ([#202](https://github.com/terraform-providers/terraform-provider-alicloud/pull/202))
 - Improve container cluster resource test case ([#201](https://github.com/terraform-providers/terraform-provider-alicloud/pull/201))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 IMPROVEMENTS:
 
+- Improve ots table resource test case ([#196](https://github.com/terraform-providers/terraform-provider-alicloud/pull/196))
 - Improve nat gateway resource test case ([#195](https://github.com/terraform-providers/terraform-provider-alicloud/pull/195))
 - Improve log resource test case ([#194](https://github.com/terraform-providers/terraform-provider-alicloud/pull/194))
 - Support changing ecs charge type from Prepaid to PostPaid ([#192](https://github.com/terraform-providers/terraform-provider-alicloud/pull/192))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 IMPROVEMENTS:
 
+- Improve cloud monitor resource test case ([#200](https://github.com/terraform-providers/terraform-provider-alicloud/pull/200))
 - Improve route and router interface resource test case ([#199](https://github.com/terraform-providers/terraform-provider-alicloud/pull/199))
 - Improve dns resource test case ([#198](https://github.com/terraform-providers/terraform-provider-alicloud/pull/198))
 - Improve oss resource test case ([#197](https://github.com/terraform-providers/terraform-provider-alicloud/pull/197))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 IMPROVEMENTS:
 
+- Improve security group resource test case ([#203](https://github.com/terraform-providers/terraform-provider-alicloud/pull/203))
 - Improve ram resource test case ([#202](https://github.com/terraform-providers/terraform-provider-alicloud/pull/202))
 - Improve container cluster resource test case ([#201](https://github.com/terraform-providers/terraform-provider-alicloud/pull/201))
 - Improve cloud monitor resource test case ([#200](https://github.com/terraform-providers/terraform-provider-alicloud/pull/200))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 IMPROVEMENTS:
 
+- Improve ram resource test case ([#202](https://github.com/terraform-providers/terraform-provider-alicloud/pull/202))
 - Improve container cluster resource test case ([#201](https://github.com/terraform-providers/terraform-provider-alicloud/pull/201))
 - Improve cloud monitor resource test case ([#200](https://github.com/terraform-providers/terraform-provider-alicloud/pull/200))
 - Improve route and router interface resource test case ([#199](https://github.com/terraform-providers/terraform-provider-alicloud/pull/199))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 IMPROVEMENTS:
 
+- Improve dns resource test case ([#198](https://github.com/terraform-providers/terraform-provider-alicloud/pull/198))
 - Improve oss resource test case ([#197](https://github.com/terraform-providers/terraform-provider-alicloud/pull/197))
 - Improve ots table resource test case ([#196](https://github.com/terraform-providers/terraform-provider-alicloud/pull/196))
 - Improve nat gateway resource test case ([#195](https://github.com/terraform-providers/terraform-provider-alicloud/pull/195))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 IMPROVEMENTS:
 
+- Improve log resource test case ([#194](https://github.com/terraform-providers/terraform-provider-alicloud/pull/194))
 - Support changing ecs charge type from Prepaid to PostPaid ([#192](https://github.com/terraform-providers/terraform-provider-alicloud/pull/192))
 - Add method to compare json template is equal ([#187](https://github.com/terraform-providers/terraform-provider-alicloud/pull/187))
 - Remove useless file ([#191](https://github.com/terraform-providers/terraform-provider-alicloud/pull/191))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 IMPROVEMENTS:
 
+- Improve oss resource test case ([#197](https://github.com/terraform-providers/terraform-provider-alicloud/pull/197))
 - Improve ots table resource test case ([#196](https://github.com/terraform-providers/terraform-provider-alicloud/pull/196))
 - Improve nat gateway resource test case ([#195](https://github.com/terraform-providers/terraform-provider-alicloud/pull/195))
 - Improve log resource test case ([#194](https://github.com/terraform-providers/terraform-provider-alicloud/pull/194))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 IMPROVEMENTS:
 
+- Improve container cluster resource test case ([#201](https://github.com/terraform-providers/terraform-provider-alicloud/pull/201))
 - Improve cloud monitor resource test case ([#200](https://github.com/terraform-providers/terraform-provider-alicloud/pull/200))
 - Improve route and router interface resource test case ([#199](https://github.com/terraform-providers/terraform-provider-alicloud/pull/199))
 - Improve dns resource test case ([#198](https://github.com/terraform-providers/terraform-provider-alicloud/pull/198))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 IMPROVEMENTS:
 
+- Improve route and router interface resource test case ([#199](https://github.com/terraform-providers/terraform-provider-alicloud/pull/199))
 - Improve dns resource test case ([#198](https://github.com/terraform-providers/terraform-provider-alicloud/pull/198))
 - Improve oss resource test case ([#197](https://github.com/terraform-providers/terraform-provider-alicloud/pull/197))
 - Improve ots table resource test case ([#196](https://github.com/terraform-providers/terraform-provider-alicloud/pull/196))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 IMPROVEMENTS:
 
+- Improve nat gateway resource test case ([#195](https://github.com/terraform-providers/terraform-provider-alicloud/pull/195))
 - Improve log resource test case ([#194](https://github.com/terraform-providers/terraform-provider-alicloud/pull/194))
 - Support changing ecs charge type from Prepaid to PostPaid ([#192](https://github.com/terraform-providers/terraform-provider-alicloud/pull/192))
 - Add method to compare json template is equal ([#187](https://github.com/terraform-providers/terraform-provider-alicloud/pull/187))

--- a/alicloud/data_source_alicloud_dns_domains_test.go
+++ b/alicloud/data_source_alicloud_dns_domains_test.go
@@ -25,24 +25,6 @@ func TestAccAlicloudDnsDomainsDataSource_ali_domain(t *testing.T) {
 	})
 }
 
-func TestAccAlicloudDnsDomainsDataSource_version_code(t *testing.T) {
-	resource.Test(t, resource.TestCase{
-		PreCheck: func() {
-			testAccPreCheck(t)
-		},
-		Providers: testAccProviders,
-		Steps: []resource.TestStep{
-			{
-				Config: testAccCheckAlicloudDomainsDataSourceVersionCodeConfig,
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAlicloudDataSourceID("data.alicloud_dns_domains.domain"),
-					resource.TestCheckResourceAttr("data.alicloud_dns_domains.domain", "domains.#", "1"),
-				),
-			},
-		},
-	})
-}
-
 func TestAccAlicloudDnsDomainsDataSource_name_regex(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
@@ -61,40 +43,15 @@ func TestAccAlicloudDnsDomainsDataSource_name_regex(t *testing.T) {
 	})
 }
 
-func TestAccAlicloudDnsDomainsDataSource_group_name_regex(t *testing.T) {
-	resource.Test(t, resource.TestCase{
-		PreCheck: func() {
-			testAccPreCheck(t)
-		},
-		Providers: testAccProviders,
-		Steps: []resource.TestStep{
-			{
-				Config: testAccCheckAlicloudDomainsDataSourceGroupNameRegexConfig,
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAlicloudDataSourceID("data.alicloud_dns_domains.domain"),
-					resource.TestCheckResourceAttr("data.alicloud_dns_domains.domain", "domains.#", "2"),
-				),
-			},
-		},
-	})
-}
-
 const testAccCheckAlicloudDomainsDataSourceAliDomainConfig = `
 data "alicloud_dns_domains" "domain" {
   ali_domain = true
 }`
 
-const testAccCheckAlicloudDomainsDataSourceVersionCodeConfig = `
-data "alicloud_dns_domains" "domain" {
-  version_code = "mianfei"
-}`
-
 const testAccCheckAlicloudDomainsDataSourceNameRegexConfig = `
+resource "alicloud_dns" "dns" {
+  name = "yufish.com"
+}
 data "alicloud_dns_domains" "domain" {
-  domain_name_regex = ".*"
-}`
-
-const testAccCheckAlicloudDomainsDataSourceGroupNameRegexConfig = `
-data "alicloud_dns_domains" "domain" {
-  group_name_regex = ".*"
+  domain_name_regex = "${alicloud_dns.dns.name}"
 }`

--- a/alicloud/data_source_alicloud_dns_groups_test.go
+++ b/alicloud/data_source_alicloud_dns_groups_test.go
@@ -18,7 +18,7 @@ func TestAccAlicloudDnsGroupsDataSource_name_regex(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAlicloudDataSourceID("data.alicloud_dns_groups.group"),
 					resource.TestCheckResourceAttr("data.alicloud_dns_groups.group", "groups.#", "1"),
-					resource.TestCheckResourceAttr("data.alicloud_dns_groups.group", "groups.0.group_name", "ALL\n"),
+					resource.TestCheckResourceAttr("data.alicloud_dns_groups.group", "groups.0.group_name", "ALL"),
 				),
 			},
 		},

--- a/alicloud/data_source_alicloud_ram_account_alias_test.go
+++ b/alicloud/data_source_alicloud_ram_account_alias_test.go
@@ -17,7 +17,6 @@ func TestAccAlicloudRamAccountAliasDataSource_basic(t *testing.T) {
 				Config: testAccCheckAlicloudAccountAliasDataSourceBasic,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAlicloudDataSourceID("data.alicloud_ram_account_aliases.alias"),
-					resource.TestCheckResourceAttr("data.alicloud_ram_account_aliases.alias", "account_alias", "1307087942598154"),
 				),
 			},
 		},

--- a/alicloud/data_source_alicloud_ram_groups_test.go
+++ b/alicloud/data_source_alicloud_ram_groups_test.go
@@ -18,8 +18,8 @@ func TestAccAlicloudRamGroupsDataSource_for_user(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAlicloudDataSourceID("data.alicloud_ram_groups.group"),
 					resource.TestCheckResourceAttr("data.alicloud_ram_groups.group", "groups.#", "1"),
-					resource.TestCheckResourceAttr("data.alicloud_ram_groups.group", "groups.0.name", "group3"),
-					resource.TestCheckResourceAttr("data.alicloud_ram_groups.group", "groups.0.comments", "33"),
+					resource.TestCheckResourceAttr("data.alicloud_ram_groups.group", "groups.0.name", "testAccCheckAlicloudRamGroupsDataSourceForUserConfig"),
+					resource.TestCheckResourceAttr("data.alicloud_ram_groups.group", "groups.0.comments", "group comments"),
 				),
 			},
 		},
@@ -38,8 +38,8 @@ func TestAccAlicloudRamGroupsDataSource_for_policy(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAlicloudDataSourceID("data.alicloud_ram_groups.group"),
 					resource.TestCheckResourceAttr("data.alicloud_ram_groups.group", "groups.#", "1"),
-					resource.TestCheckResourceAttr("data.alicloud_ram_groups.group", "groups.0.name", "group1"),
-					resource.TestCheckResourceAttr("data.alicloud_ram_groups.group", "groups.0.comments", "1"),
+					resource.TestCheckResourceAttr("data.alicloud_ram_groups.group", "groups.0.name", "testAccCheckAlicloudRamGroupsDataSourceForPolicyConfig"),
+					resource.TestCheckResourceAttr("data.alicloud_ram_groups.group", "groups.0.comments", "group comments"),
 				),
 			},
 		},
@@ -57,7 +57,6 @@ func TestAccAlicloudRamGroupsDataSource_for_all(t *testing.T) {
 				Config: testAccCheckAlicloudRamGroupsDataSourceForAllConfig,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAlicloudDataSourceID("data.alicloud_ram_groups.group"),
-					resource.TestCheckResourceAttr("data.alicloud_ram_groups.group", "groups.#", "5"),
 				),
 			},
 		},
@@ -75,7 +74,7 @@ func TestAccAlicloudRamGroupsDataSource_group_name_regex(t *testing.T) {
 				Config: testAccCheckAlicloudRamGroupsDataSourceGroupNameRegexConfig,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAlicloudDataSourceID("data.alicloud_ram_groups.group"),
-					resource.TestCheckResourceAttr("data.alicloud_ram_groups.group", "groups.#", "4"),
+					resource.TestCheckResourceAttr("data.alicloud_ram_groups.group", "groups.#", "1"),
 				),
 			},
 		},
@@ -83,14 +82,65 @@ func TestAccAlicloudRamGroupsDataSource_group_name_regex(t *testing.T) {
 }
 
 const testAccCheckAlicloudRamGroupsDataSourceForUserConfig = `
+variable "name" {
+  default = "testAccCheckAlicloudRamGroupsDataSourceForUserConfig"
+}
+resource "alicloud_ram_user" "user" {
+  name = "${var.name}"
+  display_name = "displayname"
+  mobile = "86-18888888888"
+  email = "hello.uuu@aaa.com"
+  comments = "yoyoyo"
+}
+
+resource "alicloud_ram_group" "group" {
+  name = "${var.name}"
+  comments = "group comments"
+  force=true
+}
+resource "alicloud_ram_group_membership" "membership" {
+  group_name = "${alicloud_ram_group.group.name}"
+  user_names = ["${alicloud_ram_user.user.name}"]
+}
+
 data "alicloud_ram_groups" "group" {
-  user_name = "user1"
+  user_name = "${alicloud_ram_group_membership.membership.user_names[0]}"
 }`
 
 const testAccCheckAlicloudRamGroupsDataSourceForPolicyConfig = `
+variable "name" {
+  default = "testAccCheckAlicloudRamGroupsDataSourceForPolicyConfig"
+}
+resource "alicloud_ram_policy" "policy" {
+  name = "${var.name}"
+  statement = [
+    {
+      effect = "Deny"
+      action = [
+        "oss:ListObjects",
+        "oss:ListObjects"]
+      resource = [
+        "acs:oss:*:*:mybucket",
+        "acs:oss:*:*:mybucket/*"]
+    }]
+  description = "this is a policy test"
+  force = true
+}
+
+resource "alicloud_ram_group" "group" {
+  name = "${var.name}"
+  comments = "group comments"
+  force=true
+}
+
+resource "alicloud_ram_group_policy_attachment" "attach" {
+  policy_name = "${alicloud_ram_policy.policy.name}"
+  group_name = "${alicloud_ram_group.group.name}"
+  policy_type = "${alicloud_ram_policy.policy.type}"
+}
 data "alicloud_ram_groups" "group" {
-  policy_name = "AliyunMobileTestingFullAccess"
-  policy_type = "System"
+  policy_name = "${alicloud_ram_group_policy_attachment.attach.policy_name}"
+  policy_type = "Custom"
 }`
 
 const testAccCheckAlicloudRamGroupsDataSourceForAllConfig = `
@@ -98,6 +148,11 @@ data "alicloud_ram_groups" "group" {
 }`
 
 const testAccCheckAlicloudRamGroupsDataSourceGroupNameRegexConfig = `
+resource "alicloud_ram_group" "group" {
+  name = "testAccCheckAlicloudRamGroupsDataSourceGroupNameRegexConfig"
+  comments = "group comments"
+  force=true
+}
 data "alicloud_ram_groups" "group" {
-  name_regex = "^group"
+  name_regex = "${alicloud_ram_group.group.name}"
 }`

--- a/alicloud/data_source_alicloud_ram_policies_test.go
+++ b/alicloud/data_source_alicloud_ram_policies_test.go
@@ -18,11 +18,8 @@ func TestAccAlicloudRamPoliciesDataSource_for_group(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAlicloudDataSourceID("data.alicloud_ram_policies.policy"),
 					resource.TestCheckResourceAttr("data.alicloud_ram_policies.policy", "policies.#", "1"),
-					resource.TestCheckResourceAttr("data.alicloud_ram_policies.policy", "policies.0.policy_name", "ReadOnlyAccess"),
-					resource.TestCheckResourceAttr("data.alicloud_ram_policies.policy", "policies.0.policy_type", "System"),
-					resource.TestCheckResourceAttr("data.alicloud_ram_policies.policy", "policies.0.description", "只读访问所有阿里云资源的权限"),
-					resource.TestCheckResourceAttr("data.alicloud_ram_policies.policy", "policies.0.default_version", "v2"),
-					resource.TestCheckResourceAttr("data.alicloud_ram_policies.policy", "policies.0.policy_document", "{\n    \"Version\": \"1\", \n    \"Statement\": [\n        {\n            \"Action\": [\n                \"*:Describe*\", \n                \"*:List*\", \n                \"*:Get*\", \n                \"*:BatchGet*\", \n                \"*:Query*\", \n                \"*:BatchQuery*\", \n                \"actiontrail:LookupEvents\", \n                \"dm:Desc*\", \n                \"dm:SenderStatistics*\"\n            ], \n            \"Resource\": \"*\", \n            \"Effect\": \"Allow\"\n        }\n    ]\n}"),
+					resource.TestCheckResourceAttr("data.alicloud_ram_policies.policy", "policies.0.name", "testAccCheckAlicloudRamPoliciessDataSourceForGroupConfig"),
+					resource.TestCheckResourceAttr("data.alicloud_ram_policies.policy", "policies.0.type", "Custom"),
 				),
 			},
 		},
@@ -58,25 +55,7 @@ func TestAccAlicloudRamPoliciesDataSource_for_user(t *testing.T) {
 				Config: testAccCheckAlicloudRamPoliciessDataSourceForUserConfig,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAlicloudDataSourceID("data.alicloud_ram_policies.policy"),
-					resource.TestCheckResourceAttr("data.alicloud_ram_policies.policy", "policies.#", "2"),
-				),
-			},
-		},
-	})
-}
-
-func TestAccAlicloudRamPoliciesDataSource_for_all(t *testing.T) {
-	resource.Test(t, resource.TestCase{
-		PreCheck: func() {
-			testAccPreCheck(t)
-		},
-		Providers: testAccProviders,
-		Steps: []resource.TestStep{
-			{
-				Config: testAccCheckAlicloudRamPoliciessDataSourceForAllConfig,
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAlicloudDataSourceID("data.alicloud_ram_policies.policy"),
-					resource.TestCheckResourceAttr("data.alicloud_ram_policies.policy", "policies.#", "131"),
+					resource.TestCheckResourceAttr("data.alicloud_ram_policies.policy", "policies.#", "1"),
 				),
 			},
 		},
@@ -94,7 +73,7 @@ func TestAccAlicloudRamPoliciesDataSource_policy_name_regex(t *testing.T) {
 				Config: testAccCheckAlicloudRamPoliciessDataSourcePolicyNameRegexConfig,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAlicloudDataSourceID("data.alicloud_ram_policies.policy"),
-					resource.TestCheckResourceAttr("data.alicloud_ram_policies.policy", "policies.#", "74"),
+					resource.TestCheckResourceAttr("data.alicloud_ram_policies.policy", "policies.#", "1"),
 				),
 			},
 		},
@@ -120,31 +99,148 @@ func TestAccAlicloudRamPoliciesDataSource_policy_type(t *testing.T) {
 }
 
 const testAccCheckAlicloudRamPoliciessDataSourceForGroupConfig = `
+variable "name" {
+  default = "testAccCheckAlicloudRamPoliciessDataSourceForGroupConfig"
+}
+resource "alicloud_ram_policy" "policy" {
+  name = "${var.name}"
+  statement = [
+    {
+      effect = "Deny"
+      action = [
+        "oss:ListObjects",
+        "oss:ListObjects"]
+      resource = [
+        "acs:oss:*:*:mybucket",
+        "acs:oss:*:*:mybucket/*"]
+    }]
+  description = "this is a policy test"
+  force = true
+}
+
+resource "alicloud_ram_group" "group" {
+  name = "${var.name}"
+  comments = "group comments"
+  force=true
+}
+
+resource "alicloud_ram_group_policy_attachment" "attach" {
+  policy_name = "${alicloud_ram_policy.policy.name}"
+  group_name = "${alicloud_ram_group.group.name}"
+  policy_type = "${alicloud_ram_policy.policy.type}"
+}
 data "alicloud_ram_policies" "policy" {
-  group_name = "group2"
+  group_name = "${alicloud_ram_group_policy_attachment.attach.group_name}"
 }`
 
 const testAccCheckAlicloudRamPoliciessDataSourceForRoleConfig = `
+variable "name" {
+  default = "testAccCheckAlicloudRamPoliciessDataSourceForRoleConfig"
+}
+resource "alicloud_ram_policy" "policy" {
+  name = "${var.name}"
+  statement = [
+    {
+      effect = "Deny"
+      action = [
+        "oss:ListObjects",
+        "oss:ListObjects"]
+      resource = [
+        "acs:oss:*:*:mybucket",
+        "acs:oss:*:*:mybucket/*"]
+    }]
+  description = "this is a policy test"
+  force = true
+}
+
+resource "alicloud_ram_role" "role" {
+  name = "${var.name}"
+  services = ["apigateway.aliyuncs.com", "ecs.aliyuncs.com"]
+  description = "this is a test"
+  force = true
+}
+
+resource "alicloud_ram_role_policy_attachment" "attach" {
+  policy_name = "${alicloud_ram_policy.policy.name}"
+  role_name = "${alicloud_ram_role.role.name}"
+  policy_type = "${alicloud_ram_policy.policy.type}"
+}
 data "alicloud_ram_policies" "policy" {
-  role_name = "testrole"
+  role_name = "${alicloud_ram_role_policy_attachment.attach.role_name}"
   type = "Custom"
 }`
 
 const testAccCheckAlicloudRamPoliciessDataSourceForUserConfig = `
-data "alicloud_ram_policies" "policy" {
-  user_name = "user1"
-}`
+variable "name" {
+  default = "testAccCheckAlicloudRamPoliciessDataSourceForUserConfig"
+}
+resource "alicloud_ram_policy" "policy" {
+  name = "${var.name}"
+  statement = [
+    {
+      effect = "Deny"
+      action = [
+        "oss:ListObjects",
+        "oss:ListObjects"]
+      resource = [
+        "acs:oss:*:*:mybucket",
+        "acs:oss:*:*:mybucket/*"]
+    }]
+  description = "this is a policy test"
+  force = true
+}
 
-const testAccCheckAlicloudRamPoliciessDataSourceForAllConfig = `
+resource "alicloud_ram_user" "user" {
+  name = "${var.name}"
+  display_name = "displayname"
+  mobile = "86-18888888888"
+  email = "hello.uuu@aaa.com"
+  comments = "yoyoyo"
+}
+
+resource "alicloud_ram_user_policy_attachment" "attach" {
+  policy_name = "${alicloud_ram_policy.policy.name}"
+  user_name = "${alicloud_ram_user.user.name}"
+  policy_type = "${alicloud_ram_policy.policy.type}"
+}
+
 data "alicloud_ram_policies" "policy" {
+  user_name = "${alicloud_ram_user_policy_attachment.attach.user_name}"
 }`
 
 const testAccCheckAlicloudRamPoliciessDataSourcePolicyNameRegexConfig = `
+resource "alicloud_ram_policy" "policy" {
+  name = "testAccCheckAlicloudRamPoliciessDataSourcePolicyNameRegexConfig"
+  statement = [
+    {
+      effect = "Deny"
+      action = [
+        "oss:ListObjects"]
+      resource = [
+        "acs:oss:*:*:mybucket"]
+    }]
+  description = "this is a policy test"
+  force = true
+}
 data "alicloud_ram_policies" "policy" {
-  name_regex = ".*Full.*"
+  name_regex = "${alicloud_ram_policy.policy.name}"
 }`
 
 const testAccCheckAlicloudRamPoliciessDataSourcePolicyTypeConfig = `
+resource "alicloud_ram_policy" "policy" {
+  name = "testAccCheckAlicloudRamPoliciessDataSourcePolicyNameRegexConfig"
+  statement = [
+    {
+      effect = "Deny"
+      action = [
+        "oss:ListObjects"]
+      resource = [
+        "acs:oss:*:*:mybucket"]
+    }]
+  description = "this is a policy test"
+  force = true
+}
 data "alicloud_ram_policies" "policy" {
+  name_regex = "${alicloud_ram_policy.policy.name}"
   type = "Custom"
 }`

--- a/alicloud/errors.go
+++ b/alicloud/errors.go
@@ -108,6 +108,8 @@ const (
 	RecordForbiddenDNSChange    = "RecordForbidden.DNSChange"
 	FobiddenNotEmptyGroup       = "Fobidden.NotEmptyGroup"
 	DomainRecordNotBelongToUser = "DomainRecordNotBelongToUser"
+	InvalidDomainNotFound       = "InvalidDomain.NotFound"
+	InvalidDomainNameNoExist    = "InvalidDomainName.NoExist"
 
 	// ram user
 	DeleteConflictUserGroup        = "DeleteConflict.User.Group"

--- a/alicloud/import_alicloud_cms_alarm_test.go
+++ b/alicloud/import_alicloud_cms_alarm_test.go
@@ -12,7 +12,7 @@ func TestAccAlicloudCmsAlarm_import(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckContainerClusterDestroy,
+		CheckDestroy: testAccCheckCmsAlarmDestroy,
 		Steps: []resource.TestStep{
 			resource.TestStep{
 				Config: testAccCmsAlarm_basic,

--- a/alicloud/import_alicloud_cs_application_test.go
+++ b/alicloud/import_alicloud_cs_application_test.go
@@ -12,7 +12,7 @@ func TestAccAlicloudCSApplication_import(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckContainerClusterDestroy,
+		CheckDestroy: testAccCheckContainerApplicationDestroy,
 		Steps: []resource.TestStep{
 			resource.TestStep{
 				Config: testAccCSApplication_basic(testWebTemplate, testMultiTemplate),

--- a/alicloud/import_alicloud_cs_swarm_test.go
+++ b/alicloud/import_alicloud_cs_swarm_test.go
@@ -12,7 +12,7 @@ func TestAccAlicloudCSSwarm_importBasic(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckContainerClusterDestroy,
+		CheckDestroy: testAccCheckSwarmClusterDestroy,
 		Steps: []resource.TestStep{
 			resource.TestStep{
 				Config: testAccCSSwarm_basic,

--- a/alicloud/import_alicloud_log_machine_group_test.go
+++ b/alicloud/import_alicloud_log_machine_group_test.go
@@ -12,7 +12,7 @@ func TestAccAlicloudLogMachineGroup_import(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckInstanceDestroy,
+		CheckDestroy: testAccCheckAlicloudLogMachineGroupDestroy,
 		Steps: []resource.TestStep{
 			resource.TestStep{
 				Config: testAlicloudLogMachineGroupIp,

--- a/alicloud/import_alicloud_log_store_index_test.go
+++ b/alicloud/import_alicloud_log_store_index_test.go
@@ -33,7 +33,7 @@ func TestAccAlicloudLogStoreIndex_importField(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckInstanceDestroy,
+		CheckDestroy: testAccCheckAlicloudLogStoreIndexDestroy,
 		Steps: []resource.TestStep{
 			resource.TestStep{
 				Config: testAlicloudLogStoreIndexField,

--- a/alicloud/import_alicloud_nat_gateway_test.go
+++ b/alicloud/import_alicloud_nat_gateway_test.go
@@ -6,34 +6,13 @@ import (
 	"github.com/hashicorp/terraform/helper/resource"
 )
 
-func TestAccAlicloudNatGateway_importBasic(t *testing.T) {
-	resourceName := "alicloud_nat_gateway.foo"
-
-	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckInstanceDestroy,
-		Steps: []resource.TestStep{
-			resource.TestStep{
-				Config: testAccNatGatewayConfig,
-			},
-
-			resource.TestStep{
-				ResourceName:      resourceName,
-				ImportState:       true,
-				ImportStateVerify: true,
-			},
-		},
-	})
-}
-
 func TestAccAlicloudNatGateway_importSpec(t *testing.T) {
 	resourceName := "alicloud_nat_gateway.foo"
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckInstanceDestroy,
+		CheckDestroy: testAccCheckNatGatewayDestroy,
 		Steps: []resource.TestStep{
 			resource.TestStep{
 				Config: testAccNatGatewayConfigSpec,

--- a/alicloud/import_alicloud_ots_table_test.go
+++ b/alicloud/import_alicloud_ots_table_test.go
@@ -6,7 +6,10 @@ import (
 	"github.com/hashicorp/terraform/helper/resource"
 )
 
-func TestAccAlicloudOtsTable_importBasic(t *testing.T) {
+// At present, OTS sdk does not support creating OTS instance and import test case does not support provider config,
+// so this test can not be run successfully.
+
+func SkipTestAccAlicloudOtsTable_importBasic(t *testing.T) {
 	resourceName := "alicloud_ots_table.basic"
 
 	resource.Test(t, resource.TestCase{

--- a/alicloud/import_alicloud_security_group_test.go
+++ b/alicloud/import_alicloud_security_group_test.go
@@ -12,7 +12,7 @@ func TestAccAlicloudSecurityGroup_importBasic(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckInstanceDestroy,
+		CheckDestroy: testAccCheckSecurityGroupDestroy,
 		Steps: []resource.TestStep{
 			resource.TestStep{
 				Config: testAccSecurityGroupConfig,
@@ -33,7 +33,7 @@ func TestAccAlicloudSecurityGroup_importWithVpc(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckInstanceDestroy,
+		CheckDestroy: testAccCheckSecurityGroupDestroy,
 		Steps: []resource.TestStep{
 			resource.TestStep{
 				Config: testAccSecurityGroupConfig_withVpc,

--- a/alicloud/import_alicloud_slb_listener_test.go
+++ b/alicloud/import_alicloud_slb_listener_test.go
@@ -12,7 +12,7 @@ func TestAccAlicloudSlbListener_importHttp(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckInstanceDestroy,
+		CheckDestroy: testAccCheckSlbListenerDestroy,
 		Steps: []resource.TestStep{
 			resource.TestStep{
 				Config: testAccSlbListenerHttp,
@@ -33,7 +33,7 @@ func TestAccAlicloudSlbListener_importTcp(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckInstanceDestroy,
+		CheckDestroy: testAccCheckSlbListenerDestroy,
 		Steps: []resource.TestStep{
 			resource.TestStep{
 				Config: testAccSlbListenerTcp,
@@ -54,7 +54,7 @@ func TestAccAlicloudSlbListener_importUdp(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckInstanceDestroy,
+		CheckDestroy: testAccCheckSlbListenerDestroy,
 		Steps: []resource.TestStep{
 			resource.TestStep{
 				Config: testAccSlbListenerUdp,

--- a/alicloud/import_alicloud_slb_server_group_test.go
+++ b/alicloud/import_alicloud_slb_server_group_test.go
@@ -19,9 +19,10 @@ func TestAccAlicloudSlbServerGroup_import(t *testing.T) {
 			},
 
 			resource.TestStep{
-				ResourceName:      resourceName,
-				ImportState:       true,
-				ImportStateVerify: true,
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"load_balancer_id"},
 			},
 		},
 	})

--- a/alicloud/import_alicloud_slb_test.go
+++ b/alicloud/import_alicloud_slb_test.go
@@ -12,7 +12,7 @@ func TestAccAlicloudSlb_importBandwidth(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckInstanceDestroy,
+		CheckDestroy: testAccCheckSlbDestroy,
 		Steps: []resource.TestStep{
 			resource.TestStep{
 				Config: testAccSlbBandWidth,
@@ -33,7 +33,7 @@ func TestAccAlicloudSlb_importTraffic(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckInstanceDestroy,
+		CheckDestroy: testAccCheckSlbDestroy,
 		Steps: []resource.TestStep{
 			resource.TestStep{
 				Config: testAccSlbTraffic,
@@ -54,7 +54,7 @@ func TestAccAlicloudSlb_importVpc(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckInstanceDestroy,
+		CheckDestroy: testAccCheckSlbDestroy,
 		Steps: []resource.TestStep{
 			resource.TestStep{
 				Config: testAccSlb4Vpc,

--- a/alicloud/import_alicloud_vpc_test.go
+++ b/alicloud/import_alicloud_vpc_test.go
@@ -12,7 +12,7 @@ func TestAccAlicloudVpc_importBasic(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckInstanceDestroy,
+		CheckDestroy: testAccCheckVpcDestroy,
 		Steps: []resource.TestStep{
 			resource.TestStep{
 				Config: testAccVpcConfig,

--- a/alicloud/import_alicloud_vroute_entry_test.go
+++ b/alicloud/import_alicloud_vroute_entry_test.go
@@ -12,7 +12,7 @@ func TestAccAlicloudRouteEntry_importBasic(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckInstanceDestroy,
+		CheckDestroy: testAccCheckRouteEntryDestroy,
 		Steps: []resource.TestStep{
 			resource.TestStep{
 				Config: testAccRouteEntryConfig,

--- a/alicloud/import_alicloud_vswitch_test.go
+++ b/alicloud/import_alicloud_vswitch_test.go
@@ -12,7 +12,7 @@ func TestAccAlicloudVswitch_importBasic(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckInstanceDestroy,
+		CheckDestroy: testAccCheckVswitchDestroy,
 		Steps: []resource.TestStep{
 			resource.TestStep{
 				Config: testAccVswitchConfig,

--- a/alicloud/resource_alicloud_cms_alarm_test.go
+++ b/alicloud/resource_alicloud_cms_alarm_test.go
@@ -27,7 +27,7 @@ func TestAccAlicloudCmsAlarm_basic(t *testing.T) {
 				Config: testAccCmsAlarm_basic,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckCmsAlarmExists("alicloud_cms_alarm.basic", &alarm),
-					resource.TestCheckResourceAttr("alicloud_cms_alarm.basic", "name", "tf-testAccCmsAlarm_basic"),
+					resource.TestCheckResourceAttr("alicloud_cms_alarm.basic", "name", "testAccCmsAlarm_basic"),
 					resource.TestCheckResourceAttr("alicloud_cms_alarm.basic", "dimensions.%", "2"),
 					resource.TestCheckResourceAttr("alicloud_cms_alarm.basic", "dimensions.device", "/dev/vda1,/dev/vdb1"),
 				),
@@ -53,7 +53,7 @@ func TestAccAlicloudCmsAlarm_update(t *testing.T) {
 				Config: testAccCmsAlarm_update,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckCmsAlarmExists("alicloud_cms_alarm.update", &alarm),
-					resource.TestCheckResourceAttr("alicloud_cms_alarm.update", "name", "tf-testAccCmsAlarm_update"),
+					resource.TestCheckResourceAttr("alicloud_cms_alarm.update", "name", "testAccCmsAlarm_update"),
 					resource.TestCheckResourceAttr("alicloud_cms_alarm.update", "operator", "<="),
 					resource.TestCheckResourceAttr("alicloud_cms_alarm.update", "triggered_count", "2"),
 				),
@@ -88,7 +88,7 @@ func TestAccAlicloudCmsAlarm_disable(t *testing.T) {
 				Config: testAccCmsAlarm_disable,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckCmsAlarmExists("alicloud_cms_alarm.disable", &alarm),
-					resource.TestCheckResourceAttr("alicloud_cms_alarm.disable", "name", "tf-testAccCmsAlarm_disable"),
+					resource.TestCheckResourceAttr("alicloud_cms_alarm.disable", "name", "testAccCmsAlarm_disable"),
 					resource.TestCheckResourceAttr("alicloud_cms_alarm.disable", "enabled", "false"),
 				),
 			},
@@ -134,10 +134,7 @@ func testAccCheckCmsAlarmDestroy(s *terraform.State) error {
 
 		alarm, err := client.DescribeAlarm(rs.Primary.ID)
 
-		if err != nil {
-			if NotFoundError(err) {
-				return nil
-			}
+		if err != nil && !NotFoundError(err) {
 			return err
 		}
 
@@ -151,7 +148,7 @@ func testAccCheckCmsAlarmDestroy(s *terraform.State) error {
 
 const testAccCmsAlarm_basic = `
 resource "alicloud_cms_alarm" "basic" {
-  name = "tf-testAccCmsAlarm_basic"
+  name = "testAccCmsAlarm_basic"
   project = "acs_ecs_dashboard"
   metric = "disk_writebytes"
   dimensions = {
@@ -172,7 +169,7 @@ resource "alicloud_cms_alarm" "basic" {
 
 const testAccCmsAlarm_update = `
 resource "alicloud_cms_alarm" "update" {
-  name = "tf-testAccCmsAlarm_update"
+  name = "testAccCmsAlarm_update"
   project = "acs_ecs_dashboard"
   metric = "disk_writebytes"
   dimensions = {
@@ -193,7 +190,7 @@ resource "alicloud_cms_alarm" "update" {
 
 const testAccCmsAlarm_updateAfter = `
 resource "alicloud_cms_alarm" "update" {
-  name = "tf-testAccCmsAlarm_update"
+  name = "testAccCmsAlarm_update"
   project = "acs_ecs_dashboard"
   metric = "disk_writebytes"
   dimensions = {
@@ -214,7 +211,7 @@ resource "alicloud_cms_alarm" "update" {
 
 const testAccCmsAlarm_disable = `
 resource "alicloud_cms_alarm" "disable" {
-  name = "tf-testAccCmsAlarm_disable"
+  name = "testAccCmsAlarm_disable"
   project = "acs_ecs_dashboard"
   metric = "disk_writebytes"
   dimensions = {

--- a/alicloud/resource_alicloud_dns_record_test.go
+++ b/alicloud/resource_alicloud_dns_record_test.go
@@ -115,8 +115,10 @@ func testAccCheckDnsRecordDestroy(s *terraform.State) error {
 		}
 
 		response, err := conn.DescribeDomainRecordInfoNew(request)
-
-		if response.RecordId != "" || err != nil {
+		if err != nil {
+			return err
+		}
+		if response.RecordId != "" {
 			return fmt.Errorf("Error Domain record still exist.")
 		}
 	}

--- a/alicloud/resource_alicloud_dns_test.go
+++ b/alicloud/resource_alicloud_dns_test.go
@@ -5,7 +5,6 @@ import (
 	"log"
 	"testing"
 
-	"github.com/denverdino/aliyungo/common"
 	"github.com/denverdino/aliyungo/dns"
 	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/terraform"
@@ -33,7 +32,7 @@ func TestAccAlicloudDns_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(
 						"alicloud_dns.dns",
 						"name",
-						"starmove.com"),
+						"yufish.com"),
 				),
 			},
 		},
@@ -87,13 +86,8 @@ func testAccCheckDnsDestroy(s *terraform.State) error {
 
 		_, err := conn.DescribeDomainInfo(request)
 
-		if err != nil {
-			e, _ := err.(*common.Error)
-			if e.ErrorResponse.Code == "InvalidDomainName.NoExist" {
-				return nil
-			} else {
-				return fmt.Errorf("Error Domain still exist.")
-			}
+		if err != nil && !IsExceptedErrors(err, []string{InvalidDomainNameNoExist}) {
+			return fmt.Errorf("Error Domain still exist.")
 		}
 	}
 
@@ -102,6 +96,6 @@ func testAccCheckDnsDestroy(s *terraform.State) error {
 
 const testAccDnsConfig = `
 resource "alicloud_dns" "dns" {
-  name = "starmove.com"
+  name = "yufish.com"
 }
 `

--- a/alicloud/resource_alicloud_log_machine_group_test.go
+++ b/alicloud/resource_alicloud_log_machine_group_test.go
@@ -90,17 +90,13 @@ func testAccCheckAlicloudLogMachineGroupDestroy(s *terraform.State) error {
 
 		split := strings.Split(rs.Primary.ID, COLON_SEPARATED)
 
-		group, err := client.DescribeLogMachineGroup(split[0], split[1])
-		if err != nil {
+		if _, err := client.DescribeLogMachineGroup(split[0], split[1]); err != nil {
 			if NotFoundError(err) {
-				return nil
+				continue
 			}
 			return fmt.Errorf("Check log machine group got an error: %#v.", err)
 		}
-
-		if group.Name != "" {
-			return fmt.Errorf("Log machine group %s still exists.", rs.Primary.ID)
-		}
+		return fmt.Errorf("Log machine group %s still exists.", rs.Primary.ID)
 	}
 
 	return nil

--- a/alicloud/resource_alicloud_log_store_index_test.go
+++ b/alicloud/resource_alicloud_log_store_index_test.go
@@ -119,18 +119,18 @@ func testAccCheckAlicloudLogStoreIndexDestroy(s *terraform.State) error {
 		i, err := client.DescribeLogStoreIndex(split[0], split[1])
 		if err != nil {
 			if NotFoundError(err) {
-				return nil
+				continue
 			}
 			return fmt.Errorf("Check log store index got an error: %#v.", err)
 		}
 
 		if len(split) == 2 {
 			if i.Line == nil {
-				return nil
+				continue
 			}
 		} else {
 			if _, ok := i.Keys[split[2]]; !ok {
-				return nil
+				continue
 			}
 		}
 

--- a/alicloud/resource_alicloud_log_store_test.go
+++ b/alicloud/resource_alicloud_log_store_test.go
@@ -70,10 +70,7 @@ func testAccCheckAlicloudLogStoreDestroy(s *terraform.State) error {
 
 		split := strings.Split(rs.Primary.ID, COLON_SEPARATED)
 		store, err := client.DescribeLogStore(split[0], split[1])
-		if err != nil {
-			if NotFoundError(err) {
-				return nil
-			}
+		if err != nil && !NotFoundError(err) {
 			return fmt.Errorf("Check log store got an error: %#v.", err)
 		}
 

--- a/alicloud/resource_alicloud_oss_bucket_object_test.go
+++ b/alicloud/resource_alicloud_oss_bucket_object_test.go
@@ -8,7 +8,6 @@ import (
 	"os"
 	"testing"
 
-	"github.com/aliyun/aliyun-oss-go-sdk/oss"
 	"github.com/hashicorp/terraform/helper/acctest"
 	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/helper/schema"
@@ -184,8 +183,7 @@ func testAccCheckOssBucketObjectDestroyWithProvider(s *terraform.State, provider
 		}
 
 		// Verify the error is what we want
-		e, _ := err.(oss.ServiceError)
-		if e.Code == OssBucketNotFound {
+		if IsExceptedErrors(err, []string{OssBucketNotFound}) {
 			continue
 		}
 

--- a/alicloud/resource_alicloud_oss_bucket_test.go
+++ b/alicloud/resource_alicloud_oss_bucket_test.go
@@ -284,8 +284,7 @@ func testAccCheckOssBucketDestroyWithProvider(s *terraform.State, provider *sche
 		}
 
 		// Verify the error is what we want
-		e, _ := err.(oss.ServiceError)
-		if e.Code == OssBucketNotFound {
+		if IsExceptedErrors(err, []string{OssBucketNotFound}) {
 			continue
 		}
 

--- a/alicloud/resource_alicloud_ots_table_test.go
+++ b/alicloud/resource_alicloud_ots_table_test.go
@@ -10,7 +10,10 @@ import (
 	"github.com/hashicorp/terraform/terraform"
 )
 
-func TestAccAlicloudOtsTable_Basic(t *testing.T) {
+// At present, OTS sdk does not support creating OTS instance, and you should manually create a instance before running the test case.
+// After running the test, you should set it to 'Skip'
+
+func SkipTestAccAlicloudOtsTable_Basic(t *testing.T) {
 	var table tablestore.DescribeTableResponse
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
@@ -86,12 +89,12 @@ func testAccCheckOtsTableDestroy(s *terraform.State) error {
 
 const testAccOtsTable = `
 provider "alicloud" {
-  ots_instance_name = "tf-test"
+  ots_instance_name = "testAccOtsTable"
   region = "cn-hangzhou"
 }
 resource "alicloud_ots_table" "basic" {
   provider = "alicloud"
-  table_name = "ots_table_c"
+  table_name = "testAccOtsTable"
   primary_key = {
     name = "pk1"
     type = "Integer"

--- a/alicloud/resource_alicloud_ram_access_key_test.go
+++ b/alicloud/resource_alicloud_ram_access_key_test.go
@@ -101,10 +101,7 @@ func testAccCheckRamAccessKeyDestroy(s *terraform.State) error {
 				}
 			}
 		}
-		if err != nil {
-			if RamEntityNotExist(err) {
-				return nil
-			}
+		if err != nil && !RamEntityNotExist(err) {
 			return err
 		}
 	}

--- a/alicloud/resource_alicloud_ram_account_alias_test.go
+++ b/alicloud/resource_alicloud_ram_account_alias_test.go
@@ -30,7 +30,7 @@ func TestAccAlicloudRamAccountAlias_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(
 						"alicloud_ram_account_alias.alias",
 						"account_alias",
-						"hallo"),
+						"testaccramaccountaliasconfig"),
 				),
 			},
 		},
@@ -75,10 +75,7 @@ func testAccCheckRamAccountAliasDestroy(s *terraform.State) error {
 
 		_, err := conn.GetAccountAlias()
 
-		if err != nil {
-			if RamEntityNotExist(err) {
-				return nil
-			}
+		if err != nil && !RamEntityNotExist(err) {
 			return err
 		}
 	}
@@ -87,5 +84,5 @@ func testAccCheckRamAccountAliasDestroy(s *terraform.State) error {
 
 const testAccRamAccountAliasConfig = `
 resource "alicloud_ram_account_alias" "alias" {
-  account_alias = "hallo"
+  account_alias = "testaccramaccountaliasconfig"
 }`

--- a/alicloud/resource_alicloud_ram_group_policy_attachment_test.go
+++ b/alicloud/resource_alicloud_ram_group_policy_attachment_test.go
@@ -90,10 +90,7 @@ func testAccCheckRamGroupPolicyAttachmentDestroy(s *terraform.State) error {
 
 		response, err := conn.ListPoliciesForGroup(request)
 
-		if err != nil {
-			if RamEntityNotExist(err) {
-				return nil
-			}
+		if err != nil && !RamEntityNotExist(err) {
 			return err
 		}
 

--- a/alicloud/resource_alicloud_ram_group_test.go
+++ b/alicloud/resource_alicloud_ram_group_test.go
@@ -2,7 +2,6 @@ package alicloud
 
 import (
 	"fmt"
-	"log"
 	"testing"
 
 	"github.com/denverdino/aliyungo/ram"
@@ -58,18 +57,15 @@ func testAccCheckRamGroupExists(n string, group *ram.Group) resource.TestCheckFu
 		client := testAccProvider.Meta().(*AliyunClient)
 		conn := client.ramconn
 
-		request := ram.GroupQueryRequest{
-			GroupName: rs.Primary.Attributes["name"],
-		}
-
-		response, err := conn.GetGroup(request)
-		log.Printf("[WARN] Group id %#v", rs.Primary.ID)
+		response, err := conn.GetGroup(ram.GroupQueryRequest{
+			GroupName: rs.Primary.ID,
+		})
 
 		if err == nil {
 			*group = response.Group
 			return nil
 		}
-		return fmt.Errorf("Error finding group %#v", rs.Primary.ID)
+		return fmt.Errorf("Error finding group %#v", err)
 	}
 }
 
@@ -85,15 +81,12 @@ func testAccCheckRamGroupDestroy(s *terraform.State) error {
 		conn := client.ramconn
 
 		request := ram.GroupQueryRequest{
-			GroupName: rs.Primary.Attributes["name"],
+			GroupName: rs.Primary.ID,
 		}
 
 		_, err := conn.GetGroup(request)
 
-		if err != nil {
-			if RamEntityNotExist(err) {
-				return nil
-			}
+		if err != nil && !RamEntityNotExist(err) {
 			return err
 		}
 	}

--- a/alicloud/resource_alicloud_ram_login_profile_test.go
+++ b/alicloud/resource_alicloud_ram_login_profile_test.go
@@ -83,10 +83,7 @@ func testAccCheckRamLoginProfileDestroy(s *terraform.State) error {
 
 		_, err := conn.GetLoginProfile(request)
 
-		if err != nil {
-			if RamEntityNotExist(err) {
-				return nil
-			}
+		if err != nil && !RamEntityNotExist(err) {
 			return err
 		}
 	}

--- a/alicloud/resource_alicloud_ram_policy_test.go
+++ b/alicloud/resource_alicloud_ram_policy_test.go
@@ -92,10 +92,7 @@ func testAccCheckRamPolicyDestroy(s *terraform.State) error {
 
 		_, err := conn.GetPolicy(request)
 
-		if err != nil {
-			if RamEntityNotExist(err) {
-				return nil
-			}
+		if err != nil && !RamEntityNotExist(err) {
 			return err
 		}
 	}

--- a/alicloud/resource_alicloud_ram_role_policy_attachment_test.go
+++ b/alicloud/resource_alicloud_ram_role_policy_attachment_test.go
@@ -90,10 +90,7 @@ func testAccCheckRamRolePolicyAttachmentDestroy(s *terraform.State) error {
 
 		response, err := conn.ListPoliciesForRole(request)
 
-		if err != nil {
-			if RamEntityNotExist(err) {
-				return nil
-			}
+		if err != nil && !RamEntityNotExist(err) {
 			return err
 		}
 
@@ -128,7 +125,6 @@ resource "alicloud_ram_policy" "policy" {
 resource "alicloud_ram_role" "role" {
   name = "rolename"
   services = ["apigateway.aliyuncs.com", "ecs.aliyuncs.com"]
-  ram_users = ["acs:ram::123456789:root", "acs:ram::1234567890:user/username"]
   description = "this is a test"
   force = true
 }

--- a/alicloud/resource_alicloud_ram_role_test.go
+++ b/alicloud/resource_alicloud_ram_role_test.go
@@ -90,10 +90,7 @@ func testAccCheckRamRoleDestroy(s *terraform.State) error {
 
 		_, err := conn.GetRole(request)
 
-		if err != nil {
-			if RamEntityNotExist(err) {
-				return nil
-			}
+		if err != nil && !RamEntityNotExist(err) {
 			return err
 		}
 	}
@@ -104,7 +101,6 @@ const testAccRamRoleConfig = `
 resource "alicloud_ram_role" "role" {
   name = "rolename"
   services = ["apigateway.aliyuncs.com", "ecs.aliyuncs.com"]
-  ram_users = ["acs:ram::123456789:root", "acs:ram::1234567890:user/username"]
   description = "this is a test"
   force = true
 }`

--- a/alicloud/resource_alicloud_ram_user_test.go
+++ b/alicloud/resource_alicloud_ram_user_test.go
@@ -94,10 +94,7 @@ func testAccCheckRamUserDestroy(s *terraform.State) error {
 
 		_, err := conn.GetUser(request)
 
-		if err != nil {
-			if RamEntityNotExist(err) {
-				return nil
-			}
+		if err != nil && !RamEntityNotExist(err) {
 			return err
 		}
 	}

--- a/alicloud/resource_alicloud_router_interface_test.go
+++ b/alicloud/resource_alicloud_router_interface_test.go
@@ -71,10 +71,8 @@ func testAccCheckRouterInterfaceDestroy(s *terraform.State) error {
 		client := testAccProvider.Meta().(*AliyunClient)
 
 		ri, err := client.DescribeRouterInterface(rs.Primary.ID)
-		if err != nil {
-			if NotFoundError(err) {
-				return nil
-			}
+		if err != nil && !NotFoundError(err) {
+			return err
 		}
 
 		if ri.RouterInterfaceId == rs.Primary.ID {

--- a/alicloud/resource_alicloud_security_group_rule_test.go
+++ b/alicloud/resource_alicloud_security_group_rule_test.go
@@ -367,11 +367,7 @@ func testAccCheckSecurityGroupRuleDestroy(s *terraform.State) error {
 		_, err = client.DescribeSecurityGroupRule(parts[0], parts[1], parts[2], parts[3], parts[4], parts[5], parts[6], prior)
 
 		// Verify the error is what we want
-		if err != nil {
-			// Verify the error is what we want
-			if IsExceptedErrors(err, []string{InvalidSecurityGroupIdNotFound}) {
-				continue
-			}
+		if err != nil && !IsExceptedErrors(err, []string{InvalidSecurityGroupIdNotFound}) {
 			return err
 		}
 	}

--- a/alicloud/resource_alicloud_security_group_test.go
+++ b/alicloud/resource_alicloud_security_group_test.go
@@ -112,7 +112,7 @@ func testAccCheckSecurityGroupDestroy(s *terraform.State) error {
 
 		if err != nil {
 			if NotFoundError(err) || IsExceptedErrors(err, []string{InvalidSecurityGroupIdNotFound}) {
-				return nil
+				continue
 			}
 			return err
 		}

--- a/alicloud/resource_alicloud_slb.go
+++ b/alicloud/resource_alicloud_slb.go
@@ -265,16 +265,11 @@ func resourceAliyunSlbCreate(d *schema.ResourceData, meta interface{}) error {
 func resourceAliyunSlbRead(d *schema.ResourceData, meta interface{}) error {
 	loadBalancer, err := meta.(*AliyunClient).DescribeLoadBalancerAttribute(d.Id())
 	if err != nil {
-		if IsExceptedErrors(err, []string{LoadBalancerNotFound}) {
+		if NotFoundError(err) {
 			d.SetId("")
 			return nil
 		}
 		return err
-	}
-
-	if loadBalancer == nil {
-		d.SetId("")
-		return nil
 	}
 
 	d.Set("name", loadBalancer.LoadBalancerName)

--- a/alicloud/resource_alicloud_slb_attachment.go
+++ b/alicloud/resource_alicloud_slb_attachment.go
@@ -74,10 +74,6 @@ func resourceAliyunSlbAttachmentCreate(d *schema.ResourceData, meta interface{})
 		return err
 	}
 
-	if loadBalancer == nil {
-		d.SetId("")
-		return fmt.Errorf("Specified SLB Id %s is not found in %#v.", d.Get("load_balancer_id").(string), getRegion(d, meta))
-	}
 	d.SetId(loadBalancer.LoadBalancerId)
 
 	return resourceAliyunSlbAttachmentUpdate(d, meta)
@@ -87,16 +83,11 @@ func resourceAliyunSlbAttachmentRead(d *schema.ResourceData, meta interface{}) e
 
 	loadBalancer, err := meta.(*AliyunClient).DescribeLoadBalancerAttribute(d.Id())
 	if err != nil {
-		if IsExceptedError(err, LoadBalancerNotFound) {
+		if NotFoundError(err) {
 			d.SetId("")
 			return nil
 		}
 		return err
-	}
-
-	if loadBalancer == nil {
-		d.SetId("")
-		return nil
 	}
 
 	backendServerType := loadBalancer.BackendServers
@@ -203,15 +194,11 @@ func removeBackendServers(d *schema.ResourceData, meta interface{}, servers []in
 
 			loadBalancer, err := client.DescribeLoadBalancerAttribute(d.Id())
 			if err != nil {
-				if IsExceptedError(err, LoadBalancerNotFound) {
+				if NotFoundError(err) {
 					return nil
 				}
 				return resource.NonRetryableError(fmt.Errorf("DescribeLoadBalancerAttribute got an error: %#v", err))
 
-			}
-
-			if loadBalancer == nil {
-				return nil
 			}
 
 			servers := loadBalancer.BackendServers.BackendServer

--- a/alicloud/resource_alicloud_slb_attachment_test.go
+++ b/alicloud/resource_alicloud_slb_attachment_test.go
@@ -78,47 +78,59 @@ func testAccCheckAttachment(n string, slb *slb.LoadBalancerType) resource.TestCh
 }
 
 const testAccSlbAttachment = `
-data "alicloud_images" "image" {
+data "alicloud_zones" "default" {
+	"available_disk_category"= "cloud_efficiency"
+	"available_resource_creation"= "VSwitch"
+}
+data "alicloud_instance_types" "default" {
+ 	availability_zone = "${data.alicloud_zones.default.zones.0.id}"
+	cpu_core_count = 1
+	memory_size = 2
+}
+data "alicloud_images" "default" {
+        name_regex = "^ubuntu_14.*_64"
 	most_recent = true
 	owners = "system"
-	name_regex = "^centos_6\\w{1,5}[64]{1}.*"
+}
+variable "name" {
+	default = "testAccSlbAttachment"
 }
 
-data "alicloud_zones" "zone" {}
-
 resource "alicloud_vpc" "main" {
+	name = "${var.name}"
 	cidr_block = "172.16.0.0/16"
 }
 
 resource "alicloud_vswitch" "main" {
 	vpc_id = "${alicloud_vpc.main.id}"
 	cidr_block = "172.16.0.0/16"
-	availability_zone = "${data.alicloud_zones.zone.zones.0.id}"
+	availability_zone = "${data.alicloud_zones.default.zones.0.id}"
 	depends_on = [
 	"alicloud_vpc.main"]
 }
 
 resource "alicloud_security_group" "group" {
+	name = "${var.name}"
 	vpc_id = "${alicloud_vpc.main.id}"
 }
 
 resource "alicloud_instance" "foo" {
 	# cn-beijing
-	image_id = "${data.alicloud_images.image.images.0.id}"
+	image_id = "${data.alicloud_images.default.images.0.id}"
 
 	# series III
-	instance_type = "ecs.n4.large"
+	instance_type = "${data.alicloud_instance_types.default.instance_types.0.id}"
 	internet_charge_type = "PayByBandwidth"
 	internet_max_bandwidth_out = "5"
 	system_disk_category = "cloud_efficiency"
 
 	security_groups = ["${alicloud_security_group.group.id}"]
-	instance_name = "test_foo"
+	instance_name = "${var.name}"
 	vswitch_id = "${alicloud_vswitch.main.id}"
 }
 
 resource "alicloud_slb" "foo" {
-	name = "tf_test_slb_bind"
+	name = "${var.name}"
 	vswitch_id = "${alicloud_vswitch.main.id}"
 }
 

--- a/alicloud/resource_alicloud_slb_listener_test.go
+++ b/alicloud/resource_alicloud_slb_listener_test.go
@@ -135,8 +135,8 @@ func testAccCheckSlbListenerDestroy(s *terraform.State) error {
 		}
 		loadBalancer, err := client.DescribeLoadBalancerAttribute(parts[0])
 		if err != nil {
-			if IsExceptedError(err, LoadBalancerNotFound) {
-				return nil
+			if NotFoundError(err) {
+				continue
 			}
 			return fmt.Errorf("DescribeLoadBalancerAttribute got an error: %#v", err)
 		}

--- a/alicloud/resource_alicloud_slb_rule.go
+++ b/alicloud/resource_alicloud_slb_rule.go
@@ -123,11 +123,11 @@ func resourceAliyunSlbRuleRead(d *schema.ResourceData, meta interface{}) error {
 	})
 
 	if err != nil {
-		if IsExceptedError(err, InvalidRuleIdNotFound) {
+		if NotFoundError(err) {
 			d.SetId("")
 			return nil
 		}
-		return fmt.Errorf("DescribeRuleAttribute got an error: %#v", err)
+		return err
 	}
 
 	d.Set("name", rule.RuleName)

--- a/alicloud/resource_alicloud_slb_test.go
+++ b/alicloud/resource_alicloud_slb_test.go
@@ -156,9 +156,6 @@ func testAccCheckSlbExists(n string, slb *slb.LoadBalancerType) resource.TestChe
 		if err != nil {
 			return err
 		}
-		if instance == nil {
-			return fmt.Errorf("SLB not found")
-		}
 
 		*slb = *instance
 		return nil
@@ -174,19 +171,13 @@ func testAccCheckSlbDestroy(s *terraform.State) error {
 		}
 
 		// Try to find the Slb
-		instance, err := client.DescribeLoadBalancerAttribute(rs.Primary.ID)
-
-		if instance != nil {
-			return fmt.Errorf("SLB still exist")
-		}
-
-		if err != nil {
-			if IsExceptedError(err, LoadBalancerNotFound) {
-				return nil
+		if _, err := client.DescribeLoadBalancerAttribute(rs.Primary.ID); err != nil {
+			if NotFoundError(err) {
+				continue
 			}
 			return fmt.Errorf("DescribeLoadBalancerAttribute got an error: %#v", err)
 		}
-
+		return fmt.Errorf("SLB still exist")
 	}
 
 	return nil

--- a/alicloud/resource_alicloud_vpc_test.go
+++ b/alicloud/resource_alicloud_vpc_test.go
@@ -62,7 +62,7 @@ func TestAccAlicloudVpc_update(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckVpcExists("alicloud_vpc.foo", &vpc),
 					resource.TestCheckResourceAttr(
-						"alicloud_vpc.foo", "name", "tf_test_bar"),
+						"alicloud_vpc.foo", "name", "testAccVpcConfigUpdate"),
 				),
 			},
 		},
@@ -145,7 +145,7 @@ func testAccCheckVpcDestroy(s *terraform.State) error {
 
 const testAccVpcConfig = `
 resource "alicloud_vpc" "foo" {
-        name = "tf_test_foo"
+        name = "testAccVpcConfig"
         cidr_block = "172.16.0.0/12"
 }
 `
@@ -153,21 +153,24 @@ resource "alicloud_vpc" "foo" {
 const testAccVpcConfigUpdate = `
 resource "alicloud_vpc" "foo" {
 	cidr_block = "172.16.0.0/12"
-	name = "tf_test_bar"
+	name = "testAccVpcConfigUpdate"
 }
 `
 
 const testAccVpcConfigMulti = `
+provider "alicloud" {
+	region="cn-shanghai"
+}
 resource "alicloud_vpc" "bar_1" {
 	cidr_block = "172.16.0.0/12"
-	name = "tf_test_bar_1"
+	name = "testAccVpcConfigMulti-1"
 }
 resource "alicloud_vpc" "bar_2" {
 	cidr_block = "192.168.0.0/16"
-	name = "tf_test_bar_2"
+	name = "testAccVpcConfigMulti-2"
 }
 resource "alicloud_vpc" "bar_3" {
 	cidr_block = "10.1.0.0/21"
-	name = "tf_test_bar_3"
+	name = "testAccVpcConfigMulti-3"
 }
 `

--- a/alicloud/resource_alicloud_vswitch_test.go
+++ b/alicloud/resource_alicloud_vswitch_test.go
@@ -117,7 +117,7 @@ data "alicloud_zones" "default" {
 }
 
 resource "alicloud_vpc" "foo" {
-  name = "tf_test_foo"
+  name = "testAccVswitchConfig"
   cidr_block = "172.16.0.0/12"
 }
 
@@ -125,6 +125,7 @@ resource "alicloud_vswitch" "foo" {
   vpc_id = "${alicloud_vpc.foo.id}"
   cidr_block = "172.16.0.0/21"
   availability_zone = "${data.alicloud_zones.default.zones.0.id}"
+  name = "testAccVswitchConfig"
 }
 `
 
@@ -134,7 +135,7 @@ data "alicloud_zones" "default" {
 }
 
 resource "alicloud_vpc" "foo" {
-  name = "tf_test_foo"
+  name = "testAccVswitchMulti"
   cidr_block = "172.16.0.0/12"
 }
 
@@ -142,16 +143,19 @@ resource "alicloud_vswitch" "foo_0" {
   vpc_id = "${alicloud_vpc.foo.id}"
   cidr_block = "172.16.0.0/24"
   availability_zone = "${data.alicloud_zones.default.zones.0.id}"
+  name = "testAccVswitchMulti-1"
 }
 resource "alicloud_vswitch" "foo_1" {
   vpc_id = "${alicloud_vpc.foo.id}"
   cidr_block = "172.16.1.0/24"
   availability_zone = "${data.alicloud_zones.default.zones.0.id}"
+  name = "testAccVswitchMulti-2"
 }
 resource "alicloud_vswitch" "foo_2" {
   vpc_id = "${alicloud_vpc.foo.id}"
   cidr_block = "172.16.2.0/24"
   availability_zone = "${data.alicloud_zones.default.zones.0.id}"
+  name = "testAccVswitchMulti-3"
 }
 
 `


### PR DESCRIPTION
```
TF_ACC=1 go test ./alicloud -v -run=TestAccAlicloudV -timeout=600m
=== RUN   TestAccAlicloudVpcsDataSource_cidr_block
--- PASS: TestAccAlicloudVpcsDataSource_cidr_block (12.96s)
=== RUN   TestAccAlicloudVSwitchesDataSource
--- PASS: TestAccAlicloudVSwitchesDataSource (19.56s)
=== RUN   TestAccAlicloudVpc_importBasic
--- PASS: TestAccAlicloudVpc_importBasic (10.16s)
=== RUN   TestAccAlicloudVswitch_importBasic
--- PASS: TestAccAlicloudVswitch_importBasic (18.84s)
=== RUN   TestAccAlicloudVpc_basic
--- PASS: TestAccAlicloudVpc_basic (10.27s)
=== RUN   TestAccAlicloudVpc_update
--- PASS: TestAccAlicloudVpc_update (13.47s)
=== RUN   TestAccAlicloudVpc_multi
--- PASS: TestAccAlicloudVpc_multi (10.70s)
=== RUN   TestAccAlicloudVswitch_basic
--- PASS: TestAccAlicloudVswitch_basic (18.66s)
=== RUN   TestAccAlicloudVswitch_multi
--- PASS: TestAccAlicloudVswitch_multi (25.07s)
PASS
ok  	github.com/alibaba/terraform-provider/alicloud	139.721s
```