### PR TITLE
Add resource CEN bandwidth package

### DIFF
--- a/alicloud/errors.go
+++ b/alicloud/errors.go
@@ -204,12 +204,15 @@ const (
 	VpnInvalidSpec           = "InvalidSpec.NotFound"
 	VpnEnable                = "enable"
 	// CEN
-	OperationBlocking              = "Operation.Blocking"
-	ParameterCenInstanceIdNotExist = "ParameterCenInstanceId"
-	CenQuotaExceeded               = "QuotaExceeded.CenCountExceeded"
-	InvalidCenInstanceStatus       = "InvalidOperation.CenInstanceStatus"
-	InvalidChildInstanceStatus     = "InvalidOperation.ChildInstanceStatus"
-	ParameterInstanceIdNotExist    = "ParameterInstanceId"
+	OperationBlocking                = "Operation.Blocking"
+	ParameterCenInstanceIdNotExist   = "ParameterCenInstanceId"
+	CenQuotaExceeded                 = "QuotaExceeded.CenCountExceeded"
+	InvalidCenInstanceStatus         = "InvalidOperation.CenInstanceStatus"
+	InvalidChildInstanceStatus       = "InvalidOperation.ChildInstanceStatus"
+	ParameterInstanceIdNotExist      = "ParameterInstanceId"
+	ForbiddenRelease                 = "Forbidden.Release"
+	InvalidCenBandwidthLimitsNotZero = "InvalidOperation.CenBandwidthLimitsNotZero"
+	ParameterBwpInstanceId           = "ParameterBwpInstanceId"
 	// kv-store
 	InvalidKVStoreInstanceIdNotFound = "InvalidInstanceId.NotFound"
 )

--- a/alicloud/import_alicloud_cen_bandwidth_package_test.go
+++ b/alicloud/import_alicloud_cen_bandwidth_package_test.go
@@ -1,0 +1,30 @@
+package alicloud
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform/helper/resource"
+)
+
+func TestAccAlicloudCenBandwidthPackage_importBasic(t *testing.T) {
+	resourceName := "alicloud_cen_bandwidth_package.foo"
+	ignoreFields := []string{"period"}
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckCenBandwidthPackageDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccCenBandwidthPackageConfig,
+			},
+
+			resource.TestStep{
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: ignoreFields,
+			},
+		},
+	})
+}

--- a/alicloud/provider.go
+++ b/alicloud/provider.go
@@ -187,6 +187,7 @@ func Provider() terraform.ResourceProvider {
 			"alicloud_ssl_vpn_client_cert":         resourceAliyunSslVpnClientCert(),
 			"alicloud_cen_instance":                resourceAlicloudCenInstance(),
 			"alicloud_cen_instance_attachment":     resourceAlicloudCenInstanceAttachment(),
+			"alicloud_cen_bandwidth_package":       resourceAlicloudCenBandwidthPackage(),
 			"alicloud_kvstore_instance":            resourceAlicloudKVStoreInstance(),
 			"alicloud_kvstore_backup_policy":       resourceAlicloudKVStoreBackupPolicy(),
 		},

