### PR TITLE
 Add new datasource oss_buckets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,10 @@
 ## 1.17.0 (Unreleased)
+
+IMPROVEMENTS:
+
+- **New Data Source:** `alicloud_disks` ([#343](https://github.com/terraform-providers/terraform-provider-alicloud/pull/343))
+- **New Resource:** `alicloud_cen_bandwidth_package` ([#333](https://github.com/terraform-providers/terraform-provider-alicloud/pull/333))
+
 ## 1.16.0 (September 16, 2018)
 
 FEATURES:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 IMPROVEMENTS:
 
+- **New Data Source:** `alicloud_oss_buckets` ([#345](https://github.com/terraform-providers/terraform-provider-alicloud/pull/345))
 - Improve example/kubernetes to support multi-az ([#344](https://github.com/terraform-providers/terraform-provider-alicloud/pull/344))
 - **New Data Source:** `alicloud_disks` ([#343](https://github.com/terraform-providers/terraform-provider-alicloud/pull/343))
 - **New Resource:** `alicloud_cen_bandwidth_package` ([#333](https://github.com/terraform-providers/terraform-provider-alicloud/pull/333))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 IMPROVEMENTS:
 
+- Improve example/kubernetes to support multi-az ([#344](https://github.com/terraform-providers/terraform-provider-alicloud/pull/344))
 - **New Data Source:** `alicloud_disks` ([#343](https://github.com/terraform-providers/terraform-provider-alicloud/pull/343))
 - **New Resource:** `alicloud_cen_bandwidth_package` ([#333](https://github.com/terraform-providers/terraform-provider-alicloud/pull/333))
 

--- a/alicloud/data_source_alicloud_disks.go
+++ b/alicloud/data_source_alicloud_disks.go
@@ -1,0 +1,275 @@
+package alicloud
+
+import (
+	"fmt"
+	"log"
+	"regexp"
+
+	"github.com/aliyun/alibaba-cloud-sdk-go/sdk/requests"
+	"github.com/aliyun/alibaba-cloud-sdk-go/services/ecs"
+	"github.com/hashicorp/terraform/helper/schema"
+)
+
+func dataSourceAlicloudDisks() *schema.Resource {
+	return &schema.Resource{
+		Read: dataSourceAlicloudDisksRead,
+
+		Schema: map[string]*schema.Schema{
+			"ids": {
+				Type:     schema.TypeList,
+				Optional: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+				ForceNew: true,
+				MinItems: 1,
+			},
+			"name_regex": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ValidateFunc: validateNameRegex,
+				ForceNew:     true,
+			},
+			"type": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ForceNew:     true,
+				ValidateFunc: validateAllowedStringValue([]string{string(DiskTypeSystem), string(DiskTypeData)}),
+			},
+			"category": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ForceNew:     true,
+				ValidateFunc: validateAllowedStringValue([]string{string(DiskCloud), string(DiskEphemeralSSD), string(DiskCloudEfficiency), string(DiskCloudSSD)}),
+			},
+			"encrypted": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ForceNew:     true,
+				ValidateFunc: validateAllowedStringValue([]string{string(OnFlag), string(OffFlag)}),
+			},
+			"instance_id": {
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: true,
+			},
+			"tags": tagsSchema(),
+			"output_file": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+
+			// Computed values
+			"disks": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"name": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"description": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"region_id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"availability_zone": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"status": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"type": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"category": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"encrypted": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"size": {
+							Type:     schema.TypeInt,
+							Computed: true,
+						},
+						"image_id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"snapshot_id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"instance_id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"creation_time": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"attached_time": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"detached_time": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"expiration_time": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"tags": tagsSchema(),
+					},
+				},
+			},
+		},
+	}
+}
+
+func dataSourceAlicloudDisksRead(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*AliyunClient)
+
+	args := ecs.CreateDescribeDisksRequest()
+
+	if v, ok := d.GetOk("ids"); ok && len(v.([]interface{})) > 0 {
+		args.DiskIds = convertListToJsonString(v.([]interface{}))
+	}
+	if v, ok := d.GetOk("type"); ok && v.(string) != "" {
+		args.DiskType = v.(string)
+	}
+	if v, ok := d.GetOk("category"); ok && v.(string) != "" {
+		args.Category = v.(string)
+	}
+	if v, ok := d.GetOk("encrypted"); ok && v.(string) != "" {
+		if v == string(OnFlag) {
+			args.Encrypted = requests.NewBoolean(true)
+		} else {
+			args.Encrypted = requests.NewBoolean(false)
+		}
+	}
+	if v, ok := d.GetOk("instance_id"); ok && v.(string) != "" {
+		args.InstanceId = v.(string)
+	}
+	if v, ok := d.GetOk("tags"); ok {
+		var tags []ecs.DescribeDisksTag
+
+		for key, value := range v.(map[string]interface{}) {
+			tags = append(tags, ecs.DescribeDisksTag{
+				Key:   key,
+				Value: value.(string),
+			})
+		}
+		args.Tag = &tags
+	}
+
+	var allDisks []ecs.Disk
+	args.PageSize = requests.NewInteger(PageSizeLarge)
+	args.PageNumber = requests.NewInteger(1)
+	for {
+		resp, err := client.ecsconn.DescribeDisks(args)
+		if err != nil {
+			return err
+		}
+
+		if resp == nil || len(resp.Disks.Disk) < 1 {
+			break
+		}
+
+		allDisks = append(allDisks, resp.Disks.Disk...)
+
+		if len(resp.Disks.Disk) < PageSizeLarge {
+			break
+		}
+
+		if page, err := getNextpageNumber(args.PageNumber); err != nil {
+			return err
+		} else {
+			args.PageNumber = page
+		}
+	}
+
+	var filteredDisksTemp []ecs.Disk
+
+	nameRegex, ok := d.GetOk("name_regex")
+	if ok && nameRegex.(string) != "" {
+		var r *regexp.Regexp
+		if nameRegex != "" {
+			r = regexp.MustCompile(nameRegex.(string))
+		}
+		for _, disk := range allDisks {
+			if r != nil && !r.MatchString(disk.DiskName) {
+				continue
+			}
+
+			filteredDisksTemp = append(filteredDisksTemp, disk)
+		}
+	} else {
+		filteredDisksTemp = allDisks
+	}
+
+	if len(filteredDisksTemp) < 1 {
+		return fmt.Errorf("Your query returned no results. Please change your search criteria and try again.")
+	}
+
+	log.Printf("[DEBUG] alicloud_disks - Disks found: %#v", filteredDisksTemp)
+
+	return disksDescriptionAttributes(d, filteredDisksTemp)
+}
+
+func disksDescriptionAttributes(d *schema.ResourceData, disks []ecs.Disk) error {
+	var ids []string
+	var s []map[string]interface{}
+	for _, disk := range disks {
+		mapping := map[string]interface{}{
+			"id":                disk.DiskId,
+			"name":              disk.DiskName,
+			"description":       disk.Description,
+			"region_id":         disk.RegionId,
+			"availability_zone": disk.ZoneId,
+			"status":            disk.Status,
+			"type":              disk.Type,
+			"category":          disk.Category,
+			"encrypted":         string(OnFlag),
+			"size":              disk.Size,
+			"image_id":          disk.ImageId,
+			"snapshot_id":       disk.SourceSnapshotId,
+			"instance_id":       disk.InstanceId,
+			"creation_time":     disk.CreationTime,
+			"attached_time":     disk.AttachedTime,
+			"detached_time":     disk.DetachedTime,
+			"expiration_time":   disk.ExpiredTime,
+			"tags":              tagsToMap(disk.Tags.Tag),
+		}
+		if !disk.Encrypted {
+			mapping["encrypted"] = string(OffFlag)
+		}
+
+		log.Printf("[DEBUG] alicloud_disks - adding disk mapping: %v", mapping)
+		ids = append(ids, disk.DiskId)
+		s = append(s, mapping)
+	}
+
+	d.SetId(dataResourceIdHash(ids))
+	if err := d.Set("disks", s); err != nil {
+		return err
+	}
+
+	// create a json file in current directory and write data source to it.
+	if output, ok := d.GetOk("output_file"); ok && output.(string) != "" {
+		writeToFile(output.(string), s)
+	}
+	return nil
+}

--- a/alicloud/data_source_alicloud_disks_test.go
+++ b/alicloud/data_source_alicloud_disks_test.go
@@ -1,0 +1,202 @@
+package alicloud
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform/helper/resource"
+)
+
+func TestAccAlicloudDisksDataSource_basic(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCheckAlicloudDisksDataSourceBasic,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAlicloudDataSourceID("data.alicloud_disks.disks"),
+					resource.TestCheckResourceAttr("data.alicloud_disks.disks", "disks.#", "1"),
+					resource.TestCheckResourceAttrSet("data.alicloud_disks.disks", "disks.0.id"),
+					resource.TestCheckResourceAttr("data.alicloud_disks.disks", "disks.0.name", "tf-testAccCheckAlicloudDisksDataSourceBasic"),
+					resource.TestCheckResourceAttr("data.alicloud_disks.disks", "disks.0.description", "tf-testAccCheckAlicloudDisksDataSourceBasic_description"),
+					resource.TestCheckResourceAttrSet("data.alicloud_disks.disks", "disks.0.region_id"),
+					resource.TestCheckResourceAttrSet("data.alicloud_disks.disks", "disks.0.availability_zone"),
+					resource.TestCheckResourceAttr("data.alicloud_disks.disks", "disks.0.status", "Available"),
+					resource.TestCheckResourceAttr("data.alicloud_disks.disks", "disks.0.type", "data"),
+					resource.TestCheckResourceAttr("data.alicloud_disks.disks", "disks.0.category", "cloud_efficiency"),
+					resource.TestCheckResourceAttr("data.alicloud_disks.disks", "disks.0.encrypted", "off"),
+					resource.TestCheckResourceAttr("data.alicloud_disks.disks", "disks.0.size", "20"),
+					resource.TestCheckResourceAttr("data.alicloud_disks.disks", "disks.0.image_id", ""),
+					resource.TestCheckResourceAttr("data.alicloud_disks.disks", "disks.0.snapshot_id", ""),
+					resource.TestCheckResourceAttr("data.alicloud_disks.disks", "disks.0.instance_id", ""),
+					resource.TestCheckResourceAttrSet("data.alicloud_disks.disks", "disks.0.creation_time"),
+					resource.TestCheckResourceAttr("data.alicloud_disks.disks", "disks.0.attached_time", ""),
+					resource.TestCheckResourceAttr("data.alicloud_disks.disks", "disks.0.detached_time", ""),
+					resource.TestCheckResourceAttrSet("data.alicloud_disks.disks", "disks.0.expiration_time"),
+					resource.TestCheckResourceAttr("data.alicloud_disks.disks", "disks.0.tags.%", "2"),
+					resource.TestCheckResourceAttr("data.alicloud_disks.disks", "disks.0.tags.Name", "TerraformTest"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAlicloudDisksDataSource_filterByAllFields(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCheckAlicloudDisksDataSourceFilterByAllFields,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAlicloudDataSourceID("data.alicloud_disks.disks"),
+					resource.TestCheckResourceAttr("data.alicloud_disks.disks", "disks.#", "1"),
+					resource.TestCheckResourceAttr("data.alicloud_disks.disks", "disks.0.name", "tf-testAccCheckAlicloudDisksDataSourceFilterByAllFields"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAlicloudDisksDataSource_filterByInstanceId(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCheckAlicloudDisksDataSourceFilterByInstanceId,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAlicloudDataSourceID("data.alicloud_disks.disks"),
+					resource.TestCheckResourceAttr("data.alicloud_disks.disks", "disks.#", "1"),
+					resource.TestCheckResourceAttr("data.alicloud_disks.disks", "disks.0.name", "tf-testAccCheckAlicloudDisksDataSourceFilterByInstanceId"),
+					resource.TestCheckResourceAttr("data.alicloud_disks.disks", "disks.0.status", "In_use"),
+					resource.TestCheckResourceAttrSet("data.alicloud_disks.disks", "disks.0.instance_id"),
+					resource.TestCheckResourceAttrSet("data.alicloud_disks.disks", "disks.0.creation_time"),
+					resource.TestCheckResourceAttrSet("data.alicloud_disks.disks", "disks.0.attached_time"),
+				),
+			},
+		},
+	})
+}
+
+const testAccCheckAlicloudDisksDataSourceBasic = `
+variable "name" {
+	default = "tf-testAccCheckAlicloudDisksDataSourceBasic"
+}
+
+data "alicloud_zones" "az" {
+	"available_resource_creation"= "VSwitch"
+}
+
+resource "alicloud_disk" "sample_disk" {
+	availability_zone = "${data.alicloud_zones.az.zones.0.id}"
+	category = "cloud_efficiency"
+	name = "${var.name}"
+    description = "${var.name}_description"
+	size = "20"
+	tags {
+	    Name = "TerraformTest"
+	    Name1 = "TerraformTest"
+	}
+}
+
+data "alicloud_disks" "disks" {
+    name_regex = "${alicloud_disk.sample_disk.name}"
+}
+`
+
+const testAccCheckAlicloudDisksDataSourceFilterByAllFields = `
+variable "name" {
+	default = "tf-testAccCheckAlicloudDisksDataSourceFilterByAllFields"
+}
+
+data "alicloud_zones" "az" {
+	"available_resource_creation"= "VSwitch"
+}
+
+resource "alicloud_disk" "sample_disk" {
+	availability_zone = "${data.alicloud_zones.az.zones.0.id}"
+	category = "cloud_efficiency"
+	name = "${var.name}"
+    description = "${var.name}_description"
+	size = "20"
+	tags {
+	    Name = "TerraformTest"
+	    Name1 = "TerraformTest"
+	}
+}
+
+data "alicloud_disks" "disks" {
+    ids = ["${alicloud_disk.sample_disk.id}"]
+    name_regex = "${alicloud_disk.sample_disk.name}"
+    type = "data"
+    category = "cloud_efficiency"
+    encrypted = "off"
+    tags = {
+        Name = "TerraformTest"
+    }
+}
+`
+
+const testAccCheckAlicloudDisksDataSourceFilterByInstanceId = `
+variable "name" {
+	default = "tf-testAccCheckAlicloudDisksDataSourceFilterByInstanceId"
+}
+
+data "alicloud_zones" "az" {
+	"available_resource_creation"= "VSwitch"
+}
+data "alicloud_images" "images" {
+	name_regex = "ubuntu*"
+}
+data "alicloud_instance_types" "default" {
+ 	availability_zone = "${data.alicloud_zones.az.zones.0.id}"
+	cpu_core_count = 1
+	memory_size = 2
+}
+
+resource "alicloud_disk" "sample_disk" {
+	availability_zone = "${data.alicloud_zones.az.zones.0.id}"
+	category = "cloud_efficiency"
+	name = "${var.name}"
+    description = "${var.name}_description"
+	size = "20"
+}
+
+resource "alicloud_vpc" "sample_vpc" {
+	name = "${var.name}"
+  	cidr_block = "172.16.0.0/12"
+}
+
+resource "alicloud_vswitch" "sample_vswitch" {
+	name = "${var.name}"
+  	vpc_id = "${alicloud_vpc.sample_vpc.id}"
+  	cidr_block = "172.16.0.0/16"
+  	availability_zone = "${data.alicloud_zones.az.zones.0.id}"
+}
+
+resource "alicloud_security_group" "sample_security_group" {
+	name = "${var.name}"
+	vpc_id = "${alicloud_vpc.sample_vpc.id}"
+}
+
+resource "alicloud_instance" "sample_instance" {
+	vswitch_id = "${alicloud_vswitch.sample_vswitch.id}"
+	private_ip = "172.16.10.10"
+	image_id = "${data.alicloud_images.images.images.0.id}"
+	instance_type = "${data.alicloud_instance_types.default.instance_types.0.id}"
+  	instance_name = "${var.name}"
+	system_disk_category = "cloud_efficiency"
+	security_groups = ["${alicloud_security_group.sample_security_group.id}"]
+}
+
+resource "alicloud_disk_attachment" "sample_disk_attachment" {
+  disk_id = "${alicloud_disk.sample_disk.id}"
+  instance_id = "${alicloud_instance.sample_instance.id}"
+}
+
+data "alicloud_disks" "disks" {
+    instance_id = "${alicloud_disk_attachment.sample_disk_attachment.instance_id}"
+    type = "data"
+}
+`

--- a/alicloud/data_source_alicloud_oss_buckets.go
+++ b/alicloud/data_source_alicloud_oss_buckets.go
@@ -1,0 +1,386 @@
+package alicloud
+
+import (
+	"fmt"
+	"log"
+	"regexp"
+
+	"github.com/aliyun/aliyun-oss-go-sdk/oss"
+	"github.com/hashicorp/terraform/helper/schema"
+)
+
+func dataSourceAlicloudOssBuckets() *schema.Resource {
+	return &schema.Resource{
+		Read: dataSourceAlicloudOssBucketsRead,
+
+		Schema: map[string]*schema.Schema{
+			"name_regex": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ValidateFunc: validateNameRegex,
+				ForceNew:     true,
+			},
+			"output_file": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+
+			// Computed values
+			"buckets": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"name": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"acl": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"extranet_endpoint": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"intranet_endpoint": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"location": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"owner": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"storage_class": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"creation_date": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+
+						"cors_rules": {
+							Type:     schema.TypeList,
+							Computed: true,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"allowed_headers": {
+										Type:     schema.TypeList,
+										Computed: true,
+										Elem:     &schema.Schema{Type: schema.TypeString},
+									},
+									"allowed_methods": {
+										Type:     schema.TypeList,
+										Computed: true,
+										Elem:     &schema.Schema{Type: schema.TypeString},
+									},
+									"allowed_origins": {
+										Type:     schema.TypeList,
+										Computed: true,
+										Elem:     &schema.Schema{Type: schema.TypeString},
+									},
+									"expose_headers": {
+										Type:     schema.TypeList,
+										Computed: true,
+										Elem:     &schema.Schema{Type: schema.TypeString},
+									},
+									"max_age_seconds": {
+										Type:     schema.TypeInt,
+										Computed: true,
+									},
+								},
+							},
+						},
+
+						"website": {
+							Type:     schema.TypeList,
+							Computed: true,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"index_document": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+
+									"error_document": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+								},
+							},
+							MaxItems: 1,
+						},
+
+						"logging": {
+							Type:     schema.TypeList,
+							Computed: true,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"target_bucket": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+									"target_prefix": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+								},
+							},
+							MaxItems: 1,
+						},
+
+						"referer_config": {
+							Type:     schema.TypeList,
+							Computed: true,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"allow_empty": {
+										Type:     schema.TypeBool,
+										Computed: true,
+									},
+									"referers": {
+										Type:     schema.TypeList,
+										Computed: true,
+										Elem:     &schema.Schema{Type: schema.TypeString},
+									},
+								},
+							},
+							MaxItems: 1,
+						},
+
+						"lifecycle_rule": {
+							Type:     schema.TypeList,
+							Computed: true,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"id": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+									"prefix": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+									"enabled": {
+										Type:     schema.TypeBool,
+										Computed: true,
+									},
+									"expiration": {
+										Type:     schema.TypeList,
+										Computed: true,
+										Elem: &schema.Resource{
+											Schema: map[string]*schema.Schema{
+												"date": {
+													Type:     schema.TypeString,
+													Optional: true,
+												},
+												"days": {
+													Type:     schema.TypeInt,
+													Optional: true,
+												},
+											},
+										},
+										MaxItems: 1,
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func dataSourceAlicloudOssBucketsRead(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*AliyunClient)
+
+	var allBuckets []oss.BucketProperties
+	nextMarker := ""
+	for {
+		var options []oss.Option
+		if nextMarker != "" {
+			options = append(options, oss.Marker(nextMarker))
+		}
+
+		resp, err := client.ossconn.ListBuckets(options...)
+		if err != nil {
+			return err
+		}
+
+		if resp.Buckets == nil || len(resp.Buckets) < 1 {
+			break
+		}
+
+		allBuckets = append(allBuckets, resp.Buckets...)
+
+		nextMarker = resp.NextMarker
+		if nextMarker == "" {
+			break
+		}
+	}
+
+	var filteredBucketsTemp []oss.BucketProperties
+	nameRegex, ok := d.GetOk("name_regex")
+	if ok && nameRegex.(string) != "" {
+		var r *regexp.Regexp
+		if nameRegex != "" {
+			r = regexp.MustCompile(nameRegex.(string))
+		}
+		for _, bucket := range allBuckets {
+			if r != nil && !r.MatchString(bucket.Name) {
+				continue
+			}
+			filteredBucketsTemp = append(filteredBucketsTemp, bucket)
+		}
+	} else {
+		filteredBucketsTemp = allBuckets
+	}
+
+	if len(filteredBucketsTemp) < 1 {
+		return fmt.Errorf("Your query returned no results. Please change your search criteria and try again.")
+	}
+
+	log.Printf("[DEBUG] alicloud_oss_buckets - Bucket found: %#v", filteredBucketsTemp)
+
+	return bucketsDescriptionAttributes(d, filteredBucketsTemp, meta)
+}
+
+func bucketsDescriptionAttributes(d *schema.ResourceData, buckets []oss.BucketProperties, meta interface{}) error {
+	client := meta.(*AliyunClient)
+
+	var ids []string
+	var s []map[string]interface{}
+	for _, bucket := range buckets {
+		mapping := map[string]interface{}{
+			"name":          bucket.Name,
+			"location":      bucket.Location,
+			"storage_class": bucket.StorageClass,
+			"creation_date": bucket.CreationDate.Format("2006-01-02"),
+		}
+
+		// Add additional information
+		resp, err := client.ossconn.GetBucketInfo(bucket.Name)
+		if err == nil {
+			mapping["acl"] = resp.BucketInfo.ACL
+			mapping["extranet_endpoint"] = resp.BucketInfo.ExtranetEndpoint
+			mapping["intranet_endpoint"] = resp.BucketInfo.IntranetEndpoint
+			mapping["owner"] = resp.BucketInfo.Owner.ID
+		} else {
+			log.Printf("[WARN] Unable to get additional information for the bucket %s: %v", bucket.Name, err)
+		}
+
+		// Add CORS rule information
+		var ruleMappings []map[string]interface{}
+		cors, err := client.ossconn.GetBucketCORS(bucket.Name)
+		if err != nil && !IsExceptedErrors(err, []string{NoSuchCORSConfiguration}) {
+			log.Printf("[WARN] Unable to get CORS information for the bucket %s: %v", bucket.Name, err)
+		} else if err == nil && cors.CORSRules != nil {
+			for _, rule := range cors.CORSRules {
+				ruleMapping := make(map[string]interface{})
+				ruleMapping["allowed_headers"] = rule.AllowedHeader
+				ruleMapping["allowed_methods"] = rule.AllowedMethod
+				ruleMapping["allowed_origins"] = rule.AllowedOrigin
+				ruleMapping["expose_headers"] = rule.ExposeHeader
+				ruleMapping["max_age_seconds"] = rule.MaxAgeSeconds
+				ruleMappings = append(ruleMappings, ruleMapping)
+			}
+		}
+		mapping["cors_rules"] = ruleMappings
+
+		// Add website configuration
+		var websiteMappings []map[string]interface{}
+		ws, err := client.ossconn.GetBucketWebsite(bucket.Name)
+		if err != nil && !IsExceptedErrors(err, []string{NoSuchWebsiteConfiguration}) {
+			log.Printf("[WARN] Unable to get website information for the bucket %s: %v", bucket.Name, err)
+		} else if err == nil && &ws != nil {
+			websiteMapping := make(map[string]interface{})
+			if v := &ws.IndexDocument; v != nil {
+				websiteMapping["index_document"] = v.Suffix
+			}
+			if v := &ws.ErrorDocument; v != nil {
+				websiteMapping["error_document"] = v.Key
+			}
+			websiteMappings = append(websiteMappings, websiteMapping)
+		}
+		mapping["website"] = websiteMappings
+
+		// Add logging information
+		var loggingMappings []map[string]interface{}
+		logging, err := client.ossconn.GetBucketLogging(bucket.Name)
+		if err != nil {
+			log.Printf("[WARN] Unable to get logging information for the bucket %s: %v", bucket.Name, err)
+		} else if logging.LoggingEnabled.TargetBucket != "" || logging.LoggingEnabled.TargetPrefix != "" {
+			loggingMapping := map[string]interface{}{
+				"target_bucket": logging.LoggingEnabled.TargetBucket,
+				"target_prefix": logging.LoggingEnabled.TargetPrefix,
+			}
+			loggingMappings = append(loggingMappings, loggingMapping)
+		}
+		mapping["logging"] = loggingMappings
+
+		// Add referer information
+		var refererMappings []map[string]interface{}
+		referer, err := client.ossconn.GetBucketReferer(bucket.Name)
+		if err != nil {
+			log.Printf("[WARN] Unable to get referer information for the bucket %s: %v", bucket.Name, err)
+		} else {
+			refererMapping := map[string]interface{}{
+				"allow_empty": referer.AllowEmptyReferer,
+				"referers":    referer.RefererList,
+			}
+			refererMappings = append(refererMappings, refererMapping)
+		}
+		mapping["referer_config"] = refererMappings
+
+		// Add lifecycle information
+		var lifecycleRuleMappings []map[string]interface{}
+		lifecycle, err := client.ossconn.GetBucketLifecycle(bucket.Name)
+		if err != nil {
+			log.Printf("[WARN] Unable to get lifecycle information for the bucket %s: %v", bucket.Name, err)
+		} else if len(lifecycle.Rules) > 0 {
+			for _, lifecycleRule := range lifecycle.Rules {
+				ruleMapping := make(map[string]interface{})
+				ruleMapping["id"] = lifecycleRule.ID
+				ruleMapping["prefix"] = lifecycleRule.Prefix
+				if LifecycleRuleStatus(lifecycleRule.Status) == ExpirationStatusEnabled {
+					ruleMapping["enabled"] = true
+				} else {
+					ruleMapping["enabled"] = false
+				}
+
+				// Expiration
+				expirationMapping := make(map[string]interface{})
+				if !lifecycleRule.Expiration.Date.IsZero() {
+					expirationMapping["date"] = (lifecycleRule.Expiration.Date).Format("2006-01-02")
+				}
+				if &lifecycleRule.Expiration.Days != nil {
+					expirationMapping["days"] = int(lifecycleRule.Expiration.Days)
+				}
+				ruleMapping["expiration"] = []map[string]interface{}{expirationMapping}
+				lifecycleRuleMappings = append(lifecycleRuleMappings, ruleMapping)
+			}
+		}
+		mapping["lifecycle_rule"] = lifecycleRuleMappings
+
+		log.Printf("[DEBUG] alicloud_oss_buckets - adding bucket mapping: %v", mapping)
+		ids = append(ids, bucket.Name)
+		s = append(s, mapping)
+	}
+
+	d.SetId(dataResourceIdHash(ids))
+	if err := d.Set("buckets", s); err != nil {
+		return err
+	}
+
+	// create a json file in current directory and write data source to it.
+	if output, ok := d.GetOk("output_file"); ok && output.(string) != "" {
+		writeToFile(output.(string), s)
+	}
+	return nil
+}

--- a/alicloud/data_source_alicloud_oss_buckets_test.go
+++ b/alicloud/data_source_alicloud_oss_buckets_test.go
@@ -1,0 +1,200 @@
+package alicloud
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform/helper/acctest"
+	"github.com/hashicorp/terraform/helper/resource"
+)
+
+func TestAccAlicloudOssBucketsDataSource_basic(t *testing.T) {
+	randInt := acctest.RandInt()
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCheckAlicloudOssBucketsDataSourceBasic(randInt),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAlicloudDataSourceID("data.alicloud_oss_buckets.buckets"),
+					resource.TestCheckResourceAttr("data.alicloud_oss_buckets.buckets", "buckets.#", "1"),
+					resource.TestCheckResourceAttr("data.alicloud_oss_buckets.buckets", "buckets.0.name", fmt.Sprintf("tf-testacc-bucket-ds-basic-%d", randInt)),
+					resource.TestCheckResourceAttr("data.alicloud_oss_buckets.buckets", "buckets.0.acl", "public-read"),
+					resource.TestCheckResourceAttrSet("data.alicloud_oss_buckets.buckets", "buckets.0.extranet_endpoint"),
+					resource.TestCheckResourceAttrSet("data.alicloud_oss_buckets.buckets", "buckets.0.intranet_endpoint"),
+					resource.TestCheckResourceAttrSet("data.alicloud_oss_buckets.buckets", "buckets.0.location"),
+					resource.TestCheckResourceAttrSet("data.alicloud_oss_buckets.buckets", "buckets.0.owner"),
+					resource.TestCheckResourceAttr("data.alicloud_oss_buckets.buckets", "buckets.0.storage_class", "Standard"),
+					resource.TestCheckResourceAttrSet("data.alicloud_oss_buckets.buckets", "buckets.0.creation_date"),
+					resource.TestCheckResourceAttr("data.alicloud_oss_buckets.buckets", "buckets.0.cors_rules.#", "0"),
+					resource.TestCheckResourceAttr("data.alicloud_oss_buckets.buckets", "buckets.0.website.#", "0"),
+					resource.TestCheckResourceAttr("data.alicloud_oss_buckets.buckets", "buckets.0.logging.#", "0"),
+					resource.TestCheckResourceAttr("data.alicloud_oss_buckets.buckets", "buckets.0.referer_config.#", "1"),
+					resource.TestCheckResourceAttr("data.alicloud_oss_buckets.buckets", "buckets.0.referer_config.0.allow_empty", "true"),
+					resource.TestCheckResourceAttr("data.alicloud_oss_buckets.buckets", "buckets.0.referer_config.0.referers.#", "0"),
+					resource.TestCheckResourceAttr("data.alicloud_oss_buckets.buckets", "buckets.0.lifecycle_rule.#", "0"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAlicloudOssBucketsDataSource_full(t *testing.T) {
+	randInt := acctest.RandInt()
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCheckAlicloudOssBucketsDataSourceFull(randInt),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAlicloudDataSourceID("data.alicloud_oss_buckets.buckets"),
+					resource.TestCheckResourceAttr("data.alicloud_oss_buckets.buckets", "buckets.#", "1"),
+					resource.TestCheckResourceAttr("data.alicloud_oss_buckets.buckets", "buckets.0.name", fmt.Sprintf("tf-testacc-bucket-ds-full-%d-sample", randInt)),
+					resource.TestCheckResourceAttr("data.alicloud_oss_buckets.buckets", "buckets.0.acl", "public-read"),
+					resource.TestCheckResourceAttrSet("data.alicloud_oss_buckets.buckets", "buckets.0.extranet_endpoint"),
+					resource.TestCheckResourceAttrSet("data.alicloud_oss_buckets.buckets", "buckets.0.intranet_endpoint"),
+					resource.TestCheckResourceAttrSet("data.alicloud_oss_buckets.buckets", "buckets.0.location"),
+					resource.TestCheckResourceAttrSet("data.alicloud_oss_buckets.buckets", "buckets.0.owner"),
+					resource.TestCheckResourceAttr("data.alicloud_oss_buckets.buckets", "buckets.0.storage_class", "Standard"),
+					resource.TestCheckResourceAttrSet("data.alicloud_oss_buckets.buckets", "buckets.0.creation_date"),
+
+					resource.TestCheckResourceAttr("data.alicloud_oss_buckets.buckets", "buckets.0.cors_rules.#", "2"),
+					resource.TestCheckResourceAttr("data.alicloud_oss_buckets.buckets", "buckets.0.cors_rules.0.allowed_headers.#", "1"),
+					resource.TestCheckResourceAttr("data.alicloud_oss_buckets.buckets", "buckets.0.cors_rules.0.allowed_headers.0", "authorization"),
+					resource.TestCheckResourceAttr("data.alicloud_oss_buckets.buckets", "buckets.0.cors_rules.0.allowed_methods.#", "2"),
+					resource.TestCheckResourceAttr("data.alicloud_oss_buckets.buckets", "buckets.0.cors_rules.0.allowed_methods.0", "PUT"),
+					resource.TestCheckResourceAttr("data.alicloud_oss_buckets.buckets", "buckets.0.cors_rules.0.allowed_methods.1", "GET"),
+					resource.TestCheckResourceAttr("data.alicloud_oss_buckets.buckets", "buckets.0.cors_rules.0.allowed_origins.#", "1"),
+					resource.TestCheckResourceAttr("data.alicloud_oss_buckets.buckets", "buckets.0.cors_rules.0.allowed_origins.0", "*"),
+					resource.TestCheckResourceAttr("data.alicloud_oss_buckets.buckets", "buckets.0.cors_rules.0.expose_headers.#", "0"),
+					resource.TestCheckResourceAttr("data.alicloud_oss_buckets.buckets", "buckets.0.cors_rules.0.max_age_seconds", "0"),
+
+					resource.TestCheckResourceAttr("data.alicloud_oss_buckets.buckets", "buckets.0.cors_rules.1.allowed_headers.#", "1"),
+					resource.TestCheckResourceAttr("data.alicloud_oss_buckets.buckets", "buckets.0.cors_rules.1.allowed_headers.0", "authorization"),
+					resource.TestCheckResourceAttr("data.alicloud_oss_buckets.buckets", "buckets.0.cors_rules.1.allowed_methods.#", "1"),
+					resource.TestCheckResourceAttr("data.alicloud_oss_buckets.buckets", "buckets.0.cors_rules.1.allowed_methods.0", "GET"),
+					resource.TestCheckResourceAttr("data.alicloud_oss_buckets.buckets", "buckets.0.cors_rules.1.allowed_origins.#", "1"),
+					resource.TestCheckResourceAttr("data.alicloud_oss_buckets.buckets", "buckets.0.cors_rules.1.allowed_origins.0", "http://www.a.com"),
+					resource.TestCheckResourceAttr("data.alicloud_oss_buckets.buckets", "buckets.0.cors_rules.1.expose_headers.#", "1"),
+					resource.TestCheckResourceAttr("data.alicloud_oss_buckets.buckets", "buckets.0.cors_rules.1.expose_headers.0", "x-oss-test"),
+					resource.TestCheckResourceAttr("data.alicloud_oss_buckets.buckets", "buckets.0.cors_rules.1.max_age_seconds", "100"),
+
+					resource.TestCheckResourceAttr("data.alicloud_oss_buckets.buckets", "buckets.0.website.#", "1"),
+					resource.TestCheckResourceAttr("data.alicloud_oss_buckets.buckets", "buckets.0.website.0.index_document", "index.html"),
+					resource.TestCheckResourceAttr("data.alicloud_oss_buckets.buckets", "buckets.0.website.0.error_document", "error.html"),
+
+					resource.TestCheckResourceAttr("data.alicloud_oss_buckets.buckets", "buckets.0.logging.#", "1"),
+					resource.TestCheckResourceAttr("data.alicloud_oss_buckets.buckets", "buckets.0.logging.0.target_bucket", fmt.Sprintf("tf-testacc-bucket-ds-full-%d-log", randInt)),
+					resource.TestCheckResourceAttr("data.alicloud_oss_buckets.buckets", "buckets.0.logging.0.target_prefix", "log/"),
+
+					resource.TestCheckResourceAttr("data.alicloud_oss_buckets.buckets", "buckets.0.referer_config.#", "1"),
+					resource.TestCheckResourceAttr("data.alicloud_oss_buckets.buckets", "buckets.0.referer_config.0.allow_empty", "false"),
+					resource.TestCheckResourceAttr("data.alicloud_oss_buckets.buckets", "buckets.0.referer_config.0.referers.#", "1"),
+					resource.TestCheckResourceAttr("data.alicloud_oss_buckets.buckets", "buckets.0.referer_config.0.referers.0", "http://www.aliyun.com"),
+
+					resource.TestCheckResourceAttr("data.alicloud_oss_buckets.buckets", "buckets.0.lifecycle_rule.#", "2"),
+					resource.TestCheckResourceAttr("data.alicloud_oss_buckets.buckets", "buckets.0.lifecycle_rule.0.id", "rule1"),
+					resource.TestCheckResourceAttr("data.alicloud_oss_buckets.buckets", "buckets.0.lifecycle_rule.0.prefix", "path1/"),
+					resource.TestCheckResourceAttr("data.alicloud_oss_buckets.buckets", "buckets.0.lifecycle_rule.0.enabled", "true"),
+					resource.TestCheckResourceAttr("data.alicloud_oss_buckets.buckets", "buckets.0.lifecycle_rule.0.expiration.#", "1"),
+					resource.TestCheckResourceAttr("data.alicloud_oss_buckets.buckets", "buckets.0.lifecycle_rule.0.expiration.0.days", "365"),
+
+					resource.TestCheckResourceAttr("data.alicloud_oss_buckets.buckets", "buckets.0.lifecycle_rule.1.id", "rule2"),
+					resource.TestCheckResourceAttr("data.alicloud_oss_buckets.buckets", "buckets.0.lifecycle_rule.1.prefix", "path2/"),
+					resource.TestCheckResourceAttr("data.alicloud_oss_buckets.buckets", "buckets.0.lifecycle_rule.1.enabled", "true"),
+					resource.TestCheckResourceAttr("data.alicloud_oss_buckets.buckets", "buckets.0.lifecycle_rule.1.expiration.#", "1"),
+					resource.TestCheckResourceAttr("data.alicloud_oss_buckets.buckets", "buckets.0.lifecycle_rule.1.expiration.0.date", "2018-01-12"),
+				),
+			},
+		},
+	})
+}
+
+func testAccCheckAlicloudOssBucketsDataSourceBasic(randInt int) string {
+	return fmt.Sprintf(`
+variable "name" {
+	default = "tf-testacc-bucket-ds-basic-%d"
+}
+
+resource "alicloud_oss_bucket" "sample_bucket" {
+	bucket = "${var.name}"
+	acl = "public-read"
+}
+
+data "alicloud_oss_buckets" "buckets" {
+    name_regex = "${alicloud_oss_bucket.sample_bucket.bucket}"
+}
+`, randInt)
+}
+
+func testAccCheckAlicloudOssBucketsDataSourceFull(randInt int) string {
+	return fmt.Sprintf(`
+variable "name" {
+	default = "tf-testacc-bucket-ds-full-%d"
+}
+
+resource "alicloud_oss_bucket" "log_bucket"{
+	bucket = "${var.name}-log"
+}
+
+resource "alicloud_oss_bucket" "sample_bucket" {
+	bucket = "${var.name}-sample"
+	acl = "public-read"
+
+    cors_rule = [
+    	{
+			allowed_origins=["*"]
+			allowed_methods=["PUT","GET"]
+			allowed_headers=["authorization"]
+		},
+		{
+			allowed_origins=["http://www.a.com"]
+			allowed_methods=["GET"]
+			allowed_headers=["authorization"]
+			expose_headers=["x-oss-test"]
+			max_age_seconds=100
+		}
+    ]
+
+	website = {
+		index_document = "index.html"
+		error_document = "error.html"
+	}
+
+	logging {
+		target_bucket = "${alicloud_oss_bucket.log_bucket.id}"
+		target_prefix = "log/"
+	}
+
+	referer_config {
+		allow_empty = false
+		referers = ["http://www.aliyun.com"]
+	}
+
+	lifecycle_rule = [
+		{
+			id = "rule1"
+			prefix = "path1/"
+			enabled = true
+			expiration {
+				days = 365
+			}
+		},
+		{
+			id = "rule2"
+			prefix = "path2/"
+			enabled = true
+			expiration {
+				date = "2018-01-12"
+			}
+		}
+	]
+}
+
+data "alicloud_oss_buckets" "buckets" {
+    name_regex = "${alicloud_oss_bucket.sample_bucket.bucket}"
+}
+`, randInt)
+}

