### PR TITLE
add new data source alicloud_disks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,10 @@
 ## 1.17.0 (Unreleased)
+
+IMPROVEMENTS:
+
+- **New Data Source:** `alicloud_disks` ([#343](https://github.com/terraform-providers/terraform-provider-alicloud/pull/343))
+- **New Resource:** `alicloud_cen_bandwidth_package` ([#333](https://github.com/terraform-providers/terraform-provider-alicloud/pull/333))
+
 ## 1.16.0 (September 16, 2018)
 
 FEATURES:

--- a/alicloud/data_source_alicloud_disks.go
+++ b/alicloud/data_source_alicloud_disks.go
@@ -1,0 +1,275 @@
+package alicloud
+
+import (
+	"fmt"
+	"log"
+	"regexp"
+
+	"github.com/aliyun/alibaba-cloud-sdk-go/sdk/requests"
+	"github.com/aliyun/alibaba-cloud-sdk-go/services/ecs"
+	"github.com/hashicorp/terraform/helper/schema"
+)
+
+func dataSourceAlicloudDisks() *schema.Resource {
+	return &schema.Resource{
+		Read: dataSourceAlicloudDisksRead,
+
+		Schema: map[string]*schema.Schema{
+			"ids": {
+				Type:     schema.TypeList,
+				Optional: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+				ForceNew: true,
+				MinItems: 1,
+			},
+			"name_regex": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ValidateFunc: validateNameRegex,
+				ForceNew:     true,
+			},
+			"type": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ForceNew:     true,
+				ValidateFunc: validateAllowedStringValue([]string{string(DiskTypeSystem), string(DiskTypeData)}),
+			},
+			"category": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ForceNew:     true,
+				ValidateFunc: validateAllowedStringValue([]string{string(DiskCloud), string(DiskEphemeralSSD), string(DiskCloudEfficiency), string(DiskCloudSSD)}),
+			},
+			"encrypted": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ForceNew:     true,
+				ValidateFunc: validateAllowedStringValue([]string{string(OnFlag), string(OffFlag)}),
+			},
+			"instance_id": {
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: true,
+			},
+			"tags": tagsSchema(),
+			"output_file": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+
+			// Computed values
+			"disks": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"name": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"description": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"region_id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"availability_zone": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"status": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"type": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"category": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"encrypted": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"size": {
+							Type:     schema.TypeInt,
+							Computed: true,
+						},
+						"image_id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"snapshot_id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"instance_id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"creation_time": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"attached_time": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"detached_time": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"expiration_time": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"tags": tagsSchema(),
+					},
+				},
+			},
+		},
+	}
+}
+
+func dataSourceAlicloudDisksRead(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*AliyunClient)
+
+	args := ecs.CreateDescribeDisksRequest()
+
+	if v, ok := d.GetOk("ids"); ok && len(v.([]interface{})) > 0 {
+		args.DiskIds = convertListToJsonString(v.([]interface{}))
+	}
+	if v, ok := d.GetOk("type"); ok && v.(string) != "" {
+		args.DiskType = v.(string)
+	}
+	if v, ok := d.GetOk("category"); ok && v.(string) != "" {
+		args.Category = v.(string)
+	}
+	if v, ok := d.GetOk("encrypted"); ok && v.(string) != "" {
+		if v == string(OnFlag) {
+			args.Encrypted = requests.NewBoolean(true)
+		} else {
+			args.Encrypted = requests.NewBoolean(false)
+		}
+	}
+	if v, ok := d.GetOk("instance_id"); ok && v.(string) != "" {
+		args.InstanceId = v.(string)
+	}
+	if v, ok := d.GetOk("tags"); ok {
+		var tags []ecs.DescribeDisksTag
+
+		for key, value := range v.(map[string]interface{}) {
+			tags = append(tags, ecs.DescribeDisksTag{
+				Key:   key,
+				Value: value.(string),
+			})
+		}
+		args.Tag = &tags
+	}
+
+	var allDisks []ecs.Disk
+	args.PageSize = requests.NewInteger(PageSizeLarge)
+	args.PageNumber = requests.NewInteger(1)
+	for {
+		resp, err := client.ecsconn.DescribeDisks(args)
+		if err != nil {
+			return err
+		}
+
+		if resp == nil || len(resp.Disks.Disk) < 1 {
+			break
+		}
+
+		allDisks = append(allDisks, resp.Disks.Disk...)
+
+		if len(resp.Disks.Disk) < PageSizeLarge {
+			break
+		}
+
+		if page, err := getNextpageNumber(args.PageNumber); err != nil {
+			return err
+		} else {
+			args.PageNumber = page
+		}
+	}
+
+	var filteredDisksTemp []ecs.Disk
+
+	nameRegex, ok := d.GetOk("name_regex")
+	if ok && nameRegex.(string) != "" {
+		var r *regexp.Regexp
+		if nameRegex != "" {
+			r = regexp.MustCompile(nameRegex.(string))
+		}
+		for _, disk := range allDisks {
+			if r != nil && !r.MatchString(disk.DiskName) {
+				continue
+			}
+
+			filteredDisksTemp = append(filteredDisksTemp, disk)
+		}
+	} else {
+		filteredDisksTemp = allDisks
+	}
+
+	if len(filteredDisksTemp) < 1 {
+		return fmt.Errorf("Your query returned no results. Please change your search criteria and try again.")
+	}
+
+	log.Printf("[DEBUG] alicloud_disks - Disks found: %#v", filteredDisksTemp)
+
+	return disksDescriptionAttributes(d, filteredDisksTemp)
+}
+
+func disksDescriptionAttributes(d *schema.ResourceData, disks []ecs.Disk) error {
+	var ids []string
+	var s []map[string]interface{}
+	for _, disk := range disks {
+		mapping := map[string]interface{}{
+			"id":                disk.DiskId,
+			"name":              disk.DiskName,
+			"description":       disk.Description,
+			"region_id":         disk.RegionId,
+			"availability_zone": disk.ZoneId,
+			"status":            disk.Status,
+			"type":              disk.Type,
+			"category":          disk.Category,
+			"encrypted":         string(OnFlag),
+			"size":              disk.Size,
+			"image_id":          disk.ImageId,
+			"snapshot_id":       disk.SourceSnapshotId,
+			"instance_id":       disk.InstanceId,
+			"creation_time":     disk.CreationTime,
+			"attached_time":     disk.AttachedTime,
+			"detached_time":     disk.DetachedTime,
+			"expiration_time":   disk.ExpiredTime,
+			"tags":              tagsToMap(disk.Tags.Tag),
+		}
+		if !disk.Encrypted {
+			mapping["encrypted"] = string(OffFlag)
+		}
+
+		log.Printf("[DEBUG] alicloud_disks - adding disk mapping: %v", mapping)
+		ids = append(ids, disk.DiskId)
+		s = append(s, mapping)
+	}
+
+	d.SetId(dataResourceIdHash(ids))
+	if err := d.Set("disks", s); err != nil {
+		return err
+	}
+
+	// create a json file in current directory and write data source to it.
+	if output, ok := d.GetOk("output_file"); ok && output.(string) != "" {
+		writeToFile(output.(string), s)
+	}
+	return nil
+}

