### PR TITLE
Fix getting oss endpoint timeout error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ FEATURES:
 
 IMPROVEMENTS:
 
+- Improve docs vroute_entry ([#281](https://github.com/terraform-providers/terraform-provider-alicloud/pull/281))
 - Improve examples/router_interface ([#278](https://github.com/terraform-providers/terraform-provider-alicloud/pull/278))
 - Improve SLB instance test case ([#274](https://github.com/terraform-providers/terraform-provider-alicloud/pull/274))
 - Improve alicloud_router_interface's test case ([#272](https://github.com/terraform-providers/terraform-provider-alicloud/pull/272))
@@ -25,7 +26,7 @@ IMPROVEMENTS:
 
 BUG FIXES:
 
-
+- Fix getting oss endpoint timeout error ([#282](https://github.com/terraform-providers/terraform-provider-alicloud/pull/282))
 - Fix router interface connection error when 'opposite_interface_owner_id' is empty ([#277](https://github.com/terraform-providers/terraform-provider-alicloud/pull/277))
 - Fix router interface connection error and deleting error ([#275](https://github.com/terraform-providers/terraform-provider-alicloud/pull/275))
 - Fix disk detach error and improve test using dynamic zone and region ([#273](https://github.com/terraform-providers/terraform-provider-alicloud/pull/273))

--- a/website/docs/r/vroute_entry.html.markdown
+++ b/website/docs/r/vroute_entry.html.markdown
@@ -38,7 +38,12 @@ The following arguments are supported:
 * `router_id` - (Deprecated) This argument has beeb deprecated. Please use other arguments to launch a custom route entry.
 * `route_table_id` - (Required, Forces new resource) The ID of the route table.
 * `destination_cidrblock` - (Required, Forces new resource) The RouteEntry's target network segment.
-* `nexthop_type` - (Required, Forces new resource) The next hop type. Available value is `Instance` and `RouterInterface`. `Instance` points to ECS Instance.
+* `nexthop_type` - (Required, Forces new resource) The next hop type. Available values:
+    - `Instance` (Default): Route the traffic destined for the destination CIDR block to an ECS instance in the VPC.
+    - `RouterInterface`: Route the traffic destined for the destination CIDR block to a router interface.
+    - `VpnGateway`: Route the traffic destined for the destination CIDR block to a VPN Gateway.
+    - `HaVip`: Route the traffic destined for the destination CIDR block to an HAVIP.
+
 * `nexthop_id` - (Required, Forces new resource) The route entry's next hop. ECS instance ID or VPC router interface ID.
 
 ## Attributes Reference


### PR DESCRIPTION
Some region does not configure endpoint on location and there always happens some timeout error when getting oss location. This PR ignore the timeout error and set a default endpoint to fix this error.

The result of running oss test cases as follows:

```
TF_ACC=1 go test ./alicloud -v -run=TestAccAlicloudOss -timeout=240m
=== RUN   TestAccAlicloudOssBucket_importBasic
--- PASS: TestAccAlicloudOssBucket_importBasic (121.79s)
=== RUN   TestAccAlicloudOssBucket_importCors
--- PASS: TestAccAlicloudOssBucket_importCors (187.92s)
=== RUN   TestAccAlicloudOssBucket_importWebsite
--- PASS: TestAccAlicloudOssBucket_importWebsite (196.04s)
=== RUN   TestAccAlicloudOssBucket_importLogging
--- PASS: TestAccAlicloudOssBucket_importLogging (56.32s)
=== RUN   TestAccAlicloudOssBucket_importReferer
--- PASS: TestAccAlicloudOssBucket_importReferer (30.82s)
=== RUN   TestAccAlicloudOssBucket_importLifecycle
--- PASS: TestAccAlicloudOssBucket_importLifecycle (246.40s)
=== RUN   TestAccAlicloudOssBucketObject_source
--- PASS: TestAccAlicloudOssBucketObject_source (30.19s)
=== RUN   TestAccAlicloudOssBucketObject_content
--- PASS: TestAccAlicloudOssBucketObject_content (34.52s)
=== RUN   TestAccAlicloudOssBucketObject_acl
--- PASS: TestAccAlicloudOssBucketObject_acl (30.46s)
=== RUN   TestAccAlicloudOssBucketBasic
--- PASS: TestAccAlicloudOssBucketBasic (24.49s)
=== RUN   TestAccAlicloudOssBucketCors
--- PASS: TestAccAlicloudOssBucketCors (35.80s)
=== RUN   TestAccAlicloudOssBucketWebsite
--- PASS: TestAccAlicloudOssBucketWebsite (38.27s)
=== RUN   TestAccAlicloudOssBucketLogging
--- PASS: TestAccAlicloudOssBucketLogging (56.31s)
=== RUN   TestAccAlicloudOssBucketReferer
--- PASS: TestAccAlicloudOssBucketReferer (27.01s)
=== RUN   TestAccAlicloudOssBucketLifecycle
--- PASS: TestAccAlicloudOssBucketLifecycle (29.87s)
PASS
ok  	github.com/alibaba/terraform-provider/alicloud	1146.279s
```