### PR TITLE
add resource CEN Child Instance Attachment

### DIFF
--- a/alicloud/errors.go
+++ b/alicloud/errors.go
@@ -207,6 +207,9 @@ const (
 	OperationBlocking              = "Operation.Blocking"
 	ParameterCenInstanceIdNotExist = "ParameterCenInstanceId"
 	CenQuotaExceeded               = "QuotaExceeded.CenCountExceeded"
+	InvalidCenInstanceStatus       = "InvalidOperation.CenInstanceStatus"
+	InvalidChildInstanceStatus     = "InvalidOperation.ChildInstanceStatus"
+	ParameterInstanceIdNotExist    = "ParameterInstanceId"
 	// kv-store
 	InvalidKVStoreInstanceIdNotFound = "InvalidInstanceId.NotFound"
 )

--- a/alicloud/import_alicloud_cen_instance_attachment_test.go
+++ b/alicloud/import_alicloud_cen_instance_attachment_test.go
@@ -1,0 +1,28 @@
+package alicloud
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform/helper/resource"
+)
+
+func TestAccAlicloudCenInstanceAttachment_importBasic(t *testing.T) {
+	resourceName := "alicloud_cen_instance_attachment.foo"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckCenInstanceAttachmentDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccCenInstanceAttachmentBasic,
+			},
+
+			resource.TestStep{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}

--- a/alicloud/provider.go
+++ b/alicloud/provider.go
@@ -186,6 +186,7 @@ func Provider() terraform.ResourceProvider {
 			"alicloud_ssl_vpn_server":              resourceAliyunSslVpnServer(),
 			"alicloud_ssl_vpn_client_cert":         resourceAliyunSslVpnClientCert(),
 			"alicloud_cen_instance":                resourceAlicloudCenInstance(),
+			"alicloud_cen_instance_attachment":     resourceAlicloudCenInstanceAttachment(),
 			"alicloud_kvstore_instance":            resourceAlicloudKVStoreInstance(),
 			"alicloud_kvstore_backup_policy":       resourceAlicloudKVStoreBackupPolicy(),
 		},