--- a/alicloud/data_source_alicloud_disks_test.go
+++ b/alicloud/data_source_alicloud_disks_test.go
@@ -1,0 +1,202 @@
+package alicloud
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform/helper/resource"
+)
+
+func TestAccAlicloudDisksDataSource_basic(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCheckAlicloudDisksDataSourceBasic,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAlicloudDataSourceID("data.alicloud_disks.disks"),
+					resource.TestCheckResourceAttr("data.alicloud_disks.disks", "disks.#", "1"),
+					resource.TestCheckResourceAttrSet("data.alicloud_disks.disks", "disks.0.id"),
+					resource.TestCheckResourceAttr("data.alicloud_disks.disks", "disks.0.name", "tf-testAccCheckAlicloudDisksDataSourceBasic"),
+					resource.TestCheckResourceAttr("data.alicloud_disks.disks", "disks.0.description", "tf-testAccCheckAlicloudDisksDataSourceBasic_description"),
+					resource.TestCheckResourceAttrSet("data.alicloud_disks.disks", "disks.0.region_id"),
+					resource.TestCheckResourceAttrSet("data.alicloud_disks.disks", "disks.0.availability_zone"),
+					resource.TestCheckResourceAttr("data.alicloud_disks.disks", "disks.0.status", "Available"),
+					resource.TestCheckResourceAttr("data.alicloud_disks.disks", "disks.0.type", "data"),
+					resource.TestCheckResourceAttr("data.alicloud_disks.disks", "disks.0.category", "cloud_efficiency"),
+					resource.TestCheckResourceAttr("data.alicloud_disks.disks", "disks.0.encrypted", "off"),
+					resource.TestCheckResourceAttr("data.alicloud_disks.disks", "disks.0.size", "20"),
+					resource.TestCheckResourceAttr("data.alicloud_disks.disks", "disks.0.image_id", ""),
+					resource.TestCheckResourceAttr("data.alicloud_disks.disks", "disks.0.snapshot_id", ""),
+					resource.TestCheckResourceAttr("data.alicloud_disks.disks", "disks.0.instance_id", ""),
+					resource.TestCheckResourceAttrSet("data.alicloud_disks.disks", "disks.0.creation_time"),
+					resource.TestCheckResourceAttr("data.alicloud_disks.disks", "disks.0.attached_time", ""),
+					resource.TestCheckResourceAttr("data.alicloud_disks.disks", "disks.0.detached_time", ""),
+					resource.TestCheckResourceAttrSet("data.alicloud_disks.disks", "disks.0.expiration_time"),
+					resource.TestCheckResourceAttr("data.alicloud_disks.disks", "disks.0.tags.%", "2"),
+					resource.TestCheckResourceAttr("data.alicloud_disks.disks", "disks.0.tags.Name", "TerraformTest"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAlicloudDisksDataSource_filterByAllFields(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCheckAlicloudDisksDataSourceFilterByAllFields,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAlicloudDataSourceID("data.alicloud_disks.disks"),
+					resource.TestCheckResourceAttr("data.alicloud_disks.disks", "disks.#", "1"),
+					resource.TestCheckResourceAttr("data.alicloud_disks.disks", "disks.0.name", "tf-testAccCheckAlicloudDisksDataSourceFilterByAllFields"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAlicloudDisksDataSource_filterByInstanceId(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCheckAlicloudDisksDataSourceFilterByInstanceId,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAlicloudDataSourceID("data.alicloud_disks.disks"),
+					resource.TestCheckResourceAttr("data.alicloud_disks.disks", "disks.#", "1"),
+					resource.TestCheckResourceAttr("data.alicloud_disks.disks", "disks.0.name", "tf-testAccCheckAlicloudDisksDataSourceFilterByInstanceId"),
+					resource.TestCheckResourceAttr("data.alicloud_disks.disks", "disks.0.status", "In_use"),
+					resource.TestCheckResourceAttrSet("data.alicloud_disks.disks", "disks.0.instance_id"),
+					resource.TestCheckResourceAttrSet("data.alicloud_disks.disks", "disks.0.creation_time"),
+					resource.TestCheckResourceAttrSet("data.alicloud_disks.disks", "disks.0.attached_time"),
+				),
+			},
+		},
+	})
+}
+
+const testAccCheckAlicloudDisksDataSourceBasic = `
+variable "name" {
+	default = "tf-testAccCheckAlicloudDisksDataSourceBasic"
+}
+
+data "alicloud_zones" "az" {
+	"available_resource_creation"= "VSwitch"
+}
+
+resource "alicloud_disk" "sample_disk" {
+	availability_zone = "${data.alicloud_zones.az.zones.0.id}"
+	category = "cloud_efficiency"
+	name = "${var.name}"
+    description = "${var.name}_description"
+	size = "20"
+	tags {
+	    Name = "TerraformTest"
+	    Name1 = "TerraformTest"
+	}
+}
+
+data "alicloud_disks" "disks" {
+    name_regex = "${alicloud_disk.sample_disk.name}"
+}
+`
+
+const testAccCheckAlicloudDisksDataSourceFilterByAllFields = `
+variable "name" {
+	default = "tf-testAccCheckAlicloudDisksDataSourceFilterByAllFields"
+}
+
+data "alicloud_zones" "az" {
+	"available_resource_creation"= "VSwitch"
+}
+
+resource "alicloud_disk" "sample_disk" {
+	availability_zone = "${data.alicloud_zones.az.zones.0.id}"
+	category = "cloud_efficiency"
+	name = "${var.name}"
+    description = "${var.name}_description"
+	size = "20"
+	tags {
+	    Name = "TerraformTest"
+	    Name1 = "TerraformTest"
+	}
+}
+
+data "alicloud_disks" "disks" {
+    ids = ["${alicloud_disk.sample_disk.id}"]
+    name_regex = "${alicloud_disk.sample_disk.name}"
+    type = "data"
+    category = "cloud_efficiency"
+    encrypted = "off"
+    tags = {
+        Name = "TerraformTest"
+    }
+}
+`
+
+const testAccCheckAlicloudDisksDataSourceFilterByInstanceId = `
+variable "name" {
+	default = "tf-testAccCheckAlicloudDisksDataSourceFilterByInstanceId"
+}
+
+data "alicloud_zones" "az" {
+	"available_resource_creation"= "VSwitch"
+}
+data "alicloud_images" "images" {
+	name_regex = "ubuntu*"
+}
+data "alicloud_instance_types" "default" {
+ 	availability_zone = "${data.alicloud_zones.az.zones.0.id}"
+	cpu_core_count = 1
+	memory_size = 2
+}
+
+resource "alicloud_disk" "sample_disk" {
+	availability_zone = "${data.alicloud_zones.az.zones.0.id}"
+	category = "cloud_efficiency"
+	name = "${var.name}"
+    description = "${var.name}_description"
+	size = "20"
+}
+
+resource "alicloud_vpc" "sample_vpc" {
+	name = "${var.name}"
+  	cidr_block = "172.16.0.0/12"
+}
+
+resource "alicloud_vswitch" "sample_vswitch" {
+	name = "${var.name}"
+  	vpc_id = "${alicloud_vpc.sample_vpc.id}"
+  	cidr_block = "172.16.0.0/16"
+  	availability_zone = "${data.alicloud_zones.az.zones.0.id}"
+}
+
+resource "alicloud_security_group" "sample_security_group" {
+	name = "${var.name}"
+	vpc_id = "${alicloud_vpc.sample_vpc.id}"
+}
+
+resource "alicloud_instance" "sample_instance" {
+	vswitch_id = "${alicloud_vswitch.sample_vswitch.id}"
+	private_ip = "172.16.10.10"
+	image_id = "${data.alicloud_images.images.images.0.id}"
+	instance_type = "${data.alicloud_instance_types.default.instance_types.0.id}"
+  	instance_name = "${var.name}"
+	system_disk_category = "cloud_efficiency"
+	security_groups = ["${alicloud_security_group.sample_security_group.id}"]
+}
+
+resource "alicloud_disk_attachment" "sample_disk_attachment" {
+  disk_id = "${alicloud_disk.sample_disk.id}"
+  instance_id = "${alicloud_instance.sample_instance.id}"
+}
+
+data "alicloud_disks" "disks" {
+    instance_id = "${alicloud_disk_attachment.sample_disk_attachment.instance_id}"
+    type = "data"
+}
+`

