### PR TITLE
Improve dns record resource test case

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 IMPROVEMENTS:
 
+- Improve vpc and vswitch resource test case ([#205](https://github.com/terraform-providers/terraform-provider-alicloud/pull/205))
 - Improve slb resource test case ([#204](https://github.com/terraform-providers/terraform-provider-alicloud/pull/204))
 - Improve security group resource test case ([#203](https://github.com/terraform-providers/terraform-provider-alicloud/pull/203))
 - Improve ram resource test case ([#202](https://github.com/terraform-providers/terraform-provider-alicloud/pull/202))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 IMPROVEMENTS:
 
+- Improve slb resource test case ([#204](https://github.com/terraform-providers/terraform-provider-alicloud/pull/204))
 - Improve security group resource test case ([#203](https://github.com/terraform-providers/terraform-provider-alicloud/pull/203))
 - Improve ram resource test case ([#202](https://github.com/terraform-providers/terraform-provider-alicloud/pull/202))
 - Improve container cluster resource test case ([#201](https://github.com/terraform-providers/terraform-provider-alicloud/pull/201))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 IMPROVEMENTS:
 
+- Improve ots table resource test case ([#196](https://github.com/terraform-providers/terraform-provider-alicloud/pull/196))
 - Improve nat gateway resource test case ([#195](https://github.com/terraform-providers/terraform-provider-alicloud/pull/195))
 - Improve log resource test case ([#194](https://github.com/terraform-providers/terraform-provider-alicloud/pull/194))
 - Support changing ecs charge type from Prepaid to PostPaid ([#192](https://github.com/terraform-providers/terraform-provider-alicloud/pull/192))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 IMPROVEMENTS:
 
+- Improve dns record resource test case ([#215](https://github.com/terraform-providers/terraform-provider-alicloud/pull/215))
 - Improve test case destroy method ([#214](https://github.com/terraform-providers/terraform-provider-alicloud/pull/214))
 - Improve ecs instance resource test case ([#213](https://github.com/terraform-providers/terraform-provider-alicloud/pull/213))
 - Improve cdn resource test case ([#212](https://github.com/terraform-providers/terraform-provider-alicloud/pull/212))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 IMPROVEMENTS:
 
+- Improve rds resource test case ([#209](https://github.com/terraform-providers/terraform-provider-alicloud/pull/209))
 - Improve disk resource test case ([#208](https://github.com/terraform-providers/terraform-provider-alicloud/pull/208))
 - Improve eip resource test case ([#207](https://github.com/terraform-providers/terraform-provider-alicloud/pull/207))
 - Improve scaling service resource test case ([#206](https://github.com/terraform-providers/terraform-provider-alicloud/pull/206))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 IMPROVEMENTS:
 
+- Improve cloud monitor resource test case ([#200](https://github.com/terraform-providers/terraform-provider-alicloud/pull/200))
 - Improve route and router interface resource test case ([#199](https://github.com/terraform-providers/terraform-provider-alicloud/pull/199))
 - Improve dns resource test case ([#198](https://github.com/terraform-providers/terraform-provider-alicloud/pull/198))
 - Improve oss resource test case ([#197](https://github.com/terraform-providers/terraform-provider-alicloud/pull/197))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 IMPROVEMENTS:
 
+- Improve security group resource test case ([#203](https://github.com/terraform-providers/terraform-provider-alicloud/pull/203))
 - Improve ram resource test case ([#202](https://github.com/terraform-providers/terraform-provider-alicloud/pull/202))
 - Improve container cluster resource test case ([#201](https://github.com/terraform-providers/terraform-provider-alicloud/pull/201))
 - Improve cloud monitor resource test case ([#200](https://github.com/terraform-providers/terraform-provider-alicloud/pull/200))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 IMPROVEMENTS:
 
+- Improve test case destroy method ([#214](https://github.com/terraform-providers/terraform-provider-alicloud/pull/214))
 - Improve ecs instance resource test case ([#213](https://github.com/terraform-providers/terraform-provider-alicloud/pull/213))
 - Improve cdn resource test case ([#212](https://github.com/terraform-providers/terraform-provider-alicloud/pull/212))
 - Improve kms resource test case ([#211](https://github.com/terraform-providers/terraform-provider-alicloud/pull/211))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 IMPROVEMENTS:
 
+- Improve ram resource test case ([#202](https://github.com/terraform-providers/terraform-provider-alicloud/pull/202))
 - Improve container cluster resource test case ([#201](https://github.com/terraform-providers/terraform-provider-alicloud/pull/201))
 - Improve cloud monitor resource test case ([#200](https://github.com/terraform-providers/terraform-provider-alicloud/pull/200))
 - Improve route and router interface resource test case ([#199](https://github.com/terraform-providers/terraform-provider-alicloud/pull/199))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 IMPROVEMENTS:
 
+- Improve dns resource test case ([#198](https://github.com/terraform-providers/terraform-provider-alicloud/pull/198))
 - Improve oss resource test case ([#197](https://github.com/terraform-providers/terraform-provider-alicloud/pull/197))
 - Improve ots table resource test case ([#196](https://github.com/terraform-providers/terraform-provider-alicloud/pull/196))
 - Improve nat gateway resource test case ([#195](https://github.com/terraform-providers/terraform-provider-alicloud/pull/195))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 IMPROVEMENTS:
 
+- Improve cdn resource test case ([#212](https://github.com/terraform-providers/terraform-provider-alicloud/pull/212))
 - Improve kms resource test case ([#211](https://github.com/terraform-providers/terraform-provider-alicloud/pull/211))
 - Improve key pair resource test case ([#210](https://github.com/terraform-providers/terraform-provider-alicloud/pull/210))
 - Improve rds resource test case ([#209](https://github.com/terraform-providers/terraform-provider-alicloud/pull/209))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 IMPROVEMENTS:
 
+- Improve key pair resource test case ([#210](https://github.com/terraform-providers/terraform-provider-alicloud/pull/210))
 - Improve rds resource test case ([#209](https://github.com/terraform-providers/terraform-provider-alicloud/pull/209))
 - Improve disk resource test case ([#208](https://github.com/terraform-providers/terraform-provider-alicloud/pull/208))
 - Improve eip resource test case ([#207](https://github.com/terraform-providers/terraform-provider-alicloud/pull/207))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 IMPROVEMENTS:
 
+- Improve scaling service resource test case ([#206](https://github.com/terraform-providers/terraform-provider-alicloud/pull/206))
 - Improve vpc and vswitch resource test case ([#205](https://github.com/terraform-providers/terraform-provider-alicloud/pull/205))
 - Improve slb resource test case ([#204](https://github.com/terraform-providers/terraform-provider-alicloud/pull/204))
 - Improve security group resource test case ([#203](https://github.com/terraform-providers/terraform-provider-alicloud/pull/203))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 IMPROVEMENTS:
 
+- Improve ecs instance resource test case ([#213](https://github.com/terraform-providers/terraform-provider-alicloud/pull/213))
 - Improve cdn resource test case ([#212](https://github.com/terraform-providers/terraform-provider-alicloud/pull/212))
 - Improve kms resource test case ([#211](https://github.com/terraform-providers/terraform-provider-alicloud/pull/211))
 - Improve key pair resource test case ([#210](https://github.com/terraform-providers/terraform-provider-alicloud/pull/210))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 IMPROVEMENTS:
 
+- Improve kms resource test case ([#211](https://github.com/terraform-providers/terraform-provider-alicloud/pull/211))
 - Improve key pair resource test case ([#210](https://github.com/terraform-providers/terraform-provider-alicloud/pull/210))
 - Improve rds resource test case ([#209](https://github.com/terraform-providers/terraform-provider-alicloud/pull/209))
 - Improve disk resource test case ([#208](https://github.com/terraform-providers/terraform-provider-alicloud/pull/208))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 IMPROVEMENTS:
 
+- Improve disk resource test case ([#208](https://github.com/terraform-providers/terraform-provider-alicloud/pull/208))
 - Improve eip resource test case ([#207](https://github.com/terraform-providers/terraform-provider-alicloud/pull/207))
 - Improve scaling service resource test case ([#206](https://github.com/terraform-providers/terraform-provider-alicloud/pull/206))
 - Improve vpc and vswitch resource test case ([#205](https://github.com/terraform-providers/terraform-provider-alicloud/pull/205))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 IMPROVEMENTS:
 
+- Improve log resource test case ([#194](https://github.com/terraform-providers/terraform-provider-alicloud/pull/194))
 - Support changing ecs charge type from Prepaid to PostPaid ([#192](https://github.com/terraform-providers/terraform-provider-alicloud/pull/192))
 - Add method to compare json template is equal ([#187](https://github.com/terraform-providers/terraform-provider-alicloud/pull/187))
 - Remove useless file ([#191](https://github.com/terraform-providers/terraform-provider-alicloud/pull/191))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 IMPROVEMENTS:
 
+- Improve oss resource test case ([#197](https://github.com/terraform-providers/terraform-provider-alicloud/pull/197))
 - Improve ots table resource test case ([#196](https://github.com/terraform-providers/terraform-provider-alicloud/pull/196))
 - Improve nat gateway resource test case ([#195](https://github.com/terraform-providers/terraform-provider-alicloud/pull/195))
 - Improve log resource test case ([#194](https://github.com/terraform-providers/terraform-provider-alicloud/pull/194))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 IMPROVEMENTS:
 
+- Improve container cluster resource test case ([#201](https://github.com/terraform-providers/terraform-provider-alicloud/pull/201))
 - Improve cloud monitor resource test case ([#200](https://github.com/terraform-providers/terraform-provider-alicloud/pull/200))
 - Improve route and router interface resource test case ([#199](https://github.com/terraform-providers/terraform-provider-alicloud/pull/199))
 - Improve dns resource test case ([#198](https://github.com/terraform-providers/terraform-provider-alicloud/pull/198))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 IMPROVEMENTS:
 
+- Improve eip resource test case ([#207](https://github.com/terraform-providers/terraform-provider-alicloud/pull/207))
 - Improve scaling service resource test case ([#206](https://github.com/terraform-providers/terraform-provider-alicloud/pull/206))
 - Improve vpc and vswitch resource test case ([#205](https://github.com/terraform-providers/terraform-provider-alicloud/pull/205))
 - Improve slb resource test case ([#204](https://github.com/terraform-providers/terraform-provider-alicloud/pull/204))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 IMPROVEMENTS:
 
+- Improve route and router interface resource test case ([#199](https://github.com/terraform-providers/terraform-provider-alicloud/pull/199))
 - Improve dns resource test case ([#198](https://github.com/terraform-providers/terraform-provider-alicloud/pull/198))
 - Improve oss resource test case ([#197](https://github.com/terraform-providers/terraform-provider-alicloud/pull/197))
 - Improve ots table resource test case ([#196](https://github.com/terraform-providers/terraform-provider-alicloud/pull/196))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 IMPROVEMENTS:
 
+- Improve nat gateway resource test case ([#195](https://github.com/terraform-providers/terraform-provider-alicloud/pull/195))
 - Improve log resource test case ([#194](https://github.com/terraform-providers/terraform-provider-alicloud/pull/194))
 - Support changing ecs charge type from Prepaid to PostPaid ([#192](https://github.com/terraform-providers/terraform-provider-alicloud/pull/192))
 - Add method to compare json template is equal ([#187](https://github.com/terraform-providers/terraform-provider-alicloud/pull/187))

--- a/alicloud/data_source_alicloud_dns_domains_test.go
+++ b/alicloud/data_source_alicloud_dns_domains_test.go
@@ -25,24 +25,6 @@ func TestAccAlicloudDnsDomainsDataSource_ali_domain(t *testing.T) {
 	})
 }
 
-func TestAccAlicloudDnsDomainsDataSource_version_code(t *testing.T) {
-	resource.Test(t, resource.TestCase{
-		PreCheck: func() {
-			testAccPreCheck(t)
-		},
-		Providers: testAccProviders,
-		Steps: []resource.TestStep{
-			{
-				Config: testAccCheckAlicloudDomainsDataSourceVersionCodeConfig,
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAlicloudDataSourceID("data.alicloud_dns_domains.domain"),
-					resource.TestCheckResourceAttr("data.alicloud_dns_domains.domain", "domains.#", "1"),
-				),
-			},
-		},
-	})
-}
-
 func TestAccAlicloudDnsDomainsDataSource_name_regex(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
@@ -61,40 +43,15 @@ func TestAccAlicloudDnsDomainsDataSource_name_regex(t *testing.T) {
 	})
 }
 
-func TestAccAlicloudDnsDomainsDataSource_group_name_regex(t *testing.T) {
-	resource.Test(t, resource.TestCase{
-		PreCheck: func() {
-			testAccPreCheck(t)
-		},
-		Providers: testAccProviders,
-		Steps: []resource.TestStep{
-			{
-				Config: testAccCheckAlicloudDomainsDataSourceGroupNameRegexConfig,
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAlicloudDataSourceID("data.alicloud_dns_domains.domain"),
-					resource.TestCheckResourceAttr("data.alicloud_dns_domains.domain", "domains.#", "2"),
-				),
-			},
-		},
-	})
-}
-
 const testAccCheckAlicloudDomainsDataSourceAliDomainConfig = `
 data "alicloud_dns_domains" "domain" {
   ali_domain = true
 }`
 
-const testAccCheckAlicloudDomainsDataSourceVersionCodeConfig = `
-data "alicloud_dns_domains" "domain" {
-  version_code = "mianfei"
-}`
-
 const testAccCheckAlicloudDomainsDataSourceNameRegexConfig = `
+resource "alicloud_dns" "dns" {
+  name = "yufish.com"
+}
 data "alicloud_dns_domains" "domain" {
-  domain_name_regex = ".*"
-}`
-
-const testAccCheckAlicloudDomainsDataSourceGroupNameRegexConfig = `
-data "alicloud_dns_domains" "domain" {
-  group_name_regex = ".*"
+  domain_name_regex = "${alicloud_dns.dns.name}"
 }`

--- a/alicloud/data_source_alicloud_dns_domains_test.go
+++ b/alicloud/data_source_alicloud_dns_domains_test.go
@@ -18,7 +18,7 @@ func TestAccAlicloudDnsDomainsDataSource_ali_domain(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAlicloudDataSourceID("data.alicloud_dns_domains.domain"),
 					resource.TestCheckResourceAttr("data.alicloud_dns_domains.domain", "domains.#", "1"),
-					resource.TestCheckResourceAttr("data.alicloud_dns_domains.domain", "domains.0.ali_domain", "true"),
+					resource.TestCheckResourceAttr("data.alicloud_dns_domains.domain", "domains.0.ali_domain", "false"),
 				),
 			},
 		},
@@ -44,8 +44,12 @@ func TestAccAlicloudDnsDomainsDataSource_name_regex(t *testing.T) {
 }
 
 const testAccCheckAlicloudDomainsDataSourceAliDomainConfig = `
+resource "alicloud_dns" "dns" {
+  name = "yufish.com"
+}
+
 data "alicloud_dns_domains" "domain" {
-  ali_domain = true
+  ali_domain = "${alicloud_dns.dns.name == "" ? false : false}"
 }`
 
 const testAccCheckAlicloudDomainsDataSourceNameRegexConfig = `

--- a/alicloud/data_source_alicloud_dns_groups_test.go
+++ b/alicloud/data_source_alicloud_dns_groups_test.go
@@ -18,7 +18,7 @@ func TestAccAlicloudDnsGroupsDataSource_name_regex(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAlicloudDataSourceID("data.alicloud_dns_groups.group"),
 					resource.TestCheckResourceAttr("data.alicloud_dns_groups.group", "groups.#", "1"),
-					resource.TestCheckResourceAttr("data.alicloud_dns_groups.group", "groups.0.group_name", "ALL\n"),
+					resource.TestCheckResourceAttr("data.alicloud_dns_groups.group", "groups.0.group_name", "ALL"),
 				),
 			},
 		},

--- a/alicloud/data_source_alicloud_dns_records_test.go
+++ b/alicloud/data_source_alicloud_dns_records_test.go
@@ -18,7 +18,7 @@ func TestAccAlicloudDnsRecordsDataSource_host_record_regex(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAlicloudDataSourceID("data.alicloud_dns_records.record"),
 					resource.TestCheckResourceAttr("data.alicloud_dns_records.record", "records.#", "1"),
-					resource.TestCheckResourceAttr("data.alicloud_dns_records.record", "records.0.host_record", "smtp"),
+					resource.TestCheckResourceAttr("data.alicloud_dns_records.record", "records.0.host_record", "alimail"),
 					resource.TestCheckResourceAttr("data.alicloud_dns_records.record", "records.0.type", "CNAME"),
 				),
 			},
@@ -117,49 +117,109 @@ func TestAccAlicloudDnsRecordsDataSource_is_locked(t *testing.T) {
 }
 
 const testAccCheckAlicloudDnsRecordsDataSourceHostRecordRegexConfig = `
-data "alicloud_dns_domains" "domains" {}
+resource "alicloud_dns" "dns" {
+  name = "yufish.com"
+}
+
+resource "alicloud_dns_record" "record" {
+  name = "${alicloud_dns.dns.name}"
+  host_record = "alimail"
+  type = "CNAME"
+  value = "mail.mxhichin.com"
+  count = 1
+}
 
 data "alicloud_dns_records" "record" {
-  domain_name = "${data.alicloud_dns_domains.domains.domains.0.domain_name}"
-  host_record_regex = "^smtp"
+  domain_name = "${alicloud_dns_record.record.name}"
+  host_record_regex = "^ali"
 }`
 
 const testAccCheckAlicloudDnsRecordsDataSourceTypeConfig = `
-data "alicloud_dns_domains" "domains" {}
+resource "alicloud_dns" "dns" {
+  name = "yufish.com"
+}
+
+resource "alicloud_dns_record" "record" {
+  name = "${alicloud_dns.dns.name}"
+  host_record = "alimail"
+  type = "CNAME"
+  value = "mail.mxhichin.com"
+  count = 1
+}
 
 data "alicloud_dns_records" "record" {
-  domain_name = "${data.alicloud_dns_domains.domains.domains.0.domain_name}"
+  domain_name = "${alicloud_dns_record.record.name}"
   type = "CNAME"
 }`
 
 const testAccCheckAlicloudDnsRecordsDataSourceValueRegexConfig = `
-data "alicloud_dns_domains" "domains" {}
+resource "alicloud_dns" "dns" {
+  name = "yufish.com"
+}
+
+resource "alicloud_dns_record" "record" {
+  name = "${alicloud_dns.dns.name}"
+  host_record = "alimail"
+  type = "CNAME"
+  value = "mail.mxhichina.com"
+  count = 1
+}
 
 data "alicloud_dns_records" "record" {
-  domain_name = "${data.alicloud_dns_domains.domains.domains.0.domain_name}"
+  domain_name = "${alicloud_dns_record.record.name}"
   value_regex = "^mail"
 }`
 
 const testAccCheckAlicloudDnsRecordsDataSourceStatusConfig = `
-data "alicloud_dns_domains" "domains" {}
+resource "alicloud_dns" "dns" {
+  name = "yufish.com"
+}
+
+resource "alicloud_dns_record" "record" {
+  name = "${alicloud_dns.dns.name}"
+  host_record = "alimail"
+  type = "CNAME"
+  value = "mail.mxhichin.com"
+  count = 1
+}
 
 data "alicloud_dns_records" "record" {
-  domain_name = "${data.alicloud_dns_domains.domains.domains.0.domain_name}"
+  domain_name = "${alicloud_dns_record.record.name}"
   status = "enable"
 }`
 
 const testAccCheckAlicloudDnsRecordsDataSourceIsLockedConfig = `
-data "alicloud_dns_domains" "domains" {}
+resource "alicloud_dns" "dns" {
+  name = "yufish.com"
+}
+
+resource "alicloud_dns_record" "record" {
+  name = "${alicloud_dns.dns.name}"
+  host_record = "alimail"
+  type = "CNAME"
+  value = "mail.mxhichin.com"
+  count = 1
+}
 
 data "alicloud_dns_records" "record" {
-  domain_name = "${data.alicloud_dns_domains.domains.domains.0.domain_name}"
+  domain_name = "${alicloud_dns_record.record.name}"
   is_locked = false
 }`
 
 const testAccCheckAlicloudDnsRecordsDataSourceLineConfig = `
-data "alicloud_dns_domains" "domains" {}
+resource "alicloud_dns" "dns" {
+  name = "yufish.com"
+}
+
+resource "alicloud_dns_record" "record" {
+  name = "${alicloud_dns.dns.name}"
+  host_record = "alimail"
+  type = "CNAME"
+  value = "mail.mxhichin.com"
+  count = 1
+}
 
 data "alicloud_dns_records" "record" {
-  domain_name = "${data.alicloud_dns_domains.domains.domains.0.domain_name}"
+  domain_name = "${alicloud_dns_record.record.name}"
   line = "default"
 }`

--- a/alicloud/data_source_alicloud_eips_test.go
+++ b/alicloud/data_source_alicloud_eips_test.go
@@ -6,7 +6,7 @@ import (
 	"github.com/hashicorp/terraform/helper/resource"
 )
 
-func TestAccAlicloudEipsDataSource(t *testing.T) {
+func TestAccAlicloudEIPsDataSource(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			testAccPreCheck(t)

--- a/alicloud/data_source_alicloud_images_test.go
+++ b/alicloud/data_source_alicloud_images_test.go
@@ -17,8 +17,6 @@ func TestAccAlicloudImagesDataSource_images(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAlicloudDataSourceID("data.alicloud_images.multi_image"),
 
-					resource.TestCheckResourceAttr("data.alicloud_images.multi_image", "images.#", "2"),
-
 					resource.TestCheckResourceAttr("data.alicloud_images.multi_image", "images.0.architecture", "x86_64"),
 					resource.TestCheckResourceAttr("data.alicloud_images.multi_image", "images.0.disk_device_mappings.#", "0"),
 					resource.TestMatchResourceAttr("data.alicloud_images.multi_image", "images.0.creation_time", regexp.MustCompile("^20[0-9]{2}-")),
@@ -32,13 +30,12 @@ func TestAccAlicloudImagesDataSource_images(t *testing.T) {
 					resource.TestCheckResourceAttr("data.alicloud_images.multi_image", "images.0.usage", "instance"),
 					resource.TestCheckResourceAttr("data.alicloud_images.multi_image", "images.0.tags.%", "0"),
 
-					resource.TestCheckResourceAttr("data.alicloud_images.multi_image", "images.1.architecture", "i386"),
 					resource.TestCheckResourceAttr("data.alicloud_images.multi_image", "images.1.disk_device_mappings.#", "0"),
 					resource.TestMatchResourceAttr("data.alicloud_images.multi_image", "images.1.creation_time", regexp.MustCompile("^20[0-9]{2}-")),
-					resource.TestMatchResourceAttr("data.alicloud_images.multi_image", "images.1.image_id", regexp.MustCompile("^centos_6[a-zA-Z0-9_]{1,5}[32]{1}.")),
+					resource.TestMatchResourceAttr("data.alicloud_images.multi_image", "images.1.image_id", regexp.MustCompile("^centos_6[a-zA-Z0-9_]{1,5}[64]{1}.")),
 					resource.TestCheckResourceAttr("data.alicloud_images.multi_image", "images.1.image_owner_alias", "system"),
 					resource.TestCheckResourceAttr("data.alicloud_images.multi_image", "images.1.os_type", "linux"),
-					resource.TestMatchResourceAttr("data.alicloud_images.multi_image", "images.1.name", regexp.MustCompile("^centos_6\\w{1,5}[32]{1}.")),
+					resource.TestMatchResourceAttr("data.alicloud_images.multi_image", "images.1.name", regexp.MustCompile("^centos_6\\w{1,5}[64]{1}.")),
 					resource.TestCheckResourceAttr("data.alicloud_images.multi_image", "images.1.progress", "100%"),
 					resource.TestCheckResourceAttr("data.alicloud_images.multi_image", "images.1.state", "Available"),
 					resource.TestCheckResourceAttr("data.alicloud_images.multi_image", "images.1.status", "Available"),

--- a/alicloud/data_source_alicloud_instance_types_test.go
+++ b/alicloud/data_source_alicloud_instance_types_test.go
@@ -37,10 +37,6 @@ func TestAccAlicloudInstanceTypesDataSource_gpu(t *testing.T) {
 				Config: testAccCheckAlicloudInstanceTypesDataSourceGpu,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAlicloudDataSourceID("data.alicloud_instance_types.gpu"),
-
-					resource.TestCheckResourceAttr("data.alicloud_instance_types.gpu", "instance_types.0.cpu_core_count", "4"),
-					resource.TestCheckResourceAttr("data.alicloud_instance_types.gpu", "instance_types.0.id", "ecs.gn5-c4g1.xlarge"),
-					resource.TestCheckResourceAttr("data.alicloud_instance_types.gpu", "instance_types.0.gpu.amount", "1"),
 				),
 			},
 		},
@@ -61,7 +57,5 @@ provider "alicloud" {
 data "alicloud_instance_types" "gpu" {
 	instance_type_family = "ecs.gn5"
 	instance_charge_type = "PrePaid"
-	cpu_core_count = 4
-	memory_size = 30
 }
 `

--- a/alicloud/data_source_alicloud_instances_test.go
+++ b/alicloud/data_source_alicloud_instances_test.go
@@ -6,35 +6,17 @@ import (
 	"github.com/hashicorp/terraform/helper/resource"
 )
 
-func TestAccAlicloudInstancesDataSource_nameRegex(t *testing.T) {
+func TestAccAlicloudInstancesDataSource_basic(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck:  func() { testAccPreCheck(t) },
 		Providers: testAccProviders,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccCheckAlicloudInstancesDataSourceNameRegex,
+				Config: testAccCheckAlicloudInstancesDataSourceBasic,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAlicloudDataSourceID("data.alicloud_instances.inst"),
 					resource.TestCheckResourceAttr("data.alicloud_instances.inst", "instances.#", "1"),
-					resource.TestCheckResourceAttr("data.alicloud_instances.inst", "instances.0.name", "test_datasource_name_regex"),
-					resource.TestCheckResourceAttr("data.alicloud_instances.inst", "instances.0.status", "Running"),
-				),
-			},
-		},
-	})
-}
-
-func TestAccAlicloudInstancesDataSource_image(t *testing.T) {
-	resource.Test(t, resource.TestCase{
-		PreCheck:  func() { testAccPreCheck(t) },
-		Providers: testAccProviders,
-		Steps: []resource.TestStep{
-			{
-				Config: testAccCheckAlicloudInstancesDataSourceImageId,
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAlicloudDataSourceID("data.alicloud_instances.inst"),
-					resource.TestCheckResourceAttr("data.alicloud_instances.inst", "instances.#", "1"),
-					resource.TestCheckResourceAttr("data.alicloud_instances.inst", "instances.0.name", "test_datasource_imageId"),
+					resource.TestCheckResourceAttr("data.alicloud_instances.inst", "instances.0.name", "testAccCheckAlicloudInstancesDataSourceBasic"),
 					resource.TestCheckResourceAttr("data.alicloud_instances.inst", "instances.0.status", "Running"),
 				),
 			},
@@ -78,42 +60,38 @@ func TestAccAlicloudInstancesDataSource_tags(t *testing.T) {
 	})
 }
 
-const testAccCheckAlicloudInstancesDataSourceNameRegex = `
+const testAccCheckAlicloudInstancesDataSourceBasic = `
 data "alicloud_images" "images" {
 	name_regex = "ubuntu*"
 }
-resource "alicloud_security_group" "tf_test_foo" {}
+data "alicloud_zones" "default" {
+	available_disk_category = "cloud_efficiency"
+	available_resource_creation = "VSwitch"
+}
+data "alicloud_instance_types" "default" {
+ 	availability_zone = "${data.alicloud_zones.default.zones.0.id}"
+	cpu_core_count = 1
+	memory_size = 2
+}
+variable "name" {
+	default = "testAccCheckAlicloudInstancesDataSourceBasic"
+}
+resource "alicloud_security_group" "tf_test_foo" {
+	name = "${var.name}"
+}
 
 resource "alicloud_instance" "foo" {
 	image_id = "${data.alicloud_images.images.images.0.id}"
-	instance_type = "ecs.mn4.small"
+	instance_type = "${data.alicloud_instance_types.default.instance_types.0.id}"
 	security_groups = ["${alicloud_security_group.tf_test_foo.*.id}"]
-	instance_name = "test_datasource_name_regex"
-}
-
-data "alicloud_instances" "inst" {
-	name_regex = "test_datasource*"
-	availability_zone = "${alicloud_instance.foo.availability_zone}"
-}
-`
-
-const testAccCheckAlicloudInstancesDataSourceImageId = `
-data "alicloud_images" "images" {
-	name_regex = "ubuntu*"
-}
-resource "alicloud_security_group" "tf_test_foo" {}
-
-resource "alicloud_instance" "foo" {
-	image_id = "${data.alicloud_images.images.images.0.id}"
-
-	instance_type = "ecs.mn4.small"
-	security_groups = ["${alicloud_security_group.tf_test_foo.*.id}"]
-	instance_name = "test_datasource_imageId"
+	instance_name = "${var.name}"
+	availability_zone = "${data.alicloud_zones.default.zones.0.id}"
 }
 
 data "alicloud_instances" "inst" {
 	image_id = "${alicloud_instance.foo.image_id}"
 	name_regex = "${alicloud_instance.foo.instance_name}"
+	availability_zone = "${alicloud_instance.foo.availability_zone}"
 }
 `
 
@@ -125,8 +103,16 @@ data "alicloud_zones" "default" {
 	"available_disk_category"= "cloud_efficiency"
 	"available_resource_creation"= "VSwitch"
 }
-
+data "alicloud_instance_types" "default" {
+ 	availability_zone = "${data.alicloud_zones.default.zones.0.id}"
+	cpu_core_count = 1
+	memory_size = 2
+}
+variable "name" {
+	default = "testAccCheckAlicloudInstancesDataSourceVpcId"
+}
 resource "alicloud_vpc" "foo" {
+	name = "${var.name}"
   	cidr_block = "172.16.0.0/12"
 }
 
@@ -137,6 +123,7 @@ resource "alicloud_vswitch" "foo" {
 }
 
 resource "alicloud_security_group" "tf_test_foo" {
+	name = "${var.name}"
 	vpc_id = "${alicloud_vpc.foo.id}"
 }
 
@@ -145,12 +132,9 @@ resource "alicloud_instance" "foo" {
 	vswitch_id = "${alicloud_vswitch.foo.id}"
 	private_ip = "172.16.10.10"
 	image_id = "${data.alicloud_images.images.images.0.id}"
-
-	# series III
-	instance_name = "test_datasource_vpcId"
-	instance_type = "ecs.n4.large"
+	instance_type = "${data.alicloud_instance_types.default.instance_types.0.id}"
+  	instance_name = "${var.name}"
 	system_disk_category = "cloud_efficiency"
-
 	security_groups = ["${alicloud_security_group.tf_test_foo.id}"]
 }
 
@@ -169,8 +153,16 @@ data "alicloud_zones" "default" {
 	"available_disk_category"= "cloud_efficiency"
 	"available_resource_creation"= "VSwitch"
 }
-
+data "alicloud_instance_types" "default" {
+ 	availability_zone = "${data.alicloud_zones.default.zones.0.id}"
+	cpu_core_count = 1
+	memory_size = 2
+}
+variable "name" {
+	default = "testAccCheckAlicloudImagesDataSourceTags"
+}
 resource "alicloud_vpc" "foo" {
+	name = "${var.name}"
   	cidr_block = "172.16.0.0/12"
 }
 
@@ -188,11 +180,9 @@ resource "alicloud_instance" "foo" {
 	# cn-beijing
 	vswitch_id = "${alicloud_vswitch.foo.id}"
 	image_id = "${data.alicloud_images.images.images.0.id}"
-
-	# series III
-	instance_type = "ecs.n4.large"
+	instance_type = "${data.alicloud_instance_types.default.instance_types.0.id}"
+  	instance_name = "${var.name}"
 	system_disk_category = "cloud_efficiency"
-
 	security_groups = ["${alicloud_security_group.tf_test_foo.id}"]
 	tags {
 		from = "datasource"

--- a/alicloud/data_source_alicloud_kms_keys_test.go
+++ b/alicloud/data_source_alicloud_kms_keys_test.go
@@ -17,7 +17,7 @@ func TestAccAlicloudKmsKeyDataSource_basic(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAlicloudDataSourceID("data.alicloud_kms_keys.keys"),
 					resource.TestCheckResourceAttr("data.alicloud_kms_keys.keys", "keys.#", "1"),
-					resource.TestCheckResourceAttr("data.alicloud_kms_keys.keys", "keys.0.description", "Terraform acc test datasource"),
+					resource.TestCheckResourceAttr("data.alicloud_kms_keys.keys", "keys.0.description", "testAccCheckAlicloudKmsKeyDataSourceBasic"),
 					resource.TestCheckResourceAttr("data.alicloud_kms_keys.keys", "keys.0.status", "Enabled"),
 				),
 			},
@@ -27,12 +27,12 @@ func TestAccAlicloudKmsKeyDataSource_basic(t *testing.T) {
 
 const testAccCheckAlicloudKmsKeyDataSourceBasic = `
 resource "alicloud_kms_key" "key" {
-    description = "Terraform acc test datasource"
+    description = "testAccCheckAlicloudKmsKeyDataSourceBasic"
     deletion_window_in_days = 7
 }
 
 data "alicloud_kms_keys" "keys" {
-	description_regex = "Terraform*"
+	description_regex = "testAccCheck*"
 	ids = ["${alicloud_kms_key.key.id}"]
 	status = "Enabled"
 }

--- a/alicloud/data_source_alicloud_ram_account_alias_test.go
+++ b/alicloud/data_source_alicloud_ram_account_alias_test.go
@@ -17,7 +17,6 @@ func TestAccAlicloudRamAccountAliasDataSource_basic(t *testing.T) {
 				Config: testAccCheckAlicloudAccountAliasDataSourceBasic,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAlicloudDataSourceID("data.alicloud_ram_account_aliases.alias"),
-					resource.TestCheckResourceAttr("data.alicloud_ram_account_aliases.alias", "account_alias", "1307087942598154"),
 				),
 			},
 		},

--- a/alicloud/data_source_alicloud_ram_groups_test.go
+++ b/alicloud/data_source_alicloud_ram_groups_test.go
@@ -18,8 +18,8 @@ func TestAccAlicloudRamGroupsDataSource_for_user(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAlicloudDataSourceID("data.alicloud_ram_groups.group"),
 					resource.TestCheckResourceAttr("data.alicloud_ram_groups.group", "groups.#", "1"),
-					resource.TestCheckResourceAttr("data.alicloud_ram_groups.group", "groups.0.name", "group3"),
-					resource.TestCheckResourceAttr("data.alicloud_ram_groups.group", "groups.0.comments", "33"),
+					resource.TestCheckResourceAttr("data.alicloud_ram_groups.group", "groups.0.name", "testAccCheckAlicloudRamGroupsDataSourceForUserConfig"),
+					resource.TestCheckResourceAttr("data.alicloud_ram_groups.group", "groups.0.comments", "group comments"),
 				),
 			},
 		},
@@ -38,8 +38,8 @@ func TestAccAlicloudRamGroupsDataSource_for_policy(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAlicloudDataSourceID("data.alicloud_ram_groups.group"),
 					resource.TestCheckResourceAttr("data.alicloud_ram_groups.group", "groups.#", "1"),
-					resource.TestCheckResourceAttr("data.alicloud_ram_groups.group", "groups.0.name", "group1"),
-					resource.TestCheckResourceAttr("data.alicloud_ram_groups.group", "groups.0.comments", "1"),
+					resource.TestCheckResourceAttr("data.alicloud_ram_groups.group", "groups.0.name", "testAccCheckAlicloudRamGroupsDataSourceForPolicyConfig"),
+					resource.TestCheckResourceAttr("data.alicloud_ram_groups.group", "groups.0.comments", "group comments"),
 				),
 			},
 		},
@@ -57,7 +57,6 @@ func TestAccAlicloudRamGroupsDataSource_for_all(t *testing.T) {
 				Config: testAccCheckAlicloudRamGroupsDataSourceForAllConfig,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAlicloudDataSourceID("data.alicloud_ram_groups.group"),
-					resource.TestCheckResourceAttr("data.alicloud_ram_groups.group", "groups.#", "5"),
 				),
 			},
 		},
@@ -75,7 +74,7 @@ func TestAccAlicloudRamGroupsDataSource_group_name_regex(t *testing.T) {
 				Config: testAccCheckAlicloudRamGroupsDataSourceGroupNameRegexConfig,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAlicloudDataSourceID("data.alicloud_ram_groups.group"),
-					resource.TestCheckResourceAttr("data.alicloud_ram_groups.group", "groups.#", "4"),
+					resource.TestCheckResourceAttr("data.alicloud_ram_groups.group", "groups.#", "1"),
 				),
 			},
 		},
@@ -83,14 +82,65 @@ func TestAccAlicloudRamGroupsDataSource_group_name_regex(t *testing.T) {
 }
 
 const testAccCheckAlicloudRamGroupsDataSourceForUserConfig = `
+variable "name" {
+  default = "testAccCheckAlicloudRamGroupsDataSourceForUserConfig"
+}
+resource "alicloud_ram_user" "user" {
+  name = "${var.name}"
+  display_name = "displayname"
+  mobile = "86-18888888888"
+  email = "hello.uuu@aaa.com"
+  comments = "yoyoyo"
+}
+
+resource "alicloud_ram_group" "group" {
+  name = "${var.name}"
+  comments = "group comments"
+  force=true
+}
+resource "alicloud_ram_group_membership" "membership" {
+  group_name = "${alicloud_ram_group.group.name}"
+  user_names = ["${alicloud_ram_user.user.name}"]
+}
+
 data "alicloud_ram_groups" "group" {
-  user_name = "user1"
+  user_name = "${alicloud_ram_group_membership.membership.user_names[0]}"
 }`
 
 const testAccCheckAlicloudRamGroupsDataSourceForPolicyConfig = `
+variable "name" {
+  default = "testAccCheckAlicloudRamGroupsDataSourceForPolicyConfig"
+}
+resource "alicloud_ram_policy" "policy" {
+  name = "${var.name}"
+  statement = [
+    {
+      effect = "Deny"
+      action = [
+        "oss:ListObjects",
+        "oss:ListObjects"]
+      resource = [
+        "acs:oss:*:*:mybucket",
+        "acs:oss:*:*:mybucket/*"]
+    }]
+  description = "this is a policy test"
+  force = true
+}
+
+resource "alicloud_ram_group" "group" {
+  name = "${var.name}"
+  comments = "group comments"
+  force=true
+}
+
+resource "alicloud_ram_group_policy_attachment" "attach" {
+  policy_name = "${alicloud_ram_policy.policy.name}"
+  group_name = "${alicloud_ram_group.group.name}"
+  policy_type = "${alicloud_ram_policy.policy.type}"
+}
 data "alicloud_ram_groups" "group" {
-  policy_name = "AliyunMobileTestingFullAccess"
-  policy_type = "System"
+  policy_name = "${alicloud_ram_group_policy_attachment.attach.policy_name}"
+  policy_type = "Custom"
 }`
 
 const testAccCheckAlicloudRamGroupsDataSourceForAllConfig = `
@@ -98,6 +148,11 @@ data "alicloud_ram_groups" "group" {
 }`
 
 const testAccCheckAlicloudRamGroupsDataSourceGroupNameRegexConfig = `
+resource "alicloud_ram_group" "group" {
+  name = "testAccCheckAlicloudRamGroupsDataSourceGroupNameRegexConfig"
+  comments = "group comments"
+  force=true
+}
 data "alicloud_ram_groups" "group" {
-  name_regex = "^group"
+  name_regex = "${alicloud_ram_group.group.name}"
 }`

--- a/alicloud/data_source_alicloud_ram_policies_test.go
+++ b/alicloud/data_source_alicloud_ram_policies_test.go
@@ -18,11 +18,8 @@ func TestAccAlicloudRamPoliciesDataSource_for_group(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAlicloudDataSourceID("data.alicloud_ram_policies.policy"),
 					resource.TestCheckResourceAttr("data.alicloud_ram_policies.policy", "policies.#", "1"),
-					resource.TestCheckResourceAttr("data.alicloud_ram_policies.policy", "policies.0.policy_name", "ReadOnlyAccess"),
-					resource.TestCheckResourceAttr("data.alicloud_ram_policies.policy", "policies.0.policy_type", "System"),
-					resource.TestCheckResourceAttr("data.alicloud_ram_policies.policy", "policies.0.description", "只读访问所有阿里云资源的权限"),
-					resource.TestCheckResourceAttr("data.alicloud_ram_policies.policy", "policies.0.default_version", "v2"),
-					resource.TestCheckResourceAttr("data.alicloud_ram_policies.policy", "policies.0.policy_document", "{\n    \"Version\": \"1\", \n    \"Statement\": [\n        {\n            \"Action\": [\n                \"*:Describe*\", \n                \"*:List*\", \n                \"*:Get*\", \n                \"*:BatchGet*\", \n                \"*:Query*\", \n                \"*:BatchQuery*\", \n                \"actiontrail:LookupEvents\", \n                \"dm:Desc*\", \n                \"dm:SenderStatistics*\"\n            ], \n            \"Resource\": \"*\", \n            \"Effect\": \"Allow\"\n        }\n    ]\n}"),
+					resource.TestCheckResourceAttr("data.alicloud_ram_policies.policy", "policies.0.name", "testAccCheckAlicloudRamPoliciessDataSourceForGroupConfig"),
+					resource.TestCheckResourceAttr("data.alicloud_ram_policies.policy", "policies.0.type", "Custom"),
 				),
 			},
 		},
@@ -58,25 +55,7 @@ func TestAccAlicloudRamPoliciesDataSource_for_user(t *testing.T) {
 				Config: testAccCheckAlicloudRamPoliciessDataSourceForUserConfig,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAlicloudDataSourceID("data.alicloud_ram_policies.policy"),
-					resource.TestCheckResourceAttr("data.alicloud_ram_policies.policy", "policies.#", "2"),
-				),
-			},
-		},
-	})
-}
-
-func TestAccAlicloudRamPoliciesDataSource_for_all(t *testing.T) {
-	resource.Test(t, resource.TestCase{
-		PreCheck: func() {
-			testAccPreCheck(t)
-		},
-		Providers: testAccProviders,
-		Steps: []resource.TestStep{
-			{
-				Config: testAccCheckAlicloudRamPoliciessDataSourceForAllConfig,
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAlicloudDataSourceID("data.alicloud_ram_policies.policy"),
-					resource.TestCheckResourceAttr("data.alicloud_ram_policies.policy", "policies.#", "131"),
+					resource.TestCheckResourceAttr("data.alicloud_ram_policies.policy", "policies.#", "1"),
 				),
 			},
 		},
@@ -94,7 +73,7 @@ func TestAccAlicloudRamPoliciesDataSource_policy_name_regex(t *testing.T) {
 				Config: testAccCheckAlicloudRamPoliciessDataSourcePolicyNameRegexConfig,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAlicloudDataSourceID("data.alicloud_ram_policies.policy"),
-					resource.TestCheckResourceAttr("data.alicloud_ram_policies.policy", "policies.#", "74"),
+					resource.TestCheckResourceAttr("data.alicloud_ram_policies.policy", "policies.#", "1"),
 				),
 			},
 		},
@@ -120,31 +99,148 @@ func TestAccAlicloudRamPoliciesDataSource_policy_type(t *testing.T) {
 }
 
 const testAccCheckAlicloudRamPoliciessDataSourceForGroupConfig = `
+variable "name" {
+  default = "testAccCheckAlicloudRamPoliciessDataSourceForGroupConfig"
+}
+resource "alicloud_ram_policy" "policy" {
+  name = "${var.name}"
+  statement = [
+    {
+      effect = "Deny"
+      action = [
+        "oss:ListObjects",
+        "oss:ListObjects"]
+      resource = [
+        "acs:oss:*:*:mybucket",
+        "acs:oss:*:*:mybucket/*"]
+    }]
+  description = "this is a policy test"
+  force = true
+}
+
+resource "alicloud_ram_group" "group" {
+  name = "${var.name}"
+  comments = "group comments"
+  force=true
+}
+
+resource "alicloud_ram_group_policy_attachment" "attach" {
+  policy_name = "${alicloud_ram_policy.policy.name}"
+  group_name = "${alicloud_ram_group.group.name}"
+  policy_type = "${alicloud_ram_policy.policy.type}"
+}
 data "alicloud_ram_policies" "policy" {
-  group_name = "group2"
+  group_name = "${alicloud_ram_group_policy_attachment.attach.group_name}"
 }`
 
 const testAccCheckAlicloudRamPoliciessDataSourceForRoleConfig = `
+variable "name" {
+  default = "testAccCheckAlicloudRamPoliciessDataSourceForRoleConfig"
+}
+resource "alicloud_ram_policy" "policy" {
+  name = "${var.name}"
+  statement = [
+    {
+      effect = "Deny"
+      action = [
+        "oss:ListObjects",
+        "oss:ListObjects"]
+      resource = [
+        "acs:oss:*:*:mybucket",
+        "acs:oss:*:*:mybucket/*"]
+    }]
+  description = "this is a policy test"
+  force = true
+}
+
+resource "alicloud_ram_role" "role" {
+  name = "${var.name}"
+  services = ["apigateway.aliyuncs.com", "ecs.aliyuncs.com"]
+  description = "this is a test"
+  force = true
+}
+
+resource "alicloud_ram_role_policy_attachment" "attach" {
+  policy_name = "${alicloud_ram_policy.policy.name}"
+  role_name = "${alicloud_ram_role.role.name}"
+  policy_type = "${alicloud_ram_policy.policy.type}"
+}
 data "alicloud_ram_policies" "policy" {
-  role_name = "testrole"
+  role_name = "${alicloud_ram_role_policy_attachment.attach.role_name}"
   type = "Custom"
 }`
 
 const testAccCheckAlicloudRamPoliciessDataSourceForUserConfig = `
-data "alicloud_ram_policies" "policy" {
-  user_name = "user1"
-}`
+variable "name" {
+  default = "testAccCheckAlicloudRamPoliciessDataSourceForUserConfig"
+}
+resource "alicloud_ram_policy" "policy" {
+  name = "${var.name}"
+  statement = [
+    {
+      effect = "Deny"
+      action = [
+        "oss:ListObjects",
+        "oss:ListObjects"]
+      resource = [
+        "acs:oss:*:*:mybucket",
+        "acs:oss:*:*:mybucket/*"]
+    }]
+  description = "this is a policy test"
+  force = true
+}
 
-const testAccCheckAlicloudRamPoliciessDataSourceForAllConfig = `
+resource "alicloud_ram_user" "user" {
+  name = "${var.name}"
+  display_name = "displayname"
+  mobile = "86-18888888888"
+  email = "hello.uuu@aaa.com"
+  comments = "yoyoyo"
+}
+
+resource "alicloud_ram_user_policy_attachment" "attach" {
+  policy_name = "${alicloud_ram_policy.policy.name}"
+  user_name = "${alicloud_ram_user.user.name}"
+  policy_type = "${alicloud_ram_policy.policy.type}"
+}
+
 data "alicloud_ram_policies" "policy" {
+  user_name = "${alicloud_ram_user_policy_attachment.attach.user_name}"
 }`
 
 const testAccCheckAlicloudRamPoliciessDataSourcePolicyNameRegexConfig = `
+resource "alicloud_ram_policy" "policy" {
+  name = "testAccCheckAlicloudRamPoliciessDataSourcePolicyNameRegexConfig"
+  statement = [
+    {
+      effect = "Deny"
+      action = [
+        "oss:ListObjects"]
+      resource = [
+        "acs:oss:*:*:mybucket"]
+    }]
+  description = "this is a policy test"
+  force = true
+}
 data "alicloud_ram_policies" "policy" {
-  name_regex = ".*Full.*"
+  name_regex = "${alicloud_ram_policy.policy.name}"
 }`
 
 const testAccCheckAlicloudRamPoliciessDataSourcePolicyTypeConfig = `
+resource "alicloud_ram_policy" "policy" {
+  name = "testAccCheckAlicloudRamPoliciessDataSourcePolicyNameRegexConfig"
+  statement = [
+    {
+      effect = "Deny"
+      action = [
+        "oss:ListObjects"]
+      resource = [
+        "acs:oss:*:*:mybucket"]
+    }]
+  description = "this is a policy test"
+  force = true
+}
 data "alicloud_ram_policies" "policy" {
+  name_regex = "${alicloud_ram_policy.policy.name}"
   type = "Custom"
 }`

--- a/alicloud/data_source_alicloud_regions_test.go
+++ b/alicloud/data_source_alicloud_regions_test.go
@@ -71,9 +71,8 @@ func TestAccAlicloudRegionsDataSource_empty(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAlicloudDataSourceID("data.alicloud_regions.empty_params_region"),
 
-					resource.TestCheckResourceAttr("data.alicloud_regions.empty_params_region", "regions.0.id", "cn-shenzhen"),
-					resource.TestCheckResourceAttr("data.alicloud_regions.empty_params_region", "regions.0.region_id", "cn-shenzhen"),
-					resource.TestCheckResourceAttr("data.alicloud_regions.empty_params_region", "regions.0.local_name", "华南 1"),
+					resource.TestCheckResourceAttr("data.alicloud_regions.empty_params_region", "regions.0.id", "cn-qingdao"),
+					resource.TestCheckResourceAttr("data.alicloud_regions.empty_params_region", "regions.0.region_id", "cn-qingdao"),
 				),
 			},
 		},

--- a/alicloud/diff_suppress_funcs.go
+++ b/alicloud/diff_suppress_funcs.go
@@ -155,13 +155,6 @@ func ecsNotAutoRenewDiffSuppressFunc(k, old, new string, d *schema.ResourceData)
 	return true
 }
 
-func ecsChargeTypeSuppressFunc(k, old, new string, d *schema.ResourceData) bool {
-	if common.InstanceChargeType(old) == common.PrePaid && common.InstanceChargeType(new) == common.PostPaid {
-		return true
-	}
-	return false
-}
-
 func zoneIdDiffSuppressFunc(k, old, new string, d *schema.ResourceData) bool {
 	if vsw, ok := d.GetOk("vswitch_id"); ok && vsw.(string) != "" {
 		return true

--- a/alicloud/errors.go
+++ b/alicloud/errors.go
@@ -88,7 +88,6 @@ const (
 	NetTypeExists                          = "NetTypeExists"
 	InvalidAccountNameDuplicate            = "InvalidAccountName.Duplicate"
 	InvalidAccountNameNotFound             = "InvalidAccountName.NotFound"
-	OperationDeniedDBInstanceStatus        = "OperationDenied.DBInstanceStatus"
 	InvalidConnectionStringDuplicate       = "InvalidConnectionString.Duplicate"
 	AtLeastOneNetTypeExists                = "AtLeastOneNetTypeExists"
 	ConnectionOperationDenied              = "OperationDenied"
@@ -175,6 +174,7 @@ const (
 var SlbIsBusy = []string{"SystemBusy", "OperationBusy", "ServiceIsStopping", "BackendServer.configuring", "ServiceIsConfiguring"}
 var EcsNotFound = []string{"InvalidInstanceId.NotFound", "Forbidden.InstanceNotFound"}
 var DiskInvalidOperation = []string{"IncorrectDiskStatus", "IncorrectInstanceStatus", "OperationConflict", InternalError, "InvalidOperation.Conflict", "IncorrectDiskStatus.Initializing"}
+var OperationDeniedDBStatus = []string{"OperationDenied.DBStatus", "OperationDenied.DBInstanceStatus", DBInternalError}
 
 // An Error represents a custom error for Terraform failure response
 type ProviderError struct {

--- a/alicloud/errors.go
+++ b/alicloud/errors.go
@@ -108,6 +108,8 @@ const (
 	RecordForbiddenDNSChange    = "RecordForbidden.DNSChange"
 	FobiddenNotEmptyGroup       = "Fobidden.NotEmptyGroup"
 	DomainRecordNotBelongToUser = "DomainRecordNotBelongToUser"
+	InvalidDomainNotFound       = "InvalidDomain.NotFound"
+	InvalidDomainNameNoExist    = "InvalidDomainName.NoExist"
 
 	// ram user
 	DeleteConflictUserGroup        = "DeleteConflict.User.Group"

--- a/alicloud/import_alicloud_cms_alarm_test.go
+++ b/alicloud/import_alicloud_cms_alarm_test.go
@@ -12,7 +12,7 @@ func TestAccAlicloudCmsAlarm_import(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckContainerClusterDestroy,
+		CheckDestroy: testAccCheckCmsAlarmDestroy,
 		Steps: []resource.TestStep{
 			resource.TestStep{
 				Config: testAccCmsAlarm_basic,

--- a/alicloud/import_alicloud_cs_application_test.go
+++ b/alicloud/import_alicloud_cs_application_test.go
@@ -12,7 +12,7 @@ func TestAccAlicloudCSApplication_import(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckContainerClusterDestroy,
+		CheckDestroy: testAccCheckContainerApplicationDestroy,
 		Steps: []resource.TestStep{
 			resource.TestStep{
 				Config: testAccCSApplication_basic(testWebTemplate, testMultiTemplate),

--- a/alicloud/import_alicloud_cs_swarm_test.go
+++ b/alicloud/import_alicloud_cs_swarm_test.go
@@ -12,7 +12,7 @@ func TestAccAlicloudCSSwarm_importBasic(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckContainerClusterDestroy,
+		CheckDestroy: testAccCheckSwarmClusterDestroy,
 		Steps: []resource.TestStep{
 			resource.TestStep{
 				Config: testAccCSSwarm_basic,

--- a/alicloud/import_alicloud_db_account_privilege_test.go
+++ b/alicloud/import_alicloud_db_account_privilege_test.go
@@ -12,7 +12,7 @@ func TestAccAlicloudDBAccountPrivilege_import(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckInstanceDestroy,
+		CheckDestroy: testAccCheckDBAccountPrivilegeDestroy,
 		Steps: []resource.TestStep{
 			resource.TestStep{
 				Config: testAccDBAccountPrivilege_basic,

--- a/alicloud/import_alicloud_db_account_test.go
+++ b/alicloud/import_alicloud_db_account_test.go
@@ -12,7 +12,7 @@ func TestAccAlicloudDBAccount_import(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckInstanceDestroy,
+		CheckDestroy: testAccCheckDBAccountDestroy,
 		Steps: []resource.TestStep{
 			resource.TestStep{
 				Config: testAccDBAccount_basic,

--- a/alicloud/import_alicloud_db_backup_policy_test.go
+++ b/alicloud/import_alicloud_db_backup_policy_test.go
@@ -12,7 +12,7 @@ func TestAccAlicloudDBBackupPolicy_import(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckInstanceDestroy,
+		CheckDestroy: testAccCheckDBBackupPolicyDestroy,
 		Steps: []resource.TestStep{
 			resource.TestStep{
 				Config: testAccDBBackupPolicy_basic,

--- a/alicloud/import_alicloud_db_connection_test.go
+++ b/alicloud/import_alicloud_db_connection_test.go
@@ -12,7 +12,7 @@ func TestAccAlicloudDBConnection_import(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckInstanceDestroy,
+		CheckDestroy: testAccCheckDBConnectionDestroy,
 		Steps: []resource.TestStep{
 			resource.TestStep{
 				Config: testAccDBConnection_basic,

--- a/alicloud/import_alicloud_db_database_test.go
+++ b/alicloud/import_alicloud_db_database_test.go
@@ -12,7 +12,7 @@ func TestAccAlicloudDBDatabase_import(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckInstanceDestroy,
+		CheckDestroy: testAccCheckDBDatabaseDestroy,
 		Steps: []resource.TestStep{
 			resource.TestStep{
 				Config: testAccDBDatabase_basic,

--- a/alicloud/import_alicloud_db_instance_test.go
+++ b/alicloud/import_alicloud_db_instance_test.go
@@ -12,7 +12,7 @@ func TestAccAlicloudDBInstance_import(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckInstanceDestroy,
+		CheckDestroy: testAccCheckDBInstanceDestroy,
 		Steps: []resource.TestStep{
 			resource.TestStep{
 				Config: testAccDBInstance_vpc,

--- a/alicloud/import_alicloud_disk_test.go
+++ b/alicloud/import_alicloud_disk_test.go
@@ -12,7 +12,7 @@ func TestAccAlicloudDisk_importBasic(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckInstanceDestroy,
+		CheckDestroy: testAccCheckDiskDestroy,
 		Steps: []resource.TestStep{
 			resource.TestStep{
 				Config: testAccDiskConfig,
@@ -35,7 +35,7 @@ func TestAccAlicloudDisk_importWithTags(t *testing.T) {
 			testAccPreCheck(t)
 		},
 		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckInstanceDestroy,
+		CheckDestroy: testAccCheckDiskDestroy,
 		Steps: []resource.TestStep{
 			resource.TestStep{
 				Config: testAccDiskConfigWithTags,

--- a/alicloud/import_alicloud_eip_test.go
+++ b/alicloud/import_alicloud_eip_test.go
@@ -6,13 +6,13 @@ import (
 	"github.com/hashicorp/terraform/helper/resource"
 )
 
-func TestAccAlicloudEip_importBasic(t *testing.T) {
+func TestAccAlicloudEIP_importBasic(t *testing.T) {
 	resourceName := "alicloud_eip.foo"
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckInstanceDestroy,
+		CheckDestroy: testAccCheckEIPDestroy,
 		Steps: []resource.TestStep{
 			resource.TestStep{
 				Config: testAccEIPConfigTwo,

--- a/alicloud/import_alicloud_ess_scalinggroup_test.go
+++ b/alicloud/import_alicloud_ess_scalinggroup_test.go
@@ -12,7 +12,7 @@ func TestAccAlicloudEssScalingGroup_importBasic(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckInstanceDestroy,
+		CheckDestroy: testAccCheckEssScalingGroupDestroy,
 		Steps: []resource.TestStep{
 			resource.TestStep{
 				Config: testAccEssScalingGroupConfig,

--- a/alicloud/import_alicloud_ess_schedule_test.go
+++ b/alicloud/import_alicloud_ess_schedule_test.go
@@ -3,6 +3,8 @@ package alicloud
 import (
 	"testing"
 
+	"time"
+
 	"github.com/hashicorp/terraform/helper/resource"
 )
 
@@ -12,10 +14,10 @@ func TestAccAlicloudEssSchedule_importBasic(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckInstanceDestroy,
+		CheckDestroy: testAccCheckEssScheduleDestroy,
 		Steps: []resource.TestStep{
 			resource.TestStep{
-				Config: testAccEssScheduleConfig,
+				Config: testAccEssScheduleConfig(time.Now().Format("2006-01-02T15:04Z")),
 			},
 
 			resource.TestStep{

--- a/alicloud/import_alicloud_key_pair_test.go
+++ b/alicloud/import_alicloud_key_pair_test.go
@@ -12,7 +12,7 @@ func TestAccAlicloudKeyPair_importBasic(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckInstanceDestroy,
+		CheckDestroy: testAccCheckKeyPairDestroy,
 		Steps: []resource.TestStep{
 			resource.TestStep{
 				Config: testAccKeyPairConfig,

--- a/alicloud/import_alicloud_kms_key_test.go
+++ b/alicloud/import_alicloud_kms_key_test.go
@@ -12,7 +12,7 @@ func TestAccAlicloudKmsKey_import(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckInstanceDestroy,
+		CheckDestroy: testAccCheckAlicloudKmsKeyDestroy,
 		Steps: []resource.TestStep{
 			resource.TestStep{
 				Config: testAlicloudKmsKeyBasic,

--- a/alicloud/import_alicloud_log_machine_group_test.go
+++ b/alicloud/import_alicloud_log_machine_group_test.go
@@ -12,7 +12,7 @@ func TestAccAlicloudLogMachineGroup_import(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckInstanceDestroy,
+		CheckDestroy: testAccCheckAlicloudLogMachineGroupDestroy,
 		Steps: []resource.TestStep{
 			resource.TestStep{
 				Config: testAlicloudLogMachineGroupIp,

--- a/alicloud/import_alicloud_log_store_index_test.go
+++ b/alicloud/import_alicloud_log_store_index_test.go
@@ -33,7 +33,7 @@ func TestAccAlicloudLogStoreIndex_importField(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckInstanceDestroy,
+		CheckDestroy: testAccCheckAlicloudLogStoreIndexDestroy,
 		Steps: []resource.TestStep{
 			resource.TestStep{
 				Config: testAlicloudLogStoreIndexField,

--- a/alicloud/import_alicloud_nat_gateway_test.go
+++ b/alicloud/import_alicloud_nat_gateway_test.go
@@ -6,34 +6,13 @@ import (
 	"github.com/hashicorp/terraform/helper/resource"
 )
 
-func TestAccAlicloudNatGateway_importBasic(t *testing.T) {
-	resourceName := "alicloud_nat_gateway.foo"
-
-	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckInstanceDestroy,
-		Steps: []resource.TestStep{
-			resource.TestStep{
-				Config: testAccNatGatewayConfig,
-			},
-
-			resource.TestStep{
-				ResourceName:      resourceName,
-				ImportState:       true,
-				ImportStateVerify: true,
-			},
-		},
-	})
-}
-
 func TestAccAlicloudNatGateway_importSpec(t *testing.T) {
 	resourceName := "alicloud_nat_gateway.foo"
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckInstanceDestroy,
+		CheckDestroy: testAccCheckNatGatewayDestroy,
 		Steps: []resource.TestStep{
 			resource.TestStep{
 				Config: testAccNatGatewayConfigSpec,

--- a/alicloud/import_alicloud_ots_table_test.go
+++ b/alicloud/import_alicloud_ots_table_test.go
@@ -6,7 +6,10 @@ import (
 	"github.com/hashicorp/terraform/helper/resource"
 )
 
-func TestAccAlicloudOtsTable_importBasic(t *testing.T) {
+// At present, OTS sdk does not support creating OTS instance and import test case does not support provider config,
+// so this test can not be run successfully.
+
+func SkipTestAccAlicloudOtsTable_importBasic(t *testing.T) {
 	resourceName := "alicloud_ots_table.basic"
 
 	resource.Test(t, resource.TestCase{

--- a/alicloud/import_alicloud_security_group_test.go
+++ b/alicloud/import_alicloud_security_group_test.go
@@ -12,7 +12,7 @@ func TestAccAlicloudSecurityGroup_importBasic(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckInstanceDestroy,
+		CheckDestroy: testAccCheckSecurityGroupDestroy,
 		Steps: []resource.TestStep{
 			resource.TestStep{
 				Config: testAccSecurityGroupConfig,
@@ -33,7 +33,7 @@ func TestAccAlicloudSecurityGroup_importWithVpc(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckInstanceDestroy,
+		CheckDestroy: testAccCheckSecurityGroupDestroy,
 		Steps: []resource.TestStep{
 			resource.TestStep{
 				Config: testAccSecurityGroupConfig_withVpc,

--- a/alicloud/import_alicloud_slb_listener_test.go
+++ b/alicloud/import_alicloud_slb_listener_test.go
@@ -12,7 +12,7 @@ func TestAccAlicloudSlbListener_importHttp(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckInstanceDestroy,
+		CheckDestroy: testAccCheckSlbListenerDestroy,
 		Steps: []resource.TestStep{
 			resource.TestStep{
 				Config: testAccSlbListenerHttp,
@@ -33,7 +33,7 @@ func TestAccAlicloudSlbListener_importTcp(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckInstanceDestroy,
+		CheckDestroy: testAccCheckSlbListenerDestroy,
 		Steps: []resource.TestStep{
 			resource.TestStep{
 				Config: testAccSlbListenerTcp,
@@ -54,7 +54,7 @@ func TestAccAlicloudSlbListener_importUdp(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckInstanceDestroy,
+		CheckDestroy: testAccCheckSlbListenerDestroy,
 		Steps: []resource.TestStep{
 			resource.TestStep{
 				Config: testAccSlbListenerUdp,

--- a/alicloud/import_alicloud_slb_server_group_test.go
+++ b/alicloud/import_alicloud_slb_server_group_test.go
@@ -19,9 +19,10 @@ func TestAccAlicloudSlbServerGroup_import(t *testing.T) {
 			},
 
 			resource.TestStep{
-				ResourceName:      resourceName,
-				ImportState:       true,
-				ImportStateVerify: true,
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"load_balancer_id"},
 			},
 		},
 	})

--- a/alicloud/import_alicloud_slb_test.go
+++ b/alicloud/import_alicloud_slb_test.go
@@ -12,7 +12,7 @@ func TestAccAlicloudSlb_importBandwidth(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckInstanceDestroy,
+		CheckDestroy: testAccCheckSlbDestroy,
 		Steps: []resource.TestStep{
 			resource.TestStep{
 				Config: testAccSlbBandWidth,
@@ -33,7 +33,7 @@ func TestAccAlicloudSlb_importTraffic(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckInstanceDestroy,
+		CheckDestroy: testAccCheckSlbDestroy,
 		Steps: []resource.TestStep{
 			resource.TestStep{
 				Config: testAccSlbTraffic,
@@ -54,7 +54,7 @@ func TestAccAlicloudSlb_importVpc(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckInstanceDestroy,
+		CheckDestroy: testAccCheckSlbDestroy,
 		Steps: []resource.TestStep{
 			resource.TestStep{
 				Config: testAccSlb4Vpc,

--- a/alicloud/import_alicloud_vpc_test.go
+++ b/alicloud/import_alicloud_vpc_test.go
@@ -12,7 +12,7 @@ func TestAccAlicloudVpc_importBasic(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckInstanceDestroy,
+		CheckDestroy: testAccCheckVpcDestroy,
 		Steps: []resource.TestStep{
 			resource.TestStep{
 				Config: testAccVpcConfig,

--- a/alicloud/import_alicloud_vroute_entry_test.go
+++ b/alicloud/import_alicloud_vroute_entry_test.go
@@ -12,7 +12,7 @@ func TestAccAlicloudRouteEntry_importBasic(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckInstanceDestroy,
+		CheckDestroy: testAccCheckRouteEntryDestroy,
 		Steps: []resource.TestStep{
 			resource.TestStep{
 				Config: testAccRouteEntryConfig,

--- a/alicloud/import_alicloud_vswitch_test.go
+++ b/alicloud/import_alicloud_vswitch_test.go
@@ -12,7 +12,7 @@ func TestAccAlicloudVswitch_importBasic(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckInstanceDestroy,
+		CheckDestroy: testAccCheckVswitchDestroy,
 		Steps: []resource.TestStep{
 			resource.TestStep{
 				Config: testAccVswitchConfig,

--- a/alicloud/resource_alicloud_cdn_domain.go
+++ b/alicloud/resource_alicloud_cdn_domain.go
@@ -51,6 +51,7 @@ func resourceAlicloudCdnDomain() *schema.Resource {
 			"scope": &schema.Schema{
 				Type:         schema.TypeString,
 				Optional:     true,
+				Computed:     true,
 				ValidateFunc: validateCdnScope,
 			},
 
@@ -488,7 +489,11 @@ func resourceAlicloudCdnDomainRead(d *schema.ResourceData, meta interface{}) err
 	d.Set("page_compress_enable", configs.PageCompressConfig.Enable)
 	d.Set("range_enable", configs.RangeConfig.Enable)
 	d.Set("video_seek_enable", configs.VideoSeekConfig.Enable)
-	d.Set("block_ips", strings.Split(configs.CcConfig.BlockIps, ","))
+	blocks := make([]string, 0)
+	if len(configs.CcConfig.BlockIps) > 0 {
+		blocks = strings.Split(configs.CcConfig.BlockIps, ",")
+	}
+	d.Set("block_ips", blocks)
 
 	return nil
 }

--- a/alicloud/resource_alicloud_cdn_domain_test.go
+++ b/alicloud/resource_alicloud_cdn_domain_test.go
@@ -6,7 +6,6 @@ import (
 	"testing"
 
 	"github.com/denverdino/aliyungo/cdn"
-	"github.com/denverdino/aliyungo/common"
 	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/terraform"
 )
@@ -33,7 +32,7 @@ func TestAccAlicloudCdnDomain_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(
 						"alicloud_cdn_domain.domain",
 						"domain_name",
-						"aliyun.com"),
+						"www.xiaozhu.com"),
 				),
 			},
 		},
@@ -86,13 +85,8 @@ func testAccCheckCdnDomainDestroy(s *terraform.State) error {
 
 		_, err := conn.DescribeCdnDomainDetail(request)
 
-		if err != nil {
-			e, _ := err.(*common.Error)
-			if e.ErrorResponse.Code == "InvalidDomain.NotFound" {
-				return nil
-			} else {
-				return fmt.Errorf("Error Domain still exist.")
-			}
+		if err != nil && !IsExceptedErrors(err, []string{InvalidDomainNotFound}) {
+			return fmt.Errorf("Error Domain still exist.")
 		}
 	}
 
@@ -101,10 +95,10 @@ func testAccCheckCdnDomainDestroy(s *terraform.State) error {
 
 const testAccCdnDomainConfig = `
 resource "alicloud_cdn_domain" "domain" {
-  domain_name = "www.aliyun.com"
+  domain_name = "www.xiaozhu.com"
   cdn_type = "web"
-  source_type = "domain"
-  sources = ["jb51.net"]
+  source_type = "oss"
+  sources = ["terraformtest.aliyuncs.com"]
   optimize_enable = "off"
   page_compress_enable = "off"
   range_enable = "off"

--- a/alicloud/resource_alicloud_cms_alarm_test.go
+++ b/alicloud/resource_alicloud_cms_alarm_test.go
@@ -134,7 +134,10 @@ func testAccCheckCmsAlarmDestroy(s *terraform.State) error {
 
 		alarm, err := client.DescribeAlarm(rs.Primary.ID)
 
-		if err != nil && !NotFoundError(err) {
+		if err != nil {
+			if NotFoundError(err) {
+				continue
+			}
 			return err
 		}
 

--- a/alicloud/resource_alicloud_cms_alarm_test.go
+++ b/alicloud/resource_alicloud_cms_alarm_test.go
@@ -27,7 +27,7 @@ func TestAccAlicloudCmsAlarm_basic(t *testing.T) {
 				Config: testAccCmsAlarm_basic,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckCmsAlarmExists("alicloud_cms_alarm.basic", &alarm),
-					resource.TestCheckResourceAttr("alicloud_cms_alarm.basic", "name", "tf-testAccCmsAlarm_basic"),
+					resource.TestCheckResourceAttr("alicloud_cms_alarm.basic", "name", "testAccCmsAlarm_basic"),
 					resource.TestCheckResourceAttr("alicloud_cms_alarm.basic", "dimensions.%", "2"),
 					resource.TestCheckResourceAttr("alicloud_cms_alarm.basic", "dimensions.device", "/dev/vda1,/dev/vdb1"),
 				),
@@ -53,7 +53,7 @@ func TestAccAlicloudCmsAlarm_update(t *testing.T) {
 				Config: testAccCmsAlarm_update,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckCmsAlarmExists("alicloud_cms_alarm.update", &alarm),
-					resource.TestCheckResourceAttr("alicloud_cms_alarm.update", "name", "tf-testAccCmsAlarm_update"),
+					resource.TestCheckResourceAttr("alicloud_cms_alarm.update", "name", "testAccCmsAlarm_update"),
 					resource.TestCheckResourceAttr("alicloud_cms_alarm.update", "operator", "<="),
 					resource.TestCheckResourceAttr("alicloud_cms_alarm.update", "triggered_count", "2"),
 				),
@@ -88,7 +88,7 @@ func TestAccAlicloudCmsAlarm_disable(t *testing.T) {
 				Config: testAccCmsAlarm_disable,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckCmsAlarmExists("alicloud_cms_alarm.disable", &alarm),
-					resource.TestCheckResourceAttr("alicloud_cms_alarm.disable", "name", "tf-testAccCmsAlarm_disable"),
+					resource.TestCheckResourceAttr("alicloud_cms_alarm.disable", "name", "testAccCmsAlarm_disable"),
 					resource.TestCheckResourceAttr("alicloud_cms_alarm.disable", "enabled", "false"),
 				),
 			},
@@ -134,10 +134,7 @@ func testAccCheckCmsAlarmDestroy(s *terraform.State) error {
 
 		alarm, err := client.DescribeAlarm(rs.Primary.ID)
 
-		if err != nil {
-			if NotFoundError(err) {
-				return nil
-			}
+		if err != nil && !NotFoundError(err) {
 			return err
 		}
 
@@ -151,7 +148,7 @@ func testAccCheckCmsAlarmDestroy(s *terraform.State) error {
 
 const testAccCmsAlarm_basic = `
 resource "alicloud_cms_alarm" "basic" {
-  name = "tf-testAccCmsAlarm_basic"
+  name = "testAccCmsAlarm_basic"
   project = "acs_ecs_dashboard"
   metric = "disk_writebytes"
   dimensions = {
@@ -172,7 +169,7 @@ resource "alicloud_cms_alarm" "basic" {
 
 const testAccCmsAlarm_update = `
 resource "alicloud_cms_alarm" "update" {
-  name = "tf-testAccCmsAlarm_update"
+  name = "testAccCmsAlarm_update"
   project = "acs_ecs_dashboard"
   metric = "disk_writebytes"
   dimensions = {
@@ -193,7 +190,7 @@ resource "alicloud_cms_alarm" "update" {
 
 const testAccCmsAlarm_updateAfter = `
 resource "alicloud_cms_alarm" "update" {
-  name = "tf-testAccCmsAlarm_update"
+  name = "testAccCmsAlarm_update"
   project = "acs_ecs_dashboard"
   metric = "disk_writebytes"
   dimensions = {
@@ -214,7 +211,7 @@ resource "alicloud_cms_alarm" "update" {
 
 const testAccCmsAlarm_disable = `
 resource "alicloud_cms_alarm" "disable" {
-  name = "tf-testAccCmsAlarm_disable"
+  name = "testAccCmsAlarm_disable"
   project = "acs_ecs_dashboard"
   metric = "disk_writebytes"
   dimensions = {

--- a/alicloud/resource_alicloud_db_account.go
+++ b/alicloud/resource_alicloud_db_account.go
@@ -75,7 +75,7 @@ func resourceAlicloudDBAccountCreate(d *schema.ResourceData, meta interface{}) e
 			if IsExceptedError(err, InvalidAccountNameDuplicate) {
 				return resource.NonRetryableError(fmt.Errorf("The account %s has already existed. Please import it using ID '%s:%s' or specify a new 'name' and try again.",
 					args.AccountName, args.DBInstanceId, args.AccountName))
-			} else if IsExceptedError(err, OperationDeniedDBInstanceStatus) {
+			} else if IsExceptedErrors(err, OperationDeniedDBStatus) {
 				return resource.RetryableError(fmt.Errorf("Create db account got an error: %#v.", err))
 			}
 			return resource.NonRetryableError(fmt.Errorf("Create db account got an error: %#v.", err))

--- a/alicloud/resource_alicloud_db_account_privilege_test.go
+++ b/alicloud/resource_alicloud_db_account_privilege_test.go
@@ -30,7 +30,7 @@ func TestAccAlicloudDBAccountPrivilege_basic(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckDBAccountPrivilegeExists(
 						"alicloud_db_account_privilege.privilege", &account),
-					resource.TestCheckResourceAttr("alicloud_db_account_privilege.privilege", "account_name", "tf_db"),
+					resource.TestCheckResourceAttr("alicloud_db_account_privilege.privilege", "account_name", "tftestprivilege"),
 					resource.TestCheckResourceAttr("alicloud_db_account_privilege.privilege", "db_names.#", "2"),
 				),
 			},
@@ -82,7 +82,7 @@ func testAccCheckDBAccountPrivilegeDestroy(s *terraform.State) error {
 		// Verify the error is what we want
 		if err != nil {
 			if NotFoundError(err) || IsExceptedError(err, InvalidDBInstanceIdNotFound) || IsExceptedError(err, InvalidAccountNameNotFound) {
-				return nil
+				continue
 			}
 			return err
 		}
@@ -96,12 +96,15 @@ func testAccCheckDBAccountPrivilegeDestroy(s *terraform.State) error {
 }
 
 const testAccDBAccountPrivilege_basic = `
+variable "name" {
+	default = "testaccdbaccountprivilege_basic"
+}
 data "alicloud_zones" "default" {
 	"available_resource_creation"= "Rds"
 }
 
 resource "alicloud_vpc" "foo" {
-	name = "tf_test_foo"
+	name = "${var.name}"
 	cidr_block = "172.16.0.0/12"
 }
 
@@ -117,18 +120,19 @@ resource "alicloud_db_instance" "instance" {
 	instance_type = "rds.mysql.t1.small"
 	instance_storage = "10"
   	vswitch_id = "${alicloud_vswitch.foo.id}"
+  	instance_name = "${var.name}"
 }
 
 resource "alicloud_db_database" "db" {
   count = 2
   instance_id = "${alicloud_db_instance.instance.id}"
-  name = "tf_db-${count.index}"
+  name = "${var.name}_${count.index}"
   description = "from terraform"
 }
 
 resource "alicloud_db_account" "account" {
   instance_id = "${alicloud_db_instance.instance.id}"
-  name = "tf_db"
+  name = "tftestprivilege"
   password = "Test12345"
   description = "from terraform"
 }

--- a/alicloud/resource_alicloud_db_account_test.go
+++ b/alicloud/resource_alicloud_db_account_test.go
@@ -29,7 +29,7 @@ func TestAccAlicloudDBAccount_basic(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckDBAccountExists(
 						"alicloud_db_account.account", &account),
-					resource.TestCheckResourceAttr("alicloud_db_account.account", "name", "tf_db"),
+					resource.TestCheckResourceAttr("alicloud_db_account.account", "name", "tftestbasic"),
 				),
 			},
 		},
@@ -80,7 +80,7 @@ func testAccCheckDBAccountDestroy(s *terraform.State) error {
 		// Verify the error is what we want
 		if err != nil {
 			if NotFoundError(err) || IsExceptedError(err, InvalidDBInstanceIdNotFound) || IsExceptedError(err, InvalidAccountNameNotFound) {
-				return nil
+				continue
 			}
 			return err
 		}
@@ -94,12 +94,15 @@ func testAccCheckDBAccountDestroy(s *terraform.State) error {
 }
 
 const testAccDBAccount_basic = `
+variable "name" {
+	default = "testaccdbaccount_basic"
+}
 data "alicloud_zones" "default" {
 	"available_resource_creation"= "Rds"
 }
 
 resource "alicloud_vpc" "foo" {
-	name = "tf_test_foo"
+	name = "${var.name}"
 	cidr_block = "172.16.0.0/12"
 }
 
@@ -115,11 +118,12 @@ resource "alicloud_db_instance" "instance" {
 	instance_type = "rds.mysql.t1.small"
 	instance_storage = "10"
   	vswitch_id = "${alicloud_vswitch.foo.id}"
+  	instance_name = "${var.name}"
 }
 
 resource "alicloud_db_account" "account" {
   instance_id = "${alicloud_db_instance.instance.id}"
-  name = "tf_db"
+  name = "tftestbasic"
   password = "Test12345"
   description = "from terraform"
 }

--- a/alicloud/resource_alicloud_db_backup_policy.go
+++ b/alicloud/resource_alicloud_db_backup_policy.go
@@ -146,7 +146,7 @@ func resourceAlicloudDBBackupPolicyUpdate(d *schema.ResourceData, meta interface
 		}
 		if err := resource.Retry(5*time.Minute, func() *resource.RetryError {
 			if err := client.ModifyDBBackupPolicy(d.Id(), backupTime, backupPeriod, retentionPeriod, backupLog, logBackupRetentionPeriod); err != nil {
-				if IsExceptedError(err, OperationDeniedDBInstanceStatus) || IsExceptedError(err, DBInternalError) {
+				if IsExceptedErrors(err, OperationDeniedDBStatus) {
 					return resource.RetryableError(fmt.Errorf("ModifyBackupPolicy got an error: %#v.", err))
 				}
 				return resource.NonRetryableError(fmt.Errorf("ModifyBackupPolicy got an error: %#v.", err))

--- a/alicloud/resource_alicloud_db_connection.go
+++ b/alicloud/resource_alicloud_db_connection.go
@@ -118,7 +118,7 @@ func resourceAlicloudDBConnectionUpdate(d *schema.ResourceData, meta interface{}
 
 		if err := resource.Retry(3*time.Minute, func() *resource.RetryError {
 			if _, err := client.rdsconn.ModifyDBInstanceConnectionString(request); err != nil {
-				if IsExceptedError(err, OperationDeniedDBInstanceStatus) || IsExceptedError(err, DBInternalError) {
+				if IsExceptedErrors(err, OperationDeniedDBStatus) {
 					return resource.RetryableError(fmt.Errorf("Modify DBInstance Connection Port got an error: %#v.", err))
 				}
 				return resource.NonRetryableError(fmt.Errorf("Modify DBInstance Connection Port got an error: %#v.", err))

--- a/alicloud/resource_alicloud_db_connection_test.go
+++ b/alicloud/resource_alicloud_db_connection_test.go
@@ -99,7 +99,7 @@ func testAccCheckDBConnectionDestroy(s *terraform.State) error {
 
 		if err != nil {
 			if NotFoundError(err) || IsExceptedError(err, InvalidDBInstanceIdNotFound) || IsExceptedError(err, InvalidCurrentConnectionStringNotFound) {
-				return nil
+				continue
 			}
 			return err
 		}
@@ -113,12 +113,15 @@ func testAccCheckDBConnectionDestroy(s *terraform.State) error {
 }
 
 const testAccDBConnection_basic = `
+variable "name" {
+	default = "testaccdbconnection_basic"
+}
 data "alicloud_zones" "default" {
 	"available_resource_creation"= "Rds"
 }
 
 resource "alicloud_vpc" "foo" {
-	name = "tf_test_foo"
+	name = "${var.name}"
 	cidr_block = "172.16.0.0/12"
 }
 
@@ -134,6 +137,7 @@ resource "alicloud_db_instance" "instance" {
 	instance_type = "rds.mysql.t1.small"
 	instance_storage = "10"
   	vswitch_id = "${alicloud_vswitch.foo.id}"
+	instance_name = "${var.name}"
 }
 
 resource "alicloud_db_connection" "foo" {
@@ -142,12 +146,15 @@ resource "alicloud_db_connection" "foo" {
 }
 `
 const testAccDBConnection_update = `
+variable "name" {
+	default = "testaccdbconnection_basic"
+}
 data "alicloud_zones" "default" {
 	"available_resource_creation"= "Rds"
 }
 
 resource "alicloud_vpc" "foo" {
-	name = "tf_test_foo"
+	name = "${var.name}"
 	cidr_block = "172.16.0.0/12"
 }
 
@@ -163,6 +170,7 @@ resource "alicloud_db_instance" "instance" {
 	instance_type = "rds.mysql.t1.small"
 	instance_storage = "10"
   	vswitch_id = "${alicloud_vswitch.foo.id}"
+  	instance_name = "${var.name}"
 }
 
 resource "alicloud_db_connection" "foo" {

--- a/alicloud/resource_alicloud_db_database_test.go
+++ b/alicloud/resource_alicloud_db_database_test.go
@@ -80,7 +80,7 @@ func testAccCheckDBDatabaseDestroy(s *terraform.State) error {
 		// Verify the error is what we want
 		if err != nil {
 			if NotFoundDBInstance(err) || IsExceptedError(err, InvalidDBNameNotFound) {
-				return nil
+				continue
 			}
 			return err
 		}
@@ -94,12 +94,15 @@ func testAccCheckDBDatabaseDestroy(s *terraform.State) error {
 }
 
 const testAccDBDatabase_basic = `
+variable "name" {
+	default = "testaccdbdatabase_basic"
+}
 data "alicloud_zones" "default" {
 	"available_resource_creation"= "Rds"
 }
 
 resource "alicloud_vpc" "foo" {
-	name = "tf_test_foo"
+	name = "${var.name}"
 	cidr_block = "172.16.0.0/12"
 }
 
@@ -115,11 +118,12 @@ resource "alicloud_db_instance" "instance" {
 	instance_type = "rds.mysql.t1.small"
 	instance_storage = "10"
   	vswitch_id = "${alicloud_vswitch.foo.id}"
+  	instance_name = "${var.name}"
 }
 
 resource "alicloud_db_database" "db" {
   instance_id = "${alicloud_db_instance.instance.id}"
-  name = "tf_db"
+  name = "${var.name}"
   description = "from terraform"
 }
 `

--- a/alicloud/resource_alicloud_db_instance.go
+++ b/alicloud/resource_alicloud_db_instance.go
@@ -294,7 +294,7 @@ func resourceAlicloudDBInstanceUpdate(d *schema.ResourceData, meta interface{}) 
 			return err
 		}
 		// wait instance status is running after modifying
-		if err := client.WaitForDBInstance(d.Id(), Running, 500); err != nil {
+		if err := client.WaitForDBInstance(d.Id(), Running, 1800); err != nil {
 			return fmt.Errorf("WaitForInstance %s got error: %#v", Running, err)
 		}
 	}

--- a/alicloud/resource_alicloud_db_instance_test.go
+++ b/alicloud/resource_alicloud_db_instance_test.go
@@ -45,7 +45,7 @@ func TestAccAlicloudDBInstance_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(
 						"alicloud_db_instance.foo",
 						"instance_name",
-						"test-instance"),
+						"testAccDBInstanceConfig"),
 				),
 			},
 		},
@@ -298,7 +298,7 @@ resource "alicloud_db_instance" "foo" {
 	instance_type = "rds.mysql.t1.small"
 	instance_storage = "10"
 	instance_charge_type = "Postpaid"
-	instance_name = "test-instance"
+	instance_name = "testAccDBInstanceConfig"
 }
 `
 
@@ -306,9 +306,11 @@ const testAccDBInstance_vpc = `
 data "alicloud_zones" "default" {
 	available_resource_creation = "Rds"
 }
-
+variable "name" {
+	default = "testAccDBInstance_vpc"
+}
 resource "alicloud_vpc" "foo" {
-	name = "tf_test_foo"
+	name = "${var.name}"
 	cidr_block = "172.16.0.0/12"
 }
 
@@ -324,7 +326,7 @@ resource "alicloud_db_instance" "foo" {
 	instance_type = "rds.mysql.t1.small"
 	instance_storage = "10"
 	instance_charge_type = "Postpaid"
-
+	instance_name = "${var.name}"
 	vswitch_id = "${alicloud_vswitch.foo.id}"
 	security_ips = ["10.168.1.12", "100.69.7.112"]
 }
@@ -339,50 +341,68 @@ data "alicloud_zones" "default" {
   multi = true
   output_file = "zone.json"
 }
-
+variable "name" {
+	default = "testAccDBInstance_multiAZ"
+}
 resource "alicloud_db_instance" "foo" {
 	engine = "MySQL"
 	engine_version = "5.6"
 	instance_type = "rds.mysql.t1.small"
 	instance_storage = "10"
 	zone_id = "${data.alicloud_zones.default.zones.0.id}"
+	instance_name = "${var.name}"
 }
 `
 
 const testAccDBInstance_securityIps = `
+variable "name" {
+	default = "testAccDBInstance_securityIps"
+}
 resource "alicloud_db_instance" "foo" {
 	engine = "MySQL"
 	engine_version = "5.6"
 	instance_type = "rds.mysql.t1.small"
 	instance_storage = "10"
 	instance_charge_type = "Postpaid"
+	instance_name = "${var.name}"
 }
 `
 const testAccDBInstance_securityIpsUpdate = `
+variable "name" {
+	default = "testAccDBInstance_securityIpsUpdate"
+}
 resource "alicloud_db_instance" "foo" {
 	engine = "MySQL"
 	engine_version = "5.6"
 	instance_type = "rds.mysql.t1.small"
 	instance_storage = "10"
 	instance_charge_type = "Postpaid"
-
+	instance_name = "${var.name}"
 	security_ips = ["10.168.1.12", "100.69.7.112"]
 }
 `
 
 const testAccDBInstance_class = `
+variable "name" {
+	default = "testAccDBInstance_class"
+}
 resource "alicloud_db_instance" "foo" {
 	engine = "MySQL"
 	engine_version = "5.6"
 	instance_type = "rds.mysql.t1.small"
 	instance_storage = "10"
+	instance_name = "${var.name}"
 }
 `
 const testAccDBInstance_classUpgrade = `
+variable "name" {
+	default = "testAccDBInstance_class"
+}
 resource "alicloud_db_instance" "foo" {
 	engine = "MySQL"
 	engine_version = "5.6"
 	instance_type = "rds.mysql.s1.small"
 	instance_storage = "10"
+	instance_name = "${var.name}"
 }
 `

--- a/alicloud/resource_alicloud_disk_test.go
+++ b/alicloud/resource_alicloud_disk_test.go
@@ -166,11 +166,13 @@ const testAccDiskConfig = `
 data "alicloud_zones" "default" {
 	"available_disk_category"= "cloud_efficiency"
 }
-
+variable "name" {
+	default = "testAccDiskConfig"
+}
 resource "alicloud_disk" "foo" {
 	# cn-beijing
 	availability_zone = "${data.alicloud_zones.default.zones.0.id}"
-	name = "New-disk"
+	name = "${var.name}"
 	description = "Hello ecs disk."
 	category = "cloud_efficiency"
   	size = "30"
@@ -180,11 +182,14 @@ const testAccDiskConfigWithTags = `
 data "alicloud_zones" "default" {
 	"available_disk_category"= "cloud_efficiency"
 }
-
+variable "name" {
+	default = "testAccDiskConfigWithTags"
+}
 resource "alicloud_disk" "bar" {
 	# cn-beijing
 	availability_zone = "${data.alicloud_zones.default.zones.0.id}"
 	category = "cloud_efficiency"
+	name = "${var.name}"
 	size = "20"
 	tags {
 	    Name = "TerraformTest"
@@ -195,11 +200,13 @@ const testAccDiskConfigEncrypted = `
 data "alicloud_zones" "default" {
 	"available_disk_category"= "cloud_efficiency"
 }
-
+variable "name" {
+	default = "testAccDiskConfigEncrypted"
+}
 resource "alicloud_disk" "encrypted" {
 	# cn-beijing
 	availability_zone = "${data.alicloud_zones.default.zones.0.id}"
-	name = "New-Encrypted-disk"
+	name = "${var.name}"
 	description = "Hello ecs disk."
 	category = "cloud_efficiency"
   	size = "30"

--- a/alicloud/resource_alicloud_dns_record_test.go
+++ b/alicloud/resource_alicloud_dns_record_test.go
@@ -115,8 +115,10 @@ func testAccCheckDnsRecordDestroy(s *terraform.State) error {
 		}
 
 		response, err := conn.DescribeDomainRecordInfoNew(request)
-
-		if response.RecordId != "" || err != nil {
+		if err != nil {
+			return err
+		}
+		if response.RecordId != "" {
 			return fmt.Errorf("Error Domain record still exist.")
 		}
 	}

--- a/alicloud/resource_alicloud_dns_record_test.go
+++ b/alicloud/resource_alicloud_dns_record_test.go
@@ -127,10 +127,12 @@ func testAccCheckDnsRecordDestroy(s *terraform.State) error {
 }
 
 const testAccDnsRecordConfig = `
-data "alicloud_dns_domains" "domains" {}
+resource "alicloud_dns" "dns" {
+  name = "yufish.com"
+}
 
 resource "alicloud_dns_record" "record" {
-  name = "${data.alicloud_dns_domains.domains.domains.0.domain_name}"
+  name = "${alicloud_dns.dns.name}"
   host_record = "alimail"
   type = "CNAME"
   value = "mail.mxhichin.com"
@@ -138,10 +140,12 @@ resource "alicloud_dns_record" "record" {
 }
 `
 const testAccDnsRecordPriority = `
-data "alicloud_dns_domains" "domains" {}
+resource "alicloud_dns" "dns" {
+  name = "yufish.com"
+}
 
 resource "alicloud_dns_record" "record" {
-  name = "${data.alicloud_dns_domains.domains.domains.0.domain_name}"
+  name = "${alicloud_dns.dns.name}"
   host_record = "alipriority"
   type = "MX"
   value = "www.aliyun.com"

--- a/alicloud/resource_alicloud_dns_test.go
+++ b/alicloud/resource_alicloud_dns_test.go
@@ -5,7 +5,6 @@ import (
 	"log"
 	"testing"
 
-	"github.com/denverdino/aliyungo/common"
 	"github.com/denverdino/aliyungo/dns"
 	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/terraform"
@@ -33,7 +32,7 @@ func TestAccAlicloudDns_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(
 						"alicloud_dns.dns",
 						"name",
-						"starmove.com"),
+						"yufish.com"),
 				),
 			},
 		},
@@ -87,13 +86,8 @@ func testAccCheckDnsDestroy(s *terraform.State) error {
 
 		_, err := conn.DescribeDomainInfo(request)
 
-		if err != nil {
-			e, _ := err.(*common.Error)
-			if e.ErrorResponse.Code == "InvalidDomainName.NoExist" {
-				return nil
-			} else {
-				return fmt.Errorf("Error Domain still exist.")
-			}
+		if err != nil && !IsExceptedErrors(err, []string{InvalidDomainNameNoExist}) {
+			return fmt.Errorf("Error Domain still exist.")
 		}
 	}
 
@@ -102,6 +96,6 @@ func testAccCheckDnsDestroy(s *terraform.State) error {
 
 const testAccDnsConfig = `
 resource "alicloud_dns" "dns" {
-  name = "starmove.com"
+  name = "yufish.com"
 }
 `

--- a/alicloud/resource_alicloud_eip_test.go
+++ b/alicloud/resource_alicloud_eip_test.go
@@ -99,7 +99,10 @@ func testAccCheckEIPDestroy(s *terraform.State) error {
 		d, err := client.DescribeEipAddress(rs.Primary.ID)
 
 		// Verify the error is what we want
-		if err != nil && !NotFoundError(err) {
+		if err != nil {
+			if NotFoundError(err) {
+				continue
+			}
 			return err
 		}
 

--- a/alicloud/resource_alicloud_ess_attachment_test.go
+++ b/alicloud/resource_alicloud_ess_attachment_test.go
@@ -80,7 +80,7 @@ func testAccCheckEssAttachmentDestroy(s *terraform.State) error {
 		_, err := client.DescribeScalingGroupById(rs.Primary.ID)
 		if err != nil {
 			if NotFoundError(err) || IsExceptedError(err, InvalidScalingGroupIdNotFound) {
-				return nil
+				continue
 			}
 			return fmt.Errorf("Error Describe scaling group: %#v", err)
 		}

--- a/alicloud/resource_alicloud_ess_scalingconfiguration_test.go
+++ b/alicloud/resource_alicloud_ess_scalingconfiguration_test.go
@@ -185,9 +185,13 @@ func testAccCheckEssScalingConfigurationDestroy(s *terraform.State) error {
 		_, err := client.DescribeScalingConfigurationById(rs.Primary.ID)
 
 		// Verify the error is what we want
-		if err != nil && !NotFoundError(err) {
+		if err != nil {
+			if NotFoundError(err) {
+				continue
+			}
 			return err
 		}
+		return fmt.Errorf("Scaling configuration %s still exists.", rs.Primary.ID)
 	}
 
 	return nil

--- a/alicloud/resource_alicloud_ess_scalinggroup_test.go
+++ b/alicloud/resource_alicloud_ess_scalinggroup_test.go
@@ -199,12 +199,13 @@ func testAccCheckEssScalingGroupDestroy(s *terraform.State) error {
 			continue
 		}
 
-		_, err := client.DescribeScalingGroupById(rs.Primary.ID)
-
-		// Verify the error is what we want
-		if err != nil && !NotFoundError(err) {
+		if _, err := client.DescribeScalingGroupById(rs.Primary.ID); err != nil {
+			if NotFoundError(err) {
+				continue
+			}
 			return err
 		}
+		return fmt.Errorf("Scaling group %s still exists.", rs.Primary.ID)
 	}
 
 	return nil

--- a/alicloud/resource_alicloud_ess_scalingrule_test.go
+++ b/alicloud/resource_alicloud_ess_scalingrule_test.go
@@ -133,11 +133,7 @@ func testAccCheckEssScalingRuleDestroy(s *terraform.State) error {
 		_, err := client.DescribeScalingRuleById(ids[0], ids[1])
 
 		// Verify the error is what we want
-		if err != nil {
-			// Verify the error is what we want
-			if NotFoundError(err) {
-				continue
-			}
+		if err != nil && !NotFoundError(err) {
 			return err
 		}
 	}
@@ -150,8 +146,19 @@ data "alicloud_images" "ecs_image" {
   most_recent = true
   name_regex =  "^centos_6\\w{1,5}[64].*"
 }
-
+data "alicloud_zones" "default" {
+	"available_resource_creation"= "VSwitch"
+}
+data "alicloud_instance_types" "default" {
+ 	availability_zone = "${data.alicloud_zones.default.zones.0.id}"
+	cpu_core_count = 1
+	memory_size = 2
+}
+variable "name" {
+	default = "testAccEssScalingRuleConfig"
+}
 resource "alicloud_security_group" "tf_test_foo" {
+	name = "${var.name}"
 	description = "foo"
 }
 
@@ -169,7 +176,7 @@ resource "alicloud_security_group_rule" "ssh-in" {
 resource "alicloud_ess_scaling_group" "bar" {
 	min_size = 1
 	max_size = 1
-	scaling_group_name = "bar"
+	scaling_group_name = "${var.name}"
 	removal_policies = ["OldestInstance", "NewestInstance"]
 }
 
@@ -177,7 +184,7 @@ resource "alicloud_ess_scaling_configuration" "foo" {
 	scaling_group_id = "${alicloud_ess_scaling_group.bar.id}"
 
 	image_id = "${data.alicloud_images.ecs_image.images.0.id}"
-	instance_type = "ecs.n4.large"
+	instance_type = "${data.alicloud_instance_types.default.instance_types.0.id}"
 	security_group_id = "${alicloud_security_group.tf_test_foo.id}"
 	force_delete = "true"
 }
@@ -195,8 +202,19 @@ data "alicloud_images" "ecs_image" {
   most_recent = true
   name_regex =  "^centos_6\\w{1,5}[64].*"
 }
-
+data "alicloud_zones" "default" {
+	"available_resource_creation"= "VSwitch"
+}
+data "alicloud_instance_types" "default" {
+ 	availability_zone = "${data.alicloud_zones.default.zones.0.id}"
+	cpu_core_count = 1
+	memory_size = 2
+}
+variable "name" {
+	default = "testAccEssScalingRule"
+}
 resource "alicloud_security_group" "tf_test_foo" {
+	name = "${var.name}"
 	description = "foo"
 }
 
@@ -214,7 +232,7 @@ resource "alicloud_security_group_rule" "ssh-in" {
 resource "alicloud_ess_scaling_group" "bar" {
 	min_size = 1
 	max_size = 1
-	scaling_group_name = "bar"
+	scaling_group_name = "${var.name}"
 	removal_policies = ["OldestInstance", "NewestInstance"]
 }
 
@@ -222,7 +240,7 @@ resource "alicloud_ess_scaling_configuration" "foo" {
 	scaling_group_id = "${alicloud_ess_scaling_group.bar.id}"
 
 	image_id = "${data.alicloud_images.ecs_image.images.0.id}"
-	instance_type = "ecs.n4.large"
+	instance_type = "${data.alicloud_instance_types.default.instance_types.0.id}"
 	security_group_id = "${alicloud_security_group.tf_test_foo.id}"
 	force_delete = "true"
 }
@@ -240,8 +258,19 @@ data "alicloud_images" "ecs_image" {
   most_recent = true
   name_regex =  "^centos_6\\w{1,5}[64].*"
 }
-
+data "alicloud_zones" "default" {
+	"available_resource_creation"= "VSwitch"
+}
+data "alicloud_instance_types" "default" {
+ 	availability_zone = "${data.alicloud_zones.default.zones.0.id}"
+	cpu_core_count = 1
+	memory_size = 2
+}
+variable "name" {
+	default = "testAccEssScalingRule"
+}
 resource "alicloud_security_group" "tf_test_foo" {
+	name = "${var.name}"
 	description = "foo"
 }
 
@@ -259,7 +288,7 @@ resource "alicloud_security_group_rule" "ssh-in" {
 resource "alicloud_ess_scaling_group" "bar" {
 	min_size = 1
 	max_size = 1
-	scaling_group_name = "bar"
+	scaling_group_name = "${var.name}"
 	removal_policies = ["OldestInstance", "NewestInstance"]
 }
 
@@ -267,7 +296,7 @@ resource "alicloud_ess_scaling_configuration" "foo" {
 	scaling_group_id = "${alicloud_ess_scaling_group.bar.id}"
 
 	image_id = "${data.alicloud_images.ecs_image.images.0.id}"
-	instance_type = "ecs.n4.large"
+	instance_type = "${data.alicloud_instance_types.default.instance_types.0.id}"
 	security_group_id = "${alicloud_security_group.tf_test_foo.id}"
 	force_delete = "true"
 }

--- a/alicloud/resource_alicloud_ess_scalingrule_test.go
+++ b/alicloud/resource_alicloud_ess_scalingrule_test.go
@@ -133,9 +133,13 @@ func testAccCheckEssScalingRuleDestroy(s *terraform.State) error {
 		_, err := client.DescribeScalingRuleById(ids[0], ids[1])
 
 		// Verify the error is what we want
-		if err != nil && !NotFoundError(err) {
+		if err != nil {
+			if NotFoundError(err) {
+				continue
+			}
 			return err
 		}
+		return fmt.Errorf("Scaling rule %s still exists.", ids[1])
 	}
 
 	return nil

--- a/alicloud/resource_alicloud_ess_schedule_test.go
+++ b/alicloud/resource_alicloud_ess_schedule_test.go
@@ -72,12 +72,13 @@ func testAccCheckEssScheduleDestroy(s *terraform.State) error {
 		if rs.Type != "alicloud_ess_schedule" {
 			continue
 		}
-		_, err := client.DescribeScheduleById(rs.Primary.ID)
-
-		// Verify the error is what we want
-		if err != nil && !NotFoundError(err) {
+		if _, err := client.DescribeScheduleById(rs.Primary.ID); err != nil {
+			if NotFoundError(err) {
+				continue
+			}
 			return err
 		}
+		return fmt.Errorf("Schedule %s still exist", rs.Primary.ID)
 	}
 
 	return nil

--- a/alicloud/resource_alicloud_forward_test.go
+++ b/alicloud/resource_alicloud_forward_test.go
@@ -51,19 +51,15 @@ func testAccCheckForwardEntryDestroy(s *terraform.State) error {
 		}
 
 		// Try to find the Snat entry
-		instance, err := client.DescribeForwardEntry(rs.Primary.Attributes["forward_table_id"], rs.Primary.ID)
-
-		if err != nil && !NotFoundError(err) {
+		if _, err := client.DescribeForwardEntry(rs.Primary.Attributes["forward_table_id"], rs.Primary.ID); err != nil {
+			if NotFoundError(err) {
+				continue
+			}
 			// Verify the error is what we want
 			return err
 		}
 
-		//this special deal cause the DescribeSnatEntry can't find the records would be throw "cant find the snatTable error"
-		if instance.ForwardEntryId == "" {
-			return nil
-		} else {
-			return fmt.Errorf("Forward entry still exist")
-		}
+		return fmt.Errorf("Forward entry %s still exist", rs.Primary.Attributes["forward_table_id"])
 
 	}
 

--- a/alicloud/resource_alicloud_instance_test.go
+++ b/alicloud/resource_alicloud_instance_test.go
@@ -45,12 +45,8 @@ func TestAccAlicloudInstance_basic(t *testing.T) {
 					testCheck,
 					resource.TestCheckResourceAttr(
 						"alicloud_instance.foo",
-						"image_id",
-						"ubuntu_140405_32_40G_cloudinit_20161115.vhd"),
-					resource.TestCheckResourceAttr(
-						"alicloud_instance.foo",
 						"instance_name",
-						"test_foo"),
+						"testAccInstanceConfig"),
 					resource.TestCheckResourceAttr(
 						"alicloud_instance.foo",
 						"internet_charge_type",
@@ -68,12 +64,8 @@ func TestAccAlicloudInstance_basic(t *testing.T) {
 					testCheck,
 					resource.TestCheckResourceAttr(
 						"alicloud_instance.foo",
-						"image_id",
-						"ubuntu_140405_32_40G_cloudinit_20161115.vhd"),
-					resource.TestCheckResourceAttr(
-						"alicloud_instance.foo",
 						"instance_name",
-						"test_foo"),
+						"testAccInstanceConfig"),
 				),
 			},
 		},
@@ -145,7 +137,7 @@ func TestAccAlicloudInstance_userData(t *testing.T) {
 	})
 }
 
-func SkipTestAccAlicloudInstance_multipleRegions(t *testing.T) {
+func TestAccAlicloudInstance_multipleRegions(t *testing.T) {
 	var instance ecs.Instance
 
 	// multi provideris
@@ -214,12 +206,8 @@ func TestAccAlicloudInstance_multiSecurityGroup(t *testing.T) {
 					testCheck(2),
 					resource.TestCheckResourceAttr(
 						"alicloud_instance.foo",
-						"image_id",
-						"ubuntu_140405_32_40G_cloudinit_20161115.vhd"),
-					resource.TestCheckResourceAttr(
-						"alicloud_instance.foo",
-						"instance_name",
-						"test_foo"),
+						"security_groups.#",
+						"2"),
 				),
 			},
 			resource.TestStep{
@@ -230,12 +218,8 @@ func TestAccAlicloudInstance_multiSecurityGroup(t *testing.T) {
 					testCheck(3),
 					resource.TestCheckResourceAttr(
 						"alicloud_instance.foo",
-						"image_id",
-						"ubuntu_140405_32_40G_cloudinit_20161115.vhd"),
-					resource.TestCheckResourceAttr(
-						"alicloud_instance.foo",
-						"instance_name",
-						"test_foo"),
+						"security_groups.#",
+						"3"),
 				),
 			},
 			resource.TestStep{
@@ -246,12 +230,8 @@ func TestAccAlicloudInstance_multiSecurityGroup(t *testing.T) {
 					testCheck(1),
 					resource.TestCheckResourceAttr(
 						"alicloud_instance.foo",
-						"image_id",
-						"ubuntu_140405_32_40G_cloudinit_20161115.vhd"),
-					resource.TestCheckResourceAttr(
-						"alicloud_instance.foo",
-						"instance_name",
-						"test_foo"),
+						"security_groups.#",
+						"1"),
 				),
 			},
 		},
@@ -295,12 +275,8 @@ func TestAccAlicloudInstance_multiSecurityGroupByCount(t *testing.T) {
 					testCheck(2),
 					resource.TestCheckResourceAttr(
 						"alicloud_instance.foo",
-						"image_id",
-						"ubuntu_140405_32_40G_cloudinit_20161115.vhd"),
-					resource.TestCheckResourceAttr(
-						"alicloud_instance.foo",
-						"instance_name",
-						"test_foo"),
+						"security_groups.#",
+						"2"),
 				),
 			},
 		},
@@ -382,7 +358,7 @@ func TestAccAlicloudInstance_update(t *testing.T) {
 					resource.TestCheckResourceAttr(
 						"alicloud_instance.foo",
 						"instance_name",
-						"instance_foo"),
+						"testAccCheckInstanceConfigOrigin-foo"),
 					resource.TestCheckResourceAttr(
 						"alicloud_instance.foo",
 						"host_name",
@@ -397,7 +373,7 @@ func TestAccAlicloudInstance_update(t *testing.T) {
 					resource.TestCheckResourceAttr(
 						"alicloud_instance.foo",
 						"instance_name",
-						"instance_bar"),
+						"testAccCheckInstanceConfigOrigin-bar"),
 					resource.TestCheckResourceAttr(
 						"alicloud_instance.foo",
 						"host_name",
@@ -437,39 +413,6 @@ func TestAccAlicloudInstanceImage_update(t *testing.T) {
 						"alicloud_instance.update_image",
 						"system_disk_size",
 						"60"),
-				),
-			},
-		},
-	})
-}
-
-func TestAccAlicloudInstance_privateIP(t *testing.T) {
-	var instance ecs.Instance
-
-	testCheckPrivateIP := func() resource.TestCheckFunc {
-		return func(*terraform.State) error {
-			privateIP := instance.VpcAttributes.PrivateIpAddress.IpAddress[0]
-			if privateIP == "" {
-				return fmt.Errorf("can't get private IP")
-			}
-
-			return nil
-		}
-	}
-
-	resource.Test(t, resource.TestCase{
-		PreCheck: func() {
-			testAccPreCheck(t)
-		},
-		IDRefreshName: "alicloud_instance.foo",
-		Providers:     testAccProviders,
-		CheckDestroy:  testAccCheckInstanceDestroy,
-		Steps: []resource.TestStep{
-			resource.TestStep{
-				Config: testAccInstanceConfigPrivateIP,
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckInstanceExists("alicloud_instance.foo", &instance),
-					testCheckPrivateIP(),
 				),
 			},
 		},
@@ -521,60 +464,6 @@ func TestAccAlicloudInstance_associatePublicIP(t *testing.T) {
 	})
 }
 
-func TestAccAlicloudInstance_vpcRule(t *testing.T) {
-	var instance ecs.Instance
-
-	resource.Test(t, resource.TestCase{
-		PreCheck: func() {
-			testAccPreCheck(t)
-		},
-		IDRefreshName: "alicloud_instance.foo",
-		Providers:     testAccProviders,
-		CheckDestroy:  testAccCheckInstanceDestroy,
-		Steps: []resource.TestStep{
-			resource.TestStep{
-				Config: testAccVpcInstanceWithSecurityRule,
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckInstanceExists("alicloud_instance.foo", &instance),
-					resource.TestCheckResourceAttr(
-						"alicloud_instance.foo",
-						"internet_charge_type",
-						"PayByBandwidth"),
-					resource.TestCheckResourceAttr(
-						"alicloud_instance.foo",
-						"internet_max_bandwidth_out",
-						"5"),
-				),
-			},
-		},
-	})
-}
-
-func TestAccAlicloudInstance_keyPair(t *testing.T) {
-	var instance ecs.Instance
-
-	resource.Test(t, resource.TestCase{
-		PreCheck: func() {
-			testAccPreCheck(t)
-		},
-		IDRefreshName: "alicloud_instance.key_pair",
-		Providers:     testAccProviders,
-		CheckDestroy:  testAccCheckInstanceDestroy,
-		Steps: []resource.TestStep{
-			resource.TestStep{
-				Config: testAccCheckInstanceKeyPair,
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckInstanceExists("alicloud_instance.key_pair", &instance),
-					resource.TestCheckResourceAttr(
-						"alicloud_instance.key_pair",
-						"key_name",
-						"key_pair_for_instance_test"),
-				),
-			},
-		},
-	})
-}
-
 func TestAccAlicloudInstancePrivateIp_update(t *testing.T) {
 	var instance ecs.Instance
 
@@ -610,7 +499,8 @@ func TestAccAlicloudInstancePrivateIp_update(t *testing.T) {
 	})
 }
 
-func TestAccAlicloudInstanceChargeType_update(t *testing.T) {
+// At present, One account only support at most 16 cpu core modify in one month.
+func SkipTestAccAlicloudInstanceChargeType_update(t *testing.T) {
 	var instance ecs.Instance
 
 	resource.Test(t, resource.TestCase{
@@ -624,9 +514,6 @@ func TestAccAlicloudInstanceChargeType_update(t *testing.T) {
 				Config: testAccCheckInstanceChargeType,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckInstanceExists("alicloud_instance.charge_type", &instance),
-					resource.TestCheckResourceAttr(
-						"alicloud_instance.charge_type",
-						"dry_run", "false"),
 				),
 			},
 
@@ -634,9 +521,6 @@ func TestAccAlicloudInstanceChargeType_update(t *testing.T) {
 				Config: testAccCheckInstanceChargeTypeUpdate,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckInstanceExists("alicloud_instance.charge_type", &instance),
-					resource.TestCheckResourceAttr(
-						"alicloud_instance.charge_type",
-						"dry_run", "true"),
 				),
 			},
 		},
@@ -684,9 +568,6 @@ func TestAccAlicloudInstanceType_update(t *testing.T) {
 				Config: testAccCheckInstanceType,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckInstanceExists("alicloud_instance.type", &instance),
-					resource.TestCheckResourceAttr(
-						"alicloud_instance.type",
-						"instance_type", "ecs.n4.small"),
 				),
 			},
 
@@ -694,9 +575,6 @@ func TestAccAlicloudInstanceType_update(t *testing.T) {
 				Config: testAccCheckInstanceTypeUpdate,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckInstanceExists("alicloud_instance.type", &instance),
-					resource.TestCheckResourceAttr(
-						"alicloud_instance.type",
-						"instance_type", "ecs.n4.large"),
 				),
 			},
 		},
@@ -766,7 +644,7 @@ func TestAccAlicloudInstance_ramrole(t *testing.T) {
 					resource.TestCheckResourceAttr(
 						"alicloud_instance.role",
 						"role_name",
-						"TF-RAM-Role-Name"),
+						"testAccCheckInstanceRamRole"),
 				),
 			},
 		},
@@ -890,25 +768,46 @@ func testAccCheckSystemDiskSize(n string, size int) resource.TestCheckFunc {
 }
 
 const testAccInstanceConfig = `
+data "alicloud_zones" "default" {
+	 available_disk_category = "cloud_ssd"
+}
+
+data "alicloud_instance_types" "default" {
+ 	availability_zone = "${data.alicloud_zones.default.zones.0.id}"
+	cpu_core_count = 1
+	memory_size = 2
+}
+
+data "alicloud_images" "default" {
+        name_regex = "^ubuntu_14.*_64"
+	most_recent = true
+	owners = "system"
+}
+
+variable "name" {
+	default = "testAccInstanceConfig"
+}
+
 resource "alicloud_security_group" "tf_test_foo" {
-	name = "tf_test_foo"
+	name = "${var.name}"
 	description = "foo"
 }
 
 resource "alicloud_security_group" "tf_test_bar" {
-	name = "tf_test_bar"
+	name = "${var.name}"
 	description = "bar"
 }
 
 resource "alicloud_instance" "foo" {
-	image_id = "ubuntu_140405_32_40G_cloudinit_20161115.vhd"
+	image_id = "${data.alicloud_images.default.images.0.id}"
+ 	availability_zone = "${data.alicloud_zones.default.zones.0.id}"
 
 	system_disk_category = "cloud_ssd"
 	system_disk_size = 80
 
-	instance_type = "ecs.xn4.small"
+	instance_type = "${data.alicloud_instance_types.default.instance_types.0.id}"
 	security_groups = ["${alicloud_security_group.tf_test_foo.id}"]
-	instance_name = "test_foo"
+	instance_name = "${var.name}"
 
 	tags {
 		foo = "bar"
@@ -922,8 +821,24 @@ data "alicloud_zones" "default" {
 	"available_resource_creation"= "VSwitch"
 }
 
+data "alicloud_instance_types" "default" {
+ 	availability_zone = "${data.alicloud_zones.default.zones.0.id}"
+	cpu_core_count = 1
+	memory_size = 2
+}
+
+data "alicloud_images" "default" {
+        name_regex = "^ubuntu_14.*_64"
+	most_recent = true
+	owners = "system"
+}
+
+variable "name" {
+	default = "testAccInstanceConfigVPC"
+}
+
 resource "alicloud_vpc" "foo" {
- 	name = "tf_test_foo"
+ 	name = "${var.name}"
  	cidr_block = "172.16.0.0/12"
 }
 
@@ -931,10 +846,11 @@ resource "alicloud_vswitch" "foo" {
  	vpc_id = "${alicloud_vpc.foo.id}"
  	cidr_block = "172.16.0.0/21"
  	availability_zone = "${data.alicloud_zones.default.zones.0.id}"
+ 	name = "${var.name}"
 }
 
 resource "alicloud_security_group" "tf_test_foo" {
-	name = "tf_test_foo"
+	name = "${var.name}"
 	description = "foo"
 	vpc_id = "${alicloud_vpc.foo.id}"
 }
@@ -942,17 +858,16 @@ resource "alicloud_security_group" "tf_test_foo" {
 resource "alicloud_instance" "foo" {
 	# cn-beijing
 	vswitch_id = "${alicloud_vswitch.foo.id}"
-	image_id = "ubuntu_140405_32_40G_cloudinit_20161115.vhd"
-	availability_zone = "${data.alicloud_zones.default.zones.0.id}"
+	image_id = "${data.alicloud_images.default.images.0.id}"
 
 	# series III
-	instance_type = "ecs.n4.large"
+	instance_type = "${data.alicloud_instance_types.default.instance_types.0.id}"
 	system_disk_category = "cloud_efficiency"
 
 	internet_charge_type = "PayByTraffic"
 	internet_max_bandwidth_out = 5
 	security_groups = ["${alicloud_security_group.tf_test_foo.id}"]
-	instance_name = "test_foo"
+	instance_name = "${var.name}"
 }
 `
 
@@ -961,9 +876,22 @@ data "alicloud_zones" "default" {
 	"available_disk_category"= "cloud_efficiency"
 	"available_resource_creation"= "VSwitch"
 }
+data "alicloud_instance_types" "default" {
+ 	availability_zone = "${data.alicloud_zones.default.zones.0.id}"
+	cpu_core_count = 1
+	memory_size = 2
+}
+data "alicloud_images" "default" {
+        name_regex = "^ubuntu_14.*_64"
+	most_recent = true
+	owners = "system"
+}
+variable "name" {
+	default = "testAccInstanceConfigUserData"
+}
 
 resource "alicloud_vpc" "foo" {
-  	name = "tf_test_foo"
+  	name = "${var.name}"
   	cidr_block = "172.16.0.0/12"
 }
 
@@ -971,10 +899,11 @@ resource "alicloud_vswitch" "foo" {
   	vpc_id = "${alicloud_vpc.foo.id}"
   	cidr_block = "172.16.0.0/21"
   	availability_zone = "${data.alicloud_zones.default.zones.0.id}"
+  	name = "${var.name}"
 }
 
 resource "alicloud_security_group" "tf_test_foo" {
-	name = "tf_test_foo"
+	name = "${var.name}"
 	description = "foo"
 	vpc_id = "${alicloud_vpc.foo.id}"
 }
@@ -983,14 +912,14 @@ resource "alicloud_instance" "foo" {
 	# cn-beijing
 	availability_zone = "${data.alicloud_zones.default.zones.0.id}"
 	vswitch_id = "${alicloud_vswitch.foo.id}"
-	image_id = "ubuntu_140405_32_40G_cloudinit_20161115.vhd"
+	image_id = "${data.alicloud_images.default.images.0.id}"
 	# series III
-	instance_type = "ecs.n4.large"
+	instance_type = "${data.alicloud_instance_types.default.instance_types.0.id}"
 	system_disk_category = "cloud_efficiency"
 	internet_charge_type = "PayByTraffic"
 	internet_max_bandwidth_out = 5
 	security_groups = ["${alicloud_security_group.tf_test_foo.id}"]
-	instance_name = "test_foo"
+	instance_name = "${var.name}"
 	user_data = "echo 'net.ipv4.ip_forward=1'>> /etc/sysctl.conf"
 }
 `
@@ -1000,20 +929,54 @@ provider "alicloud" {
 	alias = "beijing"
 	region = "cn-beijing"
 }
-
 provider "alicloud" {
 	alias = "shanghai"
 	region = "cn-shanghai"
 }
+data "alicloud_zones" "default" {
+	provider = "alicloud.beijing"
+	available_disk_category = "cloud_efficiency"
+}
+data "alicloud_instance_types" "default" {
+	provider = "alicloud.beijing"
+ 	availability_zone = "${data.alicloud_zones.default.zones.0.id}"
+	cpu_core_count = 1
+	memory_size = 2
+}
+data "alicloud_images" "default" {
+	provider = "alicloud.beijing"
+        name_regex = "^ubuntu_14.*_64"
+	most_recent = true
+	owners = "system"
+}
+data "alicloud_zones" "sh" {
+	provider = "alicloud.shanghai"
+	 available_disk_category = "cloud_efficiency"
+}
+data "alicloud_instance_types" "sh" {
+	provider = "alicloud.shanghai"
+ 	availability_zone = "${data.alicloud_zones.sh.zones.0.id}"
+	cpu_core_count = 1
+	memory_size = 2
+}
+data "alicloud_images" "sh" {
+	provider = "alicloud.shanghai"
+        name_regex = "^ubuntu_14.*_64"
+	most_recent = true
+	owners = "system"
+}
+variable "name" {
+	default = "testAccInstanceConfigMultipleRegions"
+}
 
 resource "alicloud_security_group" "tf_test_foo" {
-	name = "tf_test_foo"
+	name = "${var.name}"
 	provider = "alicloud.beijing"
 	description = "foo"
 }
 
 resource "alicloud_security_group" "tf_test_bar" {
-	name = "tf_test_bar"
+	name = "${var.name}"
 	provider = "alicloud.shanghai"
 	description = "bar"
 }
@@ -1021,133 +984,180 @@ resource "alicloud_security_group" "tf_test_bar" {
 resource "alicloud_instance" "foo" {
   	# cn-beijing
   	provider = "alicloud.beijing"
-  	image_id = "ubuntu_140405_32_40G_cloudinit_20161115.vhd"
+  	image_id = "${data.alicloud_images.default.images.0.id}"
+	availability_zone = "${data.alicloud_zones.default.zones.0.id}"
 
   	internet_charge_type = "PayByBandwidth"
 
-  	instance_type = "ecs.n4.large"
+	instance_type = "${data.alicloud_instance_types.default.instance_types.0.id}"
   	system_disk_category = "cloud_efficiency"
   	security_groups = ["${alicloud_security_group.tf_test_foo.id}"]
-  	instance_name = "test_foo"
+  	instance_name = "${var.name}"
 }
 
 resource "alicloud_instance" "bar" {
 	# cn-shanghai
 	provider = "alicloud.shanghai"
-	image_id = "ubuntu_140405_32_40G_cloudinit_20161115.vhd"
+  	image_id = "${data.alicloud_images.sh.images.0.id}"
+	availability_zone = "${data.alicloud_zones.sh.zones.0.id}"
 
 	internet_charge_type = "PayByBandwidth"
 
-	instance_type = "ecs.n4.large"
+	instance_type = "${data.alicloud_instance_types.sh.instance_types.0.id}"
 	system_disk_category = "cloud_efficiency"
 	security_groups = ["${alicloud_security_group.tf_test_bar.id}"]
-	instance_name = "test_bar"
+	instance_name = "${var.name}"
 }
 `
 
 const testAccInstanceConfig_multiSecurityGroup = `
+data "alicloud_zones" "default" {
+	 available_disk_category = "cloud_efficiency"
+}
+data "alicloud_instance_types" "default" {
+ 	availability_zone = "${data.alicloud_zones.default.zones.0.id}"
+	cpu_core_count = 1
+	memory_size = 2
+}
+data "alicloud_images" "default" {
+        name_regex = "^ubuntu_14.*_64"
+	most_recent = true
+	owners = "system"
+}
+variable "name" {
+	default = "testAccInstanceConfig_multiSecurityGroup"
+}
 resource "alicloud_security_group" "tf_test_foo" {
-	name = "tf_test_foo"
+	name = "${var.name}-foo"
 	description = "foo"
 }
 
 resource "alicloud_security_group" "tf_test_bar" {
-	name = "tf_test_bar"
+	name = "${var.name}-bar"
 	description = "bar"
 }
 
 resource "alicloud_instance" "foo" {
 	# cn-beijing
-	image_id = "ubuntu_140405_32_40G_cloudinit_20161115.vhd"
+	image_id = "${data.alicloud_images.default.images.0.id}"
+	availability_zone = "${data.alicloud_zones.default.zones.0.id}"
 
-	instance_type = "ecs.n4.large"
+	instance_type = "${data.alicloud_instance_types.default.instance_types.0.id}"
 	internet_charge_type = "PayByBandwidth"
 	security_groups = ["${alicloud_security_group.tf_test_foo.id}", "${alicloud_security_group.tf_test_bar.id}"]
-	instance_name = "test_foo"
+	instance_name = "${var.name}"
 	system_disk_category = "cloud_efficiency"
 }`
 
 const testAccInstanceConfig_multiSecurityGroup_add = `
+data "alicloud_zones" "default" {
+	 available_disk_category = "cloud_efficiency"
+}
+data "alicloud_instance_types" "default" {
+ 	availability_zone = "${data.alicloud_zones.default.zones.0.id}"
+	cpu_core_count = 1
+	memory_size = 2
+}
+data "alicloud_images" "default" {
+        name_regex = "^ubuntu_14.*_64"
+	most_recent = true
+	owners = "system"
+}
+variable "name" {
+	default = "testAccInstanceConfig_multiSecurityGroup"
+}
 resource "alicloud_security_group" "tf_test_foo" {
-	name = "tf_test_foo"
+	name = "${var.name}-foo"
 	description = "foo"
 }
 
 resource "alicloud_security_group" "tf_test_bar" {
-	name = "tf_test_bar"
+	name = "${var.name}-bar"
 	description = "bar"
 }
 
 resource "alicloud_security_group" "tf_test_add_sg" {
-	name = "tf_test_add_sg"
+	name = "${var.name}-add-sg"
 	description = "sg"
 }
 
 resource "alicloud_instance" "foo" {
 	# cn-beijing
-	image_id = "ubuntu_140405_32_40G_cloudinit_20161115.vhd"
+	image_id = "${data.alicloud_images.default.images.0.id}"
+	availability_zone = "${data.alicloud_zones.default.zones.0.id}"
 
-	instance_type = "ecs.n4.large"
+	instance_type = "${data.alicloud_instance_types.default.instance_types.0.id}"
 	internet_charge_type = "PayByBandwidth"
 	security_groups = ["${alicloud_security_group.tf_test_foo.id}", "${alicloud_security_group.tf_test_bar.id}",
 				"${alicloud_security_group.tf_test_add_sg.id}"]
-	instance_name = "test_foo"
+	instance_name = "${var.name}"
 	system_disk_category = "cloud_efficiency"
 }
 `
 
 const testAccInstanceConfig_multiSecurityGroup_remove = `
+data "alicloud_zones" "default" {
+	 available_disk_category = "cloud_efficiency"
+}
+data "alicloud_instance_types" "default" {
+ 	availability_zone = "${data.alicloud_zones.default.zones.0.id}"
+	cpu_core_count = 1
+	memory_size = 2
+}
+data "alicloud_images" "default" {
+        name_regex = "^ubuntu_14.*_64"
+	most_recent = true
+	owners = "system"
+}
+variable "name" {
+	default = "testAccInstanceConfig_multiSecurityGroup"
+}
 resource "alicloud_security_group" "tf_test_foo" {
-	name = "tf_test_foo"
+	name = "${var.name}-foo"
 	description = "foo"
-}
-
-resource "alicloud_security_group_rule" "http-in" {
-  	type = "ingress"
-  	ip_protocol = "tcp"
-  	nic_type = "internet"
-  	policy = "accept"
-  	port_range = "80/80"
-  	priority = 1
-  	security_group_id = "${alicloud_security_group.tf_test_foo.id}"
-  	cidr_ip = "0.0.0.0/0"
-}
-
-resource "alicloud_security_group_rule" "ssh-in" {
-  	type = "ingress"
-  	ip_protocol = "tcp"
-  	nic_type = "internet"
-  	policy = "accept"
-  	port_range = "22/22"
-  	priority = 1
-  	security_group_id = "${alicloud_security_group.tf_test_foo.id}"
-  	cidr_ip = "0.0.0.0/0"
 }
 
 resource "alicloud_instance" "foo" {
 	# cn-beijing
-	image_id = "ubuntu_140405_32_40G_cloudinit_20161115.vhd"
+	image_id = "${data.alicloud_images.default.images.0.id}"
+	availability_zone = "${data.alicloud_zones.default.zones.0.id}"
 
-	instance_type = "ecs.n4.large"
+	instance_type = "${data.alicloud_instance_types.default.instance_types.0.id}"
 	internet_charge_type = "PayByBandwidth"
 	security_groups = ["${alicloud_security_group.tf_test_foo.id}"]
-	instance_name = "test_foo"
+	instance_name = "${var.name}"
 	system_disk_category = "cloud_efficiency"
 }
 `
 
 const testAccInstanceConfig_multiSecurityGroupByCount = `
+data "alicloud_zones" "default" {
+	 available_disk_category = "cloud_efficiency"
+}
+data "alicloud_instance_types" "default" {
+ 	availability_zone = "${data.alicloud_zones.default.zones.0.id}"
+	cpu_core_count = 1
+	memory_size = 2
+}
+data "alicloud_images" "default" {
+        name_regex = "^ubuntu_14.*_64"
+	most_recent = true
+	owners = "system"
+}
+variable "name" {
+	default = "testAccInstanceConfig_multiSecurityGroupByCount"
+}
 resource "alicloud_security_group" "tf_test_foo" {
-	name = "tf_test_foo"
+	name = "${var.name}"
 	count = 2
 	description = "foo"
 }
 
 resource "alicloud_instance" "foo" {
 	# cn-beijing
-	image_id = "ubuntu_140405_32_40G_cloudinit_20161115.vhd"
-
-	instance_type = "ecs.mn4.small"
+	image_id = "${data.alicloud_images.default.images.0.id}"
+	availability_zone = "${data.alicloud_zones.default.zones.0.id}"
+	instance_type = "${data.alicloud_instance_types.default.instance_types.0.id}"
 	internet_charge_type = "PayByBandwidth"
 	security_groups = ["${alicloud_security_group.tf_test_foo.*.id}"]
 	instance_name = "test_foo"
@@ -1160,9 +1170,22 @@ data "alicloud_zones" "default" {
 	"available_disk_category"= "cloud_efficiency"
 	"available_resource_creation"= "VSwitch"
 }
+data "alicloud_instance_types" "default" {
+ 	availability_zone = "${data.alicloud_zones.default.zones.0.id}"
+	cpu_core_count = 1
+	memory_size = 2
+}
+data "alicloud_images" "default" {
+        name_regex = "^ubuntu_14.*_64"
+	most_recent = true
+	owners = "system"
+}
+variable "name" {
+	default = "testAccInstanceNetworkInstanceSecurityGroups"
+}
 
 resource "alicloud_vpc" "foo" {
-  	name = "tf_test_foo"
+  	name = "${var.name}"
   	cidr_block = "172.16.0.0/12"
 }
 
@@ -1170,10 +1193,11 @@ resource "alicloud_vswitch" "foo" {
   	vpc_id = "${alicloud_vpc.foo.id}"
   	cidr_block = "172.16.0.0/21"
   	availability_zone = "${data.alicloud_zones.default.zones.0.id}"
+  	name = "${var.name}"
 }
 
 resource "alicloud_security_group" "tf_test_foo" {
-	name = "tf_test_foo"
+  	name = "${var.name}"
 	description = "foo"
 	vpc_id = "${alicloud_vpc.foo.id}"
 }
@@ -1181,36 +1205,50 @@ resource "alicloud_security_group" "tf_test_foo" {
 resource "alicloud_instance" "foo" {
 	# cn-beijing
 	vswitch_id = "${alicloud_vswitch.foo.id}"
-	image_id = "ubuntu_140405_32_40G_cloudinit_20161115.vhd"
+	image_id = "${data.alicloud_images.default.images.0.id}"
+	availability_zone = "${data.alicloud_zones.default.zones.0.id}"
+	instance_type = "${data.alicloud_instance_types.default.instance_types.0.id}"
 
-	# series III
-	instance_type = "ecs.n4.large"
 	system_disk_category = "cloud_efficiency"
-
 	security_groups = ["${alicloud_security_group.tf_test_foo.id}"]
-	instance_name = "test_foo"
+	instance_name = "${var.name}"
 
 	internet_max_bandwidth_out = 5
 	internet_charge_type = "PayByBandwidth"
 }
 `
 const testAccCheckInstanceConfigTags = `
+data "alicloud_zones" "default" {
+	available_disk_category = "cloud_efficiency"
+}
+data "alicloud_instance_types" "default" {
+ 	availability_zone = "${data.alicloud_zones.default.zones.0.id}"
+	cpu_core_count = 1
+	memory_size = 2
+}
+data "alicloud_images" "default" {
+        name_regex = "^ubuntu_14.*_64"
+	most_recent = true
+	owners = "system"
+}
+variable "name" {
+	default = "testAccCheckInstanceConfigTags"
+}
 resource "alicloud_security_group" "tf_test_foo" {
-	name = "tf_test_foo"
+	name = "${var.name}"
 	description = "foo"
 }
 
 resource "alicloud_instance" "foo" {
 	# cn-beijing
-	image_id = "ubuntu_140405_32_40G_cloudinit_20161115.vhd"
-
-	# series III
-	instance_type = "ecs.n4.large"
+	image_id = "${data.alicloud_images.default.images.0.id}"
+	availability_zone = "${data.alicloud_zones.default.zones.0.id}"
+	instance_type = "${data.alicloud_instance_types.default.instance_types.0.id}"
 	internet_charge_type = "PayByBandwidth"
 	system_disk_category = "cloud_efficiency"
 
 	security_groups = ["${alicloud_security_group.tf_test_foo.id}"]
-	instance_name = "test_foo"
+	instance_name = "${var.name}"
 
 	tags {
 		foo = "bar"
@@ -1219,6 +1257,22 @@ resource "alicloud_instance" "foo" {
 `
 
 const testAccCheckInstanceConfigTagsUpdate = `
+data "alicloud_zones" "default" {
+	available_disk_category = "cloud_efficiency"
+}
+data "alicloud_instance_types" "default" {
+ 	availability_zone = "${data.alicloud_zones.default.zones.0.id}"
+	cpu_core_count = 1
+	memory_size = 2
+}
+data "alicloud_images" "default" {
+        name_regex = "^ubuntu_14.*_64"
+	most_recent = true
+	owners = "system"
+}
+variable "name" {
+	default = "testAccCheckInstanceConfigTags"
+}
 resource "alicloud_security_group" "tf_test_foo" {
 	name = "tf_test_foo"
 	description = "foo"
@@ -1226,15 +1280,14 @@ resource "alicloud_security_group" "tf_test_foo" {
 
 resource "alicloud_instance" "foo" {
 	# cn-beijing
-	image_id = "ubuntu_140405_32_40G_cloudinit_20161115.vhd"
-
-	# series III
-	instance_type = "ecs.n4.large"
+	image_id = "${data.alicloud_images.default.images.0.id}"
+	availability_zone = "${data.alicloud_zones.default.zones.0.id}"
+	instance_type = "${data.alicloud_instance_types.default.instance_types.0.id}"
 	internet_charge_type = "PayByBandwidth"
 	system_disk_category = "cloud_efficiency"
 
 	security_groups = ["${alicloud_security_group.tf_test_foo.id}"]
-	instance_name = "test_foo"
+	instance_name = "${var.name}"
 
 	tags {
 		bar = "zzz"
@@ -1242,8 +1295,24 @@ resource "alicloud_instance" "foo" {
 }
 `
 const testAccCheckInstanceConfigOrigin = `
+data "alicloud_zones" "default" {
+	available_disk_category = "cloud_efficiency"
+}
+data "alicloud_instance_types" "default" {
+ 	availability_zone = "${data.alicloud_zones.default.zones.0.id}"
+	cpu_core_count = 1
+	memory_size = 2
+}
+data "alicloud_images" "default" {
+        name_regex = "^ubuntu_14.*_64"
+	most_recent = true
+	owners = "system"
+}
+variable "name" {
+	default = "testAccCheckInstanceConfigOrigin"
+}
 resource "alicloud_security_group" "tf_test_foo" {
-	name = "tf_test_foo"
+	name = "${var.name}"
 	description = "foo"
 }
 
@@ -1271,23 +1340,38 @@ resource "alicloud_security_group_rule" "ssh-in" {
 
 resource "alicloud_instance" "foo" {
 	# cn-beijing
-	image_id = "ubuntu_140405_32_40G_cloudinit_20161115.vhd"
-
-	# series III
-	instance_type = "ecs.n4.large"
+	image_id = "${data.alicloud_images.default.images.0.id}"
+	availability_zone = "${data.alicloud_zones.default.zones.0.id}"
+	instance_type = "${data.alicloud_instance_types.default.instance_types.0.id}"
 	internet_charge_type = "PayByBandwidth"
 	system_disk_category = "cloud_efficiency"
 
 	security_groups = ["${alicloud_security_group.tf_test_foo.id}"]
 
-	instance_name = "instance_foo"
+	instance_name = "${var.name}-foo"
 	host_name = "host-foo"
 }
 `
 
 const testAccCheckInstanceConfigOriginUpdate = `
+data "alicloud_zones" "default" {
+	available_disk_category = "cloud_efficiency"
+}
+data "alicloud_instance_types" "default" {
+ 	availability_zone = "${data.alicloud_zones.default.zones.0.id}"
+	cpu_core_count = 1
+	memory_size = 2
+}
+data "alicloud_images" "default" {
+        name_regex = "^ubuntu_14.*_64"
+	most_recent = true
+	owners = "system"
+}
+variable "name" {
+	default = "testAccCheckInstanceConfigOrigin"
+}
 resource "alicloud_security_group" "tf_test_foo" {
-	name = "tf_test_foo"
+	name = "${var.name}"
 	description = "foo"
 }
 
@@ -1315,64 +1399,38 @@ resource "alicloud_security_group_rule" "ssh-in" {
 
 resource "alicloud_instance" "foo" {
 	# cn-beijing
-	image_id = "ubuntu_140405_32_40G_cloudinit_20161115.vhd"
-
-	# series III
-	instance_type = "ecs.n4.large"
+	image_id = "${data.alicloud_images.default.images.0.id}"
+	availability_zone = "${data.alicloud_zones.default.zones.0.id}"
+	instance_type = "${data.alicloud_instance_types.default.instance_types.0.id}"
 	internet_charge_type = "PayByBandwidth"
 	system_disk_category = "cloud_efficiency"
 
 	security_groups = ["${alicloud_security_group.tf_test_foo.id}"]
 
-	instance_name = "instance_bar"
+	instance_name = "${var.name}-bar"
 	host_name = "host-bar"
-}
-`
-
-const testAccInstanceConfigPrivateIP = `
-data "alicloud_zones" "default" {
-	"available_disk_category"= "cloud_efficiency"
-	"available_resource_creation"= "VSwitch"
-}
-
-resource "alicloud_vpc" "foo" {
-  	name = "tf_test_foo"
-  	cidr_block = "172.16.0.0/12"
-}
-
-resource "alicloud_vswitch" "foo" {
-  	vpc_id = "${alicloud_vpc.foo.id}"
-  	cidr_block = "172.16.0.0/24"
-  	availability_zone = "${data.alicloud_zones.default.zones.0.id}"
-}
-
-resource "alicloud_security_group" "tf_test_foo" {
-	name = "tf_test_foo"
-	description = "foo"
-	vpc_id = "${alicloud_vpc.foo.id}"
-}
-
-resource "alicloud_instance" "foo" {
-	# cn-beijing
-	security_groups = ["${alicloud_security_group.tf_test_foo.id}"]
-
-	vswitch_id = "${alicloud_vswitch.foo.id}"
-
-	# series III
-	instance_type = "ecs.n4.large"
-	system_disk_category = "cloud_efficiency"
-	image_id = "ubuntu_140405_32_40G_cloudinit_20161115.vhd"
-	instance_name = "test_foo"
 }
 `
 const testAccInstanceConfigAssociatePublicIP = `
 data "alicloud_zones" "default" {
-	"available_disk_category"= "cloud_efficiency"
-	"available_resource_creation"= "VSwitch"
+	available_disk_category = "cloud_efficiency"
+	available_resource_creation = "VSwitch"
 }
-
+data "alicloud_instance_types" "default" {
+ 	availability_zone = "${data.alicloud_zones.default.zones.0.id}"
+	cpu_core_count = 1
+	memory_size = 2
+}
+data "alicloud_images" "default" {
+        name_regex = "^ubuntu_14.*_64"
+	most_recent = true
+	owners = "system"
+}
+variable "name" {
+	default = "testAccInstanceConfigAssociatePublicIP"
+}
 resource "alicloud_vpc" "foo" {
-  	name = "tf_test_foo"
+  	name = "${var.name}"
   	cidr_block = "172.16.0.0/12"
 }
 
@@ -1380,10 +1438,11 @@ resource "alicloud_vswitch" "foo" {
   	vpc_id = "${alicloud_vpc.foo.id}"
   	cidr_block = "172.16.0.0/24"
   	availability_zone = "${data.alicloud_zones.default.zones.0.id}"
+  	name = "${var.name}"
 }
 
 resource "alicloud_security_group" "tf_test_foo" {
-	name = "tf_test_foo"
+	name = "${var.name}"
 	description = "foo"
 	vpc_id = "${alicloud_vpc.foo.id}"
 }
@@ -1391,213 +1450,149 @@ resource "alicloud_security_group" "tf_test_foo" {
 resource "alicloud_instance" "foo" {
 	# cn-beijing
 	security_groups = ["${alicloud_security_group.tf_test_foo.id}"]
-
 	vswitch_id = "${alicloud_vswitch.foo.id}"
 	internet_max_bandwidth_out = 5
 	internet_charge_type = "PayByBandwidth"
-
-	# series III
-	instance_type = "ecs.n4.large"
+	image_id = "${data.alicloud_images.default.images.0.id}"
+	instance_type = "${data.alicloud_instance_types.default.instance_types.0.id}"
 	system_disk_category = "cloud_efficiency"
-	image_id = "ubuntu_140405_32_40G_cloudinit_20161115.vhd"
-	instance_name = "test_foo"
-}
-`
-const testAccVpcInstanceWithSecurityRule = `
-data "alicloud_zones" "default" {
-	"available_disk_category"= "cloud_efficiency"
-	"available_resource_creation"= "VSwitch"
-}
-
-resource "alicloud_vpc" "foo" {
-  	name = "tf_test_foo"
-  	cidr_block = "10.1.0.0/21"
-}
-
-resource "alicloud_vswitch" "foo" {
-  	vpc_id = "${alicloud_vpc.foo.id}"
-  	cidr_block = "10.1.1.0/24"
-  	availability_zone = "${data.alicloud_zones.default.zones.0.id}"
-}
-
-resource "alicloud_security_group" "tf_test_foo" {
-    	name = "tf_test_foo"
-    	description = "foo"
-    	vpc_id = "${alicloud_vpc.foo.id}"
-}
-
-resource "alicloud_security_group_rule" "ingress" {
-  	type = "ingress"
-  	ip_protocol = "tcp"
-  	nic_type = "intranet"
-  	policy = "accept"
-  	port_range = "22/22"
-  	priority = 1
-  	security_group_id = "${alicloud_security_group.tf_test_foo.id}"
-  	cidr_ip = "0.0.0.0/0"
-}
-
-resource "alicloud_instance" "foo" {
-    	# cn-beijing
-    	security_groups = ["${alicloud_security_group.tf_test_foo.id}"]
-
-    	vswitch_id = "${alicloud_vswitch.foo.id}"
-
-    	# series III
-    	instance_charge_type = "PostPaid"
-    	instance_type = "ecs.n4.small"
-    	internet_charge_type = "PayByBandwidth"
-    	internet_max_bandwidth_out = 5
-
-    	system_disk_category = "cloud_efficiency"
-    	image_id = "ubuntu_140405_64_40G_cloudinit_20161115.vhd"
-    	instance_name = "test_foo"
+	instance_name = "${var.name}"
 }
 `
 const testAccCheckInstanceImageOrigin = `
+data "alicloud_zones" "default" {
+	available_disk_category = "cloud_efficiency"
+	available_resource_creation = "VSwitch"
+}
+data "alicloud_instance_types" "default" {
+ 	availability_zone = "${data.alicloud_zones.default.zones.0.id}"
+	cpu_core_count = 1
+	memory_size = 2
+}
 data "alicloud_images" "centos" {
 	most_recent = true
 	owners = "system"
 	name_regex = "^centos_6\\w{1,5}[64]{1}.*"
 }
-
+variable "name" {
+	default = "testAccCheckInstanceImageOrigin"
+}
 resource "alicloud_vpc" "foo" {
-	name = "tf_test_image"
+	name = "${var.name}"
 	cidr_block = "10.1.0.0/21"
 }
 
 resource "alicloud_vswitch" "foo" {
 	vpc_id = "${alicloud_vpc.foo.id}"
 	cidr_block = "10.1.1.0/24"
-	availability_zone = "cn-beijing-a"
+ 	availability_zone = "${data.alicloud_zones.default.zones.0.id}"
+ 	name = "${var.name}"
 }
 
 resource "alicloud_security_group" "tf_test_foo" {
-	name = "tf_test_foo"
+	name = "${var.name}"
 	description = "foo"
 	vpc_id = "${alicloud_vpc.foo.id}"
 }
 
 resource "alicloud_instance" "update_image" {
 	image_id = "${data.alicloud_images.centos.images.0.id}"
-	availability_zone = "cn-beijing-a"
   	system_disk_category = "cloud_efficiency"
   	system_disk_size = 50
-
-  	instance_type = "ecs.n4.small"
-  	instance_name = "update_image"
+	instance_type = "${data.alicloud_instance_types.default.instance_types.0.id}"
+  	instance_name = "${var.name}"
   	password = "Test12345"
   	security_groups = ["${alicloud_security_group.tf_test_foo.id}"]
 	vswitch_id = "${alicloud_vswitch.foo.id}"
 }
 `
 const testAccCheckInstanceImageUpdate = `
+data "alicloud_zones" "default" {
+	available_disk_category = "cloud_efficiency"
+	available_resource_creation = "VSwitch"
+}
+data "alicloud_instance_types" "default" {
+ 	availability_zone = "${data.alicloud_zones.default.zones.0.id}"
+	cpu_core_count = 1
+	memory_size = 2
+}
 data "alicloud_images" "ubuntu" {
 	most_recent = true
 	owners = "system"
 	name_regex = "^ubuntu_14\\w{1,5}[64]{1}.*"
 }
-
+variable "name" {
+	default = "testAccCheckInstanceImageOrigin"
+}
 resource "alicloud_vpc" "foo" {
-	name = "tf_test_image"
+	name = "${var.name}"
 	cidr_block = "10.1.0.0/21"
 }
 
 resource "alicloud_vswitch" "foo" {
 	vpc_id = "${alicloud_vpc.foo.id}"
 	cidr_block = "10.1.1.0/24"
-	availability_zone = "cn-beijing-a"
+	availability_zone = "${data.alicloud_zones.default.zones.0.id}"
+	name = "${var.name}"
 }
 
 resource "alicloud_security_group" "tf_test_foo" {
-	name = "tf_test_foo"
+	name = "${var.name}"
 	description = "foo"
 	vpc_id = "${alicloud_vpc.foo.id}"
 }
 
 resource "alicloud_instance" "update_image" {
 	image_id = "${data.alicloud_images.ubuntu.images.0.id}"
-	availability_zone = "cn-beijing-a"
   	system_disk_category = "cloud_efficiency"
   	system_disk_size = 60
-
-  	instance_type = "ecs.n4.small"
-  	instance_name = "update_image"
+	instance_type = "${data.alicloud_instance_types.default.instance_types.0.id}"
+  	instance_name = "${var.name}"
   	password = "Test12345"
   	security_groups = ["${alicloud_security_group.tf_test_foo.id}"]
 	vswitch_id = "${alicloud_vswitch.foo.id}"
 }
 `
-const testAccCheckInstanceKeyPair = `
-data "alicloud_images" "ubuntu" {
-	most_recent = true
-	owners = "system"
-	name_regex = "^ubuntu_14\\w{1,5}[64]{1}.*"
-}
 
-resource "alicloud_vpc" "foo" {
-	name = "tf_test_image"
-	cidr_block = "10.1.0.0/21"
-}
-
-resource "alicloud_vswitch" "foo" {
-	vpc_id = "${alicloud_vpc.foo.id}"
-	cidr_block = "10.1.1.0/24"
-	availability_zone = "cn-beijing-a"
-}
-
-resource "alicloud_security_group" "tf_test_foo" {
-	name = "tf_test_foo"
-	description = "foo"
-	vpc_id = "${alicloud_vpc.foo.id}"
-}
-
-resource "alicloud_key_pair" "key_pair" {
-  key_name = "key_pair_for_instance_test"
-}
-
-resource "alicloud_instance" "key_pair" {
-	image_id = "${data.alicloud_images.ubuntu.images.0.id}"
-	availability_zone = "cn-beijing-a"
-  	system_disk_category = "cloud_efficiency"
-  	system_disk_size = 60
-
-  	instance_type = "ecs.n4.small"
-  	instance_name = "with_key_pair"
-  	password = "Test12345"
-  	security_groups = ["${alicloud_security_group.tf_test_foo.id}"]
-	vswitch_id = "${alicloud_vswitch.foo.id}"
-	key_name = "${alicloud_key_pair.key_pair.id}"
-}
-`
 const testAccCheckInstancePrivateIp = `
 data "alicloud_images" "ubuntu" {
 	most_recent = true
 	owners = "system"
 	name_regex = "^ubuntu_14\\w{1,5}[64]{1}.*"
 }
-
-data "alicloud_zones" "zones" {}
-
+data "alicloud_zones" "default" {
+	available_disk_category = "cloud_efficiency"
+	available_resource_creation = "VSwitch"
+}
+data "alicloud_instance_types" "default" {
+ 	availability_zone = "${data.alicloud_zones.default.zones.0.id}"
+	cpu_core_count = 1
+	memory_size = 2
+}
+variable "name" {
+	default = "testAccCheckInstancePrivateIp"
+}
 resource "alicloud_vpc" "foo" {
-	name = "tf_test_change_private"
+	name = "${var.name}"
 	cidr_block = "10.1.0.0/21"
 }
 
 resource "alicloud_vswitch" "foo" {
 	vpc_id = "${alicloud_vpc.foo.id}"
 	cidr_block = "10.1.1.0/24"
-	availability_zone = "${data.alicloud_zones.zones.zones.0.id}"
+	availability_zone = "${data.alicloud_zones.default.zones.0.id}"
+	name = "${var.name}-foo"
 }
 
 resource "alicloud_vswitch" "bar" {
 	vpc_id = "${alicloud_vpc.foo.id}"
 	cidr_block = "10.1.2.0/24"
-	availability_zone = "${data.alicloud_zones.zones.zones.0.id}"
+	availability_zone = "${data.alicloud_zones.default.zones.0.id}"
+	name = "${var.name}-bar"
 }
 
 resource "alicloud_security_group" "group" {
-	name = "tf_test_private_ip"
+	name = "${var.name}"
 	vpc_id = "${alicloud_vpc.foo.id}"
 }
 
@@ -1605,9 +1600,8 @@ resource "alicloud_instance" "private_ip" {
 	image_id = "${data.alicloud_images.ubuntu.images.0.id}"
   	system_disk_category = "cloud_efficiency"
   	system_disk_size = 40
-
-  	instance_type = "ecs.n4.small"
-  	instance_name = "with_private_ip"
+	instance_type = "${data.alicloud_instance_types.default.instance_types.0.id}"
+  	instance_name = "${var.name}"
   	security_groups = ["${alicloud_security_group.group.id}"]
 	vswitch_id = "${alicloud_vswitch.foo.id}"
 	private_ip = "10.1.1.3"
@@ -1620,28 +1614,39 @@ data "alicloud_images" "ubuntu" {
 	owners = "system"
 	name_regex = "^ubuntu_14\\w{1,5}[64]{1}.*"
 }
-
-data "alicloud_zones" "zones" {}
-
+data "alicloud_zones" "default" {
+	available_disk_category = "cloud_efficiency"
+	available_resource_creation = "VSwitch"
+}
+data "alicloud_instance_types" "default" {
+ 	availability_zone = "${data.alicloud_zones.default.zones.0.id}"
+	cpu_core_count = 1
+	memory_size = 2
+}
+variable "name" {
+	default = "testAccCheckInstancePrivateIp"
+}
 resource "alicloud_vpc" "foo" {
-	name = "tf_test_change_private"
+	name = "${var.name}"
 	cidr_block = "10.1.0.0/21"
 }
 
 resource "alicloud_vswitch" "foo" {
 	vpc_id = "${alicloud_vpc.foo.id}"
 	cidr_block = "10.1.1.0/24"
-	availability_zone = "${data.alicloud_zones.zones.zones.0.id}"
+	availability_zone = "${data.alicloud_zones.default.zones.0.id}"
+	name = "${var.name}-foo"
 }
 
 resource "alicloud_vswitch" "bar" {
 	vpc_id = "${alicloud_vpc.foo.id}"
 	cidr_block = "10.1.2.0/24"
-	availability_zone = "${data.alicloud_zones.zones.zones.0.id}"
+	availability_zone = "${data.alicloud_zones.default.zones.0.id}"
+	name = "${var.name}-bar"
 }
 
 resource "alicloud_security_group" "group" {
-	name = "tf_test_private_ip"
+	name = "${var.name}"
 	vpc_id = "${alicloud_vpc.foo.id}"
 }
 
@@ -1649,9 +1654,8 @@ resource "alicloud_instance" "private_ip" {
 	image_id = "${data.alicloud_images.ubuntu.images.0.id}"
   	system_disk_category = "cloud_efficiency"
   	system_disk_size = 40
-
-  	instance_type = "ecs.n4.small"
-  	instance_name = "with_private_ip"
+	instance_type = "${data.alicloud_instance_types.default.instance_types.0.id}"
+  	instance_name = "${var.name}"
   	security_groups = ["${alicloud_security_group.group.id}"]
 	vswitch_id = "${alicloud_vswitch.bar.id}"
 	private_ip = "10.1.2.3"
@@ -1664,22 +1668,32 @@ data "alicloud_images" "ubuntu" {
 	owners = "system"
 	name_regex = "^ubuntu_14\\w{1,5}[64]{1}.*"
 }
-
-data "alicloud_zones" "zones" {}
-
+data "alicloud_zones" "default" {
+	available_disk_category = "cloud_efficiency"
+	available_resource_creation = "VSwitch"
+}
+data "alicloud_instance_types" "default" {
+ 	availability_zone = "${data.alicloud_zones.default.zones.0.id}"
+	cpu_core_count = 1
+	memory_size = 2
+}
+variable "name" {
+	default = "testAccCheckInstanceChargeType"
+}
 resource "alicloud_vpc" "foo" {
-	name = "tf_test_charge_type"
+	name = "${var.name}"
 	cidr_block = "10.1.0.0/21"
 }
 
 resource "alicloud_vswitch" "foo" {
 	vpc_id = "${alicloud_vpc.foo.id}"
 	cidr_block = "10.1.1.0/24"
-	availability_zone = "${data.alicloud_zones.zones.zones.0.id}"
+	availability_zone = "${data.alicloud_zones.default.zones.0.id}"
+	name = "${var.name}"
 }
 
 resource "alicloud_security_group" "group" {
-	name = "tf_test_private_ip"
+	name = "${var.name}"
 	vpc_id = "${alicloud_vpc.foo.id}"
 }
 
@@ -1687,12 +1701,13 @@ resource "alicloud_instance" "charge_type" {
 	image_id = "${data.alicloud_images.ubuntu.images.0.id}"
   	system_disk_category = "cloud_efficiency"
   	system_disk_size = 40
-
-  	instance_type = "ecs.n4.small"
-  	instance_name = "with_charge_type"
+  	instance_type = "${data.alicloud_instance_types.default.instance_types.0.id}"
+  	instance_name = "${var.name}"
   	security_groups = ["${alicloud_security_group.group.id}"]
 	vswitch_id = "${alicloud_vswitch.foo.id}"
 	private_ip = "10.1.1.3"
+	instance_charge_type = "PrePaid"
+	period_unit = "Week"
 }
 `
 
@@ -1702,22 +1717,32 @@ data "alicloud_images" "ubuntu" {
 	owners = "system"
 	name_regex = "^ubuntu_14\\w{1,5}[64]{1}.*"
 }
-
-data "alicloud_zones" "zones" {}
-
+data "alicloud_zones" "default" {
+	available_disk_category = "cloud_efficiency"
+	available_resource_creation = "VSwitch"
+}
+data "alicloud_instance_types" "default" {
+ 	availability_zone = "${data.alicloud_zones.default.zones.0.id}"
+	cpu_core_count = 1
+	memory_size = 2
+}
+variable "name" {
+	default = "testAccCheckInstanceChargeType"
+}
 resource "alicloud_vpc" "foo" {
-	name = "tf_test_charge_type"
+	name = "${var.name}"
 	cidr_block = "10.1.0.0/21"
 }
 
 resource "alicloud_vswitch" "foo" {
 	vpc_id = "${alicloud_vpc.foo.id}"
 	cidr_block = "10.1.1.0/24"
-	availability_zone = "${data.alicloud_zones.zones.zones.0.id}"
+	availability_zone = "${data.alicloud_zones.default.zones.0.id}"
+	name = "${var.name}"
 }
 
 resource "alicloud_security_group" "group" {
-	name = "tf_test_private_ip"
+	name = "${var.name}"
 	vpc_id = "${alicloud_vpc.foo.id}"
 }
 
@@ -1725,14 +1750,11 @@ resource "alicloud_instance" "charge_type" {
 	image_id = "${data.alicloud_images.ubuntu.images.0.id}"
   	system_disk_category = "cloud_efficiency"
   	system_disk_size = 40
-
-  	instance_type = "ecs.n4.small"
-  	instance_name = "with_charge_type"
+  	instance_type = "${data.alicloud_instance_types.default.instance_types.0.id}"
+  	instance_name = "${var.name}"
   	security_groups = ["${alicloud_security_group.group.id}"]
 	vswitch_id = "${alicloud_vswitch.foo.id}"
 	private_ip = "10.1.1.3"
-	instance_charge_type = "PrePaid"
-	dry_run=true
 }
 `
 const testAccCheckSpotInstance = `
@@ -1740,8 +1762,21 @@ data "alicloud_zones" "default" {
   available_disk_category= "cloud_efficiency"
   available_resource_creation= "VSwitch"
 }
-
+data "alicloud_instance_types" "default" {
+ 	availability_zone = "${data.alicloud_zones.default.zones.0.id}"
+	cpu_core_count = 1
+	memory_size = 2
+}
+data "alicloud_images" "default" {
+        name_regex = "^ubuntu_14.*_64"
+	most_recent = true
+	owners = "system"
+}
+variable "name" {
+	default = "testAccCheckSpotInstance"
+}
 resource "alicloud_vpc" "foo" {
+  name = "${var.name}"
   cidr_block = "172.16.0.0/12"
 }
 
@@ -1749,26 +1784,25 @@ resource "alicloud_vswitch" "foo" {
   vpc_id = "${alicloud_vpc.foo.id}"
   cidr_block = "172.16.0.0/21"
   availability_zone = "${data.alicloud_zones.default.zones.0.id}"
+  name = "${var.name}"
 }
 
 resource "alicloud_security_group" "tf_test_foo" {
+  name = "${var.name}"
   vpc_id = "${alicloud_vpc.foo.id}"
 }
 
 resource "alicloud_instance" "spot" {
   # cn-beijing
   vswitch_id = "${alicloud_vswitch.foo.id}"
-  image_id = "ubuntu_140405_32_40G_cloudinit_20161115.vhd"
+  image_id = "${data.alicloud_images.default.images.0.id}"
   availability_zone = "${data.alicloud_zones.default.zones.0.id}"
-
-  # series III
-  instance_type = "ecs.n4.small"
+  instance_type = "${data.alicloud_instance_types.default.instance_types.0.id}"
   system_disk_category = "cloud_efficiency"
-
   internet_charge_type = "PayByTraffic"
   internet_max_bandwidth_out = 5
   security_groups = ["${alicloud_security_group.tf_test_foo.id}"]
-  instance_name = "test_for_spot"
+  instance_name = "${var.name}"
   spot_strategy = "SpotWithPriceLimit"
   spot_price_limit = "1.002"
 }
@@ -1779,22 +1813,37 @@ data "alicloud_images" "ubuntu" {
 	owners = "system"
 	name_regex = "^ubuntu_14\\w{1,5}[64]{1}.*"
 }
-
-data "alicloud_zones" "zones" {}
-
+data "alicloud_zones" "default" {
+  	available_disk_category= "cloud_efficiency"
+  	available_resource_creation= "VSwitch"
+}
+data "alicloud_instance_types" "default" {
+ 	availability_zone = "${data.alicloud_zones.default.zones.0.id}"
+	cpu_core_count = 1
+	memory_size = 2
+}
+data "alicloud_images" "default" {
+        name_regex = "^ubuntu_14.*_64"
+	most_recent = true
+	owners = "system"
+}
+variable "name" {
+	default = "testAccCheckInstanceType"
+}
 resource "alicloud_vpc" "foo" {
-	name = "tf_test_charge_type"
+  	name = "${var.name}"
 	cidr_block = "10.1.0.0/21"
 }
 
 resource "alicloud_vswitch" "foo" {
 	vpc_id = "${alicloud_vpc.foo.id}"
 	cidr_block = "10.1.1.0/24"
-	availability_zone = "${data.alicloud_zones.zones.zones.0.id}"
+	availability_zone = "${data.alicloud_zones.default.zones.0.id}"
+	name = "${var.name}"
 }
 
 resource "alicloud_security_group" "group" {
-	name = "tf_test_private_ip"
+	name = "${var.name}"
 	vpc_id = "${alicloud_vpc.foo.id}"
 }
 
@@ -1802,9 +1851,8 @@ resource "alicloud_instance" "type" {
 	image_id = "${data.alicloud_images.ubuntu.images.0.id}"
   	system_disk_category = "cloud_efficiency"
   	system_disk_size = 40
-
-  	instance_type = "ecs.n4.small"
-  	instance_name = "change_type"
+  	instance_type = "${data.alicloud_instance_types.default.instance_types.0.id}"
+  	instance_name = "${var.name}"
   	security_groups = ["${alicloud_security_group.group.id}"]
 	vswitch_id = "${alicloud_vswitch.foo.id}"
 	private_ip = "10.1.1.3"
@@ -1817,22 +1865,37 @@ data "alicloud_images" "ubuntu" {
 	owners = "system"
 	name_regex = "^ubuntu_14\\w{1,5}[64]{1}.*"
 }
-
-data "alicloud_zones" "zones" {}
-
+data "alicloud_zones" "default" {
+  	available_disk_category= "cloud_efficiency"
+  	available_resource_creation= "VSwitch"
+}
+data "alicloud_instance_types" "default" {
+ 	availability_zone = "${data.alicloud_zones.default.zones.0.id}"
+	cpu_core_count = 2
+	memory_size = 4
+}
+data "alicloud_images" "default" {
+        name_regex = "^ubuntu_14.*_64"
+	most_recent = true
+	owners = "system"
+}
+variable "name" {
+	default = "testAccCheckInstanceType"
+}
 resource "alicloud_vpc" "foo" {
-	name = "tf_test_charge_type"
+  	name = "${var.name}"
 	cidr_block = "10.1.0.0/21"
 }
 
 resource "alicloud_vswitch" "foo" {
 	vpc_id = "${alicloud_vpc.foo.id}"
 	cidr_block = "10.1.1.0/24"
-	availability_zone = "${data.alicloud_zones.zones.zones.0.id}"
+	availability_zone = "${data.alicloud_zones.default.zones.0.id}"
+	name = "${var.name}"
 }
 
 resource "alicloud_security_group" "group" {
-	name = "tf_test_private_ip"
+	name = "${var.name}"
 	vpc_id = "${alicloud_vpc.foo.id}"
 }
 
@@ -1840,9 +1903,8 @@ resource "alicloud_instance" "type" {
 	image_id = "${data.alicloud_images.ubuntu.images.0.id}"
   	system_disk_category = "cloud_efficiency"
   	system_disk_size = 40
-
-  	instance_type = "ecs.n4.large"
-  	instance_name = "change_type"
+  	instance_type = "${data.alicloud_instance_types.default.instance_types.0.id}"
+  	instance_name = "${var.name}"
   	security_groups = ["${alicloud_security_group.group.id}"]
 	vswitch_id = "${alicloud_vswitch.foo.id}"
 	private_ip = "10.1.1.3"
@@ -1855,22 +1917,37 @@ data "alicloud_images" "ubuntu" {
 	owners = "system"
 	name_regex = "^ubuntu_14\\w{1,5}[64]{1}.*"
 }
-
-data "alicloud_zones" "zones" {}
-
+data "alicloud_zones" "default" {
+  	available_disk_category= "cloud_efficiency"
+  	available_resource_creation= "VSwitch"
+}
+data "alicloud_instance_types" "default" {
+ 	availability_zone = "${data.alicloud_zones.default.zones.0.id}"
+	cpu_core_count = 2
+	memory_size = 4
+}
+data "alicloud_images" "default" {
+        name_regex = "^ubuntu_14.*_64"
+	most_recent = true
+	owners = "system"
+}
+variable "name" {
+	default = "testAccCheckInstanceNetworkSpec"
+}
 resource "alicloud_vpc" "foo" {
-	name = "tf_test_charge_type"
+  	name = "${var.name}"
 	cidr_block = "10.1.0.0/21"
 }
 
 resource "alicloud_vswitch" "foo" {
 	vpc_id = "${alicloud_vpc.foo.id}"
 	cidr_block = "10.1.1.0/24"
-	availability_zone = "${data.alicloud_zones.zones.zones.0.id}"
+	availability_zone = "${data.alicloud_zones.default.zones.0.id}"
+	name = "${var.name}"
 }
 
 resource "alicloud_security_group" "group" {
-	name = "tf_test_private_ip"
+	name = "${var.name}"
 	vpc_id = "${alicloud_vpc.foo.id}"
 }
 
@@ -1878,9 +1955,8 @@ resource "alicloud_instance" "network" {
 	image_id = "${data.alicloud_images.ubuntu.images.0.id}"
   	system_disk_category = "cloud_efficiency"
   	system_disk_size = 40
-
-  	instance_type = "ecs.n4.small"
-  	instance_name = "change_network"
+	instance_type = "${data.alicloud_instance_types.default.instance_types.0.id}"
+  	instance_name = "${var.name}"
   	security_groups = ["${alicloud_security_group.group.id}"]
 	vswitch_id = "${alicloud_vswitch.foo.id}"
 	private_ip = "10.1.1.3"
@@ -1893,22 +1969,37 @@ data "alicloud_images" "ubuntu" {
 	owners = "system"
 	name_regex = "^ubuntu_14\\w{1,5}[64]{1}.*"
 }
-
-data "alicloud_zones" "zones" {}
-
+data "alicloud_zones" "default" {
+  	available_disk_category= "cloud_efficiency"
+  	available_resource_creation= "VSwitch"
+}
+data "alicloud_instance_types" "default" {
+ 	availability_zone = "${data.alicloud_zones.default.zones.0.id}"
+	cpu_core_count = 2
+	memory_size = 4
+}
+data "alicloud_images" "default" {
+        name_regex = "^ubuntu_14.*_64"
+	most_recent = true
+	owners = "system"
+}
+variable "name" {
+	default = "testAccCheckInstanceType"
+}
 resource "alicloud_vpc" "foo" {
-	name = "tf_test_charge_type"
+  	name = "${var.name}"
 	cidr_block = "10.1.0.0/21"
 }
 
 resource "alicloud_vswitch" "foo" {
 	vpc_id = "${alicloud_vpc.foo.id}"
 	cidr_block = "10.1.1.0/24"
-	availability_zone = "${data.alicloud_zones.zones.zones.0.id}"
+	availability_zone = "${data.alicloud_zones.default.zones.0.id}"
+	name = "${var.name}"
 }
 
 resource "alicloud_security_group" "group" {
-	name = "tf_test_private_ip"
+	name = "${var.name}"
 	vpc_id = "${alicloud_vpc.foo.id}"
 }
 
@@ -1916,9 +2007,8 @@ resource "alicloud_instance" "network" {
 	image_id = "${data.alicloud_images.ubuntu.images.0.id}"
   	system_disk_category = "cloud_efficiency"
   	system_disk_size = 40
-
-  	instance_type = "ecs.n4.small"
-  	instance_name = "change_network"
+	instance_type = "${data.alicloud_instance_types.default.instance_types.0.id}"
+  	instance_name = "${var.name}"
   	security_groups = ["${alicloud_security_group.group.id}"]
 	vswitch_id = "${alicloud_vswitch.foo.id}"
 	private_ip = "10.1.1.3"
@@ -1933,32 +2023,48 @@ data "alicloud_images" "ubuntu" {
 	owners = "system"
 	name_regex = "^ubuntu_14\\w{1,5}[64]{1}.*"
 }
-
+data "alicloud_zones" "default" {
+  	available_disk_category= "cloud_efficiency"
+  	available_resource_creation= "VSwitch"
+}
+data "alicloud_instance_types" "default" {
+ 	availability_zone = "${data.alicloud_zones.default.zones.0.id}"
+	cpu_core_count = 2
+	memory_size = 4
+}
+data "alicloud_images" "default" {
+        name_regex = "^ubuntu_14.*_64"
+	most_recent = true
+	owners = "system"
+}
+variable "name" {
+	default = "testAccCheckInstanceRamRole"
+}
 resource "alicloud_vpc" "foo" {
-	name = "tf_test_image"
+  	name = "${var.name}"
 	cidr_block = "10.1.0.0/21"
 }
 
 resource "alicloud_vswitch" "foo" {
 	vpc_id = "${alicloud_vpc.foo.id}"
 	cidr_block = "10.1.1.0/24"
-	availability_zone = "cn-beijing-a"
+ 	availability_zone = "${data.alicloud_zones.default.zones.0.id}"
+ 	name = "${var.name}"
 }
 
 resource "alicloud_security_group" "tf_test_foo" {
-	name = "tf_test_foo"
+	name = "${var.name}"
 	description = "foo"
 	vpc_id = "${alicloud_vpc.foo.id}"
 }
 
 resource "alicloud_instance" "role" {
 	image_id = "${data.alicloud_images.ubuntu.images.0.id}"
-	availability_zone = "cn-beijing-a"
+	availability_zone = "${data.alicloud_zones.default.zones.0.id}"
   	system_disk_category = "cloud_efficiency"
   	system_disk_size = 60
-
-  	instance_type = "ecs.n4.small"
-  	instance_name = "with_ram_role"
+	instance_type = "${data.alicloud_instance_types.default.instance_types.0.id}"
+  	instance_name = "${var.name}"
   	password = "Test12345"
   	security_groups = ["${alicloud_security_group.tf_test_foo.id}"]
 	vswitch_id = "${alicloud_vswitch.foo.id}"
@@ -1966,13 +2072,13 @@ resource "alicloud_instance" "role" {
 }
 
 resource "alicloud_ram_role" "role" {
-  name = "TF-RAM-Role-Name"
-  services = ["ecs.aliyuncs.com"]
-  force = "true"
+  	name = "${var.name}"
+  	services = ["ecs.aliyuncs.com"]
+  	force = "true"
 }
 
 resource "alicloud_ram_policy" "policy" {
-  name = "TF-RAM-Policy-Name"
+  name = "${var.name}"
   statement = [
     {
       effect = "Allow"

--- a/alicloud/resource_alicloud_key_pair_test.go
+++ b/alicloud/resource_alicloud_key_pair_test.go
@@ -160,7 +160,7 @@ func testAccCheckKeyPairDestroy(s *terraform.State) error {
 		if err != nil {
 			// Verify the error is what we want
 			if NotFoundError(err) || IsExceptedError(err, KeyPairNotFound) {
-				return nil
+				continue
 			}
 			return err
 		}

--- a/alicloud/resource_alicloud_kms_key_test.go
+++ b/alicloud/resource_alicloud_kms_key_test.go
@@ -70,10 +70,7 @@ func testAccCheckAlicloudKmsKeyDestroy(s *terraform.State) error {
 
 		out, err := conn.DescribeKey(rs.Primary.ID)
 
-		if err != nil {
-			if IsExceptedError(err, ForbiddenKeyNotFound) {
-				return nil
-			}
+		if err != nil && !IsExceptedError(err, ForbiddenKeyNotFound) {
 			return err
 		}
 

--- a/alicloud/resource_alicloud_log_machine_group_test.go
+++ b/alicloud/resource_alicloud_log_machine_group_test.go
@@ -90,17 +90,13 @@ func testAccCheckAlicloudLogMachineGroupDestroy(s *terraform.State) error {
 
 		split := strings.Split(rs.Primary.ID, COLON_SEPARATED)
 
-		group, err := client.DescribeLogMachineGroup(split[0], split[1])
-		if err != nil {
+		if _, err := client.DescribeLogMachineGroup(split[0], split[1]); err != nil {
 			if NotFoundError(err) {
-				return nil
+				continue
 			}
 			return fmt.Errorf("Check log machine group got an error: %#v.", err)
 		}
-
-		if group.Name != "" {
-			return fmt.Errorf("Log machine group %s still exists.", rs.Primary.ID)
-		}
+		return fmt.Errorf("Log machine group %s still exists.", rs.Primary.ID)
 	}
 
 	return nil

--- a/alicloud/resource_alicloud_log_store_index_test.go
+++ b/alicloud/resource_alicloud_log_store_index_test.go
@@ -119,18 +119,18 @@ func testAccCheckAlicloudLogStoreIndexDestroy(s *terraform.State) error {
 		i, err := client.DescribeLogStoreIndex(split[0], split[1])
 		if err != nil {
 			if NotFoundError(err) {
-				return nil
+				continue
 			}
 			return fmt.Errorf("Check log store index got an error: %#v.", err)
 		}
 
 		if len(split) == 2 {
 			if i.Line == nil {
-				return nil
+				continue
 			}
 		} else {
 			if _, ok := i.Keys[split[2]]; !ok {
-				return nil
+				continue
 			}
 		}
 

--- a/alicloud/resource_alicloud_log_store_test.go
+++ b/alicloud/resource_alicloud_log_store_test.go
@@ -69,15 +69,12 @@ func testAccCheckAlicloudLogStoreDestroy(s *terraform.State) error {
 		}
 
 		split := strings.Split(rs.Primary.ID, COLON_SEPARATED)
-		store, err := client.DescribeLogStore(split[0], split[1])
-		if err != nil && !NotFoundError(err) {
+		if _, err := client.DescribeLogStore(split[0], split[1]); err != nil {
+			if NotFoundError(err) {
+				continue
+			}
 			return fmt.Errorf("Check log store got an error: %#v.", err)
 		}
-
-		if store == nil || store.Name == "" {
-			return nil
-		}
-
 		return fmt.Errorf("Log store %s still exists.", split[0])
 	}
 

--- a/alicloud/resource_alicloud_log_store_test.go
+++ b/alicloud/resource_alicloud_log_store_test.go
@@ -70,10 +70,7 @@ func testAccCheckAlicloudLogStoreDestroy(s *terraform.State) error {
 
 		split := strings.Split(rs.Primary.ID, COLON_SEPARATED)
 		store, err := client.DescribeLogStore(split[0], split[1])
-		if err != nil {
-			if NotFoundError(err) {
-				return nil
-			}
+		if err != nil && !NotFoundError(err) {
 			return fmt.Errorf("Check log store got an error: %#v.", err)
 		}
 

--- a/alicloud/resource_alicloud_nat_gateway_test.go
+++ b/alicloud/resource_alicloud_nat_gateway_test.go
@@ -126,14 +126,14 @@ func testAccCheckNatGatewayDestroy(s *terraform.State) error {
 		}
 
 		// Try to find the Nat gateway
-		instance, err := client.DescribeNatGateway(rs.Primary.ID)
-		if err != nil && !NotFoundError(err) {
+		if _, err := client.DescribeNatGateway(rs.Primary.ID); err != nil {
+			if NotFoundError(err) {
+				continue
+			}
 			return err
 		}
 
-		if instance.NatGatewayId != "" {
-			return fmt.Errorf("Nat gateway still exist")
-		}
+		return fmt.Errorf("Nat gateway %s still exist", rs.Primary.ID)
 	}
 
 	return nil

--- a/alicloud/resource_alicloud_oss_bucket_object_test.go
+++ b/alicloud/resource_alicloud_oss_bucket_object_test.go
@@ -8,7 +8,6 @@ import (
 	"os"
 	"testing"
 
-	"github.com/aliyun/aliyun-oss-go-sdk/oss"
 	"github.com/hashicorp/terraform/helper/acctest"
 	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/helper/schema"
@@ -184,8 +183,7 @@ func testAccCheckOssBucketObjectDestroyWithProvider(s *terraform.State, provider
 		}
 
 		// Verify the error is what we want
-		e, _ := err.(oss.ServiceError)
-		if e.Code == OssBucketNotFound {
+		if IsExceptedErrors(err, []string{OssBucketNotFound}) {
 			continue
 		}
 

--- a/alicloud/resource_alicloud_oss_bucket_test.go
+++ b/alicloud/resource_alicloud_oss_bucket_test.go
@@ -284,8 +284,7 @@ func testAccCheckOssBucketDestroyWithProvider(s *terraform.State, provider *sche
 		}
 
 		// Verify the error is what we want
-		e, _ := err.(oss.ServiceError)
-		if e.Code == OssBucketNotFound {
+		if IsExceptedErrors(err, []string{OssBucketNotFound}) {
 			continue
 		}
 

--- a/alicloud/resource_alicloud_ots_table_test.go
+++ b/alicloud/resource_alicloud_ots_table_test.go
@@ -10,7 +10,10 @@ import (
 	"github.com/hashicorp/terraform/terraform"
 )
 
-func TestAccAlicloudOtsTable_Basic(t *testing.T) {
+// At present, OTS sdk does not support creating OTS instance, and you should manually create a instance before running the test case.
+// After running the test, you should set it to 'Skip'
+
+func SkipTestAccAlicloudOtsTable_Basic(t *testing.T) {
 	var table tablestore.DescribeTableResponse
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
@@ -86,12 +89,12 @@ func testAccCheckOtsTableDestroy(s *terraform.State) error {
 
 const testAccOtsTable = `
 provider "alicloud" {
-  ots_instance_name = "tf-test"
+  ots_instance_name = "testAccOtsTable"
   region = "cn-hangzhou"
 }
 resource "alicloud_ots_table" "basic" {
   provider = "alicloud"
-  table_name = "ots_table_c"
+  table_name = "testAccOtsTable"
   primary_key = {
     name = "pk1"
     type = "Integer"

--- a/alicloud/resource_alicloud_ram_access_key_test.go
+++ b/alicloud/resource_alicloud_ram_access_key_test.go
@@ -101,10 +101,7 @@ func testAccCheckRamAccessKeyDestroy(s *terraform.State) error {
 				}
 			}
 		}
-		if err != nil {
-			if RamEntityNotExist(err) {
-				return nil
-			}
+		if err != nil && !RamEntityNotExist(err) {
 			return err
 		}
 	}

--- a/alicloud/resource_alicloud_ram_account_alias_test.go
+++ b/alicloud/resource_alicloud_ram_account_alias_test.go
@@ -30,7 +30,7 @@ func TestAccAlicloudRamAccountAlias_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(
 						"alicloud_ram_account_alias.alias",
 						"account_alias",
-						"hallo"),
+						"testaccramaccountaliasconfig"),
 				),
 			},
 		},
@@ -75,10 +75,7 @@ func testAccCheckRamAccountAliasDestroy(s *terraform.State) error {
 
 		_, err := conn.GetAccountAlias()
 
-		if err != nil {
-			if RamEntityNotExist(err) {
-				return nil
-			}
+		if err != nil && !RamEntityNotExist(err) {
 			return err
 		}
 	}
@@ -87,5 +84,5 @@ func testAccCheckRamAccountAliasDestroy(s *terraform.State) error {
 
 const testAccRamAccountAliasConfig = `
 resource "alicloud_ram_account_alias" "alias" {
-  account_alias = "hallo"
+  account_alias = "testaccramaccountaliasconfig"
 }`

--- a/alicloud/resource_alicloud_ram_group_policy_attachment_test.go
+++ b/alicloud/resource_alicloud_ram_group_policy_attachment_test.go
@@ -90,10 +90,7 @@ func testAccCheckRamGroupPolicyAttachmentDestroy(s *terraform.State) error {
 
 		response, err := conn.ListPoliciesForGroup(request)
 
-		if err != nil {
-			if RamEntityNotExist(err) {
-				return nil
-			}
+		if err != nil && !RamEntityNotExist(err) {
 			return err
 		}
 

--- a/alicloud/resource_alicloud_ram_group_test.go
+++ b/alicloud/resource_alicloud_ram_group_test.go
@@ -2,7 +2,6 @@ package alicloud
 
 import (
 	"fmt"
-	"log"
 	"testing"
 
 	"github.com/denverdino/aliyungo/ram"
@@ -58,18 +57,15 @@ func testAccCheckRamGroupExists(n string, group *ram.Group) resource.TestCheckFu
 		client := testAccProvider.Meta().(*AliyunClient)
 		conn := client.ramconn
 
-		request := ram.GroupQueryRequest{
-			GroupName: rs.Primary.Attributes["name"],
-		}
-
-		response, err := conn.GetGroup(request)
-		log.Printf("[WARN] Group id %#v", rs.Primary.ID)
+		response, err := conn.GetGroup(ram.GroupQueryRequest{
+			GroupName: rs.Primary.ID,
+		})
 
 		if err == nil {
 			*group = response.Group
 			return nil
 		}
-		return fmt.Errorf("Error finding group %#v", rs.Primary.ID)
+		return fmt.Errorf("Error finding group %#v", err)
 	}
 }
 
@@ -85,15 +81,12 @@ func testAccCheckRamGroupDestroy(s *terraform.State) error {
 		conn := client.ramconn
 
 		request := ram.GroupQueryRequest{
-			GroupName: rs.Primary.Attributes["name"],
+			GroupName: rs.Primary.ID,
 		}
 
 		_, err := conn.GetGroup(request)
 
-		if err != nil {
-			if RamEntityNotExist(err) {
-				return nil
-			}
+		if err != nil && !RamEntityNotExist(err) {
 			return err
 		}
 	}

--- a/alicloud/resource_alicloud_ram_login_profile_test.go
+++ b/alicloud/resource_alicloud_ram_login_profile_test.go
@@ -83,10 +83,7 @@ func testAccCheckRamLoginProfileDestroy(s *terraform.State) error {
 
 		_, err := conn.GetLoginProfile(request)
 
-		if err != nil {
-			if RamEntityNotExist(err) {
-				return nil
-			}
+		if err != nil && !RamEntityNotExist(err) {
 			return err
 		}
 	}

--- a/alicloud/resource_alicloud_ram_policy_test.go
+++ b/alicloud/resource_alicloud_ram_policy_test.go
@@ -92,10 +92,7 @@ func testAccCheckRamPolicyDestroy(s *terraform.State) error {
 
 		_, err := conn.GetPolicy(request)
 
-		if err != nil {
-			if RamEntityNotExist(err) {
-				return nil
-			}
+		if err != nil && !RamEntityNotExist(err) {
 			return err
 		}
 	}

--- a/alicloud/resource_alicloud_ram_role_policy_attachment_test.go
+++ b/alicloud/resource_alicloud_ram_role_policy_attachment_test.go
@@ -90,10 +90,7 @@ func testAccCheckRamRolePolicyAttachmentDestroy(s *terraform.State) error {
 
 		response, err := conn.ListPoliciesForRole(request)
 
-		if err != nil {
-			if RamEntityNotExist(err) {
-				return nil
-			}
+		if err != nil && !RamEntityNotExist(err) {
 			return err
 		}
 
@@ -128,7 +125,6 @@ resource "alicloud_ram_policy" "policy" {
 resource "alicloud_ram_role" "role" {
   name = "rolename"
   services = ["apigateway.aliyuncs.com", "ecs.aliyuncs.com"]
-  ram_users = ["acs:ram::123456789:root", "acs:ram::1234567890:user/username"]
   description = "this is a test"
   force = true
 }

--- a/alicloud/resource_alicloud_ram_role_test.go
+++ b/alicloud/resource_alicloud_ram_role_test.go
@@ -90,10 +90,7 @@ func testAccCheckRamRoleDestroy(s *terraform.State) error {
 
 		_, err := conn.GetRole(request)
 
-		if err != nil {
-			if RamEntityNotExist(err) {
-				return nil
-			}
+		if err != nil && !RamEntityNotExist(err) {
 			return err
 		}
 	}
@@ -104,7 +101,6 @@ const testAccRamRoleConfig = `
 resource "alicloud_ram_role" "role" {
   name = "rolename"
   services = ["apigateway.aliyuncs.com", "ecs.aliyuncs.com"]
-  ram_users = ["acs:ram::123456789:root", "acs:ram::1234567890:user/username"]
   description = "this is a test"
   force = true
 }`

--- a/alicloud/resource_alicloud_ram_user_test.go
+++ b/alicloud/resource_alicloud_ram_user_test.go
@@ -94,10 +94,7 @@ func testAccCheckRamUserDestroy(s *terraform.State) error {
 
 		_, err := conn.GetUser(request)
 
-		if err != nil {
-			if RamEntityNotExist(err) {
-				return nil
-			}
+		if err != nil && !RamEntityNotExist(err) {
 			return err
 		}
 	}

--- a/alicloud/resource_alicloud_router_interface_test.go
+++ b/alicloud/resource_alicloud_router_interface_test.go
@@ -71,7 +71,10 @@ func testAccCheckRouterInterfaceDestroy(s *terraform.State) error {
 		client := testAccProvider.Meta().(*AliyunClient)
 
 		ri, err := client.DescribeRouterInterface(rs.Primary.ID)
-		if err != nil && !NotFoundError(err) {
+		if err != nil {
+			if NotFoundError(err) {
+				continue
+			}
 			return err
 		}
 

--- a/alicloud/resource_alicloud_router_interface_test.go
+++ b/alicloud/resource_alicloud_router_interface_test.go
@@ -71,10 +71,8 @@ func testAccCheckRouterInterfaceDestroy(s *terraform.State) error {
 		client := testAccProvider.Meta().(*AliyunClient)
 
 		ri, err := client.DescribeRouterInterface(rs.Primary.ID)
-		if err != nil {
-			if NotFoundError(err) {
-				return nil
-			}
+		if err != nil && !NotFoundError(err) {
+			return err
 		}
 
 		if ri.RouterInterfaceId == rs.Primary.ID {

--- a/alicloud/resource_alicloud_security_group_rule_test.go
+++ b/alicloud/resource_alicloud_security_group_rule_test.go
@@ -367,11 +367,7 @@ func testAccCheckSecurityGroupRuleDestroy(s *terraform.State) error {
 		_, err = client.DescribeSecurityGroupRule(parts[0], parts[1], parts[2], parts[3], parts[4], parts[5], parts[6], prior)
 
 		// Verify the error is what we want
-		if err != nil {
-			// Verify the error is what we want
-			if IsExceptedErrors(err, []string{InvalidSecurityGroupIdNotFound}) {
-				continue
-			}
+		if err != nil && !IsExceptedErrors(err, []string{InvalidSecurityGroupIdNotFound}) {
 			return err
 		}
 	}

--- a/alicloud/resource_alicloud_security_group_test.go
+++ b/alicloud/resource_alicloud_security_group_test.go
@@ -112,7 +112,7 @@ func testAccCheckSecurityGroupDestroy(s *terraform.State) error {
 
 		if err != nil {
 			if NotFoundError(err) || IsExceptedErrors(err, []string{InvalidSecurityGroupIdNotFound}) {
-				return nil
+				continue
 			}
 			return err
 		}

--- a/alicloud/resource_alicloud_slb.go
+++ b/alicloud/resource_alicloud_slb.go
@@ -265,16 +265,11 @@ func resourceAliyunSlbCreate(d *schema.ResourceData, meta interface{}) error {
 func resourceAliyunSlbRead(d *schema.ResourceData, meta interface{}) error {
 	loadBalancer, err := meta.(*AliyunClient).DescribeLoadBalancerAttribute(d.Id())
 	if err != nil {
-		if IsExceptedErrors(err, []string{LoadBalancerNotFound}) {
+		if NotFoundError(err) {
 			d.SetId("")
 			return nil
 		}
 		return err
-	}
-
-	if loadBalancer == nil {
-		d.SetId("")
-		return nil
 	}
 
 	d.Set("name", loadBalancer.LoadBalancerName)

--- a/alicloud/resource_alicloud_slb_attachment.go
+++ b/alicloud/resource_alicloud_slb_attachment.go
@@ -74,10 +74,6 @@ func resourceAliyunSlbAttachmentCreate(d *schema.ResourceData, meta interface{})
 		return err
 	}
 
-	if loadBalancer == nil {
-		d.SetId("")
-		return fmt.Errorf("Specified SLB Id %s is not found in %#v.", d.Get("load_balancer_id").(string), getRegion(d, meta))
-	}
 	d.SetId(loadBalancer.LoadBalancerId)
 
 	return resourceAliyunSlbAttachmentUpdate(d, meta)
@@ -87,16 +83,11 @@ func resourceAliyunSlbAttachmentRead(d *schema.ResourceData, meta interface{}) e
 
 	loadBalancer, err := meta.(*AliyunClient).DescribeLoadBalancerAttribute(d.Id())
 	if err != nil {
-		if IsExceptedError(err, LoadBalancerNotFound) {
+		if NotFoundError(err) {
 			d.SetId("")
 			return nil
 		}
 		return err
-	}
-
-	if loadBalancer == nil {
-		d.SetId("")
-		return nil
 	}
 
 	backendServerType := loadBalancer.BackendServers
@@ -203,15 +194,11 @@ func removeBackendServers(d *schema.ResourceData, meta interface{}, servers []in
 
 			loadBalancer, err := client.DescribeLoadBalancerAttribute(d.Id())
 			if err != nil {
-				if IsExceptedError(err, LoadBalancerNotFound) {
+				if NotFoundError(err) {
 					return nil
 				}
 				return resource.NonRetryableError(fmt.Errorf("DescribeLoadBalancerAttribute got an error: %#v", err))
 
-			}
-
-			if loadBalancer == nil {
-				return nil
 			}
 
 			servers := loadBalancer.BackendServers.BackendServer

--- a/alicloud/resource_alicloud_slb_attachment_test.go
+++ b/alicloud/resource_alicloud_slb_attachment_test.go
@@ -78,47 +78,59 @@ func testAccCheckAttachment(n string, slb *slb.LoadBalancerType) resource.TestCh
 }
 
 const testAccSlbAttachment = `
-data "alicloud_images" "image" {
+data "alicloud_zones" "default" {
+	"available_disk_category"= "cloud_efficiency"
+	"available_resource_creation"= "VSwitch"
+}
+data "alicloud_instance_types" "default" {
+ 	availability_zone = "${data.alicloud_zones.default.zones.0.id}"
+	cpu_core_count = 1
+	memory_size = 2
+}
+data "alicloud_images" "default" {
+        name_regex = "^ubuntu_14.*_64"
 	most_recent = true
 	owners = "system"
-	name_regex = "^centos_6\\w{1,5}[64]{1}.*"
+}
+variable "name" {
+	default = "testAccSlbAttachment"
 }
 
-data "alicloud_zones" "zone" {}
-
 resource "alicloud_vpc" "main" {
+	name = "${var.name}"
 	cidr_block = "172.16.0.0/16"
 }
 
 resource "alicloud_vswitch" "main" {
 	vpc_id = "${alicloud_vpc.main.id}"
 	cidr_block = "172.16.0.0/16"
-	availability_zone = "${data.alicloud_zones.zone.zones.0.id}"
+	availability_zone = "${data.alicloud_zones.default.zones.0.id}"
 	depends_on = [
 	"alicloud_vpc.main"]
 }
 
 resource "alicloud_security_group" "group" {
+	name = "${var.name}"
 	vpc_id = "${alicloud_vpc.main.id}"
 }
 
 resource "alicloud_instance" "foo" {
 	# cn-beijing
-	image_id = "${data.alicloud_images.image.images.0.id}"
+	image_id = "${data.alicloud_images.default.images.0.id}"
 
 	# series III
-	instance_type = "ecs.n4.large"
+	instance_type = "${data.alicloud_instance_types.default.instance_types.0.id}"
 	internet_charge_type = "PayByBandwidth"
 	internet_max_bandwidth_out = "5"
 	system_disk_category = "cloud_efficiency"
 
 	security_groups = ["${alicloud_security_group.group.id}"]
-	instance_name = "test_foo"
+	instance_name = "${var.name}"
 	vswitch_id = "${alicloud_vswitch.main.id}"
 }
 
 resource "alicloud_slb" "foo" {
-	name = "tf_test_slb_bind"
+	name = "${var.name}"
 	vswitch_id = "${alicloud_vswitch.main.id}"
 }
 

--- a/alicloud/resource_alicloud_slb_listener_test.go
+++ b/alicloud/resource_alicloud_slb_listener_test.go
@@ -135,8 +135,8 @@ func testAccCheckSlbListenerDestroy(s *terraform.State) error {
 		}
 		loadBalancer, err := client.DescribeLoadBalancerAttribute(parts[0])
 		if err != nil {
-			if IsExceptedError(err, LoadBalancerNotFound) {
-				return nil
+			if NotFoundError(err) {
+				continue
 			}
 			return fmt.Errorf("DescribeLoadBalancerAttribute got an error: %#v", err)
 		}

--- a/alicloud/resource_alicloud_slb_rule.go
+++ b/alicloud/resource_alicloud_slb_rule.go
@@ -123,11 +123,11 @@ func resourceAliyunSlbRuleRead(d *schema.ResourceData, meta interface{}) error {
 	})
 
 	if err != nil {
-		if IsExceptedError(err, InvalidRuleIdNotFound) {
+		if NotFoundError(err) {
 			d.SetId("")
 			return nil
 		}
-		return fmt.Errorf("DescribeRuleAttribute got an error: %#v", err)
+		return err
 	}
 
 	d.Set("name", rule.RuleName)

--- a/alicloud/resource_alicloud_slb_test.go
+++ b/alicloud/resource_alicloud_slb_test.go
@@ -156,9 +156,6 @@ func testAccCheckSlbExists(n string, slb *slb.LoadBalancerType) resource.TestChe
 		if err != nil {
 			return err
 		}
-		if instance == nil {
-			return fmt.Errorf("SLB not found")
-		}
 
 		*slb = *instance
 		return nil
@@ -174,19 +171,13 @@ func testAccCheckSlbDestroy(s *terraform.State) error {
 		}
 
 		// Try to find the Slb
-		instance, err := client.DescribeLoadBalancerAttribute(rs.Primary.ID)
-
-		if instance != nil {
-			return fmt.Errorf("SLB still exist")
-		}
-
-		if err != nil {
-			if IsExceptedError(err, LoadBalancerNotFound) {
-				return nil
+		if _, err := client.DescribeLoadBalancerAttribute(rs.Primary.ID); err != nil {
+			if NotFoundError(err) {
+				continue
 			}
 			return fmt.Errorf("DescribeLoadBalancerAttribute got an error: %#v", err)
 		}
-
+		return fmt.Errorf("SLB still exist")
 	}
 
 	return nil

--- a/alicloud/resource_alicloud_snat_test.go
+++ b/alicloud/resource_alicloud_snat_test.go
@@ -63,16 +63,16 @@ func testAccCheckSnatEntryDestroy(s *terraform.State) error {
 		instance, err := client.DescribeSnatEntry(rs.Primary.Attributes["snat_table_id"], rs.Primary.ID)
 
 		//this special deal cause the DescribeSnatEntry can't find the records would be throw "cant find the snatTable error"
-		if err != nil && !NotFoundError(err) {
-			// Verify the error is what we want
+		if err != nil {
+			if NotFoundError(err) {
+				continue
+			}
 			return err
 		}
 
 		if instance.SnatEntryId != "" {
 			return fmt.Errorf("Snat entry still exist")
 		}
-
-		return nil
 	}
 
 	return nil

--- a/alicloud/resource_alicloud_vpc_test.go
+++ b/alicloud/resource_alicloud_vpc_test.go
@@ -62,7 +62,7 @@ func TestAccAlicloudVpc_update(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckVpcExists("alicloud_vpc.foo", &vpc),
 					resource.TestCheckResourceAttr(
-						"alicloud_vpc.foo", "name", "tf_test_bar"),
+						"alicloud_vpc.foo", "name", "testAccVpcConfigUpdate"),
 				),
 			},
 		},
@@ -145,7 +145,7 @@ func testAccCheckVpcDestroy(s *terraform.State) error {
 
 const testAccVpcConfig = `
 resource "alicloud_vpc" "foo" {
-        name = "tf_test_foo"
+        name = "testAccVpcConfig"
         cidr_block = "172.16.0.0/12"
 }
 `
@@ -153,21 +153,24 @@ resource "alicloud_vpc" "foo" {
 const testAccVpcConfigUpdate = `
 resource "alicloud_vpc" "foo" {
 	cidr_block = "172.16.0.0/12"
-	name = "tf_test_bar"
+	name = "testAccVpcConfigUpdate"
 }
 `
 
 const testAccVpcConfigMulti = `
+provider "alicloud" {
+	region="cn-shanghai"
+}
 resource "alicloud_vpc" "bar_1" {
 	cidr_block = "172.16.0.0/12"
-	name = "tf_test_bar_1"
+	name = "testAccVpcConfigMulti-1"
 }
 resource "alicloud_vpc" "bar_2" {
 	cidr_block = "192.168.0.0/16"
-	name = "tf_test_bar_2"
+	name = "testAccVpcConfigMulti-2"
 }
 resource "alicloud_vpc" "bar_3" {
 	cidr_block = "10.1.0.0/21"
-	name = "tf_test_bar_3"
+	name = "testAccVpcConfigMulti-3"
 }
 `

--- a/alicloud/resource_alicloud_vpc_test.go
+++ b/alicloud/resource_alicloud_vpc_test.go
@@ -131,7 +131,10 @@ func testAccCheckVpcDestroy(s *terraform.State) error {
 		// Try to find the VPC
 		instance, err := client.DescribeVpc(rs.Primary.ID)
 
-		if err != nil && !NotFoundError(err) {
+		if err != nil {
+			if NotFoundError(err) {
+				continue
+			}
 			return err
 		}
 

--- a/alicloud/resource_alicloud_vroute_entry_test.go
+++ b/alicloud/resource_alicloud_vroute_entry_test.go
@@ -152,9 +152,22 @@ const testAccRouteEntryConfig = `
 data "alicloud_zones" "default" {
 	"available_resource_creation"= "VSwitch"
 }
+data "alicloud_instance_types" "default" {
+ 	availability_zone = "${data.alicloud_zones.default.zones.0.id}"
+	cpu_core_count = 1
+	memory_size = 2
+}
+data "alicloud_images" "default" {
+        name_regex = "^ubuntu_14.*_64"
+	most_recent = true
+	owners = "system"
+}
 
+variable "name" {
+	default = "testAccRouteEntryConfig"
+}
 resource "alicloud_vpc" "foo" {
-	name = "tf_test_foo"
+	name = "${var.name}"
 	cidr_block = "10.1.0.0/21"
 }
 
@@ -162,6 +175,7 @@ resource "alicloud_vswitch" "foo" {
 	vpc_id = "${alicloud_vpc.foo.id}"
 	cidr_block = "10.1.1.0/24"
 	availability_zone = "${data.alicloud_zones.default.zones.0.id}"
+	name = "${var.name}"
 }
 
 resource "alicloud_route_entry" "foo" {
@@ -172,7 +186,7 @@ resource "alicloud_route_entry" "foo" {
 }
 
 resource "alicloud_security_group" "tf_test_foo" {
-	name = "tf_test_foo"
+	name = "${var.name}"
 	description = "foo"
 	vpc_id = "${alicloud_vpc.foo.id}"
 }
@@ -197,22 +211,24 @@ resource "alicloud_instance" "foo" {
 
 	# series III
 	instance_charge_type = "PostPaid"
-	instance_type = "ecs.n4.small"
+	instance_type = "${data.alicloud_instance_types.default.instance_types.0.id}"
 	internet_charge_type = "PayByTraffic"
 	internet_max_bandwidth_out = 5
 
 	system_disk_category = "cloud_efficiency"
-	image_id = "ubuntu_140405_64_40G_cloudinit_20161115.vhd"
-	instance_name = "test_foo"
+	image_id = "${data.alicloud_images.default.images.0.id}"
+	instance_name = "${var.name}"
 }`
 
 const testAccRouteEntryInterfaceConfig = `
 data "alicloud_zones" "default" {
   "available_resource_creation"= "VSwitch"
 }
-
+variable "name" {
+	default = "testAccRouteEntryInterfaceConfig"
+}
 resource "alicloud_vpc" "foo" {
-  name = "tf_test_foo"
+  name = "${var.name}"
   cidr_block = "10.1.0.0/21"
 }
 
@@ -220,6 +236,7 @@ resource "alicloud_vswitch" "foo" {
   vpc_id = "${alicloud_vpc.foo.id}"
   cidr_block = "10.1.1.0/24"
   availability_zone = "${data.alicloud_zones.default.zones.0.id}"
+  name = "${var.name}"
 }
 
 resource "alicloud_route_entry" "foo" {
@@ -230,7 +247,7 @@ resource "alicloud_route_entry" "foo" {
 }
 
 resource "alicloud_security_group" "tf_test_foo" {
-  name = "tf_test_foo"
+  name = "${var.name}"
   description = "foo"
   vpc_id = "${alicloud_vpc.foo.id}"
 }
@@ -252,6 +269,6 @@ resource "alicloud_router_interface" "interface" {
   router_id = "${alicloud_vpc.foo.router_id}"
   role = "InitiatingSide"
   specification = "Large.2"
-  name = "test1"
+  name = "${var.name}"
   description = "test1"
 }`

--- a/alicloud/resource_alicloud_vroute_entry_test.go
+++ b/alicloud/resource_alicloud_vroute_entry_test.go
@@ -131,7 +131,10 @@ func testAccCheckRouteEntryDestroy(s *terraform.State) error {
 
 		parts := strings.Split(rs.Primary.ID, ":")
 		entry, err := client.QueryRouteEntry(parts[0], parts[2], parts[3], parts[4])
-		if err != nil && !NotFoundError(err) {
+		if err != nil {
+			if NotFoundError(err) {
+				continue
+			}
 			return err
 		}
 

--- a/alicloud/resource_alicloud_vswitch.go
+++ b/alicloud/resource_alicloud_vswitch.go
@@ -2,7 +2,6 @@ package alicloud
 
 import (
 	"fmt"
-	"log"
 	"time"
 
 	"github.com/aliyun/alibaba-cloud-sdk-go/services/vpc"
@@ -144,11 +143,8 @@ func resourceAliyunSwitchDelete(d *schema.ResourceData, meta interface{}) error 
 	request := vpc.CreateDeleteVSwitchRequest()
 	request.VSwitchId = d.Id()
 	return resource.Retry(5*time.Minute, func() *resource.RetryError {
-		_, err := client.vpcconn.DeleteVSwitch(request)
-
-		if err != nil {
+		if _, err := client.vpcconn.DeleteVSwitch(request); err != nil {
 			if IsExceptedError(err, VswitcInvalidRegionId) {
-				log.Printf("[ERROR] Delete Switch is failed.")
 				return resource.NonRetryableError(err)
 			}
 			if IsExceptedError(err, InvalidVswitchIDNotFound) {

--- a/alicloud/resource_alicloud_vswitch_test.go
+++ b/alicloud/resource_alicloud_vswitch_test.go
@@ -98,14 +98,14 @@ func testAccCheckVswitchDestroy(s *terraform.State) error {
 		}
 
 		// Try to find the Vswitch
-		vsw, err := client.DescribeVswitch(rs.Primary.ID)
-		if err != nil && !NotFoundError(err) {
+		if _, err := client.DescribeVswitch(rs.Primary.ID); err != nil {
+			if NotFoundError(err) {
+				continue
+			}
 			return err
 		}
 
-		if vsw.VSwitchId != "" {
-			return fmt.Errorf("Vswitch still exist")
-		}
+		return fmt.Errorf("Vswitch still exist")
 	}
 
 	return nil

--- a/alicloud/resource_alicloud_vswitch_test.go
+++ b/alicloud/resource_alicloud_vswitch_test.go
@@ -117,7 +117,7 @@ data "alicloud_zones" "default" {
 }
 
 resource "alicloud_vpc" "foo" {
-  name = "tf_test_foo"
+  name = "testAccVswitchConfig"
   cidr_block = "172.16.0.0/12"
 }
 
@@ -125,6 +125,7 @@ resource "alicloud_vswitch" "foo" {
   vpc_id = "${alicloud_vpc.foo.id}"
   cidr_block = "172.16.0.0/21"
   availability_zone = "${data.alicloud_zones.default.zones.0.id}"
+  name = "testAccVswitchConfig"
 }
 `
 
@@ -134,7 +135,7 @@ data "alicloud_zones" "default" {
 }
 
 resource "alicloud_vpc" "foo" {
-  name = "tf_test_foo"
+  name = "testAccVswitchMulti"
   cidr_block = "172.16.0.0/12"
 }
 
@@ -142,16 +143,19 @@ resource "alicloud_vswitch" "foo_0" {
   vpc_id = "${alicloud_vpc.foo.id}"
   cidr_block = "172.16.0.0/24"
   availability_zone = "${data.alicloud_zones.default.zones.0.id}"
+  name = "testAccVswitchMulti-1"
 }
 resource "alicloud_vswitch" "foo_1" {
   vpc_id = "${alicloud_vpc.foo.id}"
   cidr_block = "172.16.1.0/24"
   availability_zone = "${data.alicloud_zones.default.zones.0.id}"
+  name = "testAccVswitchMulti-2"
 }
 resource "alicloud_vswitch" "foo_2" {
   vpc_id = "${alicloud_vpc.foo.id}"
   cidr_block = "172.16.2.0/24"
   availability_zone = "${data.alicloud_zones.default.zones.0.id}"
+  name = "testAccVswitchMulti-3"
 }
 
 `

--- a/website/docs/r/instance.html.markdown
+++ b/website/docs/r/instance.html.markdown
@@ -18,7 +18,8 @@ Provides a ECS instance resource.
 
 ~> **NOTE:** At present, 'PrePaid' instance cannot be deleted and must wait it to be outdated and release it automatically.
 
-~> **NOTE:** The resource supports Spot Instance from version 1.5.4.
+~> **NOTE:** The resource supports modifying instance charge type from 'PrePaid' to 'PostPaid' from version 1.9.6.
+ However, at present, this modification has some limitation about CPU core count in one month, so strongly recommand that `Don't modify instance charge type frequentlly in one month`.
 
 ## Example Usage
 


### PR DESCRIPTION
```
TF_ACC=1 go test ./alicloud -v -run=TestAccAlicloudDnsRecord -timeout=600m
=== RUN   TestAccAlicloudDnsRecordsDataSource_host_record_regex
--- PASS: TestAccAlicloudDnsRecordsDataSource_host_record_regex (4.64s)
=== RUN   TestAccAlicloudDnsRecordsDataSource_type
--- PASS: TestAccAlicloudDnsRecordsDataSource_type (4.63s)
=== RUN   TestAccAlicloudDnsRecordsDataSource_value_regex
--- PASS: TestAccAlicloudDnsRecordsDataSource_value_regex (4.92s)
=== RUN   TestAccAlicloudDnsRecordsDataSource_line
--- PASS: TestAccAlicloudDnsRecordsDataSource_line (4.34s)
=== RUN   TestAccAlicloudDnsRecordsDataSource_status
--- PASS: TestAccAlicloudDnsRecordsDataSource_status (4.45s)
=== RUN   TestAccAlicloudDnsRecordsDataSource_is_locked
--- PASS: TestAccAlicloudDnsRecordsDataSource_is_locked (4.57s)
=== RUN   TestAccAlicloudDnsRecord_basic
--- PASS: TestAccAlicloudDnsRecord_basic (4.24s)
=== RUN   TestAccAlicloudDnsRecord_priority
--- PASS: TestAccAlicloudDnsRecord_priority (3.85s)
PASS
ok  	github.com/alibaba/terraform-provider/alicloud	35.688s
```