### PR TITLE
Improve ESS test cases results from some regions does support Classic Network

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,10 @@
-## 1.12.1 (Unreleased)
+## 1.13.0 (Unreleased)
+
+IMPROVEMENTS:
+
+- Resource alicloud_slb_listener supports new field 'gzip' ([#259](https://github.com/terraform-providers/terraform-provider-alicloud/pull/259))
+
+
 ## 1.12.0 (August 10, 2018)
 
 IMPROVEMENTS:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 IMPROVEMENTS:
 
+- Resource alicloud_slb_listener supports new field 'x-forwarded-for' ([#260](https://github.com/terraform-providers/terraform-provider-alicloud/pull/260))
 - Resource alicloud_slb_listener supports new field 'gzip' ([#259](https://github.com/terraform-providers/terraform-provider-alicloud/pull/259))
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 IMPROVEMENTS:
 
+- Recover nat gateway bandwidth pacakges to meet stock user requirements ([#261](https://github.com/terraform-providers/terraform-provider-alicloud/pull/261))
 - Resource alicloud_slb_listener supports new field 'x-forwarded-for' ([#260](https://github.com/terraform-providers/terraform-provider-alicloud/pull/260))
 - Resource alicloud_slb_listener supports new field 'gzip' ([#259](https://github.com/terraform-providers/terraform-provider-alicloud/pull/259))
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 IMPROVEMENTS:
 
+- Improve ESS test cases results from some region does support Classic Network ([#262](https://github.com/terraform-providers/terraform-provider-alicloud/pull/262))
 - Recover nat gateway bandwidth pacakges to meet stock user requirements ([#261](https://github.com/terraform-providers/terraform-provider-alicloud/pull/261))
 - Resource alicloud_slb_listener supports new field 'x-forwarded-for' ([#260](https://github.com/terraform-providers/terraform-provider-alicloud/pull/260))
 - Resource alicloud_slb_listener supports new field 'gzip' ([#259](https://github.com/terraform-providers/terraform-provider-alicloud/pull/259))

--- a/alicloud/import_alicloud_ess_scalinggroup_test.go
+++ b/alicloud/import_alicloud_ess_scalinggroup_test.go
@@ -15,7 +15,7 @@ func TestAccAlicloudEssScalingGroup_importBasic(t *testing.T) {
 		CheckDestroy: testAccCheckEssScalingGroupDestroy,
 		Steps: []resource.TestStep{
 			resource.TestStep{
-				Config: testAccEssScalingGroupConfig,
+				Config: testAccEssScalingGroup_vpc,
 			},
 
 			resource.TestStep{

--- a/alicloud/resource_alicloud_ess_scalingconfiguration_test.go
+++ b/alicloud/resource_alicloud_ess_scalingconfiguration_test.go
@@ -218,15 +218,27 @@ data "alicloud_instance_types" "default" {
 variable "name" {
 	default = "testAccEssScalingConfigurationConfig"
 }
+resource "alicloud_vpc" "foo" {
+  	name = "${var.name}"
+  	cidr_block = "172.16.0.0/16"
+}
+
+resource "alicloud_vswitch" "foo" {
+  	vpc_id = "${alicloud_vpc.foo.id}"
+  	cidr_block = "172.16.0.0/24"
+  	availability_zone = "${data.alicloud_zones.default.zones.0.id}"
+}
+
 resource "alicloud_security_group" "tf_test_foo" {
 	name = "${var.name}"
 	description = "foo"
+	vpc_id = "${alicloud_vpc.foo.id}"
 }
 
 resource "alicloud_security_group_rule" "ssh-in" {
   	type = "ingress"
   	ip_protocol = "tcp"
-  	nic_type = "internet"
+  	nic_type = "intranet"
   	policy = "accept"
   	port_range = "22/22"
   	priority = 1
@@ -238,6 +250,7 @@ resource "alicloud_ess_scaling_group" "foo" {
 	min_size = 1
 	max_size = 1
 	scaling_group_name = "${var.name}"
+	vswitch_ids = ["${alicloud_vswitch.foo.id}"]
 	removal_policies = ["OldestInstance", "NewestInstance"]
 }
 

--- a/alicloud/resource_alicloud_ess_scalingrule_test.go
+++ b/alicloud/resource_alicloud_ess_scalingrule_test.go
@@ -161,15 +161,27 @@ data "alicloud_instance_types" "default" {
 variable "name" {
 	default = "testAccEssScalingRuleConfig"
 }
+resource "alicloud_vpc" "foo" {
+  	name = "${var.name}"
+  	cidr_block = "172.16.0.0/16"
+}
+
+resource "alicloud_vswitch" "foo" {
+  	vpc_id = "${alicloud_vpc.foo.id}"
+  	cidr_block = "172.16.0.0/24"
+  	availability_zone = "${data.alicloud_zones.default.zones.0.id}"
+}
+
 resource "alicloud_security_group" "tf_test_foo" {
 	name = "${var.name}"
 	description = "foo"
+	vpc_id = "${alicloud_vpc.foo.id}"
 }
 
 resource "alicloud_security_group_rule" "ssh-in" {
   	type = "ingress"
   	ip_protocol = "tcp"
-  	nic_type = "internet"
+  	nic_type = "intranet"
   	policy = "accept"
   	port_range = "22/22"
   	priority = 1
@@ -181,6 +193,7 @@ resource "alicloud_ess_scaling_group" "bar" {
 	min_size = 1
 	max_size = 1
 	scaling_group_name = "${var.name}"
+	vswitch_ids = ["${alicloud_vswitch.foo.id}"]
 	removal_policies = ["OldestInstance", "NewestInstance"]
 }
 
@@ -217,15 +230,26 @@ data "alicloud_instance_types" "default" {
 variable "name" {
 	default = "testAccEssScalingRule"
 }
+resource "alicloud_vpc" "foo" {
+  	name = "${var.name}"
+  	cidr_block = "172.16.0.0/16"
+}
+
+resource "alicloud_vswitch" "foo" {
+  	vpc_id = "${alicloud_vpc.foo.id}"
+  	cidr_block = "172.16.0.0/24"
+  	availability_zone = "${data.alicloud_zones.default.zones.0.id}"
+}
+
 resource "alicloud_security_group" "tf_test_foo" {
 	name = "${var.name}"
 	description = "foo"
+	vpc_id = "${alicloud_vpc.foo.id}"
 }
-
 resource "alicloud_security_group_rule" "ssh-in" {
   	type = "ingress"
   	ip_protocol = "tcp"
-  	nic_type = "internet"
+  	nic_type = "intranet"
   	policy = "accept"
   	port_range = "22/22"
   	priority = 1
@@ -237,6 +261,7 @@ resource "alicloud_ess_scaling_group" "bar" {
 	min_size = 1
 	max_size = 1
 	scaling_group_name = "${var.name}"
+	vswitch_ids = ["${alicloud_vswitch.foo.id}"]
 	removal_policies = ["OldestInstance", "NewestInstance"]
 }
 
@@ -273,15 +298,27 @@ data "alicloud_instance_types" "default" {
 variable "name" {
 	default = "testAccEssScalingRule"
 }
+resource "alicloud_vpc" "foo" {
+  	name = "${var.name}"
+  	cidr_block = "172.16.0.0/16"
+}
+
+resource "alicloud_vswitch" "foo" {
+  	vpc_id = "${alicloud_vpc.foo.id}"
+  	cidr_block = "172.16.0.0/24"
+  	availability_zone = "${data.alicloud_zones.default.zones.0.id}"
+}
+
 resource "alicloud_security_group" "tf_test_foo" {
 	name = "${var.name}"
 	description = "foo"
+	vpc_id = "${alicloud_vpc.foo.id}"
 }
 
 resource "alicloud_security_group_rule" "ssh-in" {
   	type = "ingress"
   	ip_protocol = "tcp"
-  	nic_type = "internet"
+  	nic_type = "intranet"
   	policy = "accept"
   	port_range = "22/22"
   	priority = 1
@@ -293,6 +330,7 @@ resource "alicloud_ess_scaling_group" "bar" {
 	min_size = 1
 	max_size = 1
 	scaling_group_name = "${var.name}"
+	vswitch_ids = ["${alicloud_vswitch.foo.id}"]
 	removal_policies = ["OldestInstance", "NewestInstance"]
 }
 

--- a/alicloud/resource_alicloud_slb_listener.go
+++ b/alicloud/resource_alicloud_slb_listener.go
@@ -205,6 +205,14 @@ func resourceAliyunSlbListener() *schema.Resource {
 				Optional:         true,
 				DiffSuppressFunc: sslCertificateIdDiffSuppressFunc,
 			},
+
+			//http, https
+			"gzip": &schema.Schema{
+				Type:             schema.TypeBool,
+				Optional:         true,
+				Default:          true,
+				DiffSuppressFunc: httpHttpsDiffSuppressFunc,
+			},
 		},
 	}
 }
@@ -328,6 +336,15 @@ func resourceAliyunSlbListenerUpdate(d *schema.ResourceData, meta interface{}) e
 	if d.HasChange("health_check") {
 		d.SetPartial("health_check")
 		update = true
+	}
+	if d.HasChange("gzip") {
+		d.SetPartial("gzip")
+		update = true
+		if d.Get("gzip").(bool) {
+			httpArgs.QueryParams["Gzip"] = string(OnFlag)
+		} else {
+			httpArgs.QueryParams["Gzip"] = string(OffFlag)
+		}
 	}
 
 	// http https tcp udp and health_check=on
@@ -626,6 +643,9 @@ func readListener(d *schema.ResourceData, listener map[string]interface{}) {
 	}
 	if val, ok := listener["ServerCertificateId"]; ok {
 		d.Set("ssl_certificate_id", val.(string))
+	}
+	if val, ok := listener["Gzip"]; ok {
+		d.Set("gzip", val.(string) == string(OnFlag))
 	}
 
 	return

--- a/alicloud/resource_alicloud_slb_listener_test.go
+++ b/alicloud/resource_alicloud_slb_listener_test.go
@@ -31,6 +31,8 @@ func TestAccAlicloudSlbListener_http(t *testing.T) {
 						"alicloud_slb_listener.http", "backend_port", "80"),
 					resource.TestCheckResourceAttr(
 						"alicloud_slb_listener.http", "health_check", "on"),
+					resource.TestCheckResourceAttr(
+						"alicloud_slb_listener.http", "gzip", "true"),
 				),
 			},
 		},

--- a/alicloud/resource_alicloud_slb_listener_test.go
+++ b/alicloud/resource_alicloud_slb_listener_test.go
@@ -33,6 +33,14 @@ func TestAccAlicloudSlbListener_http(t *testing.T) {
 						"alicloud_slb_listener.http", "health_check", "on"),
 					resource.TestCheckResourceAttr(
 						"alicloud_slb_listener.http", "gzip", "true"),
+					resource.TestCheckResourceAttr(
+						"alicloud_slb_listener.http", "x_forwarded_for.0.retrive_client_ip", "true"),
+					resource.TestCheckResourceAttr(
+						"alicloud_slb_listener.http", "x_forwarded_for.0.retrive_slb_ip", "true"),
+					resource.TestCheckResourceAttr(
+						"alicloud_slb_listener.http", "x_forwarded_for.0.retrive_slb_id", "true"),
+					resource.TestCheckResourceAttr(
+						"alicloud_slb_listener.http", "x_forwarded_for.0.retrive_slb_proto", "false"),
 				),
 			},
 		},
@@ -177,6 +185,10 @@ resource "alicloud_slb_listener" "http" {
   health_check_interval = 5
   health_check_http_code = "http_2xx,http_3xx"
   bandwidth = 10
+  x_forwarded_for = {
+    retrive_slb_ip = true
+    retrive_slb_id = true
+  }
 }
 `
 

--- a/website/docs/r/nat_gateway.html.markdown
+++ b/website/docs/r/nat_gateway.html.markdown
@@ -10,11 +10,13 @@ description: |-
 
 Provides a resource to create a VPC NAT Gateway.
 
-~> **NOTE:** From version 1.7.1, the resource deprecates bandwidth packages.
-And if you want to add public IP, you can use resource 'alicloud_eip_association' to bind several elastic IPs for one Nat Gateway.
 
 ~> **NOTE:** Resource bandwidth packages will not be supported since 00:00 on November 4, 2017, and public IP can be replaced be elastic IPs.
 If a Nat Gateway has already bought some bandwidth packages, it can not bind elastic IP and you have to submit the [work order](https://selfservice.console.aliyun.com/ticket/createIndex) to solve.
+If you want to add public IP, you can use resource 'alicloud_eip_association' to bind several elastic IPs for one Nat Gateway.
+
+~> **NOTE:** From version 1.7.1, this resource has deprecated bandwidth packages.
+But, in order to manage stock bandwidth packages, version 1.13.0 re-support configuring 'bandwidth_packages'.
 
 
 ## Example Usage
@@ -49,8 +51,15 @@ The following arguments are supported:
 * `specification` - (Optional) The specification of the nat gateway. Valid values are `Small`, `Middle` and `Large`. Default to `Small`. Details refer to [Nat Gateway Specification](https://www.alibabacloud.com/help/doc-detail/42757.htm).
 * `name` - (Optional) Name of the nat gateway. The value can have a string of 2 to 128 characters, must contain only alphanumeric characters or hyphens, such as "-",".","_", and must not begin or end with a hyphen, and must not begin with http:// or https://. Defaults to null.
 * `description` - (Optional) Description of the nat gateway, This description can have a string of 2 to 256 characters, It cannot begin with http:// or https://. Defaults to null.
-* `bandwidth_packages` - (Deprecated) It has been deprecated from provider version 1.7.1. Resource 'alicloud_eip_association' can bind several elastic IPs for one Nat Gateway.
+* `bandwidth_packages` - (Optional) A list of bandwidth packages for the nat gatway. Only support nat gateway created before 00:00 on November 4, 2017. Available in v1.13.0+ and v1.7.1-.
 
+## Block bandwidth packages
+The bandwidth package mapping supports the following:
+
+* `ip_count` - (Required) The IP number of the current bandwidth package. Its value range from 1 to 50.
+* `bandwidth` - (Required) The bandwidth value of the current bandwidth package. Its value range from 5 to 5000.
+* `zone` - (Optional) The AZ for the current bandwidth. If this value is not specified, Terraform will set a random AZ.
+* `public_ip_addresses` - (Computer) The public ip for bandwidth package. the public ip count equal `ip_count`, multi ip would complex with ",", such as "10.0.0.1,10.0.0.2".
 
 ## Attributes Reference
 

--- a/website/docs/r/slb_listener.html.markdown
+++ b/website/docs/r/slb_listener.html.markdown
@@ -68,6 +68,7 @@ The following arguments are supported:
 * `health_check_interval` - (Optinal) Time interval of health checks. It is required when `health_check` is on. Valid value range: [1-50] in seconds. Default to 2.
 * `health_check_http_code` - (Optinal) Regular health check HTTP status code. Multiple codes are segmented by “,”. It is required when `health_check` is on. Default to `http_2xx`.  Valid values are: `http_2xx`,  `http_3xx`, `http_4xx` and `http_5xx`.
 * `ssl_certificate_id` - (Optinal) Security certificate ID. It is required when `protocol` is `https`.
+* `gzip` - (Optinal) Whether to enable "Gzip Compression". If enabled, files of specific file types will be compressed, otherwise, no files will be compressed. Default to true. Available in v1.13.0+.
 
 ## Listener fields and protocol mapping
 
@@ -95,7 +96,8 @@ unhealthy_threshold | http & https & tcp & udp | 1-10 |
 health_check_timeout | http & https & tcp & udp | 1-300 |
 health_check_interval | http & https & tcp & udp | 1-50 |
 health_check_http_code | http & https & tcp | http_2xx,http_3xx,http_4xx,http_5xx | 
-ssl_certificate_id | https |  |  
+ssl_certificate_id | https |  |
+gzip | http & https | true or false  |
 
 
 The listener mapping supports the following:

--- a/website/docs/r/slb_listener.html.markdown
+++ b/website/docs/r/slb_listener.html.markdown
@@ -69,6 +69,15 @@ The following arguments are supported:
 * `health_check_http_code` - (Optinal) Regular health check HTTP status code. Multiple codes are segmented by “,”. It is required when `health_check` is on. Default to `http_2xx`.  Valid values are: `http_2xx`,  `http_3xx`, `http_4xx` and `http_5xx`.
 * `ssl_certificate_id` - (Optinal) Security certificate ID. It is required when `protocol` is `https`.
 * `gzip` - (Optinal) Whether to enable "Gzip Compression". If enabled, files of specific file types will be compressed, otherwise, no files will be compressed. Default to true. Available in v1.13.0+.
+* `x_forwarded_for` - (Optinal) Whether to set additional HTTP Header field "X-Forwarded-For" (documented below). Available in v1.13.0+.
+
+### Block x_forwarded_for
+
+The x_forwarded_for mapping supports the following:
+
+* `retrive_slb_ip` - (Optional) Whether to use the XForwardedFor_SLBIP header to obtain the public IP address of the SLB instance. Default to false.
+* `retrive_slb_id` - (Optional) Whether to use the XForwardedFor header to obtain the ID of the SLB instance. Default to false.
+* `retrive_slb_proto` - (Optional) Whether to use the XForwardedFor_proto header to obtain the protocol used by the listener. Default to true.
 
 ## Listener fields and protocol mapping
 
@@ -98,6 +107,7 @@ health_check_interval | http & https & tcp & udp | 1-50 |
 health_check_http_code | http & https & tcp | http_2xx,http_3xx,http_4xx,http_5xx | 
 ssl_certificate_id | https |  |
 gzip | http & https | true or false  |
+x_forwarded_for | http & https |  |
 
 
 The listener mapping supports the following:


### PR DESCRIPTION
The result of running test cases as follows:

```
TF_ACC=1 go test ./alicloud -v -run=TestAccAlicloudEss -timeout=240m
		=== RUN   TestAccAlicloudEssAttachment_import
^[--- PASS: TestAccAlicloudEssAttachment_import (190.54s)
=== RUN   TestAccAlicloudEssScalingGroup_importBasic
--- PASS: TestAccAlicloudEssScalingGroup_importBasic (57.14s)
=== RUN   TestAccAlicloudEssSchedule_importBasic
--- PASS: TestAccAlicloudEssSchedule_importBasic (54.92s)
=== RUN   TestAccAlicloudEssAttachment_basic
--- PASS: TestAccAlicloudEssAttachment_basic (189.99s)
=== RUN   TestAccAlicloudEssScalingConfiguration_basic
--- PASS: TestAccAlicloudEssScalingConfiguration_basic (27.81s)
=== RUN   TestAccAlicloudEssScalingConfiguration_multiConfig
--- PASS: TestAccAlicloudEssScalingConfiguration_multiConfig (52.09s)
=== RUN   TestAccAlicloudEssScalingConfiguration_active
--- PASS: TestAccAlicloudEssScalingConfiguration_active (54.51s)
=== RUN   TestAccAlicloudEssScalingConfiguration_disable
--- PASS: TestAccAlicloudEssScalingConfiguration_disable (25.65s)
=== RUN   TestAccAlicloudEssScalingGroup_basic
--- PASS: TestAccAlicloudEssScalingGroup_basic (180.96s)
=== RUN   TestAccAlicloudEssScalingGroup_vpc
--- PASS: TestAccAlicloudEssScalingGroup_vpc (181.25s)
=== RUN   TestAccAlicloudEssScalingGroup_slb
--- PASS: TestAccAlicloudEssScalingGroup_slb (28.49s)
=== RUN   TestAccAlicloudEssScalingRule_basic
--- PASS: TestAccAlicloudEssScalingRule_basic (55.27s)
=== RUN   TestAccAlicloudEssScalingRule_update
--- PASS: TestAccAlicloudEssScalingRule_update (64.21s)
=== RUN   TestAccAlicloudEssSchedule_basic
--- PASS: TestAccAlicloudEssSchedule_basic (49.63s)
PASS
ok  	github.com/alibaba/terraform-provider/alicloud	1212.513s
```