### PR TITLE
Resource alicloud_slb_listener supports new field 'x-forwarded-for'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,10 @@
-## 1.12.1 (Unreleased)
+## 1.13.0 (Unreleased)
+
+IMPROVEMENTS:
+
+- Resource alicloud_slb_listener supports new field 'gzip' ([#259](https://github.com/terraform-providers/terraform-provider-alicloud/pull/259))
+
+
 ## 1.12.0 (August 10, 2018)
 
 IMPROVEMENTS:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 IMPROVEMENTS:
 
+- Resource alicloud_slb_listener supports new field 'x-forwarded-for' ([#260](https://github.com/terraform-providers/terraform-provider-alicloud/pull/260))
 - Resource alicloud_slb_listener supports new field 'gzip' ([#259](https://github.com/terraform-providers/terraform-provider-alicloud/pull/259))
 
 

--- a/alicloud/resource_alicloud_slb_listener.go
+++ b/alicloud/resource_alicloud_slb_listener.go
@@ -205,6 +205,14 @@ func resourceAliyunSlbListener() *schema.Resource {
 				Optional:         true,
 				DiffSuppressFunc: sslCertificateIdDiffSuppressFunc,
 			},
+
+			//http, https
+			"gzip": &schema.Schema{
+				Type:             schema.TypeBool,
+				Optional:         true,
+				Default:          true,
+				DiffSuppressFunc: httpHttpsDiffSuppressFunc,
+			},
 		},
 	}
 }
@@ -328,6 +336,15 @@ func resourceAliyunSlbListenerUpdate(d *schema.ResourceData, meta interface{}) e
 	if d.HasChange("health_check") {
 		d.SetPartial("health_check")
 		update = true
+	}
+	if d.HasChange("gzip") {
+		d.SetPartial("gzip")
+		update = true
+		if d.Get("gzip").(bool) {
+			httpArgs.QueryParams["Gzip"] = string(OnFlag)
+		} else {
+			httpArgs.QueryParams["Gzip"] = string(OffFlag)
+		}
 	}
 
 	// http https tcp udp and health_check=on
@@ -626,6 +643,9 @@ func readListener(d *schema.ResourceData, listener map[string]interface{}) {
 	}
 	if val, ok := listener["ServerCertificateId"]; ok {
 		d.Set("ssl_certificate_id", val.(string))
+	}
+	if val, ok := listener["Gzip"]; ok {
+		d.Set("gzip", val.(string) == string(OnFlag))
 	}
 
 	return

--- a/alicloud/resource_alicloud_slb_listener_test.go
+++ b/alicloud/resource_alicloud_slb_listener_test.go
@@ -31,6 +31,8 @@ func TestAccAlicloudSlbListener_http(t *testing.T) {
 						"alicloud_slb_listener.http", "backend_port", "80"),
 					resource.TestCheckResourceAttr(
 						"alicloud_slb_listener.http", "health_check", "on"),
+					resource.TestCheckResourceAttr(
+						"alicloud_slb_listener.http", "gzip", "true"),
 				),
 			},
 		},

--- a/alicloud/resource_alicloud_slb_listener_test.go
+++ b/alicloud/resource_alicloud_slb_listener_test.go
@@ -33,6 +33,14 @@ func TestAccAlicloudSlbListener_http(t *testing.T) {
 						"alicloud_slb_listener.http", "health_check", "on"),
 					resource.TestCheckResourceAttr(
 						"alicloud_slb_listener.http", "gzip", "true"),
+					resource.TestCheckResourceAttr(
+						"alicloud_slb_listener.http", "x_forwarded_for.0.retrive_client_ip", "true"),
+					resource.TestCheckResourceAttr(
+						"alicloud_slb_listener.http", "x_forwarded_for.0.retrive_slb_ip", "true"),
+					resource.TestCheckResourceAttr(
+						"alicloud_slb_listener.http", "x_forwarded_for.0.retrive_slb_id", "true"),
+					resource.TestCheckResourceAttr(
+						"alicloud_slb_listener.http", "x_forwarded_for.0.retrive_slb_proto", "false"),
 				),
 			},
 		},