--- a/alicloud/resource_alicloud_cen_instance_attachment.go
+++ b/alicloud/resource_alicloud_cen_instance_attachment.go
@@ -1,0 +1,164 @@
+package alicloud
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/aliyun/alibaba-cloud-sdk-go/services/cbn"
+	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/helper/schema"
+)
+
+func resourceAlicloudCenInstanceAttachment() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceAlicloudCenInstanceAttachmentCreate,
+		Read:   resourceAlicloudCenInstanceAttachmentRead,
+		Delete: resourceAlicloudCenInstanceAttachmentDelete,
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
+
+		Schema: map[string]*schema.Schema{
+			"instance_id": &schema.Schema{
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"child_instance_id": &schema.Schema{
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"child_instance_region_id": &schema.Schema{
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+		},
+	}
+}
+
+func resourceAlicloudCenInstanceAttachmentCreate(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*AliyunClient)
+	cenId := d.Get("instance_id").(string)
+	instanceId := d.Get("child_instance_id").(string)
+	instanceRegionId := d.Get("child_instance_region_id").(string)
+	instanceType, err := getCenInstanceType(instanceId)
+	if err != nil {
+		return err
+	}
+
+	request := cbn.CreateAttachCenChildInstanceRequest()
+	request.CenId = cenId
+	request.ChildInstanceId = instanceId
+	request.ChildInstanceType = instanceType
+	request.ChildInstanceRegionId = instanceRegionId
+
+	err = resource.Retry(5*time.Minute, func() *resource.RetryError {
+		_, err := client.cenconn.AttachCenChildInstance(request)
+		if err != nil {
+			if IsExceptedErrors(err, []string{InvalidCenInstanceStatus, InvalidChildInstanceStatus}) {
+				return resource.RetryableError(fmt.Errorf("Attach CEN child instance timeout and got an error: %#v", err))
+			}
+			return resource.NonRetryableError(err)
+		}
+		return nil
+	})
+	if err != nil {
+		return fmt.Errorf("Attach child instance %s to CEN %s and got an error: %#v.", instanceId, cenId, err)
+	}
+
+	waitTime := DefaultCenTimeout
+	if instanceType == "VBR" {
+		waitTime = DefaultCenTimeoutLong
+	}
+	if err := client.WaitForCenChildInstanceAttached(instanceId, cenId, Status("Attached"), waitTime); err != nil {
+		return fmt.Errorf("Timeout when WaitForCenChildInstanceAttached, CEN ID %s, child instance ID %s, error info %#v.", cenId, instanceId, err)
+	}
+
+	d.SetId(cenId + ":" + instanceId)
+
+	return resourceAlicloudCenInstanceAttachmentRead(d, meta)
+}
+
+func resourceAlicloudCenInstanceAttachmentRead(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*AliyunClient)
+	cenId, instanceId, err := getCenIdAndAnotherId(d.Id())
+	if err != nil {
+		return err
+	}
+
+	resp, err := client.DescribeCenAttachedChildInstanceById(instanceId, cenId)
+	if err != nil {
+		if NotFoundError(err) {
+			d.SetId("")
+			return nil
+		}
+		return err
+	}
+
+	d.Set("instance_id", resp.CenId)
+	d.Set("child_instance_id", resp.ChildInstanceId)
+	d.Set("child_instance_region_id", resp.ChildInstanceRegionId)
+
+	return nil
+}
+
+func resourceAlicloudCenInstanceAttachmentDelete(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*AliyunClient)
+	instanceRegionId := d.Get("child_instance_region_id").(string)
+	cenId, instanceId, err := getCenIdAndAnotherId(d.Id())
+	if err != nil {
+		return err
+	}
+	instanceType, err := getCenInstanceType(instanceId)
+	if err != nil {
+		return err
+	}
+
+	request := cbn.CreateDetachCenChildInstanceRequest()
+	request.CenId = cenId
+	request.ChildInstanceId = instanceId
+	request.ChildInstanceType = instanceType
+	request.ChildInstanceRegionId = instanceRegionId
+
+	err = resource.Retry(5*time.Minute, func() *resource.RetryError {
+
+		_, err = client.cenconn.DetachCenChildInstance(request)
+		if err != nil {
+			if IsExceptedError(err, ParameterInstanceIdNotExist) {
+				return nil
+			}
+			if IsExceptedError(err, InvalidCenInstanceStatus) {
+				return resource.RetryableError(fmt.Errorf("Detach CEN child instance timeout and got an error: %#v", err))
+			}
+
+			return resource.NonRetryableError(err)
+		}
+
+		_, err := client.DescribeCenAttachedChildInstanceById(instanceId, cenId)
+		if err != nil {
+			if NotFoundError(err) {
+				return nil
+			}
+			return resource.NonRetryableError(err)
+		}
+
+		return nil
+	})
+
+	if err != nil {
+		return fmt.Errorf("Detach child instance %s from CEN %s got an error: %#v.", instanceId, cenId, err)
+	}
+
+	waitTime := DefaultCenTimeout
+	if instanceType == "VBR" {
+		waitTime = DefaultCenTimeoutLong
+	}
+
+	if err := client.WaitForCenChildInstanceDetached(instanceId, cenId, waitTime); err != nil {
+		return fmt.Errorf("Timeout when WaitForCenChildInstanceDetached, CEN ID %s, child instance ID %s, error info: %#v", cenId, instanceId, err)
+	}
+
+	return nil
+}

