### PR TITLE
Fix losing key pair error after updating ecs instance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 1.11.0 (Unreleased)
+## 1.10.1 (Unreleased)
 
 IMPROVEMENTS:
 
@@ -14,6 +14,7 @@ IMPROVEMENTS:
 
 BUG FIXES:
 
+- Fix losing key pair error after updating ecs instance ([#245](https://github.com/terraform-providers/terraform-provider-alicloud/pull/245))
 - Fix BackendServer.configuring error when creating slb rule ([#242](https://github.com/terraform-providers/terraform-provider-alicloud/pull/242))
 - Fix bug "...zoneinfo.zip: no such file or directory" happened in windows. ([#238](https://github.com/terraform-providers/terraform-provider-alicloud/pull/238))
 - Fix ess_scalingrule InvalidScalingRuleId.NotFound error ([#234](https://github.com/terraform-providers/terraform-provider-alicloud/pull/234))

--- a/alicloud/resource_alicloud_instance_test.go
+++ b/alicloud/resource_alicloud_instance_test.go
@@ -413,6 +413,8 @@ func TestAccAlicloudInstanceImage_update(t *testing.T) {
 						"alicloud_instance.update_image",
 						"system_disk_size",
 						"60"),
+					resource.TestCheckResourceAttr(
+						"alicloud_instance.update_image", "key_name", "testAccCheckInstanceImageOrigin"),
 				),
 			},
 		},
@@ -1505,6 +1507,15 @@ resource "alicloud_instance" "update_image" {
   	security_groups = ["${alicloud_security_group.tf_test_foo.id}"]
 	vswitch_id = "${alicloud_vswitch.foo.id}"
 }
+
+resource "alicloud_key_pair" "key" {
+  	key_name = "${var.name}"
+}
+
+resource "alicloud_key_pair_attachment" "atta" {
+  	key_name = "${alicloud_key_pair.key.key_name}"
+  	instance_ids = ["${alicloud_instance.update_image.id}"]
+}
 `
 const testAccCheckInstanceImageUpdate = `
 data "alicloud_zones" "default" {
@@ -1551,6 +1562,15 @@ resource "alicloud_instance" "update_image" {
   	password = "Test12345"
   	security_groups = ["${alicloud_security_group.tf_test_foo.id}"]
 	vswitch_id = "${alicloud_vswitch.foo.id}"
+}
+
+resource "alicloud_key_pair" "key" {
+  	key_name = "${var.name}"
+}
+
+resource "alicloud_key_pair_attachment" "atta" {
+  	key_name = "${alicloud_key_pair.key.key_name}"
+  	instance_ids = ["${alicloud_instance.update_image.id}"]
 }
 `
 


### PR DESCRIPTION
The running test case as follows:
```
TF_ACC=1 go test ./alicloud -v -run=TestAccAlicloudInstanceImage_update -timeout=240m
=== RUN   TestAccAlicloudInstanceImage_update
--- PASS: TestAccAlicloudInstanceImage_update (226.28s)
PASS
ok  	github.com/alibaba/terraform-provider/alicloud	226.337s

TF_ACC=1 go test ./alicloud -v -run=TestAccAlicloudKeyPairAttachment -timeout=240m
=== RUN   TestAccAlicloudKeyPairAttachment_basic
--- PASS: TestAccAlicloudKeyPairAttachment_basic (144.68s)
PASS
ok  	github.com/alibaba/terraform-provider/alicloud	144.742s
```