--- a/alicloud/resource_alicloud_cen_bandwidth_package.go
+++ b/alicloud/resource_alicloud_cen_bandwidth_package.go
@@ -1,0 +1,314 @@
+package alicloud
+
+import (
+	"fmt"
+	"strings"
+
+	"time"
+
+	"github.com/aliyun/alibaba-cloud-sdk-go/sdk/requests"
+	"github.com/aliyun/alibaba-cloud-sdk-go/services/cbn"
+	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/helper/schema"
+)
+
+func resourceAlicloudCenBandwidthPackage() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceAlicloudCenBandwidthPackageCreate,
+		Read:   resourceAlicloudCenBandwidthPackageRead,
+		Update: resourceAlicloudCenBandwidthPackageUpdate,
+		Delete: resourceAlicloudCenBandwidthPackageDelete,
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
+
+		Schema: map[string]*schema.Schema{
+			"bandwidth": &schema.Schema{
+				Type:     schema.TypeInt,
+				Required: true,
+				ValidateFunc: func(v interface{}, k string) (ws []string, errors []error) {
+					value := v.(int)
+					if value < 1 {
+						errors = append(errors, fmt.Errorf("%s cannot be smaller than 1Mbps", k))
+					}
+
+					return
+				},
+			},
+
+			"geographic_region_ids": &schema.Schema{
+				Type:     schema.TypeSet,
+				Required: true,
+				ForceNew: true,
+				Elem: &schema.Schema{
+					Type: schema.TypeString,
+				},
+				MaxItems: 2,
+				MinItems: 1,
+			},
+
+			"name": &schema.Schema{
+				Type:     schema.TypeString,
+				Optional: true,
+				ValidateFunc: func(v interface{}, k string) (ws []string, errors []error) {
+					value := v.(string)
+					if len(value) < 2 || len(value) > 128 {
+						errors = append(errors, fmt.Errorf("%s cannot be shorter than 2 characters or longer than 128 characters", k))
+					}
+
+					if strings.HasPrefix(value, "http://") || strings.HasPrefix(value, "https://") {
+						errors = append(errors, fmt.Errorf("%s cannot starts with http:// or https://", k))
+					}
+
+					return
+				},
+			},
+
+			"description": &schema.Schema{
+				Type:     schema.TypeString,
+				Optional: true,
+				ValidateFunc: func(v interface{}, k string) (ws []string, errors []error) {
+					value := v.(string)
+					if len(value) < 2 || len(value) > 256 {
+						errors = append(errors, fmt.Errorf("%s cannot be shorter than 2 characters or longer than 256 characters", k))
+					}
+
+					if strings.HasPrefix(value, "http://") || strings.HasPrefix(value, "https://") {
+						errors = append(errors, fmt.Errorf("%s cannot starts with http:// or https://", k))
+					}
+
+					return
+				},
+			},
+
+			"charge_type": &schema.Schema{
+				Type:     schema.TypeString,
+				Optional: true,
+				Default:  PostPaid,
+				ValidateFunc: func(v interface{}, k string) (ws []string, errors []error) {
+					value := PayType(v.(string))
+					if value != PrePaid && value != PostPaid {
+						errors = append(errors, fmt.Errorf("%s must be one of: %s or %s", k, string(PrePaid), string(PostPaid)))
+					}
+					return
+				},
+			},
+
+			"period": &schema.Schema{
+				Type:     schema.TypeInt,
+				Optional: true,
+				Default:  1,
+				ValidateFunc: func(v interface{}, k string) (ws []string, errors []error) {
+					value := v.(int)
+					if value != 1 && value != 2 && value != 3 && value != 6 && value != 12 {
+						errors = append(errors, fmt.Errorf("%s must be one of: 1, 2, 3, 6, 12", k))
+					}
+					return
+				},
+				DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
+					return PayType(d.Get("charge_type").(string)) == PostPaid
+				},
+			},
+
+			"expired_time": &schema.Schema{
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+
+			"status": &schema.Schema{
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func resourceAlicloudCenBandwidthPackageCreate(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*AliyunClient)
+	var cenbwp *cbn.CreateCenBandwidthPackageResponse
+	err := resource.Retry(3*time.Minute, func() *resource.RetryError {
+		args := buildAliCloudCenBandwidthPackageArgs(d, meta)
+		resp, err := client.cenconn.CreateCenBandwidthPackage(args)
+		if err != nil {
+			if IsExceptedError(err, OperationBlocking) {
+				return resource.RetryableError(fmt.Errorf("Create CEN bandwidth package timeout and got an error: %#v.", err))
+			}
+			return resource.NonRetryableError(err)
+		}
+		cenbwp = resp
+		return nil
+	})
+	if err != nil {
+		return fmt.Errorf("Create CEN bandwidth package got an error :%#v", err)
+	}
+
+	d.SetId(cenbwp.CenBandwidthPackageId)
+
+	err = client.WaitForCenBandwidthPackage(d.Id(), Idle, DefaultCenTimeout)
+	if err != nil {
+		return fmt.Errorf("Timeout when WaitForCenBandwidthPackageIdle, bandwidth package ID %s", err)
+	}
+
+	return resourceAlicloudCenBandwidthPackageRead(d, meta)
+}
+
+func resourceAlicloudCenBandwidthPackageRead(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*AliyunClient)
+	resp, err := client.DescribeCenBandwidthPackage(d.Id())
+	if err != nil {
+		if NotFoundError(err) {
+			d.SetId("")
+			return nil
+		}
+		return err
+	}
+
+	geographicRegionId := make([]string, 0)
+	geographicRegionId = append(geographicRegionId, convertGeographicRegionId(resp.GeographicRegionAId))
+	geographicRegionId = append(geographicRegionId, convertGeographicRegionId(resp.GeographicRegionBId))
+
+	d.Set("geographic_region_ids", geographicRegionId)
+	d.Set("bandwidth", resp.Bandwidth)
+	d.Set("name", resp.Name)
+	d.Set("description", resp.Description)
+	d.Set("expired_time", resp.ExpiredTime)
+	d.Set("status", resp.Status)
+
+	if resp.BandwidthPackageChargeType == "POSTPAY" {
+		d.Set("charge_type", PostPaid)
+	} else {
+		d.Set("charge_type", PrePaid)
+	}
+
+	return nil
+}
+
+func resourceAlicloudCenBandwidthPackageUpdate(d *schema.ResourceData, meta interface{}) error {
+	d.Partial(true)
+
+	client := meta.(*AliyunClient)
+	attributeUpdate := false
+	request1 := cbn.CreateModifyCenBandwidthPackageAttributeRequest()
+	request1.CenBandwidthPackageId = d.Id()
+
+	if d.HasChange("name") {
+		request1.Name = d.Get("name").(string)
+		attributeUpdate = true
+	}
+
+	if d.HasChange("description") {
+		request1.Description = d.Get("description").(string)
+		attributeUpdate = true
+	}
+
+	if attributeUpdate {
+		if _, err := client.cenconn.ModifyCenBandwidthPackageAttribute(request1); err != nil {
+			return err
+		}
+		d.SetPartial("name")
+		d.SetPartial("description")
+	}
+
+	if d.HasChange("bandwidth") {
+		bandwidth := d.Get("bandwidth").(int)
+		request2 := cbn.CreateModifyCenBandwidthPackageSpecRequest()
+		request2.CenBandwidthPackageId = d.Id()
+		request2.Bandwidth = requests.NewInteger(bandwidth)
+
+		if _, err := client.cenconn.ModifyCenBandwidthPackageSpec(request2); err != nil {
+			return err
+		}
+		/* modify function may delay for a while */
+		if err := client.WaitForCenBandwidthPackageUpdate(d.Id(), bandwidth, DefaultCenTimeout); err != nil {
+			return err
+		}
+		d.SetPartial("bandwidth")
+	}
+
+	d.Partial(false)
+
+	return resourceAlicloudCenBandwidthPackageRead(d, meta)
+}
+
+func resourceAlicloudCenBandwidthPackageDelete(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*AliyunClient)
+	cenBwpId := d.Id()
+	request := cbn.CreateDeleteCenBandwidthPackageRequest()
+	request.CenBandwidthPackageId = cenBwpId
+
+	return resource.Retry(5*time.Minute, func() *resource.RetryError {
+		_, err := client.cenconn.DeleteCenBandwidthPackage(request)
+		if err != nil {
+			if IsExceptedErrors(err, []string{ForbiddenRelease, InvalidCenBandwidthLimitsNotZero}) {
+				return resource.NonRetryableError(err)
+			}
+			if IsExceptedError(err, ParameterBwpInstanceId) {
+				return nil
+			}
+			return resource.RetryableError(fmt.Errorf("Delete CEN bandwidth package %s timeout and got an error: %#v.", cenBwpId, err))
+		}
+
+		if _, err := client.DescribeCenBandwidthPackage(cenBwpId); err != nil {
+			if NotFoundError(err) {
+				return nil
+			}
+			return resource.NonRetryableError(err)
+		}
+
+		return resource.RetryableError(fmt.Errorf("Delete CEN bandwidth package %s, but not completed", cenBwpId))
+	})
+}
+
+func convertGeographicRegionId(regionId string) (retStr string) {
+	switch regionId {
+	case "china":
+		retStr = "China"
+	case "north-america":
+		retStr = "North-America"
+	case "asia-pacific":
+		retStr = "Asia-Pacific"
+	case "europe":
+		retStr = "Europe"
+	case "middle-east":
+		retStr = "Middle-East"
+	}
+
+	return
+}
+
+func buildAliCloudCenBandwidthPackageArgs(d *schema.ResourceData, meta interface{}) *cbn.CreateCenBandwidthPackageRequest {
+	request := cbn.CreateCreateCenBandwidthPackageRequest()
+	request.Bandwidth = requests.NewInteger(d.Get("bandwidth").(int))
+
+	geographicRegionId := d.Get("geographic_region_ids").(*schema.Set).List()
+	if len(geographicRegionId) == 1 {
+		request.GeographicRegionAId = geographicRegionId[0].(string)
+		request.GeographicRegionBId = geographicRegionId[0].(string)
+	} else if len(geographicRegionId) == 2 {
+		request.GeographicRegionAId = geographicRegionId[0].(string)
+		request.GeographicRegionBId = geographicRegionId[1].(string)
+	}
+
+	if v := d.Get("name").(string); v != "" {
+		request.Name = v
+	}
+
+	if v := d.Get("description").(string); v != "" {
+		request.Description = v
+	}
+
+	changeType := d.Get("charge_type").(string)
+	if changeType == string(PostPaid) {
+		changeType = "POSTPAY"
+	} else {
+		changeType = "PREPAY"
+		request.Period = requests.NewInteger(d.Get("period").(int))
+		request.PricingCycle = "Month"
+	}
+
+	request.BandwidthPackageChargeType = changeType
+	request.AutoPay = requests.NewBoolean(true)
+	request.ClientToken = buildClientToken("TF-CreateCenBandwidthPackage")
+
+	return request
+}

