### PR TITLE
Improve SLB test cases results from international regions does support PayByBandwidth and 'Guaranteed-performance' instance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,18 +2,19 @@
 
 IMPROVEMENTS:
 
-- Improve EIP test cases results from international regions does support PayByBandwidth ([#263](https://github.com/terraform-providers/terraform-provider-alicloud/pull/263))
-- Improve ESS test cases results from some region does support Classic Network ([#262](https://github.com/terraform-providers/terraform-provider-alicloud/pull/262))
-- Recover nat gateway bandwidth pacakges to meet stock user requirements ([#261](https://github.com/terraform-providers/terraform-provider-alicloud/pull/261))
-- Resource alicloud_slb_listener supports new field 'x-forwarded-for' ([#260](https://github.com/terraform-providers/terraform-provider-alicloud/pull/260))
-- Resource alicloud_slb_listener supports new field 'gzip' ([#259](https://github.com/terraform-providers/terraform-provider-alicloud/pull/259))
+- Improve SLB test cases results from international regions does support PayByBandwidth and ' Guaranteed-performance' instance ([#263](https://github.com/terraform-providers/terraform-provider-alicloud/pull/263))
+- Improve EIP test cases results from international regions does support PayByBandwidth ([#262](https://github.com/terraform-providers/terraform-provider-alicloud/pull/262))
+- Improve ESS test cases results from some region does support Classic Network ([#261](https://github.com/terraform-providers/terraform-provider-alicloud/pull/261))
+- Recover nat gateway bandwidth pacakges to meet stock user requirements ([#260](https://github.com/terraform-providers/terraform-provider-alicloud/pull/260))
+- Resource alicloud_slb_listener supports new field 'x-forwarded-for' ([#259](https://github.com/terraform-providers/terraform-provider-alicloud/pull/259))
+- Resource alicloud_slb_listener supports new field 'gzip' ([#258](https://github.com/terraform-providers/terraform-provider-alicloud/pull/258))
 
 
 ## 1.12.0 (August 10, 2018)
 
 IMPROVEMENTS:
 
-- Improve `make build` ([#257](https://github.com/terraform-providers/terraform-provider-alicloud/pull/257))
+- Improve `make build` ([#256](https://github.com/terraform-providers/terraform-provider-alicloud/pull/256))
 - Improve examples slb and slb-vpc by modifying 'paybytraffic' to 'PayByTraffic' ([#256](https://github.com/terraform-providers/terraform-provider-alicloud/pull/256))
 - Improve example/router-interface by adding resource alicloud_router_interface_connection ([#255](https://github.com/terraform-providers/terraform-provider-alicloud/pull/255))
 - Support more specification of router interface ([#253](https://github.com/terraform-providers/terraform-provider-alicloud/pull/253))
@@ -25,7 +26,7 @@ IMPROVEMENTS:
 
 BUG FIXES:
 
-- Fix network resource throttling error ([#258](https://github.com/terraform-providers/terraform-provider-alicloud/pull/258))
+- Fix network resource throttling error ([#257](https://github.com/terraform-providers/terraform-provider-alicloud/pull/257))
 - Fix resource alicloud_fc_trigger "source_arn" inputting empty error ([#253](https://github.com/terraform-providers/terraform-provider-alicloud/pull/253))
 - Fix describing vpcs with name_regex no results error ([#250](https://github.com/terraform-providers/terraform-provider-alicloud/pull/250))
 - Fix creating slb listener in international region failed error ([#246](https://github.com/terraform-providers/terraform-provider-alicloud/pull/246))

--- a/alicloud/diff_suppress_funcs.go
+++ b/alicloud/diff_suppress_funcs.go
@@ -108,10 +108,7 @@ func slbInternetChargeTypeDiffSuppressFunc(k, old, new string, d *schema.Resourc
 }
 
 func slbInstanceSpecDiffSuppressFunc(k, old, new string, d *schema.ResourceData) bool {
-	if old == "" && !d.IsNewResource() {
-		return true
-	}
-	return false
+	return old == "" && d.Id() != ""
 }
 
 func slbBandwidthDiffSuppressFunc(k, old, new string, d *schema.ResourceData) bool {

--- a/alicloud/import_alicloud_slb_server_group_test.go
+++ b/alicloud/import_alicloud_slb_server_group_test.go
@@ -15,7 +15,7 @@ func TestAccAlicloudSlbServerGroup_import(t *testing.T) {
 		CheckDestroy: testAccCheckSlbServerGroupDestroy,
 		Steps: []resource.TestStep{
 			resource.TestStep{
-				Config: testAccSlbServerGroupClassic,
+				Config: testAccSlbServerGroupVpc,
 			},
 
 			resource.TestStep{

--- a/alicloud/import_alicloud_slb_test.go
+++ b/alicloud/import_alicloud_slb_test.go
@@ -6,49 +6,7 @@ import (
 	"github.com/hashicorp/terraform/helper/resource"
 )
 
-func TestAccAlicloudSlb_importBandwidth(t *testing.T) {
-	resourceName := "alicloud_slb.bandwidth"
-
-	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckSlbDestroy,
-		Steps: []resource.TestStep{
-			resource.TestStep{
-				Config: testAccSlbBandWidth,
-			},
-
-			resource.TestStep{
-				ResourceName:      resourceName,
-				ImportState:       true,
-				ImportStateVerify: true,
-			},
-		},
-	})
-}
-
-func TestAccAlicloudSlb_importTraffic(t *testing.T) {
-	resourceName := "alicloud_slb.traffic"
-
-	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckSlbDestroy,
-		Steps: []resource.TestStep{
-			resource.TestStep{
-				Config: testAccSlbTraffic,
-			},
-
-			resource.TestStep{
-				ResourceName:      resourceName,
-				ImportState:       true,
-				ImportStateVerify: true,
-			},
-		},
-	})
-}
-
-func TestAccAlicloudSlb_importVpc(t *testing.T) {
+func TestAccAlicloudSlb_import(t *testing.T) {
 	resourceName := "alicloud_slb.vpc"
 
 	resource.Test(t, resource.TestCase{

--- a/alicloud/resource_alicloud_slb_server_group_test.go
+++ b/alicloud/resource_alicloud_slb_server_group_test.go
@@ -9,32 +9,6 @@ import (
 	"github.com/hashicorp/terraform/terraform"
 )
 
-func TestAccAlicloudSlbServerGroup_classic(t *testing.T) {
-	var group slb.DescribeVServerGroupAttributeResponse
-	resource.Test(t, resource.TestCase{
-		PreCheck: func() {
-			testAccPreCheck(t)
-		},
-
-		// module name
-		IDRefreshName: "alicloud_slb_server_group.group",
-		Providers:     testAccProviders,
-		CheckDestroy:  testAccCheckSlbServerGroupDestroy,
-		Steps: []resource.TestStep{
-			resource.TestStep{
-				Config: testAccSlbServerGroupClassic,
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckSlbServerGroupExists("alicloud_slb_server_group.group", &group),
-					resource.TestCheckResourceAttr(
-						"alicloud_slb_server_group.group", "name", "testAccSlbServerGroupClassic"),
-					resource.TestCheckResourceAttr(
-						"alicloud_slb_server_group.group", "servers.#", "3"),
-				),
-			},
-		},
-	})
-}
-
 func TestAccAlicloudSlbServerGroup_vpc(t *testing.T) {
 	var group slb.DescribeVServerGroupAttributeResponse
 	resource.Test(t, resource.TestCase{
@@ -104,100 +78,6 @@ func testAccCheckSlbServerGroupDestroy(s *terraform.State) error {
 
 	return nil
 }
-
-const testAccSlbServerGroupClassic = `
-data "alicloud_zones" "default" {
-	"available_disk_category"= "cloud_efficiency"
-	"available_resource_creation"= "VSwitch"
-}
-data "alicloud_instance_types" "default" {
- 	availability_zone = "${data.alicloud_zones.default.zones.0.id}"
-	cpu_core_count = 1
-	memory_size = 2
-}
-data "alicloud_images" "image" {
-        name_regex = "^ubuntu_14.*_64"
-	most_recent = true
-	owners = "system"
-}
-variable "name" {
-	default = "testAccSlbServerGroupClassic"
-}
-
-resource "alicloud_vpc" "main" {
-  name = "${var.name}"
-  cidr_block = "172.16.0.0/16"
-}
-
-resource "alicloud_vswitch" "main" {
-  vpc_id = "${alicloud_vpc.main.id}"
-  cidr_block = "172.16.0.0/16"
-  availability_zone = "${data.alicloud_zones.default.zones.0.id}"
-  depends_on = [
-    "alicloud_vpc.main"]
-}
-resource "alicloud_security_group" "group" {
-  name = "${var.name}-vpc"
-  vpc_id = "${alicloud_vpc.main.id}"
-}
-
-resource "alicloud_instance" "vpc" {
-  image_id = "${data.alicloud_images.image.images.0.id}"
-  instance_type = "${data.alicloud_instance_types.default.instance_types.0.id}"
-  instance_name = "${var.name}-vpc"
-  count = "2"
-  security_groups = ["${alicloud_security_group.group.*.id}"]
-  internet_charge_type = "PayByTraffic"
-  internet_max_bandwidth_out = "10"
-  availability_zone = "${data.alicloud_zones.default.zones.0.id}"
-  instance_charge_type = "PostPaid"
-  system_disk_category = "cloud_efficiency"
-  vswitch_id = "${alicloud_vswitch.main.id}"
-}
-
-resource "alicloud_security_group" "classic" {
-	name = "${var.name}-classic"
-}
-
-resource "alicloud_instance" "classic" {
-  image_id = "${data.alicloud_images.image.images.0.id}"
-  instance_type = "${data.alicloud_instance_types.default.instance_types.0.id}"
-  instance_name = "${var.name}-classic"
-  security_groups = ["${alicloud_security_group.classic.*.id}"]
-  internet_charge_type = "PayByTraffic"
-  internet_max_bandwidth_out = "10"
-  availability_zone = "${data.alicloud_zones.default.zones.0.id}"
-  instance_charge_type = "PostPaid"
-  system_disk_category = "cloud_efficiency"
-}
-
-resource "alicloud_slb" "instance" {
-  name = "${var.name}"
-  internet = true
-}
-
-resource "alicloud_slb_server_group" "group" {
-  load_balancer_id = "${alicloud_slb.instance.id}"
-  name = "${var.name}"
-  servers = [
-    {
-      server_ids = ["${alicloud_instance.vpc.*.id}"]
-      port = 100
-      weight = 10
-    },
-    {
-      server_ids = ["${alicloud_instance.classic.*.id}", "${alicloud_instance.vpc.*.id}"]
-      port = 80
-      weight = 100
-    },
-    {
-      server_ids = ["${alicloud_instance.classic.*.id}"]
-      port = 22
-      weight = 100
-    }
-  ]
-}
-`
 
 const testAccSlbServerGroupVpc = `
 data "alicloud_zones" "default" {


### PR DESCRIPTION
The results of running test cases as follows:

```
TF_ACC=1 go test ./alicloud -v -run=TestAccAlicloudSlb -timeout=240m
=== RUN   TestAccAlicloudSlbAttachment_import
--- PASS: TestAccAlicloudSlbAttachment_import (198.69s)
=== RUN   TestAccAlicloudSlbListener_importHttp
--- PASS: TestAccAlicloudSlbListener_importHttp (30.90s)
=== RUN   TestAccAlicloudSlbListener_importTcp
--- PASS: TestAccAlicloudSlbListener_importTcp (27.64s)
=== RUN   TestAccAlicloudSlbListener_importUdp
--- PASS: TestAccAlicloudSlbListener_importUdp (27.46s)
=== RUN   TestAccAlicloudSlbRule_import
--- PASS: TestAccAlicloudSlbRule_import (194.66s)
=== RUN   TestAccAlicloudSlbServerGroup_import
--- PASS: TestAccAlicloudSlbServerGroup_import (192.60s)
=== RUN   TestAccAlicloudSlb_import
--- PASS: TestAccAlicloudSlb_import (54.91s)
=== RUN   TestAccAlicloudSlbAttachment_basic
--- PASS: TestAccAlicloudSlbAttachment_basic (197.97s)
=== RUN   TestAccAlicloudSlbListener_http
--- PASS: TestAccAlicloudSlbListener_http (29.19s)
=== RUN   TestAccAlicloudSlbListener_tcp
--- PASS: TestAccAlicloudSlbListener_tcp (27.62s)
=== RUN   TestAccAlicloudSlbListener_udp
--- PASS: TestAccAlicloudSlbListener_udp (26.52s)
=== RUN   TestAccAlicloudSlbRule_basic
--- PASS: TestAccAlicloudSlbRule_basic (194.76s)
=== RUN   TestAccAlicloudSlbRule_url
--- PASS: TestAccAlicloudSlbRule_url (199.10s)
=== RUN   TestAccAlicloudSlbServerGroup_vpc
--- PASS: TestAccAlicloudSlbServerGroup_vpc (187.93s)
=== RUN   TestAccAlicloudSlb_vpc
--- PASS: TestAccAlicloudSlb_vpc (55.80s)
=== RUN   TestAccAlicloudSlb_spec
--- FAIL: TestAccAlicloudSlb_spec (43.21s)
	testing.go:513: Step 0 error: Check failed: Check 2/2 error: alicloud_slb.spec: Attribute 'specification' expected "slb.s2.small", got ""
FAIL
FAIL	github.com/alibaba/terraform-provider/alicloud	1689.001s
```