@@ -177,6 +185,10 @@ resource "alicloud_slb_listener" "http" {
   health_check_interval = 5
   health_check_http_code = "http_2xx,http_3xx"
   bandwidth = 10
+  x_forwarded_for = {
+    retrive_slb_ip = true
+    retrive_slb_id = true
+  }
 }
 `
 

--- a/website/docs/r/slb_listener.html.markdown
+++ b/website/docs/r/slb_listener.html.markdown
@@ -68,6 +68,7 @@ The following arguments are supported:
 * `health_check_interval` - (Optinal) Time interval of health checks. It is required when `health_check` is on. Valid value range: [1-50] in seconds. Default to 2.
 * `health_check_http_code` - (Optinal) Regular health check HTTP status code. Multiple codes are segmented by “,”. It is required when `health_check` is on. Default to `http_2xx`.  Valid values are: `http_2xx`,  `http_3xx`, `http_4xx` and `http_5xx`.
 * `ssl_certificate_id` - (Optinal) Security certificate ID. It is required when `protocol` is `https`.
+* `gzip` - (Optinal) Whether to enable "Gzip Compression". If enabled, files of specific file types will be compressed, otherwise, no files will be compressed. Default to true. Available in v1.13.0+.
 
 ## Listener fields and protocol mapping
 
@@ -95,7 +96,8 @@ unhealthy_threshold | http & https & tcp & udp | 1-10 |
 health_check_timeout | http & https & tcp & udp | 1-300 |
 health_check_interval | http & https & tcp & udp | 1-50 |
 health_check_http_code | http & https & tcp | http_2xx,http_3xx,http_4xx,http_5xx | 
-ssl_certificate_id | https |  |  
+ssl_certificate_id | https |  |
+gzip | http & https | true or false  |
 
 
 The listener mapping supports the following:

--- a/website/docs/r/slb_listener.html.markdown
+++ b/website/docs/r/slb_listener.html.markdown
@@ -69,6 +69,15 @@ The following arguments are supported:
 * `health_check_http_code` - (Optinal) Regular health check HTTP status code. Multiple codes are segmented by “,”. It is required when `health_check` is on. Default to `http_2xx`.  Valid values are: `http_2xx`,  `http_3xx`, `http_4xx` and `http_5xx`.
 * `ssl_certificate_id` - (Optinal) Security certificate ID. It is required when `protocol` is `https`.
 * `gzip` - (Optinal) Whether to enable "Gzip Compression". If enabled, files of specific file types will be compressed, otherwise, no files will be compressed. Default to true. Available in v1.13.0+.
+* `x_forwarded_for` - (Optinal) Whether to set additional HTTP Header field "X-Forwarded-For" (documented below). Available in v1.13.0+.
+
+### Block x_forwarded_for
+
+The x_forwarded_for mapping supports the following:
+
+* `retrive_slb_ip` - (Optional) Whether to use the XForwardedFor_SLBIP header to obtain the public IP address of the SLB instance. Default to false.
+* `retrive_slb_id` - (Optional) Whether to use the XForwardedFor header to obtain the ID of the SLB instance. Default to false.
+* `retrive_slb_proto` - (Optional) Whether to use the XForwardedFor_proto header to obtain the protocol used by the listener. Default to true.
 
 ## Listener fields and protocol mapping
 
@@ -98,6 +107,7 @@ health_check_interval | http & https & tcp & udp | 1-50 |
 health_check_http_code | http & https & tcp | http_2xx,http_3xx,http_4xx,http_5xx | 
 ssl_certificate_id | https |  |
 gzip | http & https | true or false  |
+x_forwarded_for | http & https |  |
 
 
 The listener mapping supports the following:


### PR DESCRIPTION
The result of running test cases as follows:

```
TF_ACC=1 go test ./alicloud -v -run=TestAccAlicloudSlbListener -timeout=240m
=== RUN   TestAccAlicloudSlbListener_importHttp
--- PASS: TestAccAlicloudSlbListener_importHttp (18.15s)
=== RUN   TestAccAlicloudSlbListener_importTcp
--- PASS: TestAccAlicloudSlbListener_importTcp (21.94s)
=== RUN   TestAccAlicloudSlbListener_importUdp
--- PASS: TestAccAlicloudSlbListener_importUdp (20.83s)
=== RUN   TestAccAlicloudSlbListener_http
--- PASS: TestAccAlicloudSlbListener_http (17.11s)
=== RUN   TestAccAlicloudSlbListener_tcp
--- PASS: TestAccAlicloudSlbListener_tcp (17.96s)
=== RUN   TestAccAlicloudSlbListener_udp
--- PASS: TestAccAlicloudSlbListener_udp (17.69s)
PASS
ok  	github.com/terraform-providers/terraform-provider-alicloud/alicloud	113.746s
```