### PR TITLE
Resource alicloud_router_interface support "import" function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 IMPROVEMENTS:
 
-
+- Deprecate some field of alicloud_router_interface fields and use new resource instead ([#248](https://github.com/terraform-providers/terraform-provider-alicloud/pull/248))
 - *New Resource*: _alicloud_router_interface_connection_ ([#247](https://github.com/terraform-providers/terraform-provider-alicloud/pull/247))
 - Resource alicloud_eip support name and description ([#244](https://github.com/terraform-providers/terraform-provider-alicloud/pull/244))
 - Resource alicloud_eip support PrePaid ([#243](https://github.com/terraform-providers/terraform-provider-alicloud/pull/243))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 IMPROVEMENTS:
 
+
+- *New Resource*: _alicloud_router_interface_connection_ ([#247](https://github.com/terraform-providers/terraform-provider-alicloud/pull/247))
 - Resource alicloud_eip support name and description ([#244](https://github.com/terraform-providers/terraform-provider-alicloud/pull/244))
 - Resource alicloud_eip support PrePaid ([#243](https://github.com/terraform-providers/terraform-provider-alicloud/pull/243))
 - Correct version writting error ([#241](https://github.com/terraform-providers/terraform-provider-alicloud/pull/241))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 IMPROVEMENTS:
 
+- Resource alicloud_router_interface support "import" function ([#249](https://github.com/terraform-providers/terraform-provider-alicloud/pull/249))
 - Deprecate some field of alicloud_router_interface fields and use new resource instead ([#248](https://github.com/terraform-providers/terraform-provider-alicloud/pull/248))
 - *New Resource*: _alicloud_router_interface_connection_ ([#247](https://github.com/terraform-providers/terraform-provider-alicloud/pull/247))
 - Resource alicloud_eip support name and description ([#244](https://github.com/terraform-providers/terraform-provider-alicloud/pull/244))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ IMPROVEMENTS:
 
 BUG FIXES:
 
+- Fix creating slb listener in international region failed error ([#246](https://github.com/terraform-providers/terraform-provider-alicloud/pull/246))
 - Fix losing key pair error after updating ecs instance ([#245](https://github.com/terraform-providers/terraform-provider-alicloud/pull/245))
 - Fix BackendServer.configuring error when creating slb rule ([#242](https://github.com/terraform-providers/terraform-provider-alicloud/pull/242))
 - Fix bug "...zoneinfo.zip: no such file or directory" happened in windows. ([#238](https://github.com/terraform-providers/terraform-provider-alicloud/pull/238))

--- a/alicloud/common.go
+++ b/alicloud/common.go
@@ -393,6 +393,7 @@ const ApiVersion20140526 = "2014-05-26"
 const ApiVersion20140828 = "2014-08-28"
 const ApiVersion20160815 = "2016-08-15"
 const ApiVersion20140515 = "2014-05-15"
+const ApiVersion20160428 = "2016-04-28"
 
 type CommonRequestDomain string
 

--- a/alicloud/config.go
+++ b/alicloud/config.go
@@ -60,6 +60,7 @@ type AliyunClient struct {
 	//In order to build ots table client, add accesskey and secretkey in aliyunclient temporarily.
 	AccessKey       string
 	SecretKey       string
+	SecurityToken   string
 	OtsInstanceName string
 	AccountId       string
 	ecsconn         *ecs.Client
@@ -151,6 +152,7 @@ func (c *Config) Client() (*AliyunClient, error) {
 		RegionId:        c.RegionId,
 		AccessKey:       c.AccessKey,
 		SecretKey:       c.SecretKey,
+		SecurityToken:   c.SecurityToken,
 		OtsInstanceName: c.OtsInstanceName,
 		AccountId:       c.AccountId,
 		ecsconn:         ecsconn,

--- a/alicloud/diff_suppress_funcs.go
+++ b/alicloud/diff_suppress_funcs.go
@@ -101,8 +101,8 @@ func slbInternetDiffSuppressFunc(k, old, new string, d *schema.ResourceData) boo
 
 func slbInternetChargeTypeDiffSuppressFunc(k, old, new string, d *schema.ResourceData) bool {
 	// Uniform all internet chare type value and be compatible with previous lower value.
-	if strings.ToLower(old) != strings.ToLower(string(new)) {
-		return false
+	if strings.ToLower(old) == strings.ToLower(new) {
+		return true
 	}
 	return !slbInternetDiffSuppressFunc(k, old, new, d)
 }

--- a/alicloud/diff_suppress_funcs.go
+++ b/alicloud/diff_suppress_funcs.go
@@ -229,3 +229,17 @@ func cmsDimensionsDiffSuppressFunc(k, old, new string, d *schema.ResourceData) b
 	sort.Strings(news)
 	return reflect.DeepEqual(olds, news)
 }
+
+func routerInterfaceAcceptsideDiffSuppressFunc(k, old, new string, d *schema.ResourceData) bool {
+	return d.Get("role").(string) == string(AcceptingSide)
+}
+
+func routerInterfaceVBRTypeDiffSuppressFunc(k, old, new string, d *schema.ResourceData) bool {
+	if d.Get("role").(string) == string(AcceptingSide) {
+		return true
+	}
+	if d.Get("router_type").(string) == string(VRouter) {
+		return true
+	}
+	return false
+}

--- a/alicloud/extension_slb.go
+++ b/alicloud/extension_slb.go
@@ -3,8 +3,6 @@ package alicloud
 import (
 	"fmt"
 	"strings"
-
-	"github.com/aliyun/alibaba-cloud-sdk-go/sdk/requests"
 )
 
 type SchedulerType string
@@ -107,11 +105,4 @@ func expandBackendServersWithPortToString(items []interface{}) string {
 
 	}
 	return fmt.Sprintf("[%s]", strings.Join(servers, COMMA_SEPARATED))
-}
-
-func buildSlbCommonRequest() *requests.CommonRequest {
-	request := requests.NewCommonRequest()
-	request.Domain = "slb.aliyuncs.com"
-	request.Version = ApiVersion20140515
-	return request
 }

--- a/alicloud/extension_vpc.go
+++ b/alicloud/extension_vpc.go
@@ -34,6 +34,8 @@ const (
 	Middle5 = Spec("Middle.5")
 	Large1  = Spec("Large.1")
 	Large2  = Spec("Large.2")
+
+	Negative = Spec(("Negative"))
 )
 
 type NextHopType string
@@ -45,3 +47,10 @@ const (
 	NextHopHaVip           = NextHopType("HaVip")
 	NextHopVpnGateway      = NextHopType("VpnGateway")
 )
+
+func GetAllRouterInterfaceSpec() (specifications []string) {
+	specifications = append(specifications, string(Large1), string(Large2),
+		string(Small1), string(Small2), string(Small5), string(Middle1),
+		string(Middle2), string(Middle5), string(Negative))
+	return
+}

--- a/alicloud/import_alicloud_router_interface_connection_test.go
+++ b/alicloud/import_alicloud_router_interface_connection_test.go
@@ -1,0 +1,29 @@
+package alicloud
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform/helper/resource"
+)
+
+// Import function does not support specified provider.
+func SkipTestAccAlicloudRouterInterfaceConnection_import(t *testing.T) {
+	resourceName := "alicloud_router_interface_connection.foo"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckVpcDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccRouterInterfaceConnectionConfig,
+			},
+
+			resource.TestStep{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}

--- a/alicloud/import_alicloud_router_interface_test.go
+++ b/alicloud/import_alicloud_router_interface_test.go
@@ -1,0 +1,28 @@
+package alicloud
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform/helper/resource"
+)
+
+func TestAccAlicloudRouterInterface_import(t *testing.T) {
+	resourceName := "alicloud_router_interface.interface"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckVpcDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccRouterInterfaceConfig,
+			},
+
+			resource.TestStep{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}

--- a/alicloud/provider.go
+++ b/alicloud/provider.go
@@ -152,6 +152,7 @@ func Provider() terraform.ResourceProvider {
 			"alicloud_cs_kubernetes":               resourceAlicloudCSKubernetes(),
 			"alicloud_cdn_domain":                  resourceAlicloudCdnDomain(),
 			"alicloud_router_interface":            resourceAlicloudRouterInterface(),
+			"alicloud_router_interface_connection": resourceAlicloudRouterInterfaceConnection(),
 			"alicloud_ots_table":                   resourceAlicloudOtsTable(),
 			"alicloud_ots_instance":                resourceAlicloudOtsInstance(),
 			"alicloud_ots_instance_attachment":     resourceAlicloudOtsInstanceAttachment(),

--- a/alicloud/resource_alicloud_router_interface.go
+++ b/alicloud/resource_alicloud_router_interface.go
@@ -15,6 +15,9 @@ func resourceAlicloudRouterInterface() *schema.Resource {
 		Read:   resourceAlicloudRouterInterfaceRead,
 		Update: resourceAlicloudRouterInterfaceUpdate,
 		Delete: resourceAlicloudRouterInterfaceDelete,
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
 
 		Schema: map[string]*schema.Schema{
 			"opposite_region": &schema.Schema{

--- a/alicloud/resource_alicloud_router_interface_connection.go
+++ b/alicloud/resource_alicloud_router_interface_connection.go
@@ -1,0 +1,199 @@
+package alicloud
+
+import (
+	"fmt"
+
+	"github.com/aliyun/alibaba-cloud-sdk-go/sdk/requests"
+	"github.com/aliyun/alibaba-cloud-sdk-go/services/vpc"
+	"github.com/hashicorp/terraform/helper/schema"
+)
+
+func resourceAlicloudRouterInterfaceConnection() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceAlicloudRouterInterfaceConnectionCreate,
+		Read:   resourceAlicloudRouterInterfaceConnectionRead,
+		Delete: resourceAlicloudRouterInterfaceConnectionDelete,
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
+
+		Schema: map[string]*schema.Schema{
+			"interface_id": &schema.Schema{
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"opposite_interface_id": &schema.Schema{
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"opposite_router_type": &schema.Schema{
+				Type:     schema.TypeString,
+				Optional: true,
+				ValidateFunc: validateAllowedStringValue([]string{
+					string(VRouter), string(VBR)}),
+				Default:  VRouter,
+				ForceNew: true,
+				DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
+					return !d.HasChange("opposite_interface_owner_id")
+				},
+			},
+			"opposite_router_id": &schema.Schema{
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: true,
+				Computed: true,
+				DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
+					return !d.HasChange("opposite_interface_owner_id")
+				},
+			},
+			"opposite_interface_owner_id": &schema.Schema{
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: true,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func resourceAlicloudRouterInterfaceConnectionCreate(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*AliyunClient)
+
+	oppsiteId := d.Get("opposite_interface_id").(string)
+	interfaceId := d.Get("interface_id").(string)
+	ri, err := client.DescribeRouterInterface(interfaceId)
+	if err != nil {
+		return err
+	}
+
+	// At present, the interface with "active/inactive" status can not be modify opposite connection information
+	// and it is RouterInterface product limitation.
+	if ri.OppositeInterfaceId == oppsiteId {
+		if ri.Status == string(Active) {
+			return fmt.Errorf("The specified router interface connection has existed, and please import it using id %s.", interfaceId)
+		}
+		if ri.Status == string(Inactive) {
+			if err := client.ActivateRouterInterface(interfaceId); err != nil {
+				return err
+			}
+			if err := client.WaitForRouterInterface(interfaceId, Active, DefaultTimeout); err != nil {
+				return fmt.Errorf("When activing router interface %s got an error: %#v.", interfaceId, err)
+			}
+			d.SetId(interfaceId)
+			return resourceAlicloudRouterInterfaceConnectionRead(d, meta)
+		}
+	}
+
+	req := vpc.CreateModifyRouterInterfaceAttributeRequest()
+	req.RouterInterfaceId = interfaceId
+	req.OppositeInterfaceId = oppsiteId
+
+	if owner_id, ok := d.GetOk("opposite_interface_owner_id"); ok && owner_id.(string) != ri.OppositeInterfaceOwnerId {
+		req.OppositeInterfaceOwnerId = requests.Integer(owner_id.(string))
+		if v, o := d.GetOk("opposite_router_type"); !o || v.(string) == "" {
+			return fmt.Errorf("'opposite_router_type' is required when 'opposite_interface_owner_id' is not the current account.")
+		} else {
+			req.OppositeRouterType = v.(string)
+		}
+
+		if v, o := d.GetOk("opposite_router_id"); !o || v.(string) == "" {
+			return fmt.Errorf("'opposite_router_id' is required when 'opposite_interface_owner_id' is not the current account.")
+		} else {
+			req.OppositeRouterId = v.(string)
+		}
+	} else {
+		oppositeRi, err := client.DescribeRouterInterfaceInSpecifiedRegion(ri.OppositeRegionId, oppsiteId)
+		if err != nil {
+			return err
+		}
+		req.OppositeRouterId = oppositeRi["RouterId"].(string)
+		req.OppositeRouterType = oppositeRi["RouterType"].(string)
+		owner := ri.OppositeInterfaceOwnerId
+		if owner == "" {
+			owner = client.AccountId
+		}
+		req.OppositeInterfaceOwnerId = requests.Integer(owner)
+	}
+
+	if _, err := client.vpcconn.ModifyRouterInterfaceAttribute(req); err != nil {
+		return fmt.Errorf("Modifying RouterInterface %s Connection got an error: %#v.", interfaceId, err)
+	}
+
+	if ri.Role == string(InitiatingSide) {
+		connReq := vpc.CreateConnectRouterInterfaceRequest()
+		connReq.RouterInterfaceId = interfaceId
+
+		if _, err := client.vpcconn.ConnectRouterInterface(connReq); err != nil {
+			return fmt.Errorf("Connecting router interface %s got an error: %#v.", interfaceId, err)
+		}
+
+		if err := client.WaitForRouterInterface(interfaceId, Active, DefaultTimeout); err != nil {
+			return fmt.Errorf("Connecting router interface %s got an error: %#v.", interfaceId, err)
+		}
+	}
+	d.SetId(interfaceId)
+
+	return resourceAlicloudRouterInterfaceConnectionRead(d, meta)
+}
+
+func resourceAlicloudRouterInterfaceConnectionRead(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*AliyunClient)
+	ri, err := client.DescribeRouterInterface(d.Id())
+
+	if err != nil {
+		if NotFoundError(err) {
+			d.SetId("")
+			return nil
+		}
+	}
+	if ri.Status == string(Inactive) {
+		if err := client.ActivateRouterInterface(d.Id()); err != nil {
+			return err
+		}
+		if err := client.WaitForRouterInterface(d.Id(), Active, DefaultTimeout); err != nil {
+			return fmt.Errorf("When activing router interface %s got an error: %#v.", d.Id(), err)
+		}
+	}
+
+	d.Set("interface_id", ri.RouterInterfaceId)
+	d.Set("opposite_interface_id", ri.OppositeInterfaceId)
+	d.Set("opposite_router_type", ri.OppositeRouterType)
+	d.Set("opposite_router_id", ri.OppositeRouterId)
+	d.Set("opposite_interface_owner_id", ri.OppositeInterfaceOwnerId)
+
+	return nil
+
+}
+
+func resourceAlicloudRouterInterfaceConnectionDelete(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*AliyunClient)
+
+	ri, err := client.DescribeRouterInterface(d.Id())
+	if err != nil {
+		if NotFoundError(err) {
+			d.SetId("")
+			return nil
+		}
+	}
+
+	if ri.Status == string(Idle) {
+		d.SetId("")
+		return nil
+	}
+
+	// At present, the interface with "active/inactive" status can not be modify opposite connection information
+	// and it is RouterInterface product limitation. So, the connection delete action is only modifying it to inactive.
+	if ri.Status == string(Active) {
+		if err := client.DeactivateRouterInterface(d.Id()); err != nil {
+			return err
+		}
+	}
+
+	if err := client.WaitForRouterInterface(d.Id(), Inactive, DefaultTimeoutMedium); err != nil {
+		return fmt.Errorf("Deleting routerinterface %s connection got an error: %#v.", d.Id(), err)
+	}
+
+	return nil
+}

--- a/alicloud/resource_alicloud_router_interface_connection_test.go
+++ b/alicloud/resource_alicloud_router_interface_connection_test.go
@@ -1,0 +1,144 @@
+package alicloud
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/aliyun/alibaba-cloud-sdk-go/services/vpc"
+	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/terraform"
+)
+
+func TestAccAlicloudRouterInterfaceConnection_basic(t *testing.T) {
+	var vpcInstance vpc.DescribeVpcAttributeResponse
+	var ri, oppoRI vpc.RouterInterfaceTypeInDescribeRouterInterfaces
+
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+		},
+
+		// module name
+		IDRefreshName: "alicloud_router_interface_connection.foo",
+
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckRouterInterfaceConnectionDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccRouterInterfaceConnectionConfig,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckVpcExists("alicloud_vpc.foo", &vpcInstance),
+					testAccCheckRouterInterfaceExists("alicloud_router_interface.initiate", &ri),
+					testAccCheckRouterInterfaceExists("alicloud_router_interface.opposite", &oppoRI),
+					testAccCheckRouterInterfaceConnectionExists("alicloud_router_interface_connection.foo"),
+					testAccCheckRouterInterfaceConnectionExists("alicloud_router_interface_connection.bar"),
+				),
+			},
+		},
+	})
+
+}
+
+func testAccCheckRouterInterfaceConnectionExists(n string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[n]
+		if !ok {
+			return fmt.Errorf("Not found: %s", n)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("No interface ID is set")
+		}
+
+		client := testAccProvider.Meta().(*AliyunClient)
+
+		response, err := client.DescribeRouterInterface(rs.Primary.ID)
+		if err != nil {
+			return fmt.Errorf("Error finding interface %s: %#v", rs.Primary.ID, err)
+		}
+		if response.Status != string(Active) {
+			return fmt.Errorf("Error connection router interface id %s is not Active.", response.RouterInterfaceId)
+		}
+
+		return nil
+	}
+}
+
+func testAccCheckRouterInterfaceConnectionDestroy(s *terraform.State) error {
+
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "alicloud_router_interface_connection" {
+			continue
+		}
+
+		// Try to find the interface
+		client := testAccProvider.Meta().(*AliyunClient)
+
+		ri, err := client.DescribeRouterInterface(rs.Primary.ID)
+		if err != nil {
+			if NotFoundError(err) {
+				continue
+			}
+			return err
+		}
+
+		if ri.Status == string(Active) {
+			return fmt.Errorf("Interface connection %s still exists.", rs.Primary.ID)
+		}
+	}
+	return nil
+}
+
+const testAccRouterInterfaceConnectionConfig = `
+provider "alicloud" {
+  region = "${var.region}"
+}
+
+variable "region" {
+  default = "cn-hangzhou"
+}
+variable "name" {
+  default = "TestAccAlicloudRIConnection_basic"
+}
+resource "alicloud_vpc" "foo" {
+  name = "${var.name}"
+  cidr_block = "172.16.0.0/12"
+}
+
+resource "alicloud_vpc" "bar" {
+  provider = "alicloud"
+  name = "${var.name}"
+  cidr_block = "192.168.0.0/16"
+}
+
+resource "alicloud_router_interface" "initiate" {
+  opposite_region = "${var.region}"
+  router_type = "VRouter"
+  router_id = "${alicloud_vpc.foo.router_id}"
+  role = "InitiatingSide"
+  specification = "Large.2"
+  name = "${var.name}"
+  description = "${var.name}"
+}
+
+resource "alicloud_router_interface" "opposite" {
+  provider = "alicloud"
+  opposite_region = "${var.region}"
+  router_type = "VRouter"
+  router_id = "${alicloud_vpc.bar.router_id}"
+  role = "AcceptingSide"
+  specification = "Large.1"
+  name = "${var.name}-opposite"
+  description = "${var.name}-opposite"
+}
+
+resource "alicloud_router_interface_connection" "foo" {
+  interface_id = "${alicloud_router_interface.initiate.id}"
+  opposite_interface_id = "${alicloud_router_interface.opposite.id}"
+}
+
+resource "alicloud_router_interface_connection" "bar" {
+  provider = "alicloud"
+  interface_id = "${alicloud_router_interface.opposite.id}"
+  opposite_interface_id = "${alicloud_router_interface.initiate.id}"
+}`

--- a/alicloud/resource_alicloud_router_interface_test.go
+++ b/alicloud/resource_alicloud_router_interface_test.go
@@ -10,7 +10,8 @@ import (
 )
 
 func TestAccAlicloudRouterInterface_basic(t *testing.T) {
-	var vpc vpc.DescribeVpcAttributeResponse
+	var vpcInstance vpc.DescribeVpcAttributeResponse
+	var ri vpc.RouterInterfaceTypeInDescribeRouterInterfaces
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			testAccPreCheck(t)
@@ -26,9 +27,13 @@ func TestAccAlicloudRouterInterface_basic(t *testing.T) {
 				Config: testAccRouterInterfaceConfig,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckVpcExists(
-						"alicloud_vpc.foo", &vpc),
+						"alicloud_vpc.foo", &vpcInstance),
 					testAccCheckRouterInterfaceExists(
-						"alicloud_router_interface.interface"),
+						"alicloud_router_interface.interface", &ri),
+					resource.TestCheckResourceAttr(
+						"alicloud_router_interface.interface", "name", "testAccRouterInterfaceConfig"),
+					resource.TestCheckResourceAttr(
+						"alicloud_router_interface.interface", "role", "InitiatingSide"),
 				),
 			},
 		},
@@ -36,7 +41,7 @@ func TestAccAlicloudRouterInterface_basic(t *testing.T) {
 
 }
 
-func testAccCheckRouterInterfaceExists(n string) resource.TestCheckFunc {
+func testAccCheckRouterInterfaceExists(n string, ri *vpc.RouterInterfaceTypeInDescribeRouterInterfaces) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[n]
 		if !ok {
@@ -53,9 +58,7 @@ func testAccCheckRouterInterfaceExists(n string) resource.TestCheckFunc {
 		if err != nil {
 			return fmt.Errorf("Error finding interface %s: %#v", rs.Primary.ID, err)
 		}
-		if response.RouterInterfaceId != rs.Primary.ID {
-			return fmt.Errorf("Error finding interface %s", rs.Primary.ID)
-		}
+		ri = &response
 		return nil
 	}
 }
@@ -97,6 +100,6 @@ resource "alicloud_router_interface" "interface" {
   router_id = "${alicloud_vpc.foo.router_id}"
   role = "InitiatingSide"
   specification = "Large.2"
-  name = "test1"
-  description = "test1"
+  name = "testAccRouterInterfaceConfig"
+  description = "testAccRouterInterfaceConfig"
 }`

--- a/alicloud/resource_alicloud_slb_listener.go
+++ b/alicloud/resource_alicloud_slb_listener.go
@@ -217,7 +217,7 @@ func resourceAliyunSlbListenerCreate(d *schema.ResourceData, meta interface{}) e
 	lb_id := d.Get("load_balancer_id").(string)
 	frontend := d.Get("frontend_port").(int)
 
-	req := buildListenerCommonArgs(d)
+	req := buildListenerCommonArgs(d, meta)
 	req.ApiName = fmt.Sprintf("CreateLoadBalancer%sListener", strings.ToUpper(protocol))
 
 	if Protocol(protocol) == Http || Protocol(protocol) == Https {
@@ -289,7 +289,7 @@ func resourceAliyunSlbListenerUpdate(d *schema.ResourceData, meta interface{}) e
 
 	d.Partial(true)
 
-	commonArgs := buildListenerCommonArgs(d)
+	commonArgs := buildListenerCommonArgs(d, meta)
 	commonArgs.ApiName = fmt.Sprintf("SetLoadBalancer%sListenerAttribute", strings.ToUpper(string(protocol)))
 
 	update := false
@@ -464,8 +464,8 @@ func resourceAliyunSlbListenerDelete(d *schema.ResourceData, meta interface{}) e
 	})
 }
 
-func buildListenerCommonArgs(d *schema.ResourceData) *requests.CommonRequest {
-	req := buildSlbCommonRequest()
+func buildListenerCommonArgs(d *schema.ResourceData, meta interface{}) *requests.CommonRequest {
+	req := meta.(*AliyunClient).BuildSlbCommonRequest()
 	req.QueryParams["LoadBalancerId"] = d.Get("load_balancer_id").(string)
 	req.QueryParams["ListenerPort"] = string(requests.NewInteger(d.Get("frontend_port").(int)))
 	req.QueryParams["BackendServerPort"] = string(requests.NewInteger(d.Get("backend_port").(int)))

--- a/alicloud/service_alicloud_slb.go
+++ b/alicloud/service_alicloud_slb.go
@@ -11,6 +11,20 @@ import (
 	"github.com/aliyun/alibaba-cloud-sdk-go/services/slb"
 )
 
+func (client *AliyunClient) BuildSlbCommonRequest() *requests.CommonRequest {
+	request := requests.NewCommonRequest()
+	endpoint := LoadEndpoint(client.RegionId, SLBCode)
+	if endpoint == "" {
+		endpoint, _ = client.DescribeEndpointByCode(client.RegionId, SLBCode)
+	}
+	if endpoint == "" {
+		endpoint = fmt.Sprintf("slb.%s.aliyuncs.com", client.RegionId)
+	}
+	request.Domain = endpoint
+	request.Version = ApiVersion20140515
+	request.RegionId = client.RegionId
+	return request
+}
 func (client *AliyunClient) DescribeLoadBalancerAttribute(slbId string) (loadBalancer *slb.DescribeLoadBalancerAttributeResponse, err error) {
 
 	req := slb.CreateDescribeLoadBalancerAttributeRequest()
@@ -78,7 +92,7 @@ func (client *AliyunClient) DescribeSlbVServerGroupAttribute(groupId string) (*s
 }
 
 func (client *AliyunClient) DescribeLoadBalancerListenerAttribute(loadBalancerId string, port int, protocol Protocol) (listener map[string]interface{}, err error) {
-	req := buildSlbCommonRequest()
+	req := client.BuildSlbCommonRequest()
 	req.ApiName = fmt.Sprintf("DescribeLoadBalancer%sListenerAttribute", strings.ToUpper(string(protocol)))
 	req.QueryParams["LoadBalancerId"] = loadBalancerId
 	req.QueryParams["ListenerPort"] = string(requests.NewInteger(port))

--- a/website/alicloud.erb
+++ b/website/alicloud.erb
@@ -160,6 +160,9 @@
                         <li<%= sidebar_current("docs-alicloud-resource-router-interface") %>>
                             <a href="/docs/providers/alicloud/r/router_interface.html">alicloud_router_interface</a>
                         </li>
+                        <li<%= sidebar_current("docs-alicloud-resource-router-interface-connection") %>>
+                            <a href="/docs/providers/alicloud/r/router_interface_connection.html">alicloud_router_interface_connection</a>
+                        </li>
                         <li<%= sidebar_current("docs-alicloud-resource-forward-entry") %>>
                             <a href="/docs/providers/alicloud/r/forward.html">alicloud_forward_entry</a>
                         </li>

--- a/website/docs/r/router_interface.html.markdown
+++ b/website/docs/r/router_interface.html.markdown
@@ -74,3 +74,12 @@ The following attributes are exported:
 * `opposite_interface_owner_id` - Peer account ID.
 * `health_check_source_ip` - Source IP of Packet of Line HealthCheck.
 * `health_check_target_ip` - Target IP of Packet of Line HealthCheck.
+
+## Import
+
+The router interface can be imported using the id, e.g.
+
+```
+$ terraform import alicloud_router_interface.interface ri-abc123456
+```
+

--- a/website/docs/r/router_interface.html.markdown
+++ b/website/docs/r/router_interface.html.markdown
@@ -8,9 +8,11 @@ description: |-
 
 # alicloud\_router\_interface
 
-Provides a VPC router interface resource to connect two VPCs by connecting the router interfaces .
+Provides a VPC router interface resource aim to build a connection between two VPCs.
 
-~> **NOTE:** Only one pair of connected router interfaces can exist between two routers. Up to 5 router interfaces can be created for each router and each account.
+-> **NOTE:** Only one pair of connected router interfaces can exist between two routers. Up to 5 router interfaces can be created for each router and each account.
+
+-> **NOTE:** The router interface is not connected when it is created. It can be connected by means of resource [alicloud_router_interface_connection](https://www.terraform.io/docs/providers/alicloud/r/alicloud_router_interface_connection.html).
 
 
 ## Example Usage
@@ -35,26 +37,22 @@ resource "alicloud_router_interface" "interface" {
 
 The following arguments are supported:
 
-* `opposite_region` - (Required, Force New) The Region of peer side. At present, optional value: `cn-beijing`, `cn-hangzhou`, `cn-shanghai`, `cn-shenzhen`, `cn-hongkong`, `ap-southeast-1`, `us-east-1`, `us-west-1`.
-* `router_type` - (Required, Forces New) Router Type. Optional value: VRouter, VBR.
-* `opposite_router_type` - (Optional, Force New) Peer router type. Optional value: `VRouter`, `VBR`. Default to `VRouter`.
-* `router_id` - (Required, Force New) Router ID. When `router_type` is VBR, the VBR specified by the `router_id` must be in the access point specified by `access_point_id`.
-* `opposite_router_id` - (Optional) Peer router ID. When `opposite_router_type` is VBR, the `opposite_router_id` must be in the access point specified by `opposite_access_point_id`.
+* `opposite_region` - (Required, Force New) The Region of peer side.
+* `router_type` - (Required, Forces New) Router Type. Optional value: VRouter, VBR. Accepting side router interface type only be VRouter.
+* `opposite_router_type` - (Deprecated) It has been deprecated from version 1.11.0. resource alicloud_router_interface_connection's 'opposite_router_type' instead.
+* `router_id` - (Required, Force New) The Router ID.
+* `opposite_router_id` - (Deprecated) It has been deprecated from version 1.11.0. Use resource alicloud_router_interface_connection's 'opposite_router_id' instead.
 * `role` - (Required, Force New) The role the router interface plays. Optional value: `InitiatingSide`, `AcceptingSide`.
-* `specification` - (Optional) Specification of router interfaces. If `role` is `AcceptingSide`, the value can be ignore or must be `Negative`. For more about the specification, refer to [Router interface specification](https://www.alibabacloud.com/help/doc-detail/52415.htm?spm=a3c0i.o52412zh.b99.10.698e566fdVCfKD).
-* `access_point_id` - (Optional, Force New) Access point ID. Required when `router_type` is `VBR`. Prohibited when `router_type` is `VRouter`.
-* `opposite_access_point_id` - (Optional, Force New) Access point ID of peer side. Required when `opposite_router_type` is `VBR`. Prohibited when `opposite_router_type` is `VRouter`.
-* `opposite_interface_id` - (Optional) Peer router interface ID.
-* `opposite_interface_owner_id` - (Optional) Peer account ID. Log on to the Alibaba Cloud console, select User Info > Account Management to check your account ID.
+* `specification` - (Optional) Specification of router interfaces. It is valid when `role` is `InitiatingSide`. Accepting side's role is default to set as 'Negative'. For more about the specification, refer to [Router interface specification](https://www.alibabacloud.com/help/doc-detail/36037.htm).
+* `access_point_id` - (Deprecated) It has been deprecated from version 1.11.0.
+* `opposite_access_point_id` - (Deprecated) It has been deprecated from version 1.11.0.
+* `opposite_interface_id` - (Deprecated) It has been deprecated from version 1.11.0. Use resource alicloud_router_interface_connection's 'opposite_router_id' instead.
+* `opposite_interface_owner_id` - (Deprecated) It has been deprecated from version 1.11.0. Use resource alicloud_router_interface_connection's 'opposite_interface_id' instead.
 * `name` - (Optional) Name of the router interface. Length must be 2-80 characters long. Only Chinese characters, English letters, numbers, period (.), underline (_), or dash (-) are permitted.
                                                     If it is not specified, the default value is interface ID. The name cannot start with http:// and https://.
 * `description` - (Optional) Description of the router interface. It can be 2-256 characters long or left blank. It cannot start with http:// and https://.
-* `health_check_source_ip` - (Optional) Used as the Packet Source IP of health check for disaster recovery or ECMP. It is only valid when `router_type` is `VRouter` and `opposite_router_type` is `VBR`. The IP must be an unused IP in the local VPC. It and `health_check_target_ip` must be specified at the same time.
-* `health_check_target_ip` - (Optional) Used as the Packet Target IP of health check for disaster recovery or ECMP. It is only valid when `router_type` is `VRouter` and `opposite_router_type` is `VBR`. The IP must be an unused IP in the local VPC. It and `health_check_source_ip` must be specified at the same time.
-
-~> **NOTE:**
-* If `router_type` is `VBR`, the `role` must be `InitiatingSide` and `opposite_router_type` must be `VRouter`.
-* If `opposite_router_type` is `VBR`, the `role` must be `AcceptingSide` and `router_type` must be `VRouter`.
+* `health_check_source_ip` - (Optional) Used as the Packet Source IP of health check for disaster recovery or ECMP. It is only valid when `router_type` is `VBR`. The IP must be an unused IP in the local VPC. It and `health_check_target_ip` must be specified at the same time.
+* `health_check_target_ip` - (Optional) Used as the Packet Target IP of health check for disaster recovery or ECMP. It is only valid when `router_type` is `VBR`. The IP must be an unused IP in the local VPC. It and `health_check_source_ip` must be specified at the same time.
 
 
 ## Attributes Reference
@@ -69,7 +67,7 @@ The following attributes are exported:
 * `description` - Router interface description.
 * `specification` - Router nterface specification.
 * `access_point_id` - Access point of the router interface.
-* `opposite_access_point_id` - Access point of the opposite router interface.
+* `opposite_access_point_id` - (Deprecated) It has been deprecated from version 1.11.0.
 * `opposite_router_type` - Peer router type.
 * `opposite_router_id` - Peer router ID.
 * `opposite_interface_id` - Peer router interface ID.

--- a/website/docs/r/router_interface_connection.html.markdown
+++ b/website/docs/r/router_interface_connection.html.markdown
@@ -1,0 +1,84 @@
+---
+layout: "alicloud"
+page_title: "Alicloud: alicloud_router_interface_connection"
+sidebar_current: "docs-alicloud-resource-router-interface-connection"
+description: |-
+  Provides a VPC router interface connection resource to connect two VPCs.
+---
+
+# alicloud\_router\_interface\_connection
+
+Provides a VPC router interface connection resource to connect two router interfaces which are in two different VPCs.
+After that, all of the two router interface will be active.
+
+-> **NOTE:** At present, Router interface does not support changing opposite router interface, the connection delete action is only deactiving it to inactive, not modifying the connection to empty.
+
+-> **NOTE:** If you want to changing opposite router interface, you can delete router interface and re-build them.
+
+-> **NOTE:** A integrated router interface connection tunnel requires both InitiatingSide and AcceptingSide configuring opposite router interface.
+
+## Example Usage
+
+```
+resource "alicloud_vpc" "foo" {
+  name = "vpc-for-initiating"
+  cidr_block = "172.16.0.0/12"
+}
+
+resource "alicloud_router_interface" "initiating" {
+  opposite_region = "cn-beijing"
+  router_type = "VRouter"
+  router_id = "${alicloud_vpc.foo.router_id}"
+  role = "InitiatingSide"
+  specification = "Large.2"
+  name = "initaiting"
+}
+
+resource "alicloud_vpc" "bar" {
+  name = "vpc-for-accepting"
+  cidr_block = "192.168.0.0/16"
+}
+
+resource "alicloud_router_interface" "accepting" {
+  opposite_region = "cn-beijing"
+  router_type = "VRouter"
+  router_id = "${alicloud_vpc.bar.router_id}"
+  role = "AcceptingSide"
+  name = "accepting"
+}
+// A integrated router interface connection tunnel requires both InitiatingSide and AcceptingSide configuring opposite router interface.
+resource "alicloud_router_interface_connection" "foo" {
+  interface_id = "${alicloud_router_interface.initiating.id}"
+  opposite_interface_id = "${alicloud_router_interface.accepting.id}"
+}
+
+resource "alicloud_router_interface_connection" "bar" {
+  interface_id = "${alicloud_router_interface.accepting.id}"
+  opposite_interface_id = "${alicloud_router_interface.initiating.id}"
+}
+```
+## Argument Reference
+
+The following arguments are supported:
+
+* `interface_id` - (Required, ForceNew) One side router interface ID.
+* `opposite_interface_id` - (Required, ForceNew) Another side router interface ID. It must belong the specified "opposite_interface_owner_id" account.
+* `opposite_interface_owner_id` - (Optional, ForceNew) Another side router interface account ID. Log on to the Alibaba Cloud console, select User Info > Account Management to check the account ID. Default to [Provider account_id](https://www.terraform.io/docs/providers/alicloud/index.html#account_id).
+* `opposite_router_id` - (Optional, ForceNew) Another side router ID. It must belong the specified "opposite_interface_owner_id" account. It is valid when field "opposite_interface_owner_id" is specified.
+* `opposite_router_type` - (Optional, ForceNew) Another side router Type. Optional value: VRouter, VBR. It is valid when field "opposite_interface_owner_id" is specified.
+
+
+## Attributes Reference
+
+The following attributes are exported:
+
+* `id` - Router interface ID. The value is equal to "interface_id".
+
+## Import
+
+The router interface connection can be imported using the id, e.g.
+
+```
+$ terraform import alicloud_router_interface_connection.foo ri-abc123456
+```
+


### PR DESCRIPTION
The result of running test as follows: 

```
TF_ACC=1 go test ./alicloud -v -run=TestAccAlicloudRouterInterface_ -timeout=240m
=== RUN   TestAccAlicloudRouterInterface_import
--- PASS: TestAccAlicloudRouterInterface_import (14.57s)
=== RUN   TestAccAlicloudRouterInterface_basic
--- PASS: TestAccAlicloudRouterInterface_basic (13.88s)
PASS
ok  	github.com/alibaba/terraform-provider/alicloud	28.507s
```