--- a/alicloud/resource_alicloud_cen_instance_attachment_test.go
+++ b/alicloud/resource_alicloud_cen_instance_attachment_test.go
@@ -1,0 +1,254 @@
+package alicloud
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/aliyun/alibaba-cloud-sdk-go/services/cbn"
+	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/terraform"
+)
+
+func TestAccAlicloudCenInstanceAttachment_basic(t *testing.T) {
+	var instance cbn.ChildInstance
+
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+		},
+
+		// module name
+		IDRefreshName: "alicloud_cen_instance_attachment.foo",
+		Providers:     testAccProviders,
+		CheckDestroy:  testAccCheckCenInstanceAttachmentDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccCenInstanceAttachmentBasic,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckCenInstanceAttachmentExists("alicloud_cen_instance_attachment.foo", &instance),
+					resource.TestCheckResourceAttr("alicloud_cen_instance_attachment.foo", "child_instance_region_id", "cn-hangzhou"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAlicloudCenInstanceAttachment_multi_same_regions(t *testing.T) {
+	var instance cbn.ChildInstance
+
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+		},
+
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckCenInstanceAttachmentDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccCenInstanceAttachmentMultiSameRegions,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckCenInstanceAttachmentExists("alicloud_cen_instance_attachment.bar1", &instance),
+					resource.TestCheckResourceAttr("alicloud_cen_instance_attachment.bar1", "child_instance_region_id", "cn-beijing"),
+					testAccCheckCenInstanceAttachmentExists("alicloud_cen_instance_attachment.bar2", &instance),
+					resource.TestCheckResourceAttr("alicloud_cen_instance_attachment.bar2", "child_instance_region_id", "cn-beijing"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAlicloudCenInstanceAttachment_multi_different_regions(t *testing.T) {
+	var instance cbn.ChildInstance
+
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+		},
+
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckCenInstanceAttachmentDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccCenInstanceAttachmentMultiDifferentRegions,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckCenInstanceAttachmentExists("alicloud_cen_instance_attachment.bar1", &instance),
+					resource.TestCheckResourceAttr("alicloud_cen_instance_attachment.bar1", "child_instance_region_id", "eu-central-1"),
+					testAccCheckCenInstanceAttachmentExists("alicloud_cen_instance_attachment.bar2", &instance),
+					resource.TestCheckResourceAttr("alicloud_cen_instance_attachment.bar2", "child_instance_region_id", "cn-shanghai"),
+				),
+			},
+		},
+	})
+}
+
+func testAccCheckCenInstanceAttachmentExists(n string, instance *cbn.ChildInstance) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[n]
+		if !ok {
+			return fmt.Errorf("Not found: %s", n)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("No Cen Child Instance ID is set")
+		}
+
+		client := testAccProvider.Meta().(*AliyunClient)
+
+		cenId, instanceId, err := getCenIdAndAnotherId(rs.Primary.ID)
+		if err != nil {
+			return err
+		}
+
+		childInstance, err := client.DescribeCenAttachedChildInstanceById(instanceId, cenId)
+		if err != nil {
+			return err
+		}
+
+		if childInstance.Status != "Attached" {
+			return fmt.Errorf("CEN id %s instance id %s status error", cenId, instanceId)
+		}
+
+		*instance = childInstance
+		return nil
+	}
+}
+
+func testAccCheckCenInstanceAttachmentDestroy(s *terraform.State) error {
+	client := testAccProvider.Meta().(*AliyunClient)
+
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "alicloud_instance_attachment" {
+			continue
+		}
+
+		cenId, instanceId, err := getCenIdAndAnotherId(rs.Primary.ID)
+		if err != nil {
+			return err
+		}
+
+		instance, err := client.DescribeCenAttachedChildInstanceById(instanceId, cenId)
+		if err != nil {
+			if NotFoundError(err) {
+				continue
+			}
+			return err
+		} else {
+			return fmt.Errorf("CEN %s child instance %s still attach", instance.CenId, instance.ChildInstanceId)
+		}
+	}
+
+	return nil
+}
+
+const testAccCenInstanceAttachmentBasic = `
+provider "alicloud" {
+    alias = "hz"
+    region = "cn-hangzhou"
+}
+
+variable "name"{
+    default = "tf-testAccCenInstanceAttachmentBasic"
+}
+
+resource "alicloud_cen_instance" "cen" {
+    name = "${var.name}"
+    description = "tf-testAccCenInstanceAttachmentBasicDescription"
+}
+
+resource "alicloud_vpc" "vpc" {
+    provider = "alicloud.hz"
+    name = "${var.name}"
+    cidr_block = "192.168.0.0/16"
+}
+
+resource "alicloud_cen_instance_attachment" "foo" {
+    instance_id = "${alicloud_cen_instance.cen.id}"
+    child_instance_id = "${alicloud_vpc.vpc.id}"
+    child_instance_region_id = "cn-hangzhou"
+}
+`
+
+const testAccCenInstanceAttachmentMultiSameRegions = `
+provider "alicloud" {
+    alias = "bj"
+    region = "cn-beijing"
+}
+
+variable "name"{
+    default = "tf-testAccCenInstanceAttachmentMultiSameRegions"
+}
+
+resource "alicloud_cen_instance" "cen" {
+    name = "${var.name}"
+    description = "tf-testAccCenInstanceAttachmentMultiSameRegionsDescription"
+}
+
+resource "alicloud_vpc" "vpc1" {
+    provider = "alicloud.bj"
+    name = "${var.name}"
+    cidr_block = "192.168.0.0/16"
+}
+
+resource "alicloud_vpc" "vpc2" {
+    provider = "alicloud.bj"
+    name = "${var.name}"
+    cidr_block = "172.16.0.0/12"
+}
+
+resource "alicloud_cen_instance_attachment" "bar1" {
+    instance_id = "${alicloud_cen_instance.cen.id}"
+    child_instance_id = "${alicloud_vpc.vpc1.id}"
+    child_instance_region_id = "cn-beijing"
+}
+
+resource "alicloud_cen_instance_attachment" "bar2" {
+    instance_id = "${alicloud_cen_instance.cen.id}"
+    child_instance_id = "${alicloud_vpc.vpc2.id}"
+    child_instance_region_id = "cn-beijing"
+}
+`
+
+const testAccCenInstanceAttachmentMultiDifferentRegions = `
+variable "name"{
+    default = "tf-testAccCenInstanceAttachmentMultiDifferentRegions"
+}
+
+provider "alicloud" {
+    alias = "fra"
+    region = "eu-central-1"
+}
+
+provider "alicloud" {
+    alias = "sh"
+    region = "cn-shanghai"
+}
+
+resource "alicloud_vpc" "vpc1" {
+    provider = "alicloud.fra"
+    name = "${var.name}"
+    cidr_block = "192.168.0.0/16"
+}
+
+resource "alicloud_vpc" "vpc2" {
+    provider = "alicloud.sh"
+    name = "${var.name}"
+    cidr_block = "172.16.0.0/12"
+}
+
+resource "alicloud_cen_instance" "cen" {
+    name = "${var.name}"
+    description = "tf-testAccCenInstanceAttachmentMultiDifferentRegionsDescription"
+}
+
+resource "alicloud_cen_instance_attachment" "bar1" {
+    instance_id = "${alicloud_cen_instance.cen.id}"
+    child_instance_id = "${alicloud_vpc.vpc1.id}"
+    child_instance_region_id = "eu-central-1"
+}
+
+resource "alicloud_cen_instance_attachment" "bar2" {
+    instance_id = "${alicloud_cen_instance.cen.id}"
+    child_instance_id = "${alicloud_vpc.vpc2.id}"
+    child_instance_region_id = "cn-shanghai"
+}
+`

