### PR TITLE
Fix router interface connection error when 'opposite_interface_owner_id' is empty

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,17 +2,18 @@
 
 FEATURES:
 
-- **New Data Source:** `alicloud_router_interfaces` ([#268](https://github.com/terraform-providers/terraform-provider-alicloud/pull/268))
+- **New Data Source:** `alicloud_router_interfaces` ([#269](https://github.com/terraform-providers/terraform-provider-alicloud/pull/269))
 
 IMPROVEMENTS:
 
-- Improve SLB instance test case ([#272](https://github.com/terraform-providers/terraform-provider-alicloud/pull/272))
-- Improve alicloud_router_interface's test case ([#271](https://github.com/terraform-providers/terraform-provider-alicloud/pull/271))
-- Improve data source alicloud_regions's test case ([#270](https://github.com/terraform-providers/terraform-provider-alicloud/pull/270))
-- Add notes about ordering between two alicloud_router_interface_connections ([#269](https://github.com/terraform-providers/terraform-provider-alicloud/pull/269))
-- Improve docs spelling error ([#267](https://github.com/terraform-providers/terraform-provider-alicloud/pull/267))
-- ECS instance support more tags and update instance test cases ([#266](https://github.com/terraform-providers/terraform-provider-alicloud/pull/266))
-- Improve OSS bucket test case ([#265](https://github.com/terraform-providers/terraform-provider-alicloud/pull/265))
+- Improve SLB instance test case ([#274](https://github.com/terraform-providers/terraform-provider-alicloud/pull/274))
+- Improve alicloud_router_interface's test case ([#272](https://github.com/terraform-providers/terraform-provider-alicloud/pull/272))
+- Improve data source alicloud_regions's test case ([#271](https://github.com/terraform-providers/terraform-provider-alicloud/pull/271))
+- Add notes about ordering between two alicloud_router_interface_connections ([#270](https://github.com/terraform-providers/terraform-provider-alicloud/pull/270))
+- Improve docs spelling error ([#268](https://github.com/terraform-providers/terraform-provider-alicloud/pull/268))
+- ECS instance support more tags and update instance test cases ([#267](https://github.com/terraform-providers/terraform-provider-alicloud/pull/267))
+- Improve OSS bucket test case ([#266](https://github.com/terraform-providers/terraform-provider-alicloud/pull/266))
+- Fixing a broken link ([#265](https://github.com/terraform-providers/terraform-provider-alicloud/pull/265))
 - Allow creation of slb vserver group with 0 servers ([#264](https://github.com/terraform-providers/terraform-provider-alicloud/pull/264))
 - Improve SLB test cases results from international regions does support PayByBandwidth and ' Guaranteed-performance' instance ([#263](https://github.com/terraform-providers/terraform-provider-alicloud/pull/263))
 - Improve EIP test cases results from international regions does support PayByBandwidth ([#262](https://github.com/terraform-providers/terraform-provider-alicloud/pull/262))
@@ -23,8 +24,9 @@ IMPROVEMENTS:
 
 BUG FIXES:
 
-- Fix router interface connection error and deleting error ([#273](https://github.com/terraform-providers/terraform-provider-alicloud/pull/273))
-- Fix disk detach error and improve test using dynamic zone and region ([#272](https://github.com/terraform-providers/terraform-provider-alicloud/pull/272))
+- Fix router interface connection error when 'opposite_interface_owner_id' is empty ([#277](https://github.com/terraform-providers/terraform-provider-alicloud/pull/277))
+- Fix router interface connection error and deleting error ([#275](https://github.com/terraform-providers/terraform-provider-alicloud/pull/275))
+- Fix disk detach error and improve test using dynamic zone and region ([#273](https://github.com/terraform-providers/terraform-provider-alicloud/pull/273))
 
 ## 1.12.0 (August 10, 2018)
 

--- a/alicloud/resource_alicloud_router_interface.go
+++ b/alicloud/resource_alicloud_router_interface.go
@@ -119,7 +119,7 @@ func resourceAlicloudRouterInterfaceCreate(d *schema.ResourceData, meta interfac
 
 	d.SetId(response.RouterInterfaceId)
 
-	if err := client.WaitForRouterInterface(d.Id(), Idle, 300); err != nil {
+	if err := client.WaitForRouterInterface(getRegionId(d, meta), d.Id(), Idle, 300); err != nil {
 		return fmt.Errorf("WaitForRouterInterface %s got error: %#v", Idle, err)
 	}
 
@@ -159,7 +159,7 @@ func resourceAlicloudRouterInterfaceUpdate(d *schema.ResourceData, meta interfac
 
 func resourceAlicloudRouterInterfaceRead(d *schema.ResourceData, meta interface{}) error {
 
-	ri, err := meta.(*AliyunClient).DescribeRouterInterface(d.Id())
+	ri, err := meta.(*AliyunClient).DescribeRouterInterface(getRegionId(d, meta), d.Id())
 	if err != nil {
 		if NotFoundError(err) {
 			d.SetId("")
@@ -189,7 +189,7 @@ func resourceAlicloudRouterInterfaceRead(d *schema.ResourceData, meta interface{
 func resourceAlicloudRouterInterfaceDelete(d *schema.ResourceData, meta interface{}) error {
 	client := meta.(*AliyunClient)
 
-	if ri, err := client.DescribeRouterInterface(d.Id()); err != nil {
+	if ri, err := client.DescribeRouterInterface(getRegionId(d, meta), d.Id()); err != nil {
 		if NotFoundError(err) {
 			return nil
 		}
@@ -215,7 +215,7 @@ func resourceAlicloudRouterInterfaceDelete(d *schema.ResourceData, meta interfac
 			}
 			return resource.NonRetryableError(fmt.Errorf("Error deleting interface %s: %#v", d.Id(), err))
 		}
-		if _, err := client.DescribeRouterInterface(d.Id()); err != nil {
+		if _, err := client.DescribeRouterInterface(getRegionId(d, meta), d.Id()); err != nil {
 			if NotFoundError(err) {
 				return nil
 			}

--- a/alicloud/resource_alicloud_router_interface_connection_test.go
+++ b/alicloud/resource_alicloud_router_interface_connection_test.go
@@ -52,7 +52,7 @@ func testAccCheckRouterInterfaceConnectionExists(n string) resource.TestCheckFun
 
 		client := testAccProvider.Meta().(*AliyunClient)
 
-		response, err := client.DescribeRouterInterface(rs.Primary.ID)
+		response, err := client.DescribeRouterInterface(client.RegionId, rs.Primary.ID)
 		if err != nil {
 			return fmt.Errorf("Error finding interface %s: %#v", rs.Primary.ID, err)
 		}
@@ -74,7 +74,7 @@ func testAccCheckRouterInterfaceConnectionDestroy(s *terraform.State) error {
 		// Try to find the interface
 		client := testAccProvider.Meta().(*AliyunClient)
 
-		ri, err := client.DescribeRouterInterface(rs.Primary.ID)
+		ri, err := client.DescribeRouterInterface(client.RegionId, rs.Primary.ID)
 		if err != nil {
 			if NotFoundError(err) {
 				continue

--- a/alicloud/resource_alicloud_router_interface_test.go
+++ b/alicloud/resource_alicloud_router_interface_test.go
@@ -54,7 +54,7 @@ func testAccCheckRouterInterfaceExists(n string, ri *vpc.RouterInterfaceTypeInDe
 
 		client := testAccProvider.Meta().(*AliyunClient)
 
-		response, err := client.DescribeRouterInterface(rs.Primary.ID)
+		response, err := client.DescribeRouterInterface(client.RegionId, rs.Primary.ID)
 		if err != nil {
 			return fmt.Errorf("Error finding interface %s: %#v", rs.Primary.ID, err)
 		}
@@ -73,7 +73,7 @@ func testAccCheckRouterInterfaceDestroy(s *terraform.State) error {
 		// Try to find the interface
 		client := testAccProvider.Meta().(*AliyunClient)
 
-		ri, err := client.DescribeRouterInterface(rs.Primary.ID)
+		ri, err := client.DescribeRouterInterface(client.RegionId, rs.Primary.ID)
 		if err != nil {
 			if NotFoundError(err) {
 				continue

--- a/website/docs/r/router_interface.html.markdown
+++ b/website/docs/r/router_interface.html.markdown
@@ -12,7 +12,7 @@ Provides a VPC router interface resource aim to build a connection between two V
 
 -> **NOTE:** Only one pair of connected router interfaces can exist between two routers. Up to 5 router interfaces can be created for each router and each account.
 
--> **NOTE:** The router interface is not connected when it is created. It can be connected by means of resource [alicloud_router_interface_connection](https://www.terraform.io/docs/providers/alicloud/r/alicloud_router_interface_connection.html).
+-> **NOTE:** The router interface is not connected when it is created. It can be connected by means of resource [alicloud_router_interface_connection](https://www.terraform.io/docs/providers/alicloud/r/router_interface_connection.html).
 
 
 ## Example Usage

--- a/website/docs/r/router_interface_connection.html.markdown
+++ b/website/docs/r/router_interface_connection.html.markdown
@@ -72,6 +72,7 @@ The following arguments are supported:
 * `opposite_router_id` - (Optional, ForceNew) Another side router ID. It must belong the specified "opposite_interface_owner_id" account. It is valid when field "opposite_interface_owner_id" is specified.
 * `opposite_router_type` - (Optional, ForceNew) Another side router Type. Optional value: VRouter, VBR. It is valid when field "opposite_interface_owner_id" is specified.
 
+-> **NOTE:** The value of "opposite_interface_owner_id" or "account_id" must be main account and not be sub account.
 
 ## Attributes Reference
 


### PR DESCRIPTION
Before creating router interface connection resource, you must set account id by 'opposite_interface_owner_id' or 'account_id'.

The running test cases results as follows:
```
 TF_ACC=1 go test ./alicloud -v -run=TestAccAlicloudRouterInterface -timeout=240m
=== RUN   TestAccAlicloudRouterInterfacesDataSource_oneRouter
--- PASS: TestAccAlicloudRouterInterfacesDataSource_oneRouter (37.76s)
=== RUN   TestAccAlicloudRouterInterfacesDataSource_twoRouters
--- PASS: TestAccAlicloudRouterInterfacesDataSource_twoRouters (103.99s)
=== RUN   TestAccAlicloudRouterInterface_import
--- PASS: TestAccAlicloudRouterInterface_import (34.50s)
=== RUN   TestAccAlicloudRouterInterfaceConnection_basic
--- PASS: TestAccAlicloudRouterInterfaceConnection_basic (80.72s)
=== RUN   TestAccAlicloudRouterInterface_basic
--- PASS: TestAccAlicloudRouterInterface_basic (36.80s)
PASS
ok  	github.com/alibaba/terraform-provider/alicloud	293.828s
```