--- a/alicloud/resource_alicloud_cen_bandwidth_package_test.go
+++ b/alicloud/resource_alicloud_cen_bandwidth_package_test.go
@@ -1,0 +1,315 @@
+package alicloud
+
+import (
+	"fmt"
+	"log"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/aliyun/alibaba-cloud-sdk-go/sdk/requests"
+	"github.com/aliyun/alibaba-cloud-sdk-go/services/cbn"
+	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/terraform"
+)
+
+func init() {
+	resource.AddTestSweepers("alicloud_cen_bandwidth_package", &resource.Sweeper{
+		Name: "alicloud_cen_bandwidth_package",
+		F:    testSweepCenBandwidthPackage,
+	})
+}
+
+func testSweepCenBandwidthPackage(region string) error {
+	client, err := sharedClientForRegion(region)
+	if err != nil {
+		return fmt.Errorf("error getting Alicloud client: %s", err)
+	}
+	conn := client.(*AliyunClient)
+
+	prefixes := []string{
+		"tf-testAcc",
+		"testAcc",
+	}
+
+	var insts []cbn.CenBandwidthPackage
+	req := cbn.CreateDescribeCenBandwidthPackagesRequest()
+	req.RegionId = conn.RegionId
+	req.PageSize = requests.NewInteger(PageSizeLarge)
+	req.PageNumber = requests.NewInteger(1)
+	for {
+		resp, err := conn.cenconn.DescribeCenBandwidthPackages(req)
+		if err != nil {
+			return fmt.Errorf("Error retrieving CEN Bandwidth Package: %s", err)
+		}
+		if resp == nil || len(resp.CenBandwidthPackages.CenBandwidthPackage) < 1 {
+			break
+		}
+		insts = append(insts, resp.CenBandwidthPackages.CenBandwidthPackage...)
+
+		if len(resp.CenBandwidthPackages.CenBandwidthPackage) < PageSizeLarge {
+			break
+		}
+
+		if page, err := getNextpageNumber(req.PageNumber); err != nil {
+			return err
+		} else {
+			req.PageNumber = page
+		}
+	}
+
+	sweeped := false
+	for _, v := range insts {
+		name := v.Name
+		id := v.CenBandwidthPackageId
+		skip := true
+		for _, prefix := range prefixes {
+			if strings.HasPrefix(strings.ToLower(name), strings.ToLower(prefix)) {
+				skip = false
+				break
+			}
+		}
+		if skip {
+			log.Printf("[INFO] Skipping CEN bandwidth package: %s (%s)", name, id)
+			continue
+		}
+		sweeped = true
+		log.Printf("[INFO] Deleting CEN bandwidth package: %s (%s)", name, id)
+		req := cbn.CreateDeleteCenBandwidthPackageRequest()
+		req.CenBandwidthPackageId = id
+		if _, err := conn.cenconn.DeleteCenBandwidthPackage(req); err != nil {
+			log.Printf("[ERROR] Failed to delete CEN bandwidth package (%s (%s)): %s", name, id, err)
+		}
+	}
+	if sweeped {
+		// Waiting 5 seconds to eusure these instances have been deleted.
+		time.Sleep(5 * time.Second)
+	}
+	return nil
+}
+
+func TestAccAlicloudCenBandwidthPackage_basic(t *testing.T) {
+	var cenBwp cbn.CenBandwidthPackage
+
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+		},
+
+		// module name
+		IDRefreshName: "alicloud_cen_bandwidth_package.foo",
+		Providers:     testAccProviders,
+		CheckDestroy:  testAccCheckCenBandwidthPackageDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccCenBandwidthPackageConfig,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckCenBandwidthPackageExists("alicloud_cen_bandwidth_package.foo", &cenBwp),
+					resource.TestCheckResourceAttr(
+						"alicloud_cen_bandwidth_package.foo", "name", "tf-testAccCenBandwidthPackageConfig"),
+					resource.TestCheckResourceAttr(
+						"alicloud_cen_bandwidth_package.foo", "bandwidth", "5"),
+					resource.TestCheckResourceAttr(
+						"alicloud_cen_bandwidth_package.foo", "geographic_region_ids.#", "2"),
+					testAccCheckCenBandwidthPackageRegionId(&cenBwp, "China", "Asia-Pacific"),
+					resource.TestCheckResourceAttrSet(
+						"alicloud_cen_bandwidth_package.foo", "expired_time"),
+					resource.TestCheckResourceAttrSet(
+						"alicloud_cen_bandwidth_package.foo", "status"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAlicloudCenBandwidthPackage_update(t *testing.T) {
+	var cenBwp cbn.CenBandwidthPackage
+
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+		},
+
+		// module name
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckCenBandwidthPackageDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccCenBandwidthPackageConfig,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckCenBandwidthPackageExists("alicloud_cen_bandwidth_package.foo", &cenBwp),
+					resource.TestCheckResourceAttr(
+						"alicloud_cen_bandwidth_package.foo", "name", "tf-testAccCenBandwidthPackageConfig"),
+					resource.TestCheckResourceAttr(
+						"alicloud_cen_bandwidth_package.foo", "bandwidth", "5"),
+					resource.TestCheckResourceAttr(
+						"alicloud_cen_bandwidth_package.foo", "geographic_region_ids.#", "2"),
+					testAccCheckCenBandwidthPackageRegionId(&cenBwp, "China", "Asia-Pacific"),
+					resource.TestCheckResourceAttrSet(
+						"alicloud_cen_bandwidth_package.foo", "expired_time"),
+					resource.TestCheckResourceAttrSet(
+						"alicloud_cen_bandwidth_package.foo", "status"),
+				),
+			},
+			resource.TestStep{
+				Config: testAccCenBandwidthPackageConfigUpdate,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckCenBandwidthPackageExists("alicloud_cen_bandwidth_package.foo", &cenBwp),
+					resource.TestCheckResourceAttr(
+						"alicloud_cen_bandwidth_package.foo", "name", "tf-testAccCenBandwidthPackageConfigUpdate"),
+					resource.TestCheckResourceAttr(
+						"alicloud_cen_bandwidth_package.foo", "bandwidth", "10"),
+					resource.TestCheckResourceAttr(
+						"alicloud_cen_bandwidth_package.foo", "geographic_region_ids.#", "2"),
+					testAccCheckCenBandwidthPackageRegionId(&cenBwp, "China", "Asia-Pacific"),
+					resource.TestCheckResourceAttrSet(
+						"alicloud_cen_bandwidth_package.foo", "expired_time"),
+					resource.TestCheckResourceAttrSet(
+						"alicloud_cen_bandwidth_package.foo", "status"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAlicloudCenBandwidthPackage_muti(t *testing.T) {
+	var cenBwp cbn.CenBandwidthPackage
+
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+		},
+
+		// module name
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckCenBandwidthPackageDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccCenBandwidthPackageConfigMulti,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckCenBandwidthPackageExists("alicloud_cen_bandwidth_package.bar1", &cenBwp),
+					resource.TestCheckResourceAttr(
+						"alicloud_cen_bandwidth_package.bar1", "name", "tf-testAccCenBandwidthPackageConfigMulti"),
+					resource.TestCheckResourceAttr(
+						"alicloud_cen_bandwidth_package.bar1", "bandwidth", "5"),
+					resource.TestCheckResourceAttr(
+						"alicloud_cen_bandwidth_package.bar1", "geographic_region_ids.#", "2"),
+					testAccCheckCenBandwidthPackageRegionId(&cenBwp, "China", "Asia-Pacific"),
+					resource.TestCheckResourceAttrSet(
+						"alicloud_cen_bandwidth_package.bar1", "expired_time"),
+					resource.TestCheckResourceAttrSet(
+						"alicloud_cen_bandwidth_package.bar1", "status"),
+
+					testAccCheckCenBandwidthPackageExists("alicloud_cen_bandwidth_package.bar2", &cenBwp),
+					resource.TestCheckResourceAttr(
+						"alicloud_cen_bandwidth_package.bar2", "name", "tf-testAccCenBandwidthPackageConfigMulti"),
+					resource.TestCheckResourceAttr(
+						"alicloud_cen_bandwidth_package.bar2", "bandwidth", "5"),
+					resource.TestCheckResourceAttr(
+						"alicloud_cen_bandwidth_package.bar2", "geographic_region_ids.#", "1"),
+					testAccCheckCenBandwidthPackageRegionId(&cenBwp, "China", "China"),
+					resource.TestCheckResourceAttrSet(
+						"alicloud_cen_bandwidth_package.bar2", "expired_time"),
+					resource.TestCheckResourceAttrSet(
+						"alicloud_cen_bandwidth_package.bar2", "status"),
+				),
+			},
+		},
+	})
+}
+
+func testAccCheckCenBandwidthPackageExists(n string, cenBwp *cbn.CenBandwidthPackage) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[n]
+		if !ok {
+			return fmt.Errorf("Not found: %s", n)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("No CEN bandwidth package ID is set")
+		}
+
+		client := testAccProvider.Meta().(*AliyunClient)
+		instance, err := client.DescribeCenBandwidthPackage(rs.Primary.ID)
+		if err != nil {
+			return err
+		}
+
+		*cenBwp = instance
+		return nil
+	}
+}
+
+func testAccCheckCenBandwidthPackageDestroy(s *terraform.State) error {
+	client := testAccProvider.Meta().(*AliyunClient)
+
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "alicloud_cen_bandwidth_package" {
+			continue
+		}
+
+		// Try to find the CEN
+		instance, err := client.DescribeCenBandwidthPackage(rs.Primary.ID)
+		if err != nil {
+			if NotFoundError(err) {
+				continue
+			}
+			return err
+		}
+
+		return fmt.Errorf("CEN Bandwidth Package %s still exist", instance.CenBandwidthPackageId)
+	}
+
+	return nil
+}
+
+func testAccCheckCenBandwidthPackageRegionId(cenBwp *cbn.CenBandwidthPackage, regionAId string, regionBId string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		responseRegionAId := convertGeographicRegionId(cenBwp.GeographicRegionAId)
+		responseRegionBId := convertGeographicRegionId(cenBwp.GeographicRegionBId)
+		if (responseRegionAId == regionAId && responseRegionBId == regionBId) ||
+			(responseRegionAId == regionBId && responseRegionBId == regionAId) {
+			return nil
+		} else {
+			return fmt.Errorf("CEN Bandwidth Package %s geographic region ID error", cenBwp.CenBandwidthPackageId)
+		}
+	}
+}
+
+const testAccCenBandwidthPackageConfig = `
+resource "alicloud_cen_bandwidth_package" "foo" {
+    name = "tf-testAccCenBandwidthPackageConfig"
+    bandwidth = 5
+    geographic_region_ids = [
+		"China",
+		"Asia-Pacific"]
+}
+`
+
+const testAccCenBandwidthPackageConfigUpdate = `
+resource "alicloud_cen_bandwidth_package" "foo" {
+    name = "tf-testAccCenBandwidthPackageConfigUpdate"
+    bandwidth = 10
+    geographic_region_ids = [
+		"China",
+		"Asia-Pacific"]
+}
+`
+
+const testAccCenBandwidthPackageConfigMulti = `
+resource "alicloud_cen_bandwidth_package" "bar1" {
+    name = "tf-testAccCenBandwidthPackageConfigMulti"
+    bandwidth = 5
+    geographic_region_ids = [
+		"China",
+		"Asia-Pacific"]
+}
+
+resource "alicloud_cen_bandwidth_package" "bar2" {
+    name = "tf-testAccCenBandwidthPackageConfigMulti"
+    bandwidth = 5
+    geographic_region_ids = [
+		"China",
+		"China"]
+}
+`

