### PR TITLE
Support ClientToken for some request

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ FEATURES:
 
 IMPROVEMENTS:
 
+- Support ClientToken for some request ([#301](https://github.com/terraform-providers/terraform-provider-alicloud/pull/301))
 - Enlarge sdk default timeout to fix some timeout scenario ([#300](https://github.com/terraform-providers/terraform-provider-alicloud/pull/300))
 
 ## 1.13.0 (August 28, 2018)

--- a/alicloud/common.go
+++ b/alicloud/common.go
@@ -13,6 +13,8 @@ import (
 
 	"time"
 
+	"math/rand"
+
 	"github.com/aliyun/alibaba-cloud-sdk-go/sdk/requests"
 	"github.com/aliyun/alibaba-cloud-sdk-go/services/ecs"
 	"github.com/denverdino/aliyungo/common"
@@ -515,7 +517,7 @@ func (a *Invoker) Run(f func() error) error {
 }
 
 func buildClientToken(prefix string) string {
-	token := resource.PrefixedUniqueId(prefix)
+	token := resource.PrefixedUniqueId(fmt.Sprintf("%s-%d-", prefix, rand.Int()))
 	if len(token) > 64 {
 		token = token[0:64]
 	}

--- a/alicloud/resource_alicloud_disk.go
+++ b/alicloud/resource_alicloud_disk.go
@@ -129,7 +129,7 @@ func resourceAliyunDiskCreate(d *schema.ResourceData, meta interface{}) error {
 	if v, ok := d.GetOk("encrypted"); ok {
 		args.Encrypted = requests.NewBoolean(v.(bool))
 	}
-
+	args.ClientToken = buildClientToken("TF-CreateDisk")
 	resp, err := conn.CreateDisk(args)
 	if err != nil {
 		return fmt.Errorf("CreateDisk got a error: %#v", err)

--- a/alicloud/resource_alicloud_eip.go
+++ b/alicloud/resource_alicloud_eip.go
@@ -96,7 +96,7 @@ func resourceAliyunEipCreate(d *schema.ResourceData, meta interface{}) error {
 		}
 		request.AutoPay = requests.NewBoolean(true)
 	}
-	request.ClientToken = buildClientToken("terraform-allocate-eip-")
+	request.ClientToken = buildClientToken("TF-AllocateEip")
 
 	eip, err := client.vpcconn.AllocateEipAddress(request)
 	if err != nil {

--- a/alicloud/resource_alicloud_instance.go
+++ b/alicloud/resource_alicloud_instance.go
@@ -708,6 +708,7 @@ func buildAliyunInstanceArgs(d *schema.ResourceData, meta interface{}) (*ecs.Cre
 		args.KeyPairName = v
 	}
 
+	args.ClientToken = buildClientToken("TF-CreateInstance")
 	return args, nil
 }
 
@@ -770,7 +771,7 @@ func modifyInstanceImage(d *schema.ResourceData, meta interface{}, run bool) (bo
 		args.InstanceId = d.Id()
 		args.ImageId = d.Get("image_id").(string)
 		args.SystemDiskSize = requests.NewInteger(d.Get("system_disk_size").(int))
-
+		args.ClientToken = buildClientToken("TF-ReplaceSystemDisk")
 		_, err := client.ecsconn.ReplaceSystemDisk(args)
 		if err != nil {
 			return update, fmt.Errorf("Replace system disk got an error: %#v", err)
@@ -934,6 +935,7 @@ func modifyInstanceType(d *schema.ResourceData, meta interface{}, run bool) (boo
 		args := ecs.CreateModifyInstanceSpecRequest()
 		args.InstanceId = d.Id()
 		args.InstanceType = d.Get("instance_type").(string)
+		args.ClientToken = buildClientToken("TF-ModifyInstanceSpec")
 
 		err = resource.Retry(6*time.Minute, func() *resource.RetryError {
 			if _, err := client.ecsconn.ModifyInstanceSpec(args); err != nil {
@@ -959,6 +961,7 @@ func modifyInstanceNetworkSpec(d *schema.ResourceData, meta interface{}) error {
 	update := false
 	args := ecs.CreateModifyInstanceNetworkSpecRequest()
 	args.InstanceId = d.Id()
+	args.ClientToken = buildClientToken("TF-ModifyInstanceNetworkSpec")
 
 	if d.HasChange("internet_charge_type") {
 		args.NetworkChargeType = d.Get("internet_charge_type").(string)

--- a/alicloud/resource_alicloud_nat_gateway.go
+++ b/alicloud/resource_alicloud_nat_gateway.go
@@ -102,7 +102,7 @@ func resourceAliyunNatGatewayCreate(d *schema.ResourceData, meta interface{}) er
 	args.RegionId = string(getRegion(d, meta))
 	args.VpcId = string(d.Get("vpc_id").(string))
 	args.Spec = string(d.Get("specification").(string))
-
+	args.ClientToken = buildClientToken("TF-CreateNatGateway")
 	bandwidthPackages := []vpc.CreateNatGatewayBandwidthPackage{}
 	for _, e := range d.Get("bandwidth_packages").([]interface{}) {
 		pack := e.(map[string]interface{})
@@ -127,8 +127,8 @@ func resourceAliyunNatGatewayCreate(d *schema.ResourceData, meta interface{}) er
 	}
 
 	if err := resource.Retry(3*time.Minute, func() *resource.RetryError {
-		ar := args
-		resp, err := conn.CreateNatGateway(ar)
+		ar := *args
+		resp, err := conn.CreateNatGateway(&ar)
 		if err != nil {
 			if IsExceptedError(err, VswitchStatusError) || IsExceptedError(err, TaskConflict) {
 				return resource.RetryableError(fmt.Errorf("CreateNatGateway got error: %#v", err))

--- a/alicloud/resource_alicloud_router_interface.go
+++ b/alicloud/resource_alicloud_router_interface.go
@@ -264,6 +264,7 @@ func buildAlicloudRouterInterfaceCreateArgs(d *schema.ResourceData, meta interfa
 			request.AccessPointId = resp.VirtualBorderRouterSet.VirtualBorderRouterType[0].AccessPointId
 		}
 	}
+	request.ClientToken = buildClientToken("TF-CreateRouterInterface")
 	return request, nil
 }
 

--- a/alicloud/resource_alicloud_security_group.go
+++ b/alicloud/resource_alicloud_security_group.go
@@ -49,12 +49,7 @@ func resourceAliyunSecurityGroup() *schema.Resource {
 func resourceAliyunSecurityGroupCreate(d *schema.ResourceData, meta interface{}) error {
 	conn := meta.(*AliyunClient).ecsconn
 
-	args, err := buildAliyunSecurityGroupArgs(d, meta)
-	if err != nil {
-		return err
-	}
-
-	resp, err := conn.CreateSecurityGroup(args)
+	resp, err := conn.CreateSecurityGroup(buildAliyunSecurityGroupArgs(d, meta))
 	if err != nil {
 		return err
 	}
@@ -179,7 +174,7 @@ func resourceAliyunSecurityGroupDelete(d *schema.ResourceData, meta interface{})
 
 }
 
-func buildAliyunSecurityGroupArgs(d *schema.ResourceData, meta interface{}) (*ecs.CreateSecurityGroupRequest, error) {
+func buildAliyunSecurityGroupArgs(d *schema.ResourceData, meta interface{}) *ecs.CreateSecurityGroupRequest {
 
 	args := ecs.CreateCreateSecurityGroupRequest()
 
@@ -194,6 +189,7 @@ func buildAliyunSecurityGroupArgs(d *schema.ResourceData, meta interface{}) (*ec
 	if v := d.Get("vpc_id").(string); v != "" {
 		args.VpcId = v
 	}
+	args.ClientToken = buildClientToken("TF-CreateSecurityGroup")
 
-	return args, nil
+	return args
 }

--- a/alicloud/resource_alicloud_slb.go
+++ b/alicloud/resource_alicloud_slb.go
@@ -225,6 +225,8 @@ func resourceAliyunSlbCreate(d *schema.ResourceData, meta interface{}) error {
 	args.LoadBalancerName = d.Get("name").(string)
 	args.AddressType = strings.ToLower(string(Intranet))
 	args.InternetChargeType = strings.ToLower(string(PayByTraffic))
+	args.ClientToken = buildClientToken("TF-CreateLoadBalancer")
+
 	if d.Get("internet").(bool) {
 		args.AddressType = strings.ToLower(string(Internet))
 	}

--- a/alicloud/resource_alicloud_vroute_entry.go
+++ b/alicloud/resource_alicloud_vroute_entry.go
@@ -68,19 +68,15 @@ func resourceAliyunRouteEntryCreate(d *schema.ResourceData, meta interface{}) er
 		}
 		return fmt.Errorf("Error query route table: %#v", err)
 	}
+	request := buildAliyunRouteEntryArgs(d, meta)
 
 	err = resource.Retry(3*time.Minute, func() *resource.RetryError {
 
 		if err := client.WaitForAllRouteEntries(rtId, Available, DefaultTimeout); err != nil {
 			return resource.NonRetryableError(fmt.Errorf("WaitFor route entries got error: %#v", err))
 		}
-
-		args, err := buildAliyunRouteEntryArgs(d, meta)
-		if err != nil {
-			return resource.NonRetryableError(fmt.Errorf("Building CreateRouteEntryArgs got an error: %#v", err))
-		}
-
-		if _, err := client.vpcconn.CreateRouteEntry(args); err != nil {
+		args := *request
+		if _, err := client.vpcconn.CreateRouteEntry(&args); err != nil {
 			// Route Entry does not support concurrence when creating or deleting it;
 			// Route Entry does not support creating or deleting within 5 seconds frequently
 			// It must ensure all the route entries and vswitches' status must be available before creating or deleting route entry.
@@ -181,7 +177,7 @@ func resourceAliyunRouteEntryDelete(d *schema.ResourceData, meta interface{}) er
 	})
 }
 
-func buildAliyunRouteEntryArgs(d *schema.ResourceData, meta interface{}) (*vpc.CreateRouteEntryRequest, error) {
+func buildAliyunRouteEntryArgs(d *schema.ResourceData, meta interface{}) *vpc.CreateRouteEntryRequest {
 
 	request := vpc.CreateCreateRouteEntryRequest()
 	request.RouteTableId = d.Get("route_table_id").(string)
@@ -194,8 +190,9 @@ func buildAliyunRouteEntryArgs(d *schema.ResourceData, meta interface{}) (*vpc.C
 	if v := d.Get("nexthop_id").(string); v != "" {
 		request.NextHopId = v
 	}
+	request.ClientToken = buildClientToken("TF-CreateRouteEntry")
 
-	return request, nil
+	return request
 }
 
 func buildAliyunRouteEntryDeleteArgs(d *schema.ResourceData, meta interface{}) (*vpc.DeleteRouteEntryRequest, error) {

--- a/alicloud/service_alicloud_vpn_gateway.go
+++ b/alicloud/service_alicloud_vpn_gateway.go
@@ -37,13 +37,13 @@ func (client *AliyunClient) DescribeCustomerGateway(cgwId string) (v vpc.Describ
 
 	resp, err := client.vpcconn.DescribeCustomerGateway(request)
 	if err != nil {
-		if IsExceptedError(err, VpnForbidden) || IsExceptedError(err, CgwNotFound) {
-			return v, GetNotFoundErrorFromString(GetNotFoundMessage("VPN customer gateway", cgwId))
+		if IsExceptedError(err, VpnForbidden) || IsExceptedError(err, VpnNotFound) {
+			return v, GetNotFoundErrorFromString(GetNotFoundMessage("VPN", cgwId))
 		}
 		return
 	}
 	if resp == nil || resp.CustomerGatewayId != cgwId {
-		return v, GetNotFoundErrorFromString(GetNotFoundMessage("VPN customer gateway", cgwId))
+		return v, GetNotFoundErrorFromString(GetNotFoundMessage("VPN", cgwId))
 	}
 	return *resp, nil
 }


### PR DESCRIPTION
The result of running test case as follows:

```
TF_ACC=1 go test ./alicloud -v -run=TestAccAlicloudV -timeout=240m
=== RUN   TestAccAlicloudVpcsDataSource_cidr_block
--- PASS: TestAccAlicloudVpcsDataSource_cidr_block (25.81s)
=== RUN   TestAccAlicloudVSwitchesDataSource
--- PASS: TestAccAlicloudVSwitchesDataSource (42.10s)
=== RUN   TestAccAlicloudVpc_importBasic
--- PASS: TestAccAlicloudVpc_importBasic (24.91s)
=== RUN   TestAccAlicloudVswitch_importBasic
--- PASS: TestAccAlicloudVswitch_importBasic (40.55s)
=== RUN   TestAccAlicloudVpc_basic
--- PASS: TestAccAlicloudVpc_basic (24.24s)
=== RUN   TestAccAlicloudVpc_update
--- PASS: TestAccAlicloudVpc_update (33.59s)
=== RUN   TestAccAlicloudVpc_multi
--- PASS: TestAccAlicloudVpc_multi (29.79s)
=== RUN   TestAccAlicloudVpnGateway_basic
--- PASS: TestAccAlicloudVpnGateway_basic (34.42s)
=== RUN   TestAccAlicloudVpnGateway_update
--- PASS: TestAccAlicloudVpnGateway_update (35.64s)
=== RUN   TestAccAlicloudVswitch_basic
--- PASS: TestAccAlicloudVswitch_basic (40.49s)
=== RUN   TestAccAlicloudVswitch_multi
--- PASS: TestAccAlicloudVswitch_multi (60.73s)
PASS
ok	github.com/alibaba/terraform-provider/alicloud	392.328s

$ TF_ACC=1 go test ./alicloud -v -run=TestAccAlicloudRouter -timeout=240m
=== RUN   TestAccAlicloudRouterInterfacesDataSource_oneRouter
--- PASS: TestAccAlicloudRouterInterfacesDataSource_oneRouter (36.45s)
=== RUN   TestAccAlicloudRouterInterfacesDataSource_twoRouters
--- PASS: TestAccAlicloudRouterInterfacesDataSource_twoRouters (90.37s)
=== RUN   TestAccAlicloudRouterInterface_import
--- PASS: TestAccAlicloudRouterInterface_import (35.10s)
=== RUN   TestAccAlicloudRouterInterfaceConnection_basic
--- PASS: TestAccAlicloudRouterInterfaceConnection_basic (78.63s)
=== RUN   TestAccAlicloudRouterInterface_basic
--- PASS: TestAccAlicloudRouterInterface_basic (35.77s)
PASS
ok  	github.com/alibaba/terraform-provider/alicloud	276.371s

$ TF_ACC=1 go test ./alicloud -v -run=TestAccAlicloudNatGateway_ -timeout=240m
=== RUN   TestAccAlicloudNatGateway_importSpec
--- PASS: TestAccAlicloudNatGateway_importSpec (46.43s)
=== RUN   TestAccAlicloudNatGateway_specification
--- PASS: TestAccAlicloudNatGateway_specification (59.25s)
PASS
ok  	github.com/alibaba/terraform-provider/alicloud	105.729s

$ TF_ACC=1 go test ./alicloud -v -run=TestAccAlicloudSlb -timeout=240m
=== RUN   TestAccAlicloudSlbAttachment_import
--- PASS: TestAccAlicloudSlbAttachment_import (192.32s)
=== RUN   TestAccAlicloudSlbListener_importHttp
--- PASS: TestAccAlicloudSlbListener_importHttp (29.01s)
=== RUN   TestAccAlicloudSlbListener_importTcp
--- PASS: TestAccAlicloudSlbListener_importTcp (28.03s)
=== RUN   TestAccAlicloudSlbListener_importUdp
--- PASS: TestAccAlicloudSlbListener_importUdp (29.51s)
=== RUN   TestAccAlicloudSlbRule_import
--- PASS: TestAccAlicloudSlbRule_import (192.22s)
=== RUN   TestAccAlicloudSlbServerGroup_import
--- PASS: TestAccAlicloudSlbServerGroup_import (189.37s)
=== RUN   TestAccAlicloudSlb_import
--- PASS: TestAccAlicloudSlb_import (55.63s)
=== RUN   TestAccAlicloudSlbAttachment_basic
--- PASS: TestAccAlicloudSlbAttachment_basic (196.17s)
=== RUN   TestAccAlicloudSlbListener_http
--- PASS: TestAccAlicloudSlbListener_http (28.40s)
=== RUN   TestAccAlicloudSlbListener_tcp
--- PASS: TestAccAlicloudSlbListener_tcp (25.97s)
=== RUN   TestAccAlicloudSlbListener_udp
--- PASS: TestAccAlicloudSlbListener_udp (28.42s)
=== RUN   TestAccAlicloudSlbRule_basic
--- PASS: TestAccAlicloudSlbRule_basic (191.80s)
=== RUN   TestAccAlicloudSlbRule_url
--- PASS: TestAccAlicloudSlbRule_url (195.54s)
=== RUN   TestAccAlicloudSlbServerGroup_vpc
--- PASS: TestAccAlicloudSlbServerGroup_vpc (187.75s)
=== RUN   TestAccAlicloudSlbServerGroup_empty
--- PASS: TestAccAlicloudSlbServerGroup_empty (40.10s)
=== RUN   TestAccAlicloudSlb_paybybandwidth
--- PASS: TestAccAlicloudSlb_paybybandwidth (8.36s)
=== RUN   TestAccAlicloudSlb_vpc
--- PASS: TestAccAlicloudSlb_vpc (56.05s)
=== RUN   TestAccAlicloudSlb_spec
--- PASS: TestAccAlicloudSlb_spec (30.08s)
PASS
ok  	github.com/alibaba/terraform-provider/alicloud	1704.767s

TF_ACC=1 go test ./alicloud -v -run=TestAccAlicloudInstance_ -timeout=240m
=== RUN   TestAccAlicloudInstance_import
--- PASS: TestAccAlicloudInstance_import (185.23s)
=== RUN   TestAccAlicloudInstance_basic
--- PASS: TestAccAlicloudInstance_basic (113.02s)
=== RUN   TestAccAlicloudInstance_vpc
--- PASS: TestAccAlicloudInstance_vpc (186.94s)
=== RUN   TestAccAlicloudInstance_userData
--- PASS: TestAccAlicloudInstance_userData (186.72s)
=== RUN   TestAccAlicloudInstance_multipleRegions
--- PASS: TestAccAlicloudInstance_multipleRegions (105.70s)
=== RUN   TestAccAlicloudInstance_multiSecurityGroup
--- PASS: TestAccAlicloudInstance_multiSecurityGroup (228.12s)
=== RUN   TestAccAlicloudInstance_multiSecurityGroupByCount
--- PASS: TestAccAlicloudInstance_multiSecurityGroupByCount (186.96s)
=== RUN   TestAccAlicloudInstance_NetworkInstanceSecurityGroups
--- PASS: TestAccAlicloudInstance_NetworkInstanceSecurityGroups (185.00s)
=== RUN   TestAccAlicloudInstance_tags
--- PASS: TestAccAlicloudInstance_tags (192.88s)
=== RUN   TestAccAlicloudInstance_update
--- PASS: TestAccAlicloudInstance_update (265.15s)
=== RUN   TestAccAlicloudInstance_associatePublicIP
--- PASS: TestAccAlicloudInstance_associatePublicIP (183.42s)
=== RUN   TestAccAlicloudInstance_spot
--- PASS: TestAccAlicloudInstance_spot (180.65s)
=== RUN   TestAccAlicloudInstance_ramrole
--- PASS: TestAccAlicloudInstance_ramrole (185.18s)
PASS
ok  	github.com/terraform-providers/terraform-provider-alicloud/alicloud	2385.045s
```