--- a/alicloud/provider.go
+++ b/alicloud/provider.go
@@ -71,6 +71,7 @@ func Provider() terraform.ResourceProvider {
 			"alicloud_zones":          dataSourceAlicloudZones(),
 			"alicloud_instance_types": dataSourceAlicloudInstanceTypes(),
 			"alicloud_instances":      dataSourceAlicloudInstances(),
+			"alicloud_disks":          dataSourceAlicloudDisks(),
 			"alicloud_vpcs":           dataSourceAlicloudVpcs(),
 			"alicloud_vswitches":      dataSourceAlicloudVSwitches(),
 			"alicloud_eips":           dataSourceAlicloudEips(),

--- a/website/alicloud.erb
+++ b/website/alicloud.erb
@@ -37,6 +37,9 @@
                         <li<%= sidebar_current("docs-alicloud-datasource-instances") %>>
                             <a href="/docs/providers/alicloud/d/instances.html">alicloud_instances</a>
                         </li>
+                        <li<%= sidebar_current("docs-alicloud-datasource-disks") %>>
+                            <a href="/docs/providers/alicloud/d/disks.html">alicloud_disks</a>
+                        </li>
                         <li<%= sidebar_current("docs-alicloud-datasource-vpcs") %>>
                             <a href="/docs/providers/alicloud/d/vpcs.html">alicloud_vpcs</a>
                         </li>

--- a/website/docs/d/disks.html.markdown
+++ b/website/docs/d/disks.html.markdown
@@ -1,0 +1,68 @@
+---
+layout: "alicloud"
+page_title: "Alicloud: alicloud_disks"
+sidebar_current: "docs-alicloud-datasource-disks"
+description: |-
+    Provides a list of disks to the user.
+---
+
+# alicloud\_disks
+
+This data source provides the disks of the current Alibaba Cloud user.
+
+## Example Usage
+
+```
+data "alicloud_disks" "disks_ds" {
+  name_regex = "sample_disk"
+}
+
+output "first_disk_id" {
+  value = "${data.alicloud_disks.disks_ds.disks.0.id}"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `ids` - (Optional) A list of disks IDs.
+* `name_regex` - (Optional) A regex string to filter results by disk name.
+* `type` - (Optional) Disk type. Possible values: `system` and `data`.
+* `category` - (Optional) Disk category. Possible values: `cloud` (basic cloud disk), `cloud_efficiency` (ultra cloud disk), `cloud_ssd` (SSD cloud disk), `ephemeral_ssd` (ephemeral SSD) and `ephemeral` (ephemeral disk).
+* `encrypted` - (Optional) Indicate whether the disk is encrypted or not. Possible values: `on` and `off`.
+* `instance_id` - (Optional) Filter the results by the specified ECS instance ID.
+* `tags` - (Optional) A map of tags assigned to the disks. It must be in the format:
+  ```
+  data "alicloud_disks" "disks_ds" {
+    tags = {
+      tagKey1 = "tagValue1",
+      tagKey2 = "tagValue2"
+    }
+  }
+  ```
+* `output_file` - (Optional) File name where to save data source results (after running `terraform plan`).
+
+## Attributes Reference
+
+The following attributes are exported in addition to the arguments listed above:
+
+* `disks` - A list of disks. Each element contains the following attributes:
+  * `id` - ID of the disk.
+  * `name` - Disk name.
+  * `description` - Disk description.
+  * `region_id` - Region ID the disk belongs to.
+  * `availability_zone` - Availability zone of the disk.
+  * `status` - Current status. Possible values: `In_use`, `Available`, `Attaching`, `Detaching`, `Creating` and `ReIniting`.
+  * `type` - Disk type. Possible values: `system` and `data`.
+  * `category` - Disk category. Possible values: `cloud` (basic cloud disk), `cloud_efficiency` (ultra cloud disk), `cloud_ssd` (SSD cloud disk), `ephemeral_ssd` (ephemeral SSD) and `ephemeral` (ephemeral disk).
+  * `encrypted` - Indicate whether the disk is encrypted or not. Possible values: `on` and `off`.
+  * `size` - Disk size in GiB.
+  * `image_id` - ID of the image from which the disk is created. It is null unless the disk is created using an image.
+  * `snapshot_id` - Snapshot used to create the disk. It is null if no snapshot is used to create the disk.
+  * `instance_id` - ID of the related instance. It is `null` unless the `status` is `In_use`.
+  * `creation_time` - Disk creation time.
+  * `attached_time` - Disk attachment time.
+  * `detached_time` - Disk detachment time.
+  * `expiration_time` - Disk expiration time.
+  * `tags` - A map of tags assigned to the disk.


### PR DESCRIPTION
New data source alicloud_disks.

Test results:
```
GOROOT=/usr/local/go #gosetup
GOPATH=/Users/marcplouhinec/go #gosetup
/usr/local/go/bin/go test -c -i -sweep=eu-central-1 -o /private/var/folders/v1/jvjz3zmn64q0j34yc9m9n4w00000gn/T/___non_verbose_tests github.com/alibaba/terraform-provider/alicloud #gosetup
/usr/local/go/bin/go tool test2json -t /private/var/folders/v1/jvjz3zmn64q0j34yc9m9n4w00000gn/T/___non_verbose_tests -test.v -test.run ^TestAccAlicloudDisksDataSource_ #gosetup
=== RUN   TestAccAlicloudDisksDataSource_basic
--- PASS: TestAccAlicloudDisksDataSource_basic (29.34s)
=== RUN   TestAccAlicloudDisksDataSource_filterByAllFields
--- PASS: TestAccAlicloudDisksDataSource_filterByAllFields (25.81s)
PASS
```