--- a/alicloud/service_alicloud_cen.go
+++ b/alicloud/service_alicloud_cen.go
@@ -1,10 +1,16 @@
 package alicloud
 
 import (
+	"fmt"
+	"strings"
 	"time"
 
+	"github.com/aliyun/alibaba-cloud-sdk-go/sdk/requests"
 	"github.com/aliyun/alibaba-cloud-sdk-go/services/cbn"
 )
+
+const DefaultCenTimeout = 60
+const DefaultCenTimeoutLong = 180
 
 func (client *AliyunClient) DescribeCenInstance(cenId string) (c cbn.Cen, err error) {
 	request := cbn.CreateDescribeCensRequest()
@@ -57,4 +63,95 @@ func (client *AliyunClient) WaitForCenInstance(cenId string, status Status, time
 	}
 
 	return nil
+}
+
+func (client *AliyunClient) DescribeCenAttachedChildInstanceById(instanceId, cenId string) (c cbn.ChildInstance, err error) {
+	request := cbn.CreateDescribeCenAttachedChildInstancesRequest()
+	request.CenId = cenId
+
+	for pageNum := 1; ; pageNum++ {
+		request.PageNumber = requests.NewInteger(pageNum)
+		response, err := client.cenconn.DescribeCenAttachedChildInstances(request)
+		if err != nil {
+			return c, err
+		}
+
+		instanceList := response.ChildInstances.ChildInstance
+		for instanceNum := 0; instanceNum <= len(instanceList)-1; instanceNum++ {
+			if instanceList[instanceNum].ChildInstanceId == instanceId {
+				return instanceList[instanceNum], nil
+			}
+		}
+
+		if pageNum*response.PageSize >= response.TotalCount {
+			return c, GetNotFoundErrorFromString(GetNotFoundMessage("CEN Child Instance", instanceId))
+		}
+	}
+}
+
+func (client *AliyunClient) WaitForCenChildInstanceAttached(instanceId string, cenId string, status Status, timeout int) error {
+	if timeout <= 0 {
+		timeout = DefaultTimeout
+	}
+
+	for {
+		instance, err := client.DescribeCenAttachedChildInstanceById(instanceId, cenId)
+		if err != nil {
+			return err
+		}
+		if instance.Status == string(status) {
+			break
+		}
+		timeout = timeout - DefaultIntervalShort
+		if timeout <= 0 {
+			return GetTimeErrorFromString(GetTimeoutMessage("CEN Child Instance Attachment", string(status)))
+		}
+		time.Sleep(DefaultIntervalShort * time.Second)
+	}
+
+	return nil
+}
+
+func (client *AliyunClient) WaitForCenChildInstanceDetached(instanceId string, cenId string, timeout int) error {
+	if timeout <= 0 {
+		timeout = DefaultTimeout
+	}
+
+	for {
+		_, err := client.DescribeCenAttachedChildInstanceById(instanceId, cenId)
+		if err != nil {
+			if NotFoundError(err) {
+				break
+			} else {
+				return err
+			}
+		}
+
+		timeout = timeout - DefaultIntervalShort
+		if timeout <= 0 {
+			return GetTimeErrorFromString(fmt.Sprintf("Waitting for %s detach timeout.", instanceId))
+		}
+		time.Sleep(DefaultIntervalShort * time.Second)
+	}
+
+	return nil
+}
+
+func getCenIdAndAnotherId(id string) (string, string, error) {
+	parts := strings.Split(id, ":")
+
+	if len(parts) != 2 {
+		return "", "", fmt.Errorf("invalid resource id")
+	}
+	return parts[0], parts[1], nil
+}
+
+func getCenInstanceType(id string) (c string, e error) {
+	if strings.HasPrefix(id, "vpc") {
+		return "VPC", nil
+	} else if strings.HasPrefix(id, "vbr") {
+		return "VBR", nil
+	} else {
+		return c, fmt.Errorf("CEN child instance ID invalid. Now, it only supports VPC or VBR instance.")
+	}
 }

