### PR TITLE
Improve fc test case using new datasource alicloud_account

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 FEATURES:
 
+- **New Data Source:** `alicloud_account`  ([#319](https://github.com/terraform-providers/terraform-provider-alicloud/pull/319))
 - **New Resource:** `alicloud_ssl_vpn_server` ([#313](https://github.com/terraform-providers/terraform-provider-alicloud/pull/313))
 
 IMPROVEMENTS:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ IMPROVEMENTS:
 
 BUG FIXES:
 
+- Fix DNS tests falied error ([#318](https://github.com/terraform-providers/terraform-provider-alicloud/pull/318))
 - Fix DB database not found error ([#316](https://github.com/terraform-providers/terraform-provider-alicloud/pull/316))
 
 ## 1.14.0 (August 31, 2018)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ FEATURES:
 
 IMPROVEMENTS:
 
+- Improve fc test case using new datasource `alicloud_account` ([#320](https://github.com/terraform-providers/terraform-provider-alicloud/pull/320))
 - Base64 encode ESS scaling config user_data ([#315](https://github.com/terraform-providers/terraform-provider-alicloud/pull/315))
 - Retrieve the account_id automatically if needed ([#314](https://github.com/terraform-providers/terraform-provider-alicloud/pull/314))
 

--- a/alicloud/data_source_alicloud_account.go
+++ b/alicloud/data_source_alicloud_account.go
@@ -1,0 +1,35 @@
+package alicloud
+
+import (
+	"log"
+
+	"github.com/hashicorp/terraform/helper/schema"
+)
+
+func dataSourceAlicloudAccount() *schema.Resource {
+	return &schema.Resource{
+		Read: dataSourceAlicloudAccountRead,
+
+		Schema: map[string]*schema.Schema{
+			// Computed values
+			"id": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func dataSourceAlicloudAccountRead(d *schema.ResourceData, meta interface{}) error {
+	accountId, err := meta.(*AliyunClient).AccountId()
+
+	if err != nil {
+		return err
+	}
+
+	log.Printf("[DEBUG] alicloud_account - account ID found: %#v", accountId)
+
+	d.SetId(accountId)
+
+	return nil
+}

--- a/alicloud/data_source_alicloud_account_test.go
+++ b/alicloud/data_source_alicloud_account_test.go
@@ -1,0 +1,30 @@
+package alicloud
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform/helper/resource"
+)
+
+func TestAccAlicloudAccountDataSource_basic(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+		},
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCheckAlicloudAccountDataSourceBasic,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAlicloudDataSourceID("data.alicloud_account.current"),
+					resource.TestCheckResourceAttrSet("data.alicloud_account.current", "id"),
+				),
+			},
+		},
+	})
+}
+
+const testAccCheckAlicloudAccountDataSourceBasic = `
+data "alicloud_account" "current" {
+}
+`

--- a/alicloud/data_source_alicloud_dns_domains_test.go
+++ b/alicloud/data_source_alicloud_dns_domains_test.go
@@ -3,6 +3,9 @@ package alicloud
 import (
 	"testing"
 
+	"fmt"
+
+	"github.com/hashicorp/terraform/helper/acctest"
 	"github.com/hashicorp/terraform/helper/resource"
 )
 
@@ -14,7 +17,7 @@ func TestAccAlicloudDnsDomainsDataSource_ali_domain(t *testing.T) {
 		Providers: testAccProviders,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccCheckAlicloudDomainsDataSourceAliDomainConfig,
+				Config: testAccCheckAlicloudDomainsDataSourceAliDomainConfig(acctest.RandInt()),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAlicloudDataSourceID("data.alicloud_dns_domains.domain"),
 					resource.TestCheckResourceAttr("data.alicloud_dns_domains.domain", "domains.#", "1"),
@@ -33,7 +36,7 @@ func TestAccAlicloudDnsDomainsDataSource_name_regex(t *testing.T) {
 		Providers: testAccProviders,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccCheckAlicloudDomainsDataSourceNameRegexConfig,
+				Config: testAccCheckAlicloudDomainsDataSourceNameRegexConfig(acctest.RandInt()),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAlicloudDataSourceID("data.alicloud_dns_domains.domain"),
 					resource.TestCheckResourceAttr("data.alicloud_dns_domains.domain", "domains.#", "1"),
@@ -43,25 +46,29 @@ func TestAccAlicloudDnsDomainsDataSource_name_regex(t *testing.T) {
 	})
 }
 
-const testAccCheckAlicloudDomainsDataSourceAliDomainConfig = `
+func testAccCheckAlicloudDomainsDataSourceAliDomainConfig(randInt int) string {
+	return fmt.Sprintf(`
 resource "alicloud_dns_group" "group" {
-  name = "yufishgroup"
+  name = "testdnsalidomain%v"
 }
 
 resource "alicloud_dns" "dns" {
-  name = "yufish.com"
+  name = "testdnsalidomain%v.abc"
   group_id = "${alicloud_dns_group.group.id}"
 }
 
 data "alicloud_dns_domains" "domain" {
   ali_domain = "${alicloud_dns.dns.name == "" ? false : false}"
   group_name_regex = "${alicloud_dns_group.group.name}"
-}`
+}`, randInt%1000, randInt%1000)
+}
 
-const testAccCheckAlicloudDomainsDataSourceNameRegexConfig = `
+func testAccCheckAlicloudDomainsDataSourceNameRegexConfig(randInt int) string {
+	return fmt.Sprintf(`
 resource "alicloud_dns" "dns" {
-  name = "yufish.com"
+  name = "testdnsnameregex%v.abc"
 }
 data "alicloud_dns_domains" "domain" {
   domain_name_regex = "${alicloud_dns.dns.name}"
-}`
+}`, randInt%1000)
+}

--- a/alicloud/data_source_alicloud_dns_records_test.go
+++ b/alicloud/data_source_alicloud_dns_records_test.go
@@ -3,6 +3,9 @@ package alicloud
 import (
 	"testing"
 
+	"fmt"
+
+	"github.com/hashicorp/terraform/helper/acctest"
 	"github.com/hashicorp/terraform/helper/resource"
 )
 
@@ -14,7 +17,7 @@ func TestAccAlicloudDnsRecordsDataSource_host_record_regex(t *testing.T) {
 		Providers: testAccProviders,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccCheckAlicloudDnsRecordsDataSourceHostRecordRegexConfig,
+				Config: testAccCheckAlicloudDnsRecordsDataSourceHostRecordRegexConfig(acctest.RandInt()),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAlicloudDataSourceID("data.alicloud_dns_records.record"),
 					resource.TestCheckResourceAttr("data.alicloud_dns_records.record", "records.#", "1"),
@@ -34,7 +37,7 @@ func TestAccAlicloudDnsRecordsDataSource_type(t *testing.T) {
 		Providers: testAccProviders,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccCheckAlicloudDnsRecordsDataSourceTypeConfig,
+				Config: testAccCheckAlicloudDnsRecordsDataSourceTypeConfig(acctest.RandInt()),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAlicloudDataSourceID("data.alicloud_dns_records.record"),
 					resource.TestCheckResourceAttr("data.alicloud_dns_records.record", "records.0.type", "CNAME"),
@@ -52,7 +55,7 @@ func TestAccAlicloudDnsRecordsDataSource_value_regex(t *testing.T) {
 		Providers: testAccProviders,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccCheckAlicloudDnsRecordsDataSourceValueRegexConfig,
+				Config: testAccCheckAlicloudDnsRecordsDataSourceValueRegexConfig(acctest.RandInt()),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAlicloudDataSourceID("data.alicloud_dns_records.record"),
 					resource.TestCheckResourceAttr("data.alicloud_dns_records.record", "records.0.value", "mail.mxhichina.com"),
@@ -70,7 +73,7 @@ func TestAccAlicloudDnsRecordsDataSource_line(t *testing.T) {
 		Providers: testAccProviders,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccCheckAlicloudDnsRecordsDataSourceLineConfig,
+				Config: testAccCheckAlicloudDnsRecordsDataSourceLineConfig(acctest.RandInt()),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAlicloudDataSourceID("data.alicloud_dns_records.record"),
 					resource.TestCheckResourceAttr("data.alicloud_dns_records.record", "records.0.line", "default"),
@@ -88,7 +91,7 @@ func TestAccAlicloudDnsRecordsDataSource_status(t *testing.T) {
 		Providers: testAccProviders,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccCheckAlicloudDnsRecordsDataSourceStatusConfig,
+				Config: testAccCheckAlicloudDnsRecordsDataSourceStatusConfig(acctest.RandInt()),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAlicloudDataSourceID("data.alicloud_dns_records.record"),
 					resource.TestCheckResourceAttr("data.alicloud_dns_records.record", "records.0.status", "enable"),
@@ -106,7 +109,7 @@ func TestAccAlicloudDnsRecordsDataSource_is_locked(t *testing.T) {
 		Providers: testAccProviders,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccCheckAlicloudDnsRecordsDataSourceIsLockedConfig,
+				Config: testAccCheckAlicloudDnsRecordsDataSourceIsLockedConfig(acctest.RandInt()),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAlicloudDataSourceID("data.alicloud_dns_records.record"),
 					resource.TestCheckResourceAttr("data.alicloud_dns_records.record", "records.0.locked", "false"),
@@ -116,9 +119,10 @@ func TestAccAlicloudDnsRecordsDataSource_is_locked(t *testing.T) {
 	})
 }
 
-const testAccCheckAlicloudDnsRecordsDataSourceHostRecordRegexConfig = `
+func testAccCheckAlicloudDnsRecordsDataSourceHostRecordRegexConfig(randInt int) string {
+	return fmt.Sprintf(`
 resource "alicloud_dns" "dns" {
-  name = "yufish.com"
+  name = "testdnsrecordregex%v.abc"
 }
 
 resource "alicloud_dns_record" "record" {
@@ -132,11 +136,13 @@ resource "alicloud_dns_record" "record" {
 data "alicloud_dns_records" "record" {
   domain_name = "${alicloud_dns_record.record.name}"
   host_record_regex = "^ali"
-}`
+}`, randInt)
+}
 
-const testAccCheckAlicloudDnsRecordsDataSourceTypeConfig = `
+func testAccCheckAlicloudDnsRecordsDataSourceTypeConfig(randInt int) string {
+	return fmt.Sprintf(`
 resource "alicloud_dns" "dns" {
-  name = "yufish.com"
+  name = "testdnsrecordtype%v.abc"
 }
 
 resource "alicloud_dns_record" "record" {
@@ -150,11 +156,13 @@ resource "alicloud_dns_record" "record" {
 data "alicloud_dns_records" "record" {
   domain_name = "${alicloud_dns_record.record.name}"
   type = "CNAME"
-}`
+}`, randInt)
+}
 
-const testAccCheckAlicloudDnsRecordsDataSourceValueRegexConfig = `
+func testAccCheckAlicloudDnsRecordsDataSourceValueRegexConfig(randInt int) string {
+	return fmt.Sprintf(`
 resource "alicloud_dns" "dns" {
-  name = "yufish.com"
+  name = "testdnsrecordvalueregex%v.abc"
 }
 
 resource "alicloud_dns_record" "record" {
@@ -168,11 +176,13 @@ resource "alicloud_dns_record" "record" {
 data "alicloud_dns_records" "record" {
   domain_name = "${alicloud_dns_record.record.name}"
   value_regex = "^mail"
-}`
+}`, randInt)
+}
 
-const testAccCheckAlicloudDnsRecordsDataSourceStatusConfig = `
+func testAccCheckAlicloudDnsRecordsDataSourceStatusConfig(randInt int) string {
+	return fmt.Sprintf(`
 resource "alicloud_dns" "dns" {
-  name = "yufish.com"
+  name = "testdnsrecordstatus%v.abc"
 }
 
 resource "alicloud_dns_record" "record" {
@@ -186,11 +196,13 @@ resource "alicloud_dns_record" "record" {
 data "alicloud_dns_records" "record" {
   domain_name = "${alicloud_dns_record.record.name}"
   status = "enable"
-}`
+}`, randInt)
+}
 
-const testAccCheckAlicloudDnsRecordsDataSourceIsLockedConfig = `
+func testAccCheckAlicloudDnsRecordsDataSourceIsLockedConfig(randInt int) string {
+	return fmt.Sprintf(`
 resource "alicloud_dns" "dns" {
-  name = "yufish.com"
+  name = "testdnsrecordislocked%v.abc"
 }
 
 resource "alicloud_dns_record" "record" {
@@ -204,11 +216,13 @@ resource "alicloud_dns_record" "record" {
 data "alicloud_dns_records" "record" {
   domain_name = "${alicloud_dns_record.record.name}"
   is_locked = false
-}`
+}`, randInt)
+}
 
-const testAccCheckAlicloudDnsRecordsDataSourceLineConfig = `
+func testAccCheckAlicloudDnsRecordsDataSourceLineConfig(randInt int) string {
+	return fmt.Sprintf(`
 resource "alicloud_dns" "dns" {
-  name = "yufish.com"
+  name = "testdnsrecordline%v.abc"
 }
 
 resource "alicloud_dns_record" "record" {
@@ -222,4 +236,5 @@ resource "alicloud_dns_record" "record" {
 data "alicloud_dns_records" "record" {
   domain_name = "${alicloud_dns_record.record.name}"
   line = "default"
-}`
+}`, randInt)
+}

--- a/alicloud/import_alicloud_dns_record_test.go
+++ b/alicloud/import_alicloud_dns_record_test.go
@@ -3,6 +3,7 @@ package alicloud
 import (
 	"testing"
 
+	"github.com/hashicorp/terraform/helper/acctest"
 	"github.com/hashicorp/terraform/helper/resource"
 )
 
@@ -15,7 +16,7 @@ func TestAccAlicloudDnsDomainRecord_importBasic(t *testing.T) {
 		CheckDestroy: testAccCheckDnsRecordDestroy,
 		Steps: []resource.TestStep{
 			resource.TestStep{
-				Config: testAccDnsRecordConfig,
+				Config: testAccDnsRecordConfig(acctest.RandInt()),
 			},
 
 			resource.TestStep{

--- a/alicloud/import_alicloud_dns_test.go
+++ b/alicloud/import_alicloud_dns_test.go
@@ -3,6 +3,7 @@ package alicloud
 import (
 	"testing"
 
+	"github.com/hashicorp/terraform/helper/acctest"
 	"github.com/hashicorp/terraform/helper/resource"
 )
 
@@ -15,7 +16,7 @@ func TestAccAlicloudDnsDomain_importBasic(t *testing.T) {
 		CheckDestroy: testAccCheckDnsDestroy,
 		Steps: []resource.TestStep{
 			resource.TestStep{
-				Config: testAccDnsConfig,
+				Config: testAccDnsConfig(acctest.RandInt()),
 			},
 
 			resource.TestStep{

--- a/alicloud/provider.go
+++ b/alicloud/provider.go
@@ -65,6 +65,7 @@ func Provider() terraform.ResourceProvider {
 		},
 		DataSourcesMap: map[string]*schema.Resource{
 
+			"alicloud_account":        dataSourceAlicloudAccount(),
 			"alicloud_images":         dataSourceAlicloudImages(),
 			"alicloud_regions":        dataSourceAlicloudRegions(),
 			"alicloud_zones":          dataSourceAlicloudZones(),

--- a/alicloud/resource_alicloud_dns_record_test.go
+++ b/alicloud/resource_alicloud_dns_record_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/denverdino/aliyungo/dns"
+	"github.com/hashicorp/terraform/helper/acctest"
 	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/terraform"
 )
@@ -25,7 +26,7 @@ func TestAccAlicloudDnsRecord_basic(t *testing.T) {
 		CheckDestroy: testAccCheckDnsRecordDestroy,
 		Steps: []resource.TestStep{
 			resource.TestStep{
-				Config: testAccDnsRecordConfig,
+				Config: testAccDnsRecordConfig(acctest.RandInt()),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckDnsRecordExists(
 						"alicloud_dns_record.record", &v),
@@ -84,7 +85,7 @@ func TestAccAlicloudDnsRecord_priority(t *testing.T) {
 		CheckDestroy: testAccCheckDnsRecordDestroy,
 		Steps: []resource.TestStep{
 			resource.TestStep{
-				Config: testAccDnsRecordPriority,
+				Config: testAccDnsRecordPriority(acctest.RandInt()),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckDnsRecordExists(
 						"alicloud_dns_record.record", &v),
@@ -126,9 +127,10 @@ func testAccCheckDnsRecordDestroy(s *terraform.State) error {
 	return nil
 }
 
-const testAccDnsRecordConfig = `
+func testAccDnsRecordConfig(randInt int) string {
+	return fmt.Sprintf(`
 resource "alicloud_dns" "dns" {
-  name = "yufish.com"
+  name = "testdnsrecordbasic%v.abc"
 }
 
 resource "alicloud_dns_record" "record" {
@@ -138,10 +140,13 @@ resource "alicloud_dns_record" "record" {
   value = "mail.mxhichin.com"
   count = 1
 }
-`
-const testAccDnsRecordPriority = `
+`, randInt)
+}
+
+func testAccDnsRecordPriority(randInt int) string {
+	return fmt.Sprintf(`
 resource "alicloud_dns" "dns" {
-  name = "yufish.com"
+  name = "testdnsrecordpriority%v.abc"
 }
 
 resource "alicloud_dns_record" "record" {
@@ -152,4 +157,5 @@ resource "alicloud_dns_record" "record" {
   count = 1
   priority = 10
 }
-`
+`, randInt)
+}

--- a/alicloud/resource_alicloud_dns_test.go
+++ b/alicloud/resource_alicloud_dns_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/denverdino/aliyungo/dns"
+	"github.com/hashicorp/terraform/helper/acctest"
 	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/terraform"
 )
@@ -13,6 +14,7 @@ import (
 func TestAccAlicloudDns_basic(t *testing.T) {
 	var v dns.DomainType
 
+	randInt := acctest.RandInt()
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			testAccPreCheck(t)
@@ -25,14 +27,14 @@ func TestAccAlicloudDns_basic(t *testing.T) {
 		CheckDestroy: testAccCheckDnsDestroy,
 		Steps: []resource.TestStep{
 			resource.TestStep{
-				Config: testAccDnsConfig,
+				Config: testAccDnsConfig(randInt),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckDnsExists(
 						"alicloud_dns.dns", &v),
 					resource.TestCheckResourceAttr(
 						"alicloud_dns.dns",
 						"name",
-						"yufish.com"),
+						fmt.Sprintf("testdnsbasic%v.abc", randInt)),
 				),
 			},
 		},
@@ -94,8 +96,10 @@ func testAccCheckDnsDestroy(s *terraform.State) error {
 	return nil
 }
 
-const testAccDnsConfig = `
+func testAccDnsConfig(randInt int) string {
+	return fmt.Sprintf(`
 resource "alicloud_dns" "dns" {
-  name = "yufish.com"
+  name = "testdnsbasic%v.abc"
 }
-`
+`, randInt)
+}

--- a/alicloud/resource_alicloud_fc_trigger_test.go
+++ b/alicloud/resource_alicloud_fc_trigger_test.go
@@ -105,18 +105,14 @@ func testAccCheckAlicloudFCTriggerDestroy(s *terraform.State) error {
 
 func testAlicloudFCTriggerLog(trigger, role, policy string) string {
 	return fmt.Sprintf(`
-provider "alicloud" {
-  account_id = "${var.account}"
-  region = "${var.region}"
-}
-variable "region" {
-  default = "cn-hangzhou"
-}
-variable "account" {
-  default = "1204663572767468"
-}
 variable "name" {
   default = "test-alicloud-fc-trigger"
+}
+
+data "alicloud_regions" "current_region" {
+  current = true
+}
+data "alicloud_account" "current" {
 }
 
 resource "alicloud_log_project" "foo" {
@@ -171,7 +167,7 @@ resource "alicloud_fc_trigger" "foo" {
   function = "${alicloud_fc_function.foo.name}"
   name = "${var.name}"
   role = "${alicloud_ram_role.foo.arn}"
-  source_arn = "acs:log:${var.region}:${var.account}:project/${alicloud_log_project.foo.name}"
+  source_arn = "acs:log:${data.alicloud_regions.current_region.regions.0.id}:${data.alicloud_account.current.id}:project/${alicloud_log_project.foo.name}"
   type = "log"
   config = <<EOF
   %s
@@ -206,18 +202,14 @@ resource "alicloud_ram_role_policy_attachment" "foo" {
 
 func testAlicloudFCTriggerLogUpdate(trigger, role, policy string) string {
 	return fmt.Sprintf(`
-provider "alicloud" {
-  account_id = "${var.account}"
-  region = "${var.region}"
-}
-variable "region" {
-  default = "cn-hangzhou"
-}
-variable "account" {
-  default = "1204663572767468"
-}
 variable "name" {
   default = "test-alicloud-fc-trigger"
+}
+
+data "alicloud_regions" "current_region" {
+  current = true
+}
+data "alicloud_account" "current" {
 }
 
 resource "alicloud_log_project" "foo" {
@@ -272,7 +264,7 @@ resource "alicloud_fc_trigger" "foo" {
   function = "${alicloud_fc_function.foo.name}"
   name = "${var.name}"
   role = "${alicloud_ram_role.foo.arn}"
-  source_arn = "acs:log:${var.region}:${var.account}:project/${alicloud_log_project.foo.name}"
+  source_arn = "acs:log:${data.alicloud_regions.current_region.regions.0.id}:${data.alicloud_account.current.id}:project/${alicloud_log_project.foo.name}"
   type = "log"
   config = <<EOF
   %s

--- a/website/alicloud.erb
+++ b/website/alicloud.erb
@@ -13,6 +13,9 @@
                  <li<%= sidebar_current("docs-alicloud-datasource") %>>
                     <a href="#">Data Sources</a>
                     <ul class="nav nav-visible">
+                        <li<%= sidebar_current("docs-alicloud-datasource-account") %>>
+                            <a href="/docs/providers/alicloud/d/account.html">alicloud_account</a>
+                        </li>
                         <li<%= sidebar_current("docs-alicloud-datasource-regions") %>>
                             <a href="/docs/providers/alicloud/d/regions.html">alicloud_regions</a>
                         </li>

--- a/website/docs/d/account.html.markdown
+++ b/website/docs/d/account.html.markdown
@@ -1,0 +1,28 @@
+---
+layout: "alicloud"
+page_title: "Alicloud: alicloud_account"
+sidebar_current: "docs-alicloud-datasource-account"
+description: |-
+    Provides information about the current Alibaba Cloud account.
+---
+
+# alicloud\_account
+
+This data source provides information about the current account.
+
+## Example Usage
+
+```
+data "alicloud_account" "current"{
+}
+
+output "current_account_id" {
+  value = "${data.alicloud_account.current.id}"
+}
+```
+
+## Attributes Reference
+
+The following attributes are exported:
+
+* `id` - Account ID (e.g. "1239306421830812"). It can be used to construct an ARN.


### PR DESCRIPTION
Test results
```
GOROOT=/usr/local/go #gosetup
GOPATH=/Users/marcplouhinec/go #gosetup
/usr/local/go/bin/go test -c -i -o /private/var/folders/v1/jvjz3zmn64q0j34yc9m9n4w00000gn/T/___non_verbose_tests github.com/alibaba/terraform-provider/alicloud #gosetup
/usr/local/go/bin/go tool test2json -t /private/var/folders/v1/jvjz3zmn64q0j34yc9m9n4w00000gn/T/___non_verbose_tests -test.v -test.run ^TestAccAlicloudFCTrigger_log$ #gosetup
=== RUN   TestAccAlicloudFCTrigger_log
--- PASS: TestAccAlicloudFCTrigger_log (95.69s)
PASS
```