### PR TITLE
support multiaz kubernetes cluster

### DIFF
--- a/alicloud/common.go
+++ b/alicloud/common.go
@@ -215,6 +215,14 @@ func flattenStringList(list []string) []interface{} {
 	return vs
 }
 
+func expandIntList(configured []interface{}) []int {
+	vs := make([]int, 0, len(configured))
+	for _, v := range configured {
+		vs = append(vs, v.(int))
+	}
+	return vs
+}
+
 // Convert the result for an array and returns a Json string
 func convertListToJsonString(configured []interface{}) string {
 	if len(configured) < 1 {

--- a/alicloud/extension_ecs.go
+++ b/alicloud/extension_ecs.go
@@ -72,7 +72,6 @@ var SupportedDiskCategory = map[DiskCategory]DiskCategory{
 const AllPortRange = "-1/-1"
 
 const (
-	KubernetesImageId      = "centos_7"
 	KubernetesMasterNumber = 3
 )
 

--- a/alicloud/resource_alicloud_cs_kubernetes.go
+++ b/alicloud/resource_alicloud_cs_kubernetes.go
@@ -6,6 +6,9 @@ import (
 
 	"strings"
 
+	"errors"
+	"strconv"
+
 	"github.com/aliyun/alibaba-cloud-sdk-go/services/slb"
 	"github.com/aliyun/alibaba-cloud-sdk-go/services/vpc"
 	"github.com/denverdino/aliyungo/common"
@@ -13,6 +16,11 @@ import (
 	"github.com/denverdino/aliyungo/ecs"
 	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/helper/schema"
+)
+
+const (
+	KubernetesClusterNetworkTypeFlannel = "flannel"
+	KubernetesClusterNetworkTypeTerway  = "terway"
 )
 
 func resourceAlicloudCSKubernetes() *schema.Resource {
@@ -47,10 +55,19 @@ func resourceAlicloudCSKubernetes() *schema.Resource {
 				Computed: true,
 			},
 			"vswitch_id": &schema.Schema{
-				Type:     schema.TypeString,
+				Type:       schema.TypeString,
+				Optional:   true,
+				Deprecated: "Field 'vswitch_id' has been deprecated from provider version 1.16.0. New field 'vswitch_ids' replaces it.",
+			},
+			"vswitch_ids": &schema.Schema{
+				Type:     schema.TypeList,
 				Optional: true,
 				ForceNew: true,
 				Computed: true,
+				Elem: &schema.Schema{
+					Type: schema.TypeString,
+				},
+				MaxItems: 3,
 			},
 			"new_nat_gateway": &schema.Schema{
 				Type:     schema.TypeBool,
@@ -58,48 +75,98 @@ func resourceAlicloudCSKubernetes() *schema.Resource {
 				Default:  true,
 			},
 			"master_instance_type": &schema.Schema{
-				Type:         schema.TypeString,
-				Required:     true,
-				ValidateFunc: validateInstanceType,
+				Type:       schema.TypeString,
+				Optional:   true,
+				Deprecated: "Field 'master_instance_type' has been deprecated from provider version 1.16.0. New field 'master_instance_types' replaces it.",
+			},
+			"master_instance_types": &schema.Schema{
+				Type:     schema.TypeList,
+				Required: true,
+				ForceNew: true,
+				Elem: &schema.Schema{
+					Type: schema.TypeString,
+				},
+				MinItems: 1,
+				MaxItems: 3,
 			},
 			"worker_instance_type": &schema.Schema{
-				Type:         schema.TypeString,
-				Required:     true,
-				ValidateFunc: validateInstanceType,
+				Type:       schema.TypeString,
+				Optional:   true,
+				Deprecated: "Field 'worker_instance_type' has been deprecated from provider version 1.16.0. New field 'worker_instance_types' replaces it.",
+			},
+			"worker_instance_types": &schema.Schema{
+				Type:     schema.TypeList,
+				Required: true,
+				ForceNew: true,
+				Elem: &schema.Schema{
+					Type: schema.TypeString,
+				},
+				MinItems: 1,
+				MaxItems: 3,
 			},
 			"worker_number": &schema.Schema{
-				Type:     schema.TypeInt,
+				Type:       schema.TypeInt,
+				Optional:   true,
+				Deprecated: "Field 'worker_number' has been deprecated from provider version 1.16.0. New field 'worker_numbers' replaces it.",
+			},
+
+			"worker_numbers": &schema.Schema{
+				Type:     schema.TypeList,
 				Optional: true,
-				Default:  3,
+				Elem: &schema.Schema{
+					Type:    schema.TypeInt,
+					Default: 3,
+				},
+				MinItems: 1,
+				MaxItems: 3,
 			},
 			"password": &schema.Schema{
-				Type:      schema.TypeString,
-				Required:  true,
-				Sensitive: true,
+				Type:          schema.TypeString,
+				Optional:      true,
+				ForceNew:      true,
+				Sensitive:     true,
+				ConflictsWith: []string{"key_name"},
+			},
+			"key_name": &schema.Schema{
+				Type:          schema.TypeString,
+				ForceNew:      true,
+				Optional:      true,
+				ConflictsWith: []string{"password"},
 			},
 			"pod_cidr": &schema.Schema{
 				Type:     schema.TypeString,
+				ForceNew: true,
 				Optional: true,
 			},
 			"service_cidr": &schema.Schema{
 				Type:     schema.TypeString,
+				ForceNew: true,
 				Optional: true,
+			},
+			"cluster_network_type": &schema.Schema{
+				Type:         schema.TypeString,
+				Optional:     true,
+				ForceNew:     true,
+				ValidateFunc: validateAllowedStringValue([]string{KubernetesClusterNetworkTypeFlannel, KubernetesClusterNetworkTypeTerway}),
 			},
 			"enable_ssh": &schema.Schema{
 				Type:     schema.TypeBool,
 				Optional: true,
+				ForceNew: true,
 				Default:  false,
 			},
 			"master_disk_size": &schema.Schema{
 				Type:         schema.TypeInt,
 				Optional:     true,
 				Default:      40,
+				ForceNew:     true,
 				ValidateFunc: validateIntegerInRange(40, 500),
 			},
 			"master_disk_category": &schema.Schema{
 				Type:     schema.TypeString,
 				Optional: true,
 				Default:  ecs.DiskCategoryCloudEfficiency,
+				ForceNew: true,
 				ValidateFunc: validateAllowedStringValue([]string{
 					string(ecs.DiskCategoryCloudEfficiency), string(ecs.DiskCategoryCloudSSD)}),
 			},
@@ -107,11 +174,13 @@ func resourceAlicloudCSKubernetes() *schema.Resource {
 				Type:         schema.TypeInt,
 				Optional:     true,
 				Default:      40,
+				ForceNew:     true,
 				ValidateFunc: validateIntegerInRange(20, 32768),
 			},
 			"worker_disk_category": &schema.Schema{
 				Type:     schema.TypeString,
 				Optional: true,
+				ForceNew: true,
 				Default:  ecs.DiskCategoryCloudEfficiency,
 				ValidateFunc: validateAllowedStringValue([]string{
 					string(ecs.DiskCategoryCloudEfficiency), string(ecs.DiskCategoryCloudSSD)}),
@@ -255,21 +324,40 @@ func resourceAlicloudCSKubernetes() *schema.Resource {
 func resourceAlicloudCSKubernetesCreate(d *schema.ResourceData, meta interface{}) error {
 	client := meta.(*AliyunClient)
 	conn := client.csconn
-
-	args, err := buildKunernetesArgs(d, meta)
-	if err != nil {
-		return err
-	}
 	invoker := NewInvoker()
-	if err := invoker.Run(func() error {
-		cluster, err := conn.CreateKubernetesCluster(getRegion(d, meta), args)
+
+	if isMultiAZ, err := isMultiAZClusterAndCheck(d); err != nil {
+		return err
+	} else if isMultiAZ {
+		args, err := buildKubernetesMultiAZArgs(d, meta)
 		if err != nil {
 			return err
 		}
-		d.SetId(cluster.ClusterID)
-		return nil
-	}); err != nil {
-		return fmt.Errorf("Creating Kubernetes Cluster got an error: %#v", err)
+		if err := invoker.Run(func() error {
+			cluster, err := conn.CreateKubernetesMultiAZCluster(getRegion(d, meta), args)
+			if err != nil {
+				return err
+			}
+			d.SetId(cluster.ClusterID)
+			return nil
+		}); err != nil {
+			return fmt.Errorf("Creating Kubernetes Cluster got an error: %#v", err)
+		}
+	} else {
+		args, err := buildKubernetesArgs(d, meta)
+		if err != nil {
+			return err
+		}
+		if err := invoker.Run(func() error {
+			cluster, err := conn.CreateKubernetesCluster(getRegion(d, meta), args)
+			if err != nil {
+				return err
+			}
+			d.SetId(cluster.ClusterID)
+			return nil
+		}); err != nil {
+			return fmt.Errorf("Creating Kubernetes Cluster got an error: %#v", err)
+		}
 	}
 
 	if err := invoker.Run(func() error {
@@ -285,14 +373,30 @@ func resourceAlicloudCSKubernetesUpdate(d *schema.ResourceData, meta interface{}
 	conn := meta.(*AliyunClient).csconn
 	d.Partial(true)
 	invoker := NewInvoker()
-	if d.HasChange("worker_number") && !d.IsNewResource() {
-		// Ensure instance_type is generation three
-		args, err := buildKunernetesArgs(d, meta)
-		if err != nil {
-			return err
+	if d.HasChange("worker_numbers") && !d.IsNewResource() {
+
+		workerNumbers := expandIntList(d.Get("worker_numbers").([]interface{}))
+		workerInstanceTypes := expandStringList(d.Get("worker_instance_types").([]interface{}))
+
+		args := &cs.KubernetesClusterResizeArgs{
+			DisableRollback: true,
+			TimeoutMins:     60,
+			LoginPassword:   d.Get("password").(string),
+		}
+
+		if len(workerNumbers) == 1 {
+			args.WorkerInstanceType = workerInstanceTypes[0]
+			args.NumOfNodes = int64(workerNumbers[0])
+		} else if len(workerNumbers) == 3 {
+			args.WorkerInstanceTypeA = workerInstanceTypes[0]
+			args.WorkerInstanceTypeB = workerInstanceTypes[1]
+			args.WorkerInstanceTypeC = workerInstanceTypes[2]
+			args.NumOfNodesA = int64(workerNumbers[0])
+			args.NumOfNodesB = int64(workerNumbers[1])
+			args.NumOfNodesC = int64(workerNumbers[2])
 		}
 		if err := invoker.Run(func() error {
-			return conn.ResizeKubernetes(d.Id(), args)
+			return conn.ResizeKubernetesCluster(d.Id(), args)
 		}); err != nil {
 			return fmt.Errorf("Resize Cluster got an error: %#v", err)
 		}
@@ -331,10 +435,10 @@ func resourceAlicloudCSKubernetesUpdate(d *schema.ResourceData, meta interface{}
 func resourceAlicloudCSKubernetesRead(d *schema.ResourceData, meta interface{}) error {
 	client := meta.(*AliyunClient)
 
-	var cluster cs.ClusterType
+	var cluster cs.KubernetesCluster
 	invoker := NewInvoker()
 	if err := invoker.Run(func() error {
-		c, e := client.csconn.DescribeCluster(d.Id())
+		c, e := client.csconn.DescribeKubernetesCluster(d.Id())
 		if e != nil {
 			return e
 		}
@@ -349,16 +453,46 @@ func resourceAlicloudCSKubernetesRead(d *schema.ResourceData, meta interface{}) 
 	}
 
 	d.Set("name", cluster.Name)
-	// Each k8s cluster contains 3 master nodes
-	d.Set("worker_number", cluster.Size-KubernetesMasterNumber)
-	d.Set("vswitch_id", cluster.VSwitchID)
 	d.Set("vpc_id", cluster.VPCID)
 	d.Set("security_group_id", cluster.SecurityGroupID)
+	d.Set("key_name", cluster.Parameters.KeyPair)
+	d.Set("master_disk_size", cluster.Parameters.MasterSystemDiskSize)
+	d.Set("master_disk_category", cluster.Parameters.MasterSystemDiskCategory)
+	d.Set("worker_disk_size", cluster.Parameters.WorkerSystemDiskSize)
+	d.Set("worker_disk_category", cluster.Parameters.WorkerSystemDiskCategory)
+	d.Set("availability_zone", cluster.ZoneId)
+
+	// Each k8s cluster contains 3 master nodes
+	if cluster.MetaData.MultiAZ || cluster.MetaData.SubClass == "3az" {
+		numOfNodeA, err := strconv.Atoi(cluster.Parameters.NumOfNodesA)
+		if err != nil {
+			return fmt.Errorf("error convert NumOfNodesA %s to int: %s", cluster.Parameters.NumOfNodesA, err.Error())
+		}
+		numOfNodeB, err := strconv.Atoi(cluster.Parameters.NumOfNodesB)
+		if err != nil {
+			return fmt.Errorf("error convert NumOfNodesB %s to int: %s", cluster.Parameters.NumOfNodesB, err.Error())
+		}
+		numOfNodeC, err := strconv.Atoi(cluster.Parameters.NumOfNodesC)
+		if err != nil {
+			return fmt.Errorf("error convert NumOfNodesC %s to int: %s", cluster.Parameters.NumOfNodesC, err.Error())
+		}
+		d.Set("worker_numbers", []int{numOfNodeA, numOfNodeB, numOfNodeC})
+		d.Set("vswitch_ids", []string{cluster.Parameters.VSwitchIdA, cluster.Parameters.VSwitchIdB, cluster.Parameters.VSwitchIdC})
+		d.Set("master_instance_types", []string{cluster.Parameters.MasterInstanceTypeA, cluster.Parameters.MasterInstanceTypeB, cluster.Parameters.MasterInstanceTypeC})
+		d.Set("worker_instance_types", []string{cluster.Parameters.WorkerInstanceTypeA, cluster.Parameters.WorkerInstanceTypeB, cluster.Parameters.WorkerInstanceTypeC})
+	} else {
+		numOfNode, err := strconv.Atoi(cluster.Parameters.NumOfNodes)
+		if err != nil {
+			return fmt.Errorf("error convert NumOfNodes %s to int: %s", cluster.Parameters.NumOfNodes, err.Error())
+		}
+		d.Set("worker_numbers", []int{numOfNode})
+		d.Set("vswitch_ids", []string{cluster.Parameters.VSwitchID})
+		d.Set("master_instance_types", []string{cluster.Parameters.MasterInstanceType})
+		d.Set("worker_instance_types", []string{cluster.Parameters.WorkerInstanceType})
+	}
 
 	var masterNodes []map[string]interface{}
 	var workerNodes []map[string]interface{}
-	var master, worker cs.KubernetesNodeType
-	var workerId string
 
 	pageNumber := 1
 	for {
@@ -407,13 +541,8 @@ func resourceAlicloudCSKubernetesRead(d *schema.ResourceData, meta interface{}) 
 				"private_ip": node.IpAddress[0],
 			}
 			if node.InstanceRole == "Master" {
-				master = node
 				masterNodes = append(masterNodes, mapping)
 			} else {
-				if workerId == "" {
-					workerId = node.InstanceId
-				}
-				worker = node
 				workerNodes = append(workerNodes, mapping)
 			}
 		}
@@ -426,40 +555,13 @@ func resourceAlicloudCSKubernetesRead(d *schema.ResourceData, meta interface{}) 
 	d.Set("master_nodes", masterNodes)
 	d.Set("worker_nodes", workerNodes)
 
-	d.Set("master_instance_type", master.InstanceType)
-	if disks, err := client.DescribeDisksByType(master.InstanceId, DiskTypeSystem); err != nil {
-		return fmt.Errorf("[ERROR] DescribeDisks By Id %s: %#v.", master.InstanceId, err)
-	} else if len(disks) > 0 {
-		d.Set("master_disk_size", disks[0].Size)
-		d.Set("master_disk_category", disks[0].Category)
-		d.Set("availability_zone", disks[0].ZoneId)
-	}
-
-	d.Set("worker_instance_type", worker.InstanceType)
-	// worker.InstanceId will be empty in sometimes
-
-	if disks, err := client.DescribeDisksByType(workerId, DiskTypeSystem); err != nil {
-		return fmt.Errorf("[ERROR] DescribeDisks By Id %s: %#v.", workerId, err)
-	} else if len(disks) > 0 {
-		d.Set("worker_disk_size", disks[0].Size)
-		d.Set("worker_disk_category", disks[0].Category)
-	}
-
-	if cluster.SecurityGroupID == "" {
-		if inst, err := client.DescribeInstanceAttribute(workerId); err != nil {
-			return fmt.Errorf("[ERROR] DescribeInstanceAttribute %s got an error: %#v.", workerId, err)
-		} else {
-			d.Set("security_group_id", inst.SecurityGroupIds.SecurityGroupId[0])
-		}
-	}
-
 	// Get slb information
 	connection := make(map[string]string)
 	reqSLB := slb.CreateDescribeLoadBalancersRequest()
-	reqSLB.ServerId = master.InstanceId
+	reqSLB.ServerId = masterNodes[0]["id"].(string)
 	lbs, err := client.slbconn.DescribeLoadBalancers(reqSLB)
 	if err != nil {
-		return fmt.Errorf("[ERROR] DescribeLoadBalancers by server id %s got an error: %#v.", workerId, err)
+		return fmt.Errorf("[ERROR] DescribeLoadBalancers by server id %s got an error: %#v.", masterNodes[0]["id"].(string), err)
 	}
 	for _, lb := range lbs.LoadBalancers.LoadBalancer {
 		if strings.ToLower(lb.AddressType) == strings.ToLower(string(Internet)) {
@@ -566,7 +668,31 @@ func resourceAlicloudCSKubernetesDelete(d *schema.ResourceData, meta interface{}
 	})
 }
 
-func buildKunernetesArgs(d *schema.ResourceData, meta interface{}) (*cs.KubernetesCreationArgs, error) {
+func isMultiAZClusterAndCheck(d *schema.ResourceData) (bool, error) {
+	masterInstanceTypes := expandStringList(d.Get("master_instance_types").([]interface{}))
+	workerInstanceTypes := expandStringList(d.Get("worker_instance_types").([]interface{}))
+	vswitchIDs := expandStringList(d.Get("vswitch_ids").([]interface{}))
+	workerNumbers := expandIntList(d.Get("worker_numbers").([]interface{}))
+
+	if len(masterInstanceTypes) != len(workerInstanceTypes) {
+		return false, errors.New("length of fields `master_instance_types`, `worker_instance_types` must match")
+	}
+	if len(masterInstanceTypes) == 1 {
+		// single AZ
+		return false, nil
+	} else if len(masterInstanceTypes) == 3 {
+		if len(vswitchIDs) != 3 || len(workerNumbers) != 3 {
+			return true, errors.New("length of fields `vswitch_ids`, `worker_numbers` must be 3 for multiAZ clusters")
+
+		} else {
+			return true, nil
+		}
+	} else {
+		return false, errors.New("length of fields `master_instance_types`, `worker_instance_types` should be either 3 (for MultiAZ) or 1 (for Single AZ)")
+	}
+}
+
+func buildKubernetesArgs(d *schema.ResourceData, meta interface{}) (*cs.KubernetesCreationArgs, error) {
 	client := meta.(*AliyunClient)
 
 	// Ensure instance_type is valid
@@ -574,11 +700,30 @@ func buildKunernetesArgs(d *schema.ResourceData, meta interface{}) (*cs.Kubernet
 	if err != nil {
 		return nil, err
 	}
-	if err := meta.(*AliyunClient).InstanceTypeValidation(d.Get("master_instance_type").(string), zoneId, validZones); err != nil {
+
+	var masterInstanceType, workerInstanceType, vswitchID string
+	var workerNumber int
+
+	masterInstanceType = expandStringList(d.Get("master_instance_types").([]interface{}))[0]
+	workerInstanceType = expandStringList(d.Get("worker_instance_types").([]interface{}))[0]
+
+	if list := expandStringList(d.Get("vswitch_ids").([]interface{})); len(list) > 0 {
+		vswitchID = list[0]
+	} else {
+		vswitchID = ""
+	}
+
+	if list := expandIntList(d.Get("worker_numbers").([]interface{})); len(list) > 0 {
+		workerNumber = list[0]
+	} else {
+		workerNumber = 3
+	}
+
+	if err := meta.(*AliyunClient).InstanceTypeValidation(masterInstanceType, zoneId, validZones); err != nil {
 		return nil, err
 	}
 
-	if err := meta.(*AliyunClient).InstanceTypeValidation(d.Get("worker_instance_type").(string), zoneId, validZones); err != nil {
+	if err := meta.(*AliyunClient).InstanceTypeValidation(workerInstanceType, zoneId, validZones); err != nil {
 		return nil, err
 	}
 
@@ -589,11 +734,34 @@ func buildKunernetesArgs(d *schema.ResourceData, meta interface{}) (*cs.Kubernet
 		clusterName = resource.PrefixedUniqueId(d.Get("name_prefix").(string))
 	}
 
-	stackArgs := &cs.KubernetesStackArgs{
-		MasterInstanceType:       d.Get("master_instance_type").(string),
-		WorkerInstanceType:       d.Get("worker_instance_type").(string),
-		Password:                 d.Get("password").(string),
-		NumOfNodes:               int64(d.Get("worker_number").(int)),
+	var vpcId string
+	if vswitchID != "" {
+		vsw, err := client.DescribeVswitch(vswitchID)
+		if err != nil {
+			return nil, err
+		}
+		vpcId = vsw.VpcId
+		if zoneId != "" && zoneId != vsw.ZoneId {
+			return nil, fmt.Errorf("The specified vswitch %s isn't in the zone %s.", vsw.VSwitchId, zoneId)
+		}
+		zoneId = vsw.ZoneId
+	} else if !d.Get("new_nat_gateway").(bool) {
+		return nil, fmt.Errorf("The automatic created VPC and VSwitch must set 'new_nat_gateway' to 'true'.")
+	}
+
+	return &cs.KubernetesCreationArgs{
+		Name:                     clusterName,
+		ClusterType:              "Kubernetes",
+		DisableRollback:          true,
+		TimeoutMins:              60,
+		MasterInstanceType:       masterInstanceType,
+		WorkerInstanceType:       workerInstanceType,
+		VPCID:                    vpcId,
+		VSwitchId:                vswitchID,
+		LoginPassword:            d.Get("password").(string),
+		KeyPair:                  d.Get("key_name").(string),
+		Network:                  d.Get("cluster_network_type").(string),
+		NumOfNodes:               int64(workerNumber),
 		MasterSystemDiskCategory: ecs.DiskCategory(d.Get("master_disk_category").(string)),
 		MasterSystemDiskSize:     int64(d.Get("master_disk_size").(int)),
 		WorkerSystemDiskCategory: ecs.DiskCategory(d.Get("worker_disk_category").(string)),
@@ -603,32 +771,75 @@ func buildKunernetesArgs(d *schema.ResourceData, meta interface{}) (*cs.Kubernet
 		ContainerCIDR:            d.Get("pod_cidr").(string),
 		ServiceCIDR:              d.Get("service_cidr").(string),
 		SSHFlags:                 d.Get("enable_ssh").(bool),
-		ImageID:                  KubernetesImageId,
 		CloudMonitorFlags:        d.Get("install_cloud_monitor").(bool),
 		ZoneId:                   zoneId,
-	}
+	}, nil
+}
 
-	if v, ok := d.GetOk("vswitch_id"); ok && len(Trim(v.(string))) > 0 {
-		stackArgs.VSwitchID = Trim(v.(string))
-		vsw, err := client.DescribeVswitch(stackArgs.VSwitchID)
-		if err != nil {
+func buildKubernetesMultiAZArgs(d *schema.ResourceData, meta interface{}) (*cs.KubernetesMultiAZCreationArgs, error) {
+	client := meta.(*AliyunClient)
+
+	// Ensure instance_type is valid
+	zoneId, validZones, err := client.DescribeAvailableResources(d, meta, InstanceTypeResource)
+	if err != nil {
+		return nil, err
+	}
+	instanceTypes := expandStringList(d.Get("master_instance_types").([]interface{}))
+	instanceTypes = append(instanceTypes, expandStringList(d.Get("worker_instance_types").([]interface{}))...)
+
+	for _, instanceType := range instanceTypes {
+		if err := meta.(*AliyunClient).InstanceTypeValidation(instanceType, zoneId, validZones); err != nil {
 			return nil, err
 		}
-		stackArgs.VPCID = vsw.VpcId
-		if stackArgs.ZoneId != "" && vsw.ZoneId != vsw.ZoneId {
-			return nil, fmt.Errorf("The specified vswitch %s isn't in the zone %s.", vsw.VSwitchId, stackArgs.ZoneId)
-		}
-		stackArgs.ZoneId = vsw.ZoneId
-	} else if !stackArgs.SNatEntry {
-		return nil, fmt.Errorf("The automatic created VPC and VSwitch must set 'new_nat_gateway' to 'true'.")
 	}
 
-	return &cs.KubernetesCreationArgs{
-		Name:              clusterName,
-		ClusterType:       "Kubernetes",
-		DisableRollback:   true,
-		TimeoutMins:       60,
-		KubernetesVersion: stackArgs.KubernetesVersion,
-		StackParams:       *stackArgs,
+	var clusterName string
+	if v, ok := d.GetOk("name"); ok {
+		clusterName = v.(string)
+	} else {
+		return nil, errors.New("The 'name' is required for Kubernetes MultiAZ.")
+	}
+
+	masterInstanceTypes := expandStringList(d.Get("master_instance_types").([]interface{}))
+	workerInstanceTypes := expandStringList(d.Get("worker_instance_types").([]interface{}))
+	vswitchIDs := expandStringList(d.Get("vswitch_ids").([]interface{}))
+	workerNumbers := expandIntList(d.Get("worker_numbers").([]interface{}))
+
+	vsw, err := client.DescribeVswitch(vswitchIDs[0])
+	if err != nil {
+		return nil, err
+	}
+
+	return &cs.KubernetesMultiAZCreationArgs{
+		Name:                     clusterName,
+		ClusterType:              "Kubernetes",
+		DisableRollback:          true,
+		TimeoutMins:              60,
+		MultiAZ:                  true,
+		MasterInstanceTypeA:      masterInstanceTypes[0],
+		MasterInstanceTypeB:      masterInstanceTypes[1],
+		MasterInstanceTypeC:      masterInstanceTypes[2],
+		WorkerInstanceTypeA:      workerInstanceTypes[0],
+		WorkerInstanceTypeB:      workerInstanceTypes[1],
+		WorkerInstanceTypeC:      workerInstanceTypes[2],
+		LoginPassword:            d.Get("password").(string),
+		KeyPair:                  d.Get("key_name").(string),
+		VSwitchIdA:               vswitchIDs[0],
+		VSwitchIdB:               vswitchIDs[1],
+		VSwitchIdC:               vswitchIDs[2],
+		NumOfNodesA:              int64(workerNumbers[0]),
+		NumOfNodesB:              int64(workerNumbers[1]),
+		NumOfNodesC:              int64(workerNumbers[2]),
+		VPCID:                    vsw.VpcId,
+		Network:                  d.Get("cluster_network_type").(string),
+		MasterSystemDiskCategory: ecs.DiskCategory(d.Get("master_disk_category").(string)),
+		MasterSystemDiskSize:     int64(d.Get("master_disk_size").(int)),
+		WorkerSystemDiskCategory: ecs.DiskCategory(d.Get("worker_disk_category").(string)),
+		WorkerSystemDiskSize:     int64(d.Get("worker_disk_size").(int)),
+		ContainerCIDR:            d.Get("pod_cidr").(string),
+		ServiceCIDR:              d.Get("service_cidr").(string),
+		SSHFlags:                 d.Get("enable_ssh").(bool),
+		CloudMonitorFlags:        d.Get("install_cloud_monitor").(bool),
+		KubernetesVersion:        d.Get("version").(string),
 	}, nil
 }

--- a/alicloud/resource_alicloud_cs_kubernetes_test.go
+++ b/alicloud/resource_alicloud_cs_kubernetes_test.go
@@ -27,8 +27,9 @@ func TestAccAlicloudCSKubernetes_basic(t *testing.T) {
 				Config: testAccContainerKubernetes_basic,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckContainerClusterExists("alicloud_cs_kubernetes.k8s", &k8s),
-					resource.TestCheckResourceAttr("alicloud_cs_kubernetes.k8s", "worker_number", "1"),
 					resource.TestCheckResourceAttr("alicloud_cs_kubernetes.k8s", "name", "tf-testAccContainerKubernetes-basic"),
+					resource.TestCheckResourceAttr("alicloud_cs_kubernetes.k8s", "worker_numbers.#", "1"),
+					resource.TestCheckResourceAttr("alicloud_cs_kubernetes.k8s", "worker_numbers.0", "1"),
 					resource.TestCheckResourceAttr("alicloud_cs_kubernetes.k8s", "master_nodes.#", "3"),
 					resource.TestCheckResourceAttr("alicloud_cs_kubernetes.k8s", "master_disk_category", "cloud_ssd"),
 					resource.TestCheckResourceAttr("alicloud_cs_kubernetes.k8s", "worker_disk_size", "50"),
@@ -58,12 +59,46 @@ func TestAccAlicloudCSKubernetes_autoVpc(t *testing.T) {
 				Config: testAccContainerKubernetes_autoVpc,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckContainerClusterExists("alicloud_cs_kubernetes.k8s", &k8s),
-					resource.TestCheckResourceAttr("alicloud_cs_kubernetes.k8s", "worker_number", "1"),
+					resource.TestCheckResourceAttr("alicloud_cs_kubernetes.k8s", "worker_numbers.#", "1"),
+					resource.TestCheckResourceAttr("alicloud_cs_kubernetes.k8s", "worker_numbers.0", "1"),
 					resource.TestCheckResourceAttr("alicloud_cs_kubernetes.k8s", "master_nodes.#", "3"),
 					resource.TestCheckResourceAttr("alicloud_cs_kubernetes.k8s", "worker_disk_category", "cloud_ssd"),
 					resource.TestCheckResourceAttr("alicloud_cs_kubernetes.k8s", "master_disk_size", "50"),
 					resource.TestCheckResourceAttr("alicloud_cs_kubernetes.k8s", "master_disk_category", "cloud_efficiency"),
 					resource.TestCheckResourceAttr("alicloud_cs_kubernetes.k8s", "worker_disk_size", "40"),
+					resource.TestCheckResourceAttr("alicloud_cs_kubernetes.k8s", "connections.%", "4"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAlicloudCSMultiAZKubernetes_basic(t *testing.T) {
+	var k8s cs.ClusterType
+
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+		},
+
+		IDRefreshName: "alicloud_cs_kubernetes.k8s",
+
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckKubernetesClusterDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccContainerMultiAZKubernetes_basic,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckContainerClusterExists("alicloud_cs_kubernetes.k8s", &k8s),
+					resource.TestCheckResourceAttr("alicloud_cs_kubernetes.k8s", "worker_numbers.#", "3"),
+					resource.TestCheckResourceAttr("alicloud_cs_kubernetes.k8s", "worker_numbers.0", "1"),
+					resource.TestCheckResourceAttr("alicloud_cs_kubernetes.k8s", "worker_numbers.1", "2"),
+					resource.TestCheckResourceAttr("alicloud_cs_kubernetes.k8s", "worker_numbers.2", "3"),
+					resource.TestCheckResourceAttr("alicloud_cs_kubernetes.k8s", "master_nodes.#", "3"),
+					resource.TestCheckResourceAttr("alicloud_cs_kubernetes.k8s", "worker_disk_category", "cloud_ssd"),
+					resource.TestCheckResourceAttr("alicloud_cs_kubernetes.k8s", "master_disk_size", "40"),
+					resource.TestCheckResourceAttr("alicloud_cs_kubernetes.k8s", "master_disk_category", "cloud_efficiency"),
+					resource.TestCheckResourceAttr("alicloud_cs_kubernetes.k8s", "worker_disk_size", "50"),
 					resource.TestCheckResourceAttr("alicloud_cs_kubernetes.k8s", "connections.%", "4"),
 				),
 			},
@@ -124,11 +159,11 @@ resource "alicloud_vswitch" "foo" {
 
 resource "alicloud_cs_kubernetes" "k8s" {
   name = "${var.name}"
-  vswitch_id = "${alicloud_vswitch.foo.id}"
+  vswitch_ids = ["${alicloud_vswitch.foo.id}"]
   new_nat_gateway = true
-  master_instance_type = "${data.alicloud_instance_types.default.instance_types.0.id}"
-  worker_instance_type = "${data.alicloud_instance_types.default.instance_types.0.id}"
-  worker_number = 1
+  master_instance_types = ["${data.alicloud_instance_types.default.instance_types.0.id}"]
+  worker_instance_types = ["${data.alicloud_instance_types.default.instance_types.0.id}"]
+  worker_numbers = [1]
   master_disk_category  = "cloud_ssd"
   worker_disk_size = 50
   password = "Test12345"
@@ -160,9 +195,9 @@ resource "alicloud_cs_kubernetes" "k8s" {
   name_prefix = "${var.name}"
   availability_zone = "${data.alicloud_zones.main.zones.0.id}"
   new_nat_gateway = true
-  master_instance_type = "${data.alicloud_instance_types.default.instance_types.0.id}"
-  worker_instance_type = "${data.alicloud_instance_types.default.instance_types.0.id}"
-  worker_number = 1
+  master_instance_types = ["${data.alicloud_instance_types.default.instance_types.0.id}"]
+  worker_instance_types = ["${data.alicloud_instance_types.default.instance_types.0.id}"]
+  worker_numbers = [1]
   password = "Test12345"
   pod_cidr = "172.20.0.0/16"
   service_cidr = "172.21.0.0/20"
@@ -170,5 +205,108 @@ resource "alicloud_cs_kubernetes" "k8s" {
   install_cloud_monitor = true
   worker_disk_category  = "cloud_ssd"
   master_disk_size = 50
+}
+`
+
+const testAccContainerMultiAZKubernetes_basic = `
+variable "name" {
+	default = "tf-testAccContainerMultiAZKubernetes-basic"
+}
+
+data "alicloud_zones" main {
+  available_resource_creation = "VSwitch"
+}
+
+data "alicloud_instance_types" "instance_types_0" {
+	availability_zone = "${data.alicloud_zones.main.zones.0.id}"
+	cpu_core_count = 2
+	memory_size = 4
+}
+
+data "alicloud_instance_types" "instance_types_1" {
+	availability_zone = "${data.alicloud_zones.main.zones.1.id}"
+	cpu_core_count = 2
+	memory_size = 4
+}
+data "alicloud_instance_types" "instance_types_2" {
+	availability_zone = "${data.alicloud_zones.main.zones.2.id}"
+	cpu_core_count = 2
+	memory_size = 4
+}
+
+resource "alicloud_vpc" "foo" {
+  name = "${var.name}"
+  cidr_block = "10.1.0.0/21"
+}
+
+resource "alicloud_vswitch" "vsw1" {
+  name = "${var.name}"
+  vpc_id = "${alicloud_vpc.foo.id}"
+  cidr_block = "10.1.1.0/24"
+  availability_zone = "${data.alicloud_zones.main.zones.0.id}"
+}
+
+resource "alicloud_vswitch" "vsw2" {
+  name = "${var.name}"
+  vpc_id = "${alicloud_vpc.foo.id}"
+  cidr_block = "10.1.2.0/24"
+  availability_zone = "${data.alicloud_zones.main.zones.1.id}"
+}
+
+resource "alicloud_vswitch" "vsw3" {
+  name = "${var.name}"
+  vpc_id = "${alicloud_vpc.foo.id}"
+  cidr_block = "10.1.3.0/24"
+  availability_zone = "${data.alicloud_zones.main.zones.2.id}"
+}
+
+resource "alicloud_nat_gateway" "nat_gateway" {
+  name = "${var.name}"
+  vpc_id = "${alicloud_vpc.foo.id}"
+  spec   = "Small"
+}
+
+resource "alicloud_snat_entry" "snat_entry_1" {
+  snat_table_id     = "${alicloud_nat_gateway.nat_gateway.snat_table_ids}"
+  source_vswitch_id = "${alicloud_vswitch.vsw1.id}"
+  snat_ip           = "${alicloud_eip.eip.ip_address}"
+}
+
+resource "alicloud_snat_entry" "snat_entry_2" {
+  snat_table_id     = "${alicloud_nat_gateway.nat_gateway.snat_table_ids}"
+  source_vswitch_id = "${alicloud_vswitch.vsw2.id}"
+  snat_ip           = "${alicloud_eip.eip.ip_address}"
+}
+
+resource "alicloud_snat_entry" "snat_entry_3" {
+  snat_table_id     = "${alicloud_nat_gateway.nat_gateway.snat_table_ids}"
+  source_vswitch_id = "${alicloud_vswitch.vsw3.id}"
+  snat_ip           = "${alicloud_eip.eip.ip_address}"
+}
+
+resource "alicloud_eip" "eip" {
+  name = "${var.name}"
+  bandwidth = "100"
+}
+
+resource "alicloud_eip_association" "eip_asso" {
+  allocation_id = "${alicloud_eip.eip.id}"
+  instance_id   = "${alicloud_nat_gateway.nat_gateway.id}"
+}
+
+resource "alicloud_cs_kubernetes" "k8s" {
+  name = "${var.name}"
+  vswitch_ids = ["${alicloud_vswitch.vsw1.id}", "${alicloud_vswitch.vsw2.id}", "${alicloud_vswitch.vsw3.id}"]
+  new_nat_gateway = true
+  master_instance_types = ["${data.alicloud_instance_types.instance_types_0.instance_types.0.id}", "${data.alicloud_instance_types.instance_types_0.instance_types.0.id}", "${data.alicloud_instance_types.instance_types_0.instance_types.0.id}"]
+  worker_instance_types = ["${data.alicloud_instance_types.instance_types_0.instance_types.0.id}", "${data.alicloud_instance_types.instance_types_0.instance_types.0.id}", "${data.alicloud_instance_types.instance_types_0.instance_types.0.id}"]
+  worker_numbers = [1, 2, 3]
+  master_disk_category  = "cloud_ssd"
+  worker_disk_size = 50
+  password = "Test12345"
+  pod_cidr = "192.168.1.0/24"
+  service_cidr = "192.168.2.0/24"
+  enable_ssh = true
+  install_cloud_monitor = true
 }
 `

--- a/vendor/github.com/denverdino/aliyungo/cs/clusters.go
+++ b/vendor/github.com/denverdino/aliyungo/cs/clusters.go
@@ -10,6 +10,7 @@ import (
 
 	"fmt"
 
+	"encoding/json"
 	"github.com/denverdino/aliyungo/common"
 	"github.com/denverdino/aliyungo/ecs"
 )
@@ -42,22 +43,23 @@ const (
 
 // https://help.aliyun.com/document_detail/26053.html
 type ClusterType struct {
-	AgentVersion           string           `json:"agent_version"`
-	ClusterID              string           `json:"cluster_id"`
-	Name                   string           `json:"name"`
-	Created                time.Time  `json:"created"`
-	ExternalLoadbalancerID string           `json:"external_loadbalancer_id"`
-	MasterURL              string           `json:"master_url"`
-	NetworkMode            NetworkModeType  `json:"network_mode"`
-	RegionID               common.Region    `json:"region_id"`
-	SecurityGroupID        string           `json:"security_group_id"`
-	Size                   int64            `json:"size"`
-	State                  ClusterState     `json:"state"`
-	Updated                time.Time `json:"updated"`
-	VPCID                  string           `json:"vpc_id"`
-	VSwitchID              string           `json:"vswitch_id"`
-	NodeStatus             string           `json:"node_status"`
-	DockerVersion          string           `json:"docker_version"`
+	AgentVersion           string          `json:"agent_version"`
+	ClusterID              string          `json:"cluster_id"`
+	Name                   string          `json:"name"`
+	Created                time.Time       `json:"created"`
+	ExternalLoadbalancerID string          `json:"external_loadbalancer_id"`
+	MasterURL              string          `json:"master_url"`
+	NetworkMode            NetworkModeType `json:"network_mode"`
+	RegionID               common.Region   `json:"region_id"`
+	SecurityGroupID        string          `json:"security_group_id"`
+	Size                   int64           `json:"size"`
+	State                  ClusterState    `json:"state"`
+	Updated                time.Time       `json:"updated"`
+	VPCID                  string          `json:"vpc_id"`
+	VSwitchID              string          `json:"vswitch_id"`
+	NodeStatus             string          `json:"node_status"`
+	DockerVersion          string          `json:"docker_version"`
+	ClusterType            string          `json:"cluster_type"`
 }
 
 func (client *Client) DescribeClusters(nameFilter string) (clusters []ClusterType, err error) {
@@ -102,35 +104,56 @@ func (client *Client) CreateCluster(region common.Region, args *ClusterCreationA
 	return
 }
 
+// Deprecated
 type KubernetesStackArgs struct {
 	VPCID                    string           `json:"VpcId,omitempty"`
 	VSwitchID                string           `json:"VSwitchId,omitempty"`
-	MasterInstanceType       string           `json:"MasterInstanceType"`
-	WorkerInstanceType       string           `json:"WorkerInstanceType"`
-	NumOfNodes               int64            `json:"NumOfNodes"`
-	Password                 string           `json:"LoginPassword"`
-	DockerVersion            string           `json:"DockerVersion"`
-	KubernetesVersion        string           `json:"KubernetesVersion"`
-	ZoneId                   string           `json:"ZoneId"`
-	ContainerCIDR            string           `json:"ContainerCIDR"`
-	ServiceCIDR              string           `json:"ServiceCIDR"`
-	SSHFlags                 bool             `json:"SSHFlags"`
-	MasterSystemDiskSize     int64            `json:"MasterSystemDiskSize"`
-	MasterSystemDiskCategory ecs.DiskCategory `json:"MasterSystemDiskCategory"`
-	WorkerSystemDiskSize     int64            `json:"WorkerSystemDiskSize"`
-	WorkerSystemDiskCategory ecs.DiskCategory `json:"WorkerSystemDiskCategory"`
+	MasterInstanceType       string           `json:"MasterInstanceType,omitempty"`
+	WorkerInstanceType       string           `json:"WorkerInstanceType,omitempty"`
+	NumOfNodes               int64            `json:"NumOfNodes,omitempty"`
+	Password                 string           `json:"LoginPassword,omitempty"`
+	DockerVersion            string           `json:"DockerVersion,omitempty"`
+	KubernetesVersion        string           `json:"KubernetesVersion,omitempty"`
+	ZoneId                   string           `json:"ZoneId,omitempty"`
+	ContainerCIDR            string           `json:"ContainerCIDR,omitempty"`
+	ServiceCIDR              string           `json:"ServiceCIDR,omitempty"`
+	SSHFlags                 bool             `json:"SSHFlags,omitempty"`
+	MasterSystemDiskSize     int64            `json:"MasterSystemDiskSize,omitempty"`
+	MasterSystemDiskCategory ecs.DiskCategory `json:"MasterSystemDiskCategory,omitempty"`
+	WorkerSystemDiskSize     int64            `json:"WorkerSystemDiskSize,omitempty"`
+	WorkerSystemDiskCategory ecs.DiskCategory `json:"WorkerSystemDiskCategory,omitempty"`
 	ImageID                  string           `json:"ImageId,omitempty"`
-	CloudMonitorFlags        bool             `json:"CloudMonitorFlags"`
-	SNatEntry                bool             `json:"SNatEntry"`
+	CloudMonitorFlags        bool             `json:"CloudMonitorFlags,omitempty"`
+	SNatEntry                bool             `json:"SNatEntry,omitempty"`
 }
 
 type KubernetesCreationArgs struct {
-	ClusterType       string              `json:"cluster_type"`
-	Name              string              `json:"name"`
-	DisableRollback   bool                `json:"disable_rollback"`
-	TimeoutMins       int64               `json:"timeout_mins"`
-	KubernetesVersion string              `json:"kubernetes_version"`
-	StackParams       KubernetesStackArgs `json:"stack_params"`
+	DisableRollback          bool             `json:"disable_rollback"`
+	Name                     string           `json:"name"`
+	TimeoutMins              int64            `json:"timeout_mins"`
+	ZoneId                   string           `json:"zoneid,omitempty"`
+	VPCID                    string           `json:"vpcid,omitempty"`
+	VSwitchId                string           `json:"vswitchid,omitempty"`
+	ContainerCIDR            string           `json:"container_cidr,omitempty"`
+	ServiceCIDR              string           `json:"service_cidr,omitempty"`
+	MasterInstanceType       string           `json:"master_instance_type,omitempty"`
+	MasterSystemDiskSize     int64            `json:"master_system_disk_size,omitempty"`
+	MasterSystemDiskCategory ecs.DiskCategory `json:"master_system_disk_category,omitempty"`
+	WorkerInstanceType       string           `json:"worker_instance_type,omitempty"`
+	WorkerSystemDiskSize     int64            `json:"worker_system_disk_size,omitempty"`
+	WorkerSystemDiskCategory ecs.DiskCategory `json:"worker_system_disk_category,omitempty"`
+	LoginPassword            string           `json:"login_password,omitempty"`
+	KeyPair                  string           `json:"key_pair,omitempty"`
+	NumOfNodes               int64            `json:"num_of_nodes,omitempty"`
+	SNatEntry                bool             `json:"snat_entry,omitempty"`
+	SSHFlags                 bool             `json:"ssh_flags,omitempty"`
+	CloudMonitorFlags        bool             `json:"cloud_monitor_flags,omitempty"`
+
+	ClusterType string `json:"cluster_type"`
+	Network     string `json:"network,omitempty"`
+
+	KubernetesVersion string              `json:"kubernetes_version,omitempty"`
+	StackParams       KubernetesStackArgs `json:"stack_params,omitempty"`
 }
 
 type KubernetesMultiAZCreationArgs struct {
@@ -148,21 +171,23 @@ type KubernetesMultiAZCreationArgs struct {
 	MasterInstanceTypeA      string           `json:"master_instance_type_a,omitempty"`
 	MasterInstanceTypeB      string           `json:"master_instance_type_b,omitempty"`
 	MasterInstanceTypeC      string           `json:"master_instance_type_c,omitempty"`
-	MasterSystemDiskSize     int64            `json:"master_system_disk_size"`
 	MasterSystemDiskCategory ecs.DiskCategory `json:"master_system_disk_category"`
+	MasterSystemDiskSize     int64            `json:"master_system_disk_size"`
 	WorkerInstanceTypeA      string           `json:"worker_instance_type_a,omitempty"`
 	WorkerInstanceTypeB      string           `json:"worker_instance_type_b,omitempty"`
 	WorkerInstanceTypeC      string           `json:"worker_instance_type_c,omitempty"`
-	WorkerSystemDiskSize     int64            `json:"worker_system_disk_size"`
 	WorkerSystemDiskCategory ecs.DiskCategory `json:"worker_system_disk_category"`
+	WorkerSystemDiskSize     int64            `json:"worker_system_disk_size"`
 	NumOfNodesA              int64            `json:"num_of_nodes_a"`
 	NumOfNodesB              int64            `json:"num_of_nodes_b"`
 	NumOfNodesC              int64            `json:"num_of_nodes_c"`
+	LoginPassword            string           `json:"login_password,omitempty"`
+	KeyPair                  string           `json:"key_pair,omitempty"`
 	SSHFlags                 bool             `json:"ssh_flags"`
 	CloudMonitorFlags        bool             `json:"cloud_monitor_flags"`
-	LoginPassword            string           `json:"login_password,omitempty"`
-	ImageId                  string           `json:"image_id,omitempty"`
-	KeyPair                  string           `json:"key_pair,omitempty"`
+
+	KubernetesVersion string `json:"kubernetes_version,omitempty"`
+	Network           string `json:"network,omitempty"`
 }
 
 func (client *Client) CreateKubernetesMultiAZCluster(region common.Region, args *KubernetesMultiAZCreationArgs) (cluster ClusterCreationResponse, err error) {
@@ -172,6 +197,90 @@ func (client *Client) CreateKubernetesMultiAZCluster(region common.Region, args 
 
 func (client *Client) CreateKubernetesCluster(region common.Region, args *KubernetesCreationArgs) (cluster ClusterCreationResponse, err error) {
 	err = client.Invoke(region, http.MethodPost, "/clusters", nil, args, &cluster)
+	return
+}
+
+type KubernetesClusterMetaData struct {
+	DockerVersion     string `json:"DockerVersion"`
+	EtcdVersion       string `json:"EtcdVersion"`
+	KubernetesVersion string `json:"KubernetesVersion"`
+	MultiAZ           bool   `json:"MultiAZ"`
+	SubClass          string `json:"SubClass"`
+}
+
+type KubernetesClusterParameter struct {
+	ServiceCidr              string `json:"ServiceCIDR"`
+	ContainerCidr            string `json:"ContainerCIDR"`
+	DockerVersion            string `json:"DockerVersion"`
+	EtcdVersion              string `json:"EtcdVersion"`
+	KubernetesVersion        string `json:"KubernetesVersion"`
+	VPCID                    string `json:"VpcId"`
+	KeyPair                  string `json:"KeyPair"`
+	MasterSystemDiskCategory string `json:"MasterSystemDiskCategory"`
+	MasterSystemDiskSize     string `json:"MasterSystemDiskSize"`
+	WorkerSystemDiskCategory string `json:"WorkerSystemDiskCategory"`
+	WorkerSystemDiskSize     string `json:"WorkerSystemDiskSize"`
+	ZoneId                   string `json:"ZoneId"`
+
+	// Single AZ
+	MasterInstanceType string `json:"MasterInstanceType"`
+	WorkerInstanceType string `json:"WorkerInstanceType"`
+	NumOfNodes         string `json:"NumOfNodes"`
+	VSwitchID          string `json:"VSwitchId"`
+
+	// Multi AZ
+	MasterInstanceTypeA string `json:"MasterInstanceTypeA"`
+	MasterInstanceTypeB string `json:"MasterInstanceTypeB"`
+	MasterInstanceTypeC string `json:"MasterInstanceTypeC"`
+	WorkerInstanceTypeA string `json:"WorkerInstanceTypeA"`
+	WorkerInstanceTypeB string `json:"WorkerInstanceTypeB"`
+	WorkerInstanceTypeC string `json:"WorkerInstanceTypeC"`
+	NumOfNodesA         string `json:"NumOfNodesA"`
+	NumOfNodesB         string `json:"NumOfNodesB"`
+	NumOfNodesC         string `json:"NumOfNodesC"`
+	VSwitchIdA          string `json:"VSwitchIdA"`
+	VSwitchIdB          string `json:"VSwitchIdB"`
+	VSwitchIdC          string `json:"VSwitchIdC"`
+}
+
+type KubernetesCluster struct {
+	ClusterType
+
+	AgentVersion    string          `json:"agent_version"`
+	ClusterID       string          `json:"cluster_id"`
+	Name            string          `json:"name"`
+	Created         time.Time       `json:"created"`
+	MasterURL       string          `json:"master_url"`
+	NetworkMode     NetworkModeType `json:"network_mode"`
+	RegionID        common.Region   `json:"region_id"`
+	SecurityGroupID string          `json:"security_group_id"`
+	Size            int64           `json:"size"`
+	State           ClusterState    `json:"state"`
+	Updated         time.Time       `json:"updated"`
+	VPCID           string          `json:"vpc_id"`
+	VSwitchID       string          `json:"vswitch_id"`
+	NodeStatus      string          `json:"node_status"`
+	DockerVersion   string          `json:"docker_version"`
+
+	ZoneId                 string `json:"zone_id"`
+	RawMetaData            string `json:"meta_data,omitempty"`
+	MetaData               KubernetesClusterMetaData
+	InitVersion            string `json:"init_version"`
+	CurrentVersion         string `json:"current_version"`
+	ExternalLoadbalancerId string `json:"external_loadbalancer_id"`
+
+	Parameters KubernetesClusterParameter `json:"parameters"`
+}
+
+func (client *Client) DescribeKubernetesCluster(id string) (cluster KubernetesCluster, err error) {
+	err = client.Invoke("", http.MethodGet, "/clusters/"+id, nil, nil, &cluster)
+	if err != nil {
+		return cluster, err
+	}
+	var metaData KubernetesClusterMetaData
+	err = json.Unmarshal([]byte(cluster.RawMetaData), &metaData)
+	cluster.MetaData = metaData
+	cluster.RawMetaData = ""
 	return
 }
 
@@ -193,7 +302,31 @@ func (client *Client) ResizeCluster(clusterID string, args *ClusterResizeArgs) e
 	return client.Invoke("", http.MethodPut, "/clusters/"+clusterID, nil, args, nil)
 }
 
+// deprecated
+// use ResizeKubernetesCluster instead
 func (client *Client) ResizeKubernetes(clusterID string, args *KubernetesCreationArgs) error {
+	return client.Invoke("", http.MethodPut, "/clusters/"+clusterID, nil, args, nil)
+}
+
+type KubernetesClusterResizeArgs struct {
+	DisableRollback bool   `json:"disable_rollback"`
+	TimeoutMins     int64  `json:"timeout_mins"`
+	LoginPassword   string `json:"login_password,omitempty"`
+
+	// Single AZ
+	WorkerInstanceType string `json:"worker_instance_type"`
+	NumOfNodes         int64  `json:"num_of_nodes"`
+
+	// Multi AZ
+	WorkerInstanceTypeA string `json:"worker_instance_type_a"`
+	WorkerInstanceTypeB string `json:"worker_instance_type_b"`
+	WorkerInstanceTypeC string `json:"worker_instance_type_c"`
+	NumOfNodesA         int64  `json:"num_of_nodes_a"`
+	NumOfNodesB         int64  `json:"num_of_nodes_b"`
+	NumOfNodesC         int64  `json:"num_of_nodes_c"`
+}
+
+func (client *Client) ResizeKubernetesCluster(clusterID string, args *KubernetesClusterResizeArgs) error {
 	return client.Invoke("", http.MethodPut, "/clusters/"+clusterID, nil, args, nil)
 }
 

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -413,10 +413,10 @@
 			"revisionTime": "2018-03-30T09:12:25Z"
 		},
 		{
-			"checksumSHA1": "jC8WCTTncOr6rFXKulzYyNDy+1I=",
+			"checksumSHA1": "wx0nPn0Euaf6pKcIZIr6Shwiumc=",
 			"path": "github.com/denverdino/aliyungo/cs",
-			"revision": "cc006f6d7d6afc2487454f6730dcbdf31f873a56",
-			"revisionTime": "2018-08-31T06:26:06Z"
+			"revision": "bfffcf50461de3068393e71dae146f0e4fe81d8a",
+			"revisionTime": "2018-09-12T08:33:22Z"
 		},
 		{
 			"checksumSHA1": "at2TCvaAzU3jBW7yngHYVD9e7EI=",

--- a/website/docs/r/cs_kubernetes.html.markdown
+++ b/website/docs/r/cs_kubernetes.html.markdown
@@ -14,14 +14,17 @@ This resource will help you to manager a Kubernetes Cluster. The cluster is same
 A Nat Gateway and configuring a SNAT for it can ensure one VPC network access internet. If there is no nat gateway in the
 VPC, you can set `new_nat_gateway` to "true" to create one automatically.
 
--> **NOTE:** If there is no specified `vswitch_id`, the resource will create a new VPC and VSwitch while creating kubernetes cluster.
+-> **NOTE:** If there is no specified `vswitch_ids`, the resource will create a new VPC and VSwitch while creating kubernetes cluster.
 
 -> **NOTE:** Each kubernetes cluster contains 3 master nodes and those number cannot be changed at now.
 
--> **NOTE:** Creating kubernetes cluster need to install several packages and it will cost more than one hour. Please be patient.
+-> **NOTE:** Creating kubernetes cluster need to install several packages and it will cost about 15 minutes. Please be patient.
 
 -> **NOTE:** From version 1.9.4, the provider supports to download kube config, client certificate, client key and cluster ca certificate
 after creating cluster successfully, and you can put them into the specified location, like '~/.kube/config'.
+
+-> **NOTE:** From version 1.16.0, the provider supports Multiple Availability Zones Kubernetes Cluster. To create a cluster of this kind,
+you must specify three items in `vswitch_ids`, `master_instance_types` and `worker_instance_types`.
 
 ## Example Usage
 
@@ -36,9 +39,9 @@ resource "alicloud_cs_kubernetes" "main" {
   name_prefix = "my-first-k8s"
   availability_zone = "${data.alicloud_zones.default.zones.0.id}"
   new_nat_gateway = true
-  master_instance_type = "ecs.n4.small"
-  worker_instance_type = "ecs.n4.small"
-  worker_number = 3
+  master_instance_types = ["ecs.n4.small"]
+  worker_instance_types = ["ecs.n4.small"]
+  worker_numbers = [3]
   password = "Test12345"
   pod_cidr = "192.168.1.0/24"
   service_cidr = "192.168.2.0/24"
@@ -53,13 +56,18 @@ The following arguments are supported:
 * `name` - The kubernetes cluster's name. It is the only in one Alicloud account.
 * `name_prefix` - The kubernetes cluster name's prefix. It is conflict with `name`. If it is specified, terraform will using it to build the only cluster name. Default to "Terraform-Creation".
 * `availability_zone` - (Force new resource) The Zone where new kubernetes cluster will be located. If it is not be specified, the value will be vswitch's zone.
-* `vswitch_id` - (Force new resource) The vswitch where new kubernetes cluster will be located. If it is not specified, a new VPC and VSwicth will be built. It must be in the zone which `availability_zone` specified.
+* `vswitch_id` - (Deprecated from version 1.16.0)(Force new resource) The vswitch where new kubernetes cluster will be located. If it is not specified, a new VPC and VSwicth will be built. It must be in the zone which `availability_zone` specified.
+* `vswitch_ids` - (Force new resource) The vswitch where new kubernetes cluster will be located. For SingleAZ Cluster, if it is not specified, a new VPC and VSwicth will be built. It must be in the zone which `availability_zone` specified. For MultiAZ Cluster, you must create three vswitches firstly, specify them here.
 * `new_nat_gateway` - (Force new resource) Whether to create a new nat gateway while creating kubernetes cluster. Default to true.
-* `master_instance_type` - (Required, Force new resource) The instance type of master node.
-* `worker_instance_type` - (Required, Force new resource) The instance type of worker node.
+* `master_instance_type` - (Deprecated from version 1.16.0)(Required, Force new resource) The instance type of master node.
+* `master_instance_types` - (Required, Force new resource) The instance type of master node. Specify one type for single AZ Cluster, three types for MultiAZ Cluster.
+* `worker_instance_type` - (Deprecated from version 1.16.0)(Required, Force new resource) The instance type of worker node.
+* `worker_instance_types` - (Required, Force new resource) The instance type of worker node. Specify one type for single AZ Cluster, three types for MultiAZ Cluster.
 * `worker_number` - The worker node number of the kubernetes cluster. Default to 3. It is limited up to 50 and if you want to enlarge it, please apply white list or contact with us.
-* `password` - (Required, Force new resource) The password of ssh login cluster node.
-* `pod_cidr` - (Required, Force new resource) The CIDR block for the pod network. It will be allocated automatically when `vswitch_id` is not specified.
+* `password` - (Required, Force new resource) The password of ssh login cluster node. You have to specify one of `password` and `key_name` fields.
+* `key_name` - (Required, Force new resource) The keypair of ssh login cluster node, you have to create it first.
+* `cluster_network_type` - (Required, Force new resource) The network that cluster uses, use `flannel` or `terway`.
+* `pod_cidr` - (Required, Force new resource) The CIDR block for the pod network. It will be allocated automatically when `vswitch_ids` is not specified.
 It cannot be duplicated with the VPC CIDR and CIDR used by Kubernetes cluster in VPC, cannot be modified after creation.
 Maximum number of hosts allowed in the cluster: 256. Refer to [Plan Kubernetes CIDR blocks under VPC](https://www.alibabacloud.com/help/doc-detail/64530.htm).
 * `service_cidr` - (Required, Force new resource) The CIDR block for the service network.  It will be allocated automatically when `vswitch_id` is not specified.
@@ -83,8 +91,11 @@ The following attributes are exported:
 * `id` - The ID of the container cluster.
 * `name` - The name of the container cluster.
 * `availability_zone` - The ID of availability zone.
-* `worker_number` The ECS instance node number in the current container cluster.
-* `vswitch_id` - The ID of VSwitch where the current cluster is located.
+* `key_name` - The keypair of ssh login cluster node, you have to create it first.
+* `worker_number` - (Deprecated from version 1.16.0) The ECS instance node number in the current container cluster.
+* `worker_numbers` - The ECS instance node number in the current container cluster.
+* `vswitch_id` - (Deprecated from version 1.16.0) The ID of VSwitch where the current cluster is located.
+* `vswitch_ids` - The ID of VSwitches where the current cluster is located.
 * `vpc_id` - The ID of VPC where the current cluster is located.
 * `slb_id` - (Deprecated from version 1.9.2).
 * `slb_internet` - The ID of public load balancer where the current cluster master node is located.
@@ -92,8 +103,10 @@ The following attributes are exported:
 * `security_group_id` - The ID of security group where the current cluster worker node is located.
 * `image_id` - The ID of node image.
 * `nat_gateway_id` - The ID of nat gateway used to launch kubernetes cluster.
-* `master_instance_type` - The instance type of master node.
-* `worker_instance_type` - The instance type of worker node.
+* `master_instance_type` - (Deprecated from version 1.16.0) The instance type of master node.
+* `master_instance_types` - The instance type of master node.
+* `worker_instance_type` - (Deprecated from version 1.16.0)The instance type of worker node.
+* `worker_instance_types` - The instance type of worker node.
 * `master_disk_category` - The system disk category of master node.
 * `master_disk_size` - The system disk size of master node.
 * `worker_disk_category` - The system disk category of worker node.


### PR DESCRIPTION
I marked master_instance_type, worker_instance_type, worker_number, vswitch_id as deprecated, and added master_instance_types, worker_instance_types, worker_numbers, vswitch_ids.

When three values are specified in master_instance_types and in other three new arguments, it will create a MultiAZ cluster. If one value is specified, it will create normal single AZ cluster.

Not sure if it is good to make these two types in one terraform resource, any suggestions are welcomed.