--- a/website/alicloud.erb
+++ b/website/alicloud.erb
@@ -232,6 +232,9 @@
                         <li<%= sidebar_current("docs-alicloud-resource-cen-instance") %>>
                             <a href="/docs/providers/alicloud/r/cen_instance.html">alicloud_cen_instance</a>
                         </li>
+                        <li<%= sidebar_current("docs-alicloud-cen-instance-attachment") %>>
+                            <a href="/docs/providers/alicloud/r/cen_instance_attachment.html">alicloud_cen_instance_attachment</a>
+                        </li>
                     </ul>
                 </li>
 

--- a/website/docs/r/cen_instance_attachment.html.markdown
+++ b/website/docs/r/cen_instance_attachment.html.markdown
@@ -1,0 +1,61 @@
+---
+layout: "alicloud"
+page_title: "Alicloud: alicloud_cen_instance_attachment"
+sidebar_current: "docs-alicloud-cen-instance-attachment"
+description: |-
+  Provides a Alicloud CEN child instance attachment resource.
+---
+
+# alicloud\_cen_instance_attachment
+
+Provides a CEN child instance attachment resource.
+
+## Example Usage
+
+Basic Usage
+
+```
+# Create a new instance-attachment and use it to attach one child instance to a new CEN
+variable "name"{
+	default = "tf-testAccCenInstanceAttachmentBasic"
+}
+
+resource "alicloud_cen_instance" "cen" {
+	name = "${var.name}"
+	description = "terraform01"
+}
+
+resource "alicloud_vpc" "vpc" {
+	name = "${var.name}"
+	cidr_block = "192.168.0.0/16"
+}
+
+resource "alicloud_cen_instance_attachment" "foo" {
+    instance_id = "${alicloud_cen_instance.cen.id}"
+	child_instance_id = "${alicloud_vpc.vpc.id}"
+	child_instance_region_id = "cn-beijing"
+}
+```
+## Argument Reference
+
+The following arguments are supported:
+
+* `instance_id` - (Required) The ID of the CEN.
+* `child_instance_id` - (Required) The ID of the child instance to attach.
+* `child_instance_region_id` - (Required) The region ID of the child instance to attach.
+
+~>**NOTE:** Ensure that the child instance is not used in Express Connect.
+
+## Attributes Reference
+
+The following attributes are exported:
+
+- `id` - ID of the resource, formatted as `<instance_id>:<child_instance_id>`.
+
+## Import
+
+CEN instance can be imported using the id, e.g.
+
+```
+$ terraform import alicloud_cen_instance.example cen-abc123456:vpc-abc123456
+```


### PR DESCRIPTION
support the attachment of VPC and VBR.
$TF_ACC=1 go test ./alicloud -v -run=TestAccAlicloudCenChildInstanceAttachment -timeout=300m
=== RUN   TestAccAlicloudCenChildInstanceAttachment_basic
--- PASS: TestAccAlicloudCenChildInstanceAttachment_basic (28.39s)
=== RUN   TestAccAlicloudCenChildInstanceAttachment_multi
--- PASS: TestAccAlicloudCenChildInstanceAttachment_multi (33.58s)
PASS
ok  	github.com/terraform-providers/terraform-provider-alicloud/alicloud	62.034s