--- a/alicloud/provider.go
+++ b/alicloud/provider.go
@@ -71,6 +71,7 @@ func Provider() terraform.ResourceProvider {
 			"alicloud_zones":          dataSourceAlicloudZones(),
 			"alicloud_instance_types": dataSourceAlicloudInstanceTypes(),
 			"alicloud_instances":      dataSourceAlicloudInstances(),
+			"alicloud_disks":          dataSourceAlicloudDisks(),
 			"alicloud_vpcs":           dataSourceAlicloudVpcs(),
 			"alicloud_vswitches":      dataSourceAlicloudVSwitches(),
 			"alicloud_eips":           dataSourceAlicloudEips(),

--- a/alicloud/provider.go
+++ b/alicloud/provider.go
@@ -97,6 +97,7 @@ func Provider() terraform.ResourceProvider {
 			"alicloud_slb_listeners":        dataSourceAlicloudSlbListeners(),
 			"alicloud_slb_rules":            dataSourceAlicloudSlbRules(),
 			"alicloud_slb_server_groups":    dataSourceAlicloudSlbServerGroups(),
+			"alicloud_oss_buckets":          dataSourceAlicloudOssBuckets(),
 			"alicloud_db_instances":         dataSourceAlicloudDBInstances(),
 			"alicloud_pvtz_zones":           dataSourceAlicloudPvtzZones(),
 			"alicloud_pvtz_zone_records":    dataSourceAlicloudPvtzZoneRecords(),

--- a/examples/kubernetes/main.tf
+++ b/examples/kubernetes/main.tf
@@ -1,10 +1,3 @@
-// Provider specific configs
-provider "alicloud" {
-  access_key = "${var.alicloud_access_key}"
-  secret_key = "${var.alicloud_secret_key}"
-  region = "${var.region}"
-}
-
 // Instance_types data source for instance_type
 data "alicloud_instance_types" "default" {
   cpu_core_count = "${var.cpu_core_count}"
@@ -59,11 +52,11 @@ resource "alicloud_snat_entry" "default"{
 resource "alicloud_cs_kubernetes" "k8s" {
   count = "${var.k8s_number}"
   name = "${var.k8s_name_prefix == "" ? format("%s-%s", var.example_name, format(var.number_format, count.index+1)) : format("%s-%s", var.k8s_name_prefix, format(var.number_format, count.index+1))}"
-  vswitch_id = "${length(var.vswitch_ids) > 0 ? element(split(",", join(",", var.vswitch_ids)), count.index%length(split(",", join(",", var.vswitch_ids)))) : length(var.vswitch_cidrs) < 1 ? "" : element(split(",", join(",", alicloud_vswitch.vswitches.*.id)), count.index%length(split(",", join(",", alicloud_vswitch.vswitches.*.id))))}"
+  vswitch_ids = ["${length(var.vswitch_ids) > 0 ? element(split(",", join(",", var.vswitch_ids)), count.index%length(split(",", join(",", var.vswitch_ids)))) : length(var.vswitch_cidrs) < 1 ? "" : element(split(",", join(",", alicloud_vswitch.vswitches.*.id)), count.index%length(split(",", join(",", alicloud_vswitch.vswitches.*.id))))}"]
   new_nat_gateway = false
-  master_instance_type = "${var.master_instance_type == "" ? data.alicloud_instance_types.default.instance_types.0.id : var.master_instance_type}"
-  worker_instance_type = "${var.worker_instance_type == "" ? data.alicloud_instance_types.default.instance_types.0.id : var.worker_instance_type}"
-  worker_number = "${var.k8s_worker_number}"
+  master_instance_types = ["${var.master_instance_type == "" ? data.alicloud_instance_types.default.instance_types.0.id : var.master_instance_type}"]
+  worker_instance_types = ["${var.worker_instance_type == "" ? data.alicloud_instance_types.default.instance_types.0.id : var.worker_instance_type}"]
+  worker_numbers = ["${var.k8s_worker_number}"]
   master_disk_category = "${var.master_disk_category}"
   worker_disk_category = "${var.worker_disk_category}"
   master_disk_size = "${var.master_disk_size}"

--- a/examples/kubernetes/outputs.tf
+++ b/examples/kubernetes/outputs.tf
@@ -6,7 +6,7 @@ output "vpc_id" {
 
 output "vswitch_ids" {
   description = "List ID of the VSwitches."
-  value = ["${alicloud_cs_kubernetes.k8s.*.vswitch_id}"]
+  value = ["${alicloud_cs_kubernetes.k8s.*.vswitch_ids}"]
 }
 
 output "nat_gateway_id" {

--- a/examples/kubernetes/variables.tf
+++ b/examples/kubernetes/variables.tf
@@ -1,14 +1,4 @@
-# common variables
-variable "alicloud_access_key" {
-  description = "The Alicloud Access Key ID to launch resources."
-}
-variable "alicloud_secret_key" {
-  description = "The Alicloud Access Secret Key to launch resources."
-}
-variable "region" {
-  description = "The region to launch resources."
-  default = "cn-hangzhou"
-}
+//# common variables
 variable "availability_zone" {
   description = "The available zone to launch ecs instance and other resources."
   default = ""

--- a/website/alicloud.erb
+++ b/website/alicloud.erb
@@ -37,6 +37,9 @@
                         <li<%= sidebar_current("docs-alicloud-datasource-instances") %>>
                             <a href="/docs/providers/alicloud/d/instances.html">alicloud_instances</a>
                         </li>
+                        <li<%= sidebar_current("docs-alicloud-datasource-disks") %>>
+                            <a href="/docs/providers/alicloud/d/disks.html">alicloud_disks</a>
+                        </li>
                         <li<%= sidebar_current("docs-alicloud-datasource-vpcs") %>>
                             <a href="/docs/providers/alicloud/d/vpcs.html">alicloud_vpcs</a>
                         </li>

--- a/website/alicloud.erb
+++ b/website/alicloud.erb
@@ -73,6 +73,9 @@
                         <li<%= sidebar_current("docs-alicloud-datasource-slb-server-groups") %>>
                           <a href="/docs/providers/alicloud/d/slb_server_groups.html">alicloud_slb_server_groups</a>
                         </li>
+                        <li<%= sidebar_current("docs-alicloud-datasource-oss-buckets") %>>
+                          <a href="/docs/providers/alicloud/d/oss_buckets.html">alicloud_oss_buckets</a>
+                        </li>
                         <li<%= sidebar_current("docs-alicloud-datasource-db-instances") %>>
                             <a href="/docs/providers/alicloud/d/db_instances.html">alicloud_db_instances</a>
                         </li>

--- a/website/docs/d/disks.html.markdown
+++ b/website/docs/d/disks.html.markdown
@@ -1,0 +1,68 @@
+---
+layout: "alicloud"
+page_title: "Alicloud: alicloud_disks"
+sidebar_current: "docs-alicloud-datasource-disks"
+description: |-
+    Provides a list of disks to the user.
+---
+
+# alicloud\_disks
+
+This data source provides the disks of the current Alibaba Cloud user.
+
+## Example Usage
+
+```
+data "alicloud_disks" "disks_ds" {
+  name_regex = "sample_disk"
+}
+
+output "first_disk_id" {
+  value = "${data.alicloud_disks.disks_ds.disks.0.id}"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `ids` - (Optional) A list of disks IDs.
+* `name_regex` - (Optional) A regex string to filter results by disk name.
+* `type` - (Optional) Disk type. Possible values: `system` and `data`.
+* `category` - (Optional) Disk category. Possible values: `cloud` (basic cloud disk), `cloud_efficiency` (ultra cloud disk), `cloud_ssd` (SSD cloud disk), `ephemeral_ssd` (ephemeral SSD) and `ephemeral` (ephemeral disk).
+* `encrypted` - (Optional) Indicate whether the disk is encrypted or not. Possible values: `on` and `off`.
+* `instance_id` - (Optional) Filter the results by the specified ECS instance ID.
+* `tags` - (Optional) A map of tags assigned to the disks. It must be in the format:
+  ```
+  data "alicloud_disks" "disks_ds" {
+    tags = {
+      tagKey1 = "tagValue1",
+      tagKey2 = "tagValue2"
+    }
+  }
+  ```
+* `output_file` - (Optional) File name where to save data source results (after running `terraform plan`).
+
+## Attributes Reference
+
+The following attributes are exported in addition to the arguments listed above:
+
+* `disks` - A list of disks. Each element contains the following attributes:
+  * `id` - ID of the disk.
+  * `name` - Disk name.
+  * `description` - Disk description.
+  * `region_id` - Region ID the disk belongs to.
+  * `availability_zone` - Availability zone of the disk.
+  * `status` - Current status. Possible values: `In_use`, `Available`, `Attaching`, `Detaching`, `Creating` and `ReIniting`.
+  * `type` - Disk type. Possible values: `system` and `data`.
+  * `category` - Disk category. Possible values: `cloud` (basic cloud disk), `cloud_efficiency` (ultra cloud disk), `cloud_ssd` (SSD cloud disk), `ephemeral_ssd` (ephemeral SSD) and `ephemeral` (ephemeral disk).
+  * `encrypted` - Indicate whether the disk is encrypted or not. Possible values: `on` and `off`.
+  * `size` - Disk size in GiB.
+  * `image_id` - ID of the image from which the disk is created. It is null unless the disk is created using an image.
+  * `snapshot_id` - Snapshot used to create the disk. It is null if no snapshot is used to create the disk.
+  * `instance_id` - ID of the related instance. It is `null` unless the `status` is `In_use`.
+  * `creation_time` - Disk creation time.
+  * `attached_time` - Disk attachment time.
+  * `detached_time` - Disk detachment time.
+  * `expiration_time` - Disk expiration time.
+  * `tags` - A map of tags assigned to the disk.

--- a/website/docs/d/oss_buckets.html.markdown
+++ b/website/docs/d/oss_buckets.html.markdown
@@ -1,0 +1,66 @@
+---
+layout: "alicloud"
+page_title: "Alicloud: alicloud_oss_buckets"
+sidebar_current: "docs-alicloud-datasource-oss-buckets"
+description: |-
+    Provides a list of OSS buckets to the user.
+---
+
+# alicloud\_oss_buckets
+
+This data source provides the OSS buckets of the current Alibaba Cloud user.
+
+## Example Usage
+
+```
+data "alicloud_oss_buckets" "oss_buckets_ds" {
+  name_regex = "sample_oss_bucket"
+}
+
+output "first_oss_bucket_name" {
+  value = "${data.alicloud_oss_buckets.oss_buckets_ds.buckets.0.name}"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `name_regex` - (Optional) A regex string to filter results by bucket name.
+* `output_file` - (Optional) File name where to save data source results (after running `terraform plan`).
+
+## Attributes Reference
+
+The following attributes are exported in addition to the arguments listed above:
+
+* `buckets` - A list of buckets. Each element contains the following attributes:
+  * `name` - Bucket name.
+  * `acl` - Bucket access control list. Possible values: `private`, `public-read` and `public-read-write`.
+  * `extranet_endpoint` - Internet domain name for accessing the bucket from outside.
+  * `intranet_endpoint` - Intranet domain name for accessing the bucket from an ECS instance in the same region.
+  * `location` - Region of the data center where the bucket is located.
+  * `owner` - Bucket owner.
+  * `storage_class` - Object storage type. Possible values: `Standard`, `IA` and `Archive`.
+  * `creation_date` - Bucket creation date.
+  * `cors_rules` - A list of CORS rule configurations. Each element contains the following attributes:
+    * `allowed_origins` - The origins allowed for cross-domain requests. Multiple elements can be used to specify multiple allowed origins. Each rule allows up to one wildcard "\*". If "\*" is specified, cross-domain requests of all origins are allowed.
+    * `allowed_methods` - Specify the allowed methods for cross-domain requests. Possible values: `GET`, `PUT`, `DELETE`, `POST` and `HEAD`.
+    * `allowed_headers` - Control whether the headers specified by Access-Control-Request-Headers in the OPTIONS prefetch command are allowed. Each header specified by Access-Control-Request-Headers must match a value in AllowedHeader. Each rule allows up to one wildcard “*” .
+    * `expose_headers` - Specify the response headers allowing users to access from an application (for example, a Javascript XMLHttpRequest object). The wildcard "\*" is not allowed.
+    * `max_age_seconds` - Specify the cache time for the returned result of a browser prefetch (OPTIONS) request to a specific resource.
+  * `website` - A list of one element containing configuration parameters used when the bucket is used as a website. It contains the following attributes:
+    * `index_document` - Key of the HTML document containing the home page.
+    * `error_document` - Key of the HTML document containing the error page.
+  * `logging` - A list of one element containing configuration parameters used for storing access log information. It contains the following attributes:
+    * `target_bucket` - Bucket for storing access logs.
+    * `target_prefix` - Prefix of the saved access log file paths.
+  * `referer_config` - A list of one element containing referer configuration. It contains the following attributes:
+    * `allow_empty` - Indicate whether the access request referer field can be empty.
+    * `referers` - Referer access whitelist.
+  * `lifecycle_rule` - A list CORS of lifecycle configurations. When Lifecycle is enabled, OSS automatically deletes the objects or transitions the objects (to another storage class) corresponding the lifecycle rules on a regular basis. Each element contains the following attributes:
+    * `id` - Unique ID of the rule.
+    * `prefix` - Prefix applicable to a rule. Only those objects with a matching prefix can be affected by the rule.
+    * `enabled` - Indicate whether the rule is enabled or not.
+    * `expiration` - A list of one element containing expiration attributes of an object. It contains the following attributes:
+      * `date` - Date after which the rule to take effect. The format is like 2017-03-09.
+      * `days` - Indicate the number of days after the last object update until the rules take effect.


### PR DESCRIPTION
New data source alicloud_oss_buckets.

Test results:
```
GOROOT=/usr/local/go #gosetup
GOPATH=/Users/marcplouhinec/go #gosetup
/usr/local/go/bin/go test -c -i -v -sweep=cn-beijing -o /private/var/folders/v1/jvjz3zmn64q0j34yc9m9n4w00000gn/T/___Test_in_Beijing__non_verbose_ github.com/alibaba/terraform-provider/alicloud #gosetup
github.com/alibaba/terraform-provider/alicloud
github.com/alibaba/terraform-provider/alicloud (testmain)
/usr/local/go/bin/go tool test2json -t /private/var/folders/v1/jvjz3zmn64q0j34yc9m9n4w00000gn/T/___Test_in_Beijing__non_verbose_ -test.v -test.run ^TestAccAlicloudOssBucketsDataSource_ #gosetup
=== RUN   TestAccAlicloudOssBucketsDataSource_basic
--- PASS: TestAccAlicloudOssBucketsDataSource_basic (9.44s)
=== RUN   TestAccAlicloudOssBucketsDataSource_full
--- PASS: TestAccAlicloudOssBucketsDataSource_full (13.32s)
PASS
```