--- a/website/alicloud.erb
+++ b/website/alicloud.erb
@@ -235,6 +235,9 @@
                         <li<%= sidebar_current("docs-alicloud-cen-instance-attachment") %>>
                             <a href="/docs/providers/alicloud/r/cen_instance_attachment.html">alicloud_cen_instance_attachment</a>
                         </li>
+                        <li<%= sidebar_current("docs-alicloud-cen-bandwidth-package") %>>
+                        <a href="/docs/providers/alicloud/r/cen_bandwidth_package.html">alicloud_cen_bandwidth_package</a>
+                    </li>
                     </ul>
                 </li>
 

--- a/website/docs/r/cen_bandwidth_package.html.markdown
+++ b/website/docs/r/cen_bandwidth_package.html.markdown
@@ -1,0 +1,56 @@
+---
+layout: "alicloud"
+page_title: "Alicloud: alicloud_cen_bandwidth_package"
+sidebar_current: "docs-alicloud-cen-bandwidth-package"
+description: |-
+  Provides a Alicloud CEN bandwidth package resource.
+---
+
+# alicloud\_cen_bandwidth_package
+
+Provides a CEN bandwidth package resource. The CEN bandwidth package is an abstracted object that includes an interconnection bandwidth and interconnection areas. To buy a bandwidth package, you must specify the areas to connect. An area consists of one or more Alibaba Cloud regions. The areas in CEN include Mainland China, Asia Pacific, North America, and Europe.
+
+For information about CEN and how to use it, see [Manage bandwidth packages](https://www.alibabacloud.com/help/doc-detail/65982.htm).
+
+## Example Usage
+
+Basic Usage
+
+```
+resource "alicloud_cen_bandwidth_package" "foo" {
+    name = "tf-testAccCenBandwidthPackageConfig"
+    bandwidth = 5
+    geographic_region_ids = [
+		"China",
+		"Asia-Pacific"]
+}
+```
+## Argument Reference
+
+The following arguments are supported:
+
+* `bandwidth` - (Required) The bandwidth in Mbps of the bandwidth package. Cannot be less than 1Mbps.
+* `geographic_region_ids` - (Required) List of the two areas to connect. Valid value: China | North-America | Asia-Pacific | Europe | Middle-East.
+* `name` - (Optional) The name of the bandwidth package. Defaults to null.
+* `description` - (Optional) The description of the bandwidth package. Default to null.
+* `charge_type` - (Optional) The billing method. Valid value: PostPaid | PrePaid. Default to PostPaid. If set to PrePaid, the bandwidth package can't be deleted before expired time.
+* `period` - (Optional) The purchase period in month. Valid value: 1, 2, 3, 6, 12. Default to 1.
+
+~>**NOTE:** PrePaid mode will deduct fees from the account directly. 
+
+## Attributes Reference
+
+The following attributes are exported:
+
+* `id` - The ID of the bandwidth package.
+* `expired_time` - The time of the bandwidth package to expire.
+* `status` - The status of the bandwidth, including "InUse" and "Idle".
+
+## Import
+
+CEN bandwidth package can be imported using the id, e.g.
+
+```
+$ terraform import alicloud_cen_bandwidth_package.example cenbwp-abc123456
+```
+


### PR DESCRIPTION
Resouece alicloud_cen_bandwidth_package support the creation, modification, destruction and import of the bandwidth package in a CEN. The acceptance test results are as below:
$TF_ACC=1 go test ./alicloud -v -run=TestAccAlicloudCenBandwidthPackage -timeout=300m
=== RUN   TestAccAlicloudCenBandwidthPackage_importBasic
--- PASS: TestAccAlicloudCenBandwidthPackage_importBasic (11.78s)
=== RUN   TestAccAlicloudCenBandwidthPackage_basic
--- PASS: TestAccAlicloudCenBandwidthPackage_basic (10.93s)
=== RUN   TestAccAlicloudCenBandwidthPackage_update
--- PASS: TestAccAlicloudCenBandwidthPackage_update (21.68s)
=== RUN   TestAccAlicloudCenBandwidthPackage_muti
--- PASS: TestAccAlicloudCenBandwidthPackage_muti (11.38s)
PASS
ok  	github.com/terraform-providers/terraform-provider-alicloud/alicloud