### PR TITLE
Fix DNS tests falied error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ IMPROVEMENTS:
 
 BUG FIXES:
 
+- Fix DNS tests falied error ([#318](https://github.com/terraform-providers/terraform-provider-alicloud/pull/318))
 - Fix DB database not found error ([#316](https://github.com/terraform-providers/terraform-provider-alicloud/pull/316))
 
 ## 1.14.0 (August 31, 2018)

--- a/alicloud/data_source_alicloud_dns_domains_test.go
+++ b/alicloud/data_source_alicloud_dns_domains_test.go
@@ -3,6 +3,9 @@ package alicloud
 import (
 	"testing"
 
+	"fmt"
+
+	"github.com/hashicorp/terraform/helper/acctest"
 	"github.com/hashicorp/terraform/helper/resource"
 )
 
@@ -14,7 +17,7 @@ func TestAccAlicloudDnsDomainsDataSource_ali_domain(t *testing.T) {
 		Providers: testAccProviders,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccCheckAlicloudDomainsDataSourceAliDomainConfig,
+				Config: testAccCheckAlicloudDomainsDataSourceAliDomainConfig(acctest.RandInt()),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAlicloudDataSourceID("data.alicloud_dns_domains.domain"),
 					resource.TestCheckResourceAttr("data.alicloud_dns_domains.domain", "domains.#", "1"),
@@ -33,7 +36,7 @@ func TestAccAlicloudDnsDomainsDataSource_name_regex(t *testing.T) {
 		Providers: testAccProviders,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccCheckAlicloudDomainsDataSourceNameRegexConfig,
+				Config: testAccCheckAlicloudDomainsDataSourceNameRegexConfig(acctest.RandInt()),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAlicloudDataSourceID("data.alicloud_dns_domains.domain"),
 					resource.TestCheckResourceAttr("data.alicloud_dns_domains.domain", "domains.#", "1"),
@@ -43,25 +46,29 @@ func TestAccAlicloudDnsDomainsDataSource_name_regex(t *testing.T) {
 	})
 }
 
-const testAccCheckAlicloudDomainsDataSourceAliDomainConfig = `
+func testAccCheckAlicloudDomainsDataSourceAliDomainConfig(randInt int) string {
+	return fmt.Sprintf(`
 resource "alicloud_dns_group" "group" {
-  name = "yufishgroup"
+  name = "testdnsalidomain%v"
 }
 
 resource "alicloud_dns" "dns" {
-  name = "yufish.com"
+  name = "testdnsalidomain%v.abc"
   group_id = "${alicloud_dns_group.group.id}"
 }
 
 data "alicloud_dns_domains" "domain" {
   ali_domain = "${alicloud_dns.dns.name == "" ? false : false}"
   group_name_regex = "${alicloud_dns_group.group.name}"
-}`
+}`, randInt%1000, randInt%1000)
+}
 
-const testAccCheckAlicloudDomainsDataSourceNameRegexConfig = `
+func testAccCheckAlicloudDomainsDataSourceNameRegexConfig(randInt int) string {
+	return fmt.Sprintf(`
 resource "alicloud_dns" "dns" {
-  name = "yufish.com"
+  name = "testdnsnameregex%v.abc"
 }
 data "alicloud_dns_domains" "domain" {
   domain_name_regex = "${alicloud_dns.dns.name}"
-}`
+}`, randInt%1000)
+}

--- a/alicloud/data_source_alicloud_dns_records_test.go
+++ b/alicloud/data_source_alicloud_dns_records_test.go
@@ -3,6 +3,9 @@ package alicloud
 import (
 	"testing"
 
+	"fmt"
+
+	"github.com/hashicorp/terraform/helper/acctest"
 	"github.com/hashicorp/terraform/helper/resource"
 )
 
@@ -14,7 +17,7 @@ func TestAccAlicloudDnsRecordsDataSource_host_record_regex(t *testing.T) {
 		Providers: testAccProviders,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccCheckAlicloudDnsRecordsDataSourceHostRecordRegexConfig,
+				Config: testAccCheckAlicloudDnsRecordsDataSourceHostRecordRegexConfig(acctest.RandInt()),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAlicloudDataSourceID("data.alicloud_dns_records.record"),
 					resource.TestCheckResourceAttr("data.alicloud_dns_records.record", "records.#", "1"),
@@ -34,7 +37,7 @@ func TestAccAlicloudDnsRecordsDataSource_type(t *testing.T) {
 		Providers: testAccProviders,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccCheckAlicloudDnsRecordsDataSourceTypeConfig,
+				Config: testAccCheckAlicloudDnsRecordsDataSourceTypeConfig(acctest.RandInt()),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAlicloudDataSourceID("data.alicloud_dns_records.record"),
 					resource.TestCheckResourceAttr("data.alicloud_dns_records.record", "records.0.type", "CNAME"),
@@ -52,7 +55,7 @@ func TestAccAlicloudDnsRecordsDataSource_value_regex(t *testing.T) {
 		Providers: testAccProviders,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccCheckAlicloudDnsRecordsDataSourceValueRegexConfig,
+				Config: testAccCheckAlicloudDnsRecordsDataSourceValueRegexConfig(acctest.RandInt()),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAlicloudDataSourceID("data.alicloud_dns_records.record"),
 					resource.TestCheckResourceAttr("data.alicloud_dns_records.record", "records.0.value", "mail.mxhichina.com"),
@@ -70,7 +73,7 @@ func TestAccAlicloudDnsRecordsDataSource_line(t *testing.T) {
 		Providers: testAccProviders,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccCheckAlicloudDnsRecordsDataSourceLineConfig,
+				Config: testAccCheckAlicloudDnsRecordsDataSourceLineConfig(acctest.RandInt()),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAlicloudDataSourceID("data.alicloud_dns_records.record"),
 					resource.TestCheckResourceAttr("data.alicloud_dns_records.record", "records.0.line", "default"),
@@ -88,7 +91,7 @@ func TestAccAlicloudDnsRecordsDataSource_status(t *testing.T) {
 		Providers: testAccProviders,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccCheckAlicloudDnsRecordsDataSourceStatusConfig,
+				Config: testAccCheckAlicloudDnsRecordsDataSourceStatusConfig(acctest.RandInt()),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAlicloudDataSourceID("data.alicloud_dns_records.record"),
 					resource.TestCheckResourceAttr("data.alicloud_dns_records.record", "records.0.status", "enable"),
@@ -106,7 +109,7 @@ func TestAccAlicloudDnsRecordsDataSource_is_locked(t *testing.T) {
 		Providers: testAccProviders,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccCheckAlicloudDnsRecordsDataSourceIsLockedConfig,
+				Config: testAccCheckAlicloudDnsRecordsDataSourceIsLockedConfig(acctest.RandInt()),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAlicloudDataSourceID("data.alicloud_dns_records.record"),
 					resource.TestCheckResourceAttr("data.alicloud_dns_records.record", "records.0.locked", "false"),
@@ -116,9 +119,10 @@ func TestAccAlicloudDnsRecordsDataSource_is_locked(t *testing.T) {
 	})
 }
 
-const testAccCheckAlicloudDnsRecordsDataSourceHostRecordRegexConfig = `
+func testAccCheckAlicloudDnsRecordsDataSourceHostRecordRegexConfig(randInt int) string {
+	return fmt.Sprintf(`
 resource "alicloud_dns" "dns" {
-  name = "yufish.com"
+  name = "testdnsrecordregex%v.abc"
 }
 
 resource "alicloud_dns_record" "record" {
@@ -132,11 +136,13 @@ resource "alicloud_dns_record" "record" {
 data "alicloud_dns_records" "record" {
   domain_name = "${alicloud_dns_record.record.name}"
   host_record_regex = "^ali"
-}`
+}`, randInt)
+}
 
-const testAccCheckAlicloudDnsRecordsDataSourceTypeConfig = `
+func testAccCheckAlicloudDnsRecordsDataSourceTypeConfig(randInt int) string {
+	return fmt.Sprintf(`
 resource "alicloud_dns" "dns" {
-  name = "yufish.com"
+  name = "testdnsrecordtype%v.abc"
 }
 
 resource "alicloud_dns_record" "record" {
@@ -150,11 +156,13 @@ resource "alicloud_dns_record" "record" {
 data "alicloud_dns_records" "record" {
   domain_name = "${alicloud_dns_record.record.name}"
   type = "CNAME"
-}`
+}`, randInt)
+}
 
-const testAccCheckAlicloudDnsRecordsDataSourceValueRegexConfig = `
+func testAccCheckAlicloudDnsRecordsDataSourceValueRegexConfig(randInt int) string {
+	return fmt.Sprintf(`
 resource "alicloud_dns" "dns" {
-  name = "yufish.com"
+  name = "testdnsrecordvalueregex%v.abc"
 }
 
 resource "alicloud_dns_record" "record" {
@@ -168,11 +176,13 @@ resource "alicloud_dns_record" "record" {
 data "alicloud_dns_records" "record" {
   domain_name = "${alicloud_dns_record.record.name}"
   value_regex = "^mail"
-}`
+}`, randInt)
+}
 
-const testAccCheckAlicloudDnsRecordsDataSourceStatusConfig = `
+func testAccCheckAlicloudDnsRecordsDataSourceStatusConfig(randInt int) string {
+	return fmt.Sprintf(`
 resource "alicloud_dns" "dns" {
-  name = "yufish.com"
+  name = "testdnsrecordstatus%v.abc"
 }
 
 resource "alicloud_dns_record" "record" {
@@ -186,11 +196,13 @@ resource "alicloud_dns_record" "record" {
 data "alicloud_dns_records" "record" {
   domain_name = "${alicloud_dns_record.record.name}"
   status = "enable"
-}`
+}`, randInt)
+}
 
-const testAccCheckAlicloudDnsRecordsDataSourceIsLockedConfig = `
+func testAccCheckAlicloudDnsRecordsDataSourceIsLockedConfig(randInt int) string {
+	return fmt.Sprintf(`
 resource "alicloud_dns" "dns" {
-  name = "yufish.com"
+  name = "testdnsrecordislocked%v.abc"
 }
 
 resource "alicloud_dns_record" "record" {
@@ -204,11 +216,13 @@ resource "alicloud_dns_record" "record" {
 data "alicloud_dns_records" "record" {
   domain_name = "${alicloud_dns_record.record.name}"
   is_locked = false
-}`
+}`, randInt)
+}
 
-const testAccCheckAlicloudDnsRecordsDataSourceLineConfig = `
+func testAccCheckAlicloudDnsRecordsDataSourceLineConfig(randInt int) string {
+	return fmt.Sprintf(`
 resource "alicloud_dns" "dns" {
-  name = "yufish.com"
+  name = "testdnsrecordline%v.abc"
 }
 
 resource "alicloud_dns_record" "record" {
@@ -222,4 +236,5 @@ resource "alicloud_dns_record" "record" {
 data "alicloud_dns_records" "record" {
   domain_name = "${alicloud_dns_record.record.name}"
   line = "default"
-}`
+}`, randInt)
+}

--- a/alicloud/import_alicloud_dns_record_test.go
+++ b/alicloud/import_alicloud_dns_record_test.go
@@ -3,6 +3,7 @@ package alicloud
 import (
 	"testing"
 
+	"github.com/hashicorp/terraform/helper/acctest"
 	"github.com/hashicorp/terraform/helper/resource"
 )
 
@@ -15,7 +16,7 @@ func TestAccAlicloudDnsDomainRecord_importBasic(t *testing.T) {
 		CheckDestroy: testAccCheckDnsRecordDestroy,
 		Steps: []resource.TestStep{
 			resource.TestStep{
-				Config: testAccDnsRecordConfig,
+				Config: testAccDnsRecordConfig(acctest.RandInt()),
 			},
 
 			resource.TestStep{

--- a/alicloud/import_alicloud_dns_test.go
+++ b/alicloud/import_alicloud_dns_test.go
@@ -3,6 +3,7 @@ package alicloud
 import (
 	"testing"
 
+	"github.com/hashicorp/terraform/helper/acctest"
 	"github.com/hashicorp/terraform/helper/resource"
 )
 
@@ -15,7 +16,7 @@ func TestAccAlicloudDnsDomain_importBasic(t *testing.T) {
 		CheckDestroy: testAccCheckDnsDestroy,
 		Steps: []resource.TestStep{
 			resource.TestStep{
-				Config: testAccDnsConfig,
+				Config: testAccDnsConfig(acctest.RandInt()),
 			},
 
 			resource.TestStep{

--- a/alicloud/resource_alicloud_dns_record_test.go
+++ b/alicloud/resource_alicloud_dns_record_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/denverdino/aliyungo/dns"
+	"github.com/hashicorp/terraform/helper/acctest"
 	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/terraform"
 )
@@ -25,7 +26,7 @@ func TestAccAlicloudDnsRecord_basic(t *testing.T) {
 		CheckDestroy: testAccCheckDnsRecordDestroy,
 		Steps: []resource.TestStep{
 			resource.TestStep{
-				Config: testAccDnsRecordConfig,
+				Config: testAccDnsRecordConfig(acctest.RandInt()),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckDnsRecordExists(
 						"alicloud_dns_record.record", &v),
@@ -84,7 +85,7 @@ func TestAccAlicloudDnsRecord_priority(t *testing.T) {
 		CheckDestroy: testAccCheckDnsRecordDestroy,
 		Steps: []resource.TestStep{
 			resource.TestStep{
-				Config: testAccDnsRecordPriority,
+				Config: testAccDnsRecordPriority(acctest.RandInt()),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckDnsRecordExists(
 						"alicloud_dns_record.record", &v),
@@ -126,9 +127,10 @@ func testAccCheckDnsRecordDestroy(s *terraform.State) error {
 	return nil
 }
 
-const testAccDnsRecordConfig = `
+func testAccDnsRecordConfig(randInt int) string {
+	return fmt.Sprintf(`
 resource "alicloud_dns" "dns" {
-  name = "yufish.com"
+  name = "testdnsrecordbasic%v.abc"
 }
 
 resource "alicloud_dns_record" "record" {
@@ -138,10 +140,13 @@ resource "alicloud_dns_record" "record" {
   value = "mail.mxhichin.com"
   count = 1
 }
-`
-const testAccDnsRecordPriority = `
+`, randInt)
+}
+
+func testAccDnsRecordPriority(randInt int) string {
+	return fmt.Sprintf(`
 resource "alicloud_dns" "dns" {
-  name = "yufish.com"
+  name = "testdnsrecordpriority%v.abc"
 }
 
 resource "alicloud_dns_record" "record" {
@@ -152,4 +157,5 @@ resource "alicloud_dns_record" "record" {
   count = 1
   priority = 10
 }
-`
+`, randInt)
+}

--- a/alicloud/resource_alicloud_dns_test.go
+++ b/alicloud/resource_alicloud_dns_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/denverdino/aliyungo/dns"
+	"github.com/hashicorp/terraform/helper/acctest"
 	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/terraform"
 )
@@ -13,6 +14,7 @@ import (
 func TestAccAlicloudDns_basic(t *testing.T) {
 	var v dns.DomainType
 
+	randInt := acctest.RandInt()
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			testAccPreCheck(t)
@@ -25,14 +27,14 @@ func TestAccAlicloudDns_basic(t *testing.T) {
 		CheckDestroy: testAccCheckDnsDestroy,
 		Steps: []resource.TestStep{
 			resource.TestStep{
-				Config: testAccDnsConfig,
+				Config: testAccDnsConfig(randInt),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckDnsExists(
 						"alicloud_dns.dns", &v),
 					resource.TestCheckResourceAttr(
 						"alicloud_dns.dns",
 						"name",
-						"yufish.com"),
+						fmt.Sprintf("testdnsbasic%v.abc", randInt)),
 				),
 			},
 		},
@@ -94,8 +96,10 @@ func testAccCheckDnsDestroy(s *terraform.State) error {
 	return nil
 }
 
-const testAccDnsConfig = `
+func testAccDnsConfig(randInt int) string {
+	return fmt.Sprintf(`
 resource "alicloud_dns" "dns" {
-  name = "yufish.com"
+  name = "testdnsbasic%v.abc"
 }
-`
+`, randInt)
+}


### PR DESCRIPTION
```
GOROOT=/usr/local/go #gosetup
GOPATH=/Users/marcplouhinec/go #gosetup
/usr/local/go/bin/go test -c -i -o /private/var/folders/v1/jvjz3zmn64q0j34yc9m9n4w00000gn/T/___non_verbose_tests github.com/alibaba/terraform-provider/alicloud #gosetup
/usr/local/go/bin/go tool test2json -t /private/var/folders/v1/jvjz3zmn64q0j34yc9m9n4w00000gn/T/___non_verbose_tests -test.v -test.run ^TestAccAlicloudDns #gosetup
=== RUN   TestAccAlicloudDnsDomainsDataSource_ali_domain
--- PASS: TestAccAlicloudDnsDomainsDataSource_ali_domain (22.49s)
=== RUN   TestAccAlicloudDnsDomainsDataSource_name_regex
--- PASS: TestAccAlicloudDnsDomainsDataSource_name_regex (16.18s)
=== RUN   TestAccAlicloudDnsGroupsDataSource_name_regex
--- PASS: TestAccAlicloudDnsGroupsDataSource_name_regex (10.85s)
=== RUN   TestAccAlicloudDnsRecordsDataSource_host_record_regex
--- PASS: TestAccAlicloudDnsRecordsDataSource_host_record_regex (19.89s)
=== RUN   TestAccAlicloudDnsRecordsDataSource_type
--- PASS: TestAccAlicloudDnsRecordsDataSource_type (19.53s)
=== RUN   TestAccAlicloudDnsRecordsDataSource_value_regex
--- PASS: TestAccAlicloudDnsRecordsDataSource_value_regex (18.95s)
=== RUN   TestAccAlicloudDnsRecordsDataSource_line
--- PASS: TestAccAlicloudDnsRecordsDataSource_line (18.95s)
=== RUN   TestAccAlicloudDnsRecordsDataSource_status
--- PASS: TestAccAlicloudDnsRecordsDataSource_status (20.27s)
=== RUN   TestAccAlicloudDnsRecordsDataSource_is_locked
--- PASS: TestAccAlicloudDnsRecordsDataSource_is_locked (19.35s)
=== RUN   TestAccAlicloudDnsDomainRecord_importBasic
--- PASS: TestAccAlicloudDnsDomainRecord_importBasic (17.93s)
=== RUN   TestAccAlicloudDnsDomain_importBasic
2018/09/05 16:43:51 DescribeDomainInfo error, Aliyun API Error: RequestId: 4B980197-1381-4A5D-9A73-3C16B6605EC1 Status Code: 400 Code: InvalidDomainName.NoExist Message: The specified domain name does not exist. Refresh the page and try again.
--- PASS: TestAccAlicloudDnsDomain_importBasic (14.05s)
=== RUN   TestAccAlicloudDnsGroup_basic
--- PASS: TestAccAlicloudDnsGroup_basic (11.43s)
=== RUN   TestAccAlicloudDnsRecord_basic
--- PASS: TestAccAlicloudDnsRecord_basic (16.50s)
=== RUN   TestAccAlicloudDnsRecord_priority
--- PASS: TestAccAlicloudDnsRecord_priority (16.89s)
=== RUN   TestAccAlicloudDns_basic
2018/09/05 16:44:48 DescribeDomainInfo error, Aliyun API Error: RequestId: 6E04C619-FC77-49D6-A8D4-457A058284F1 Status Code: 400 Code: InvalidDomainName.NoExist Message: The specified domain name does not exist. Refresh the page and try again.
--- PASS: TestAccAlicloudDns_basic (11.89s)
PASS
```