### PR TITLE
 Add a new datasource oss_objects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 IMPROVEMENTS:
 
+- **New Data Source:** `alicloud_fc_services` ([#348](https://github.com/terraform-providers/terraform-provider-alicloud/pull/348))
 - **New Data Source:** `alicloud_oss_buckets` ([#345](https://github.com/terraform-providers/terraform-provider-alicloud/pull/345))
 - Improve example/kubernetes to support multi-az ([#344](https://github.com/terraform-providers/terraform-provider-alicloud/pull/344))
 - **New Data Source:** `alicloud_disks` ([#343](https://github.com/terraform-providers/terraform-provider-alicloud/pull/343))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,13 +1,17 @@
 ## 1.17.0 (Unreleased)
 
-IMPROVEMENTS:
+FEATURES:
 
+- **New Data Source:** `alicloud_oss_bucket_objects` ([#350](https://github.com/terraform-providers/terraform-provider-alicloud/pull/350))
 - **New Data Source:** `alicloud_fc_functions` ([#349](https://github.com/terraform-providers/terraform-provider-alicloud/pull/349))
 - **New Data Source:** `alicloud_fc_services` ([#348](https://github.com/terraform-providers/terraform-provider-alicloud/pull/348))
 - **New Data Source:** `alicloud_oss_buckets` ([#345](https://github.com/terraform-providers/terraform-provider-alicloud/pull/345))
-- Improve example/kubernetes to support multi-az ([#344](https://github.com/terraform-providers/terraform-provider-alicloud/pull/344))
 - **New Data Source:** `alicloud_disks` ([#343](https://github.com/terraform-providers/terraform-provider-alicloud/pull/343))
 - **New Resource:** `alicloud_cen_bandwidth_package` ([#333](https://github.com/terraform-providers/terraform-provider-alicloud/pull/333))
+
+IMPROVEMENTS:
+
+- Improve example/kubernetes to support multi-az ([#344](https://github.com/terraform-providers/terraform-provider-alicloud/pull/344))
 
 ## 1.16.0 (September 16, 2018)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,10 @@
 ## 1.17.0 (Unreleased)
+
+IMPROVEMENTS:
+
+- **New Data Source:** `alicloud_disks` ([#343](https://github.com/terraform-providers/terraform-provider-alicloud/pull/343))
+- **New Resource:** `alicloud_cen_bandwidth_package` ([#333](https://github.com/terraform-providers/terraform-provider-alicloud/pull/333))
+
 ## 1.16.0 (September 16, 2018)
 
 FEATURES:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 IMPROVEMENTS:
 
+- **New Data Source:** `alicloud_oss_buckets` ([#345](https://github.com/terraform-providers/terraform-provider-alicloud/pull/345))
 - Improve example/kubernetes to support multi-az ([#344](https://github.com/terraform-providers/terraform-provider-alicloud/pull/344))
 - **New Data Source:** `alicloud_disks` ([#343](https://github.com/terraform-providers/terraform-provider-alicloud/pull/343))
 - **New Resource:** `alicloud_cen_bandwidth_package` ([#333](https://github.com/terraform-providers/terraform-provider-alicloud/pull/333))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 IMPROVEMENTS:
 
+- **New Data Source:** `alicloud_fc_functions` ([#349](https://github.com/terraform-providers/terraform-provider-alicloud/pull/349))
 - **New Data Source:** `alicloud_fc_services` ([#348](https://github.com/terraform-providers/terraform-provider-alicloud/pull/348))
 - **New Data Source:** `alicloud_oss_buckets` ([#345](https://github.com/terraform-providers/terraform-provider-alicloud/pull/345))
 - Improve example/kubernetes to support multi-az ([#344](https://github.com/terraform-providers/terraform-provider-alicloud/pull/344))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 IMPROVEMENTS:
 
+- Improve example/kubernetes to support multi-az ([#344](https://github.com/terraform-providers/terraform-provider-alicloud/pull/344))
 - **New Data Source:** `alicloud_disks` ([#343](https://github.com/terraform-providers/terraform-provider-alicloud/pull/343))
 - **New Resource:** `alicloud_cen_bandwidth_package` ([#333](https://github.com/terraform-providers/terraform-provider-alicloud/pull/333))
 

--- a/alicloud/data_source_alicloud_disks.go
+++ b/alicloud/data_source_alicloud_disks.go
@@ -1,0 +1,275 @@
+package alicloud
+
+import (
+	"fmt"
+	"log"
+	"regexp"
+
+	"github.com/aliyun/alibaba-cloud-sdk-go/sdk/requests"
+	"github.com/aliyun/alibaba-cloud-sdk-go/services/ecs"
+	"github.com/hashicorp/terraform/helper/schema"
+)
+
+func dataSourceAlicloudDisks() *schema.Resource {
+	return &schema.Resource{
+		Read: dataSourceAlicloudDisksRead,
+
+		Schema: map[string]*schema.Schema{
+			"ids": {
+				Type:     schema.TypeList,
+				Optional: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+				ForceNew: true,
+				MinItems: 1,
+			},
+			"name_regex": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ValidateFunc: validateNameRegex,
+				ForceNew:     true,
+			},
+			"type": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ForceNew:     true,
+				ValidateFunc: validateAllowedStringValue([]string{string(DiskTypeSystem), string(DiskTypeData)}),
+			},
+			"category": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ForceNew:     true,
+				ValidateFunc: validateAllowedStringValue([]string{string(DiskCloud), string(DiskEphemeralSSD), string(DiskCloudEfficiency), string(DiskCloudSSD)}),
+			},
+			"encrypted": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ForceNew:     true,
+				ValidateFunc: validateAllowedStringValue([]string{string(OnFlag), string(OffFlag)}),
+			},
+			"instance_id": {
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: true,
+			},
+			"tags": tagsSchema(),
+			"output_file": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+
+			// Computed values
+			"disks": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"name": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"description": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"region_id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"availability_zone": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"status": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"type": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"category": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"encrypted": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"size": {
+							Type:     schema.TypeInt,
+							Computed: true,
+						},
+						"image_id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"snapshot_id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"instance_id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"creation_time": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"attached_time": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"detached_time": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"expiration_time": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"tags": tagsSchema(),
+					},
+				},
+			},
+		},
+	}
+}
+
+func dataSourceAlicloudDisksRead(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*AliyunClient)
+
+	args := ecs.CreateDescribeDisksRequest()
+
+	if v, ok := d.GetOk("ids"); ok && len(v.([]interface{})) > 0 {
+		args.DiskIds = convertListToJsonString(v.([]interface{}))
+	}
+	if v, ok := d.GetOk("type"); ok && v.(string) != "" {
+		args.DiskType = v.(string)
+	}
+	if v, ok := d.GetOk("category"); ok && v.(string) != "" {
+		args.Category = v.(string)
+	}
+	if v, ok := d.GetOk("encrypted"); ok && v.(string) != "" {
+		if v == string(OnFlag) {
+			args.Encrypted = requests.NewBoolean(true)
+		} else {
+			args.Encrypted = requests.NewBoolean(false)
+		}
+	}
+	if v, ok := d.GetOk("instance_id"); ok && v.(string) != "" {
+		args.InstanceId = v.(string)
+	}
+	if v, ok := d.GetOk("tags"); ok {
+		var tags []ecs.DescribeDisksTag
+
+		for key, value := range v.(map[string]interface{}) {
+			tags = append(tags, ecs.DescribeDisksTag{
+				Key:   key,
+				Value: value.(string),
+			})
+		}
+		args.Tag = &tags
+	}
+
+	var allDisks []ecs.Disk
+	args.PageSize = requests.NewInteger(PageSizeLarge)
+	args.PageNumber = requests.NewInteger(1)
+	for {
+		resp, err := client.ecsconn.DescribeDisks(args)
+		if err != nil {
+			return err
+		}
+
+		if resp == nil || len(resp.Disks.Disk) < 1 {
+			break
+		}
+
+		allDisks = append(allDisks, resp.Disks.Disk...)
+
+		if len(resp.Disks.Disk) < PageSizeLarge {
+			break
+		}
+
+		if page, err := getNextpageNumber(args.PageNumber); err != nil {
+			return err
+		} else {
+			args.PageNumber = page
+		}
+	}
+
+	var filteredDisksTemp []ecs.Disk
+
+	nameRegex, ok := d.GetOk("name_regex")
+	if ok && nameRegex.(string) != "" {
+		var r *regexp.Regexp
+		if nameRegex != "" {
+			r = regexp.MustCompile(nameRegex.(string))
+		}
+		for _, disk := range allDisks {
+			if r != nil && !r.MatchString(disk.DiskName) {
+				continue
+			}
+
+			filteredDisksTemp = append(filteredDisksTemp, disk)
+		}
+	} else {
+		filteredDisksTemp = allDisks
+	}
+
+	if len(filteredDisksTemp) < 1 {
+		return fmt.Errorf("Your query returned no results. Please change your search criteria and try again.")
+	}
+
+	log.Printf("[DEBUG] alicloud_disks - Disks found: %#v", filteredDisksTemp)
+
+	return disksDescriptionAttributes(d, filteredDisksTemp)
+}
+
+func disksDescriptionAttributes(d *schema.ResourceData, disks []ecs.Disk) error {
+	var ids []string
+	var s []map[string]interface{}
+	for _, disk := range disks {
+		mapping := map[string]interface{}{
+			"id":                disk.DiskId,
+			"name":              disk.DiskName,
+			"description":       disk.Description,
+			"region_id":         disk.RegionId,
+			"availability_zone": disk.ZoneId,
+			"status":            disk.Status,
+			"type":              disk.Type,
+			"category":          disk.Category,
+			"encrypted":         string(OnFlag),
+			"size":              disk.Size,
+			"image_id":          disk.ImageId,
+			"snapshot_id":       disk.SourceSnapshotId,
+			"instance_id":       disk.InstanceId,
+			"creation_time":     disk.CreationTime,
+			"attached_time":     disk.AttachedTime,
+			"detached_time":     disk.DetachedTime,
+			"expiration_time":   disk.ExpiredTime,
+			"tags":              tagsToMap(disk.Tags.Tag),
+		}
+		if !disk.Encrypted {
+			mapping["encrypted"] = string(OffFlag)
+		}
+
+		log.Printf("[DEBUG] alicloud_disks - adding disk mapping: %v", mapping)
+		ids = append(ids, disk.DiskId)
+		s = append(s, mapping)
+	}
+
+	d.SetId(dataResourceIdHash(ids))
+	if err := d.Set("disks", s); err != nil {
+		return err
+	}
+
+	// create a json file in current directory and write data source to it.
+	if output, ok := d.GetOk("output_file"); ok && output.(string) != "" {
+		writeToFile(output.(string), s)
+	}
+	return nil
+}

--- a/alicloud/data_source_alicloud_disks_test.go
+++ b/alicloud/data_source_alicloud_disks_test.go
@@ -1,0 +1,202 @@
+package alicloud
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform/helper/resource"
+)
+
+func TestAccAlicloudDisksDataSource_basic(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCheckAlicloudDisksDataSourceBasic,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAlicloudDataSourceID("data.alicloud_disks.disks"),
+					resource.TestCheckResourceAttr("data.alicloud_disks.disks", "disks.#", "1"),
+					resource.TestCheckResourceAttrSet("data.alicloud_disks.disks", "disks.0.id"),
+					resource.TestCheckResourceAttr("data.alicloud_disks.disks", "disks.0.name", "tf-testAccCheckAlicloudDisksDataSourceBasic"),
+					resource.TestCheckResourceAttr("data.alicloud_disks.disks", "disks.0.description", "tf-testAccCheckAlicloudDisksDataSourceBasic_description"),
+					resource.TestCheckResourceAttrSet("data.alicloud_disks.disks", "disks.0.region_id"),
+					resource.TestCheckResourceAttrSet("data.alicloud_disks.disks", "disks.0.availability_zone"),
+					resource.TestCheckResourceAttr("data.alicloud_disks.disks", "disks.0.status", "Available"),
+					resource.TestCheckResourceAttr("data.alicloud_disks.disks", "disks.0.type", "data"),
+					resource.TestCheckResourceAttr("data.alicloud_disks.disks", "disks.0.category", "cloud_efficiency"),
+					resource.TestCheckResourceAttr("data.alicloud_disks.disks", "disks.0.encrypted", "off"),
+					resource.TestCheckResourceAttr("data.alicloud_disks.disks", "disks.0.size", "20"),
+					resource.TestCheckResourceAttr("data.alicloud_disks.disks", "disks.0.image_id", ""),
+					resource.TestCheckResourceAttr("data.alicloud_disks.disks", "disks.0.snapshot_id", ""),
+					resource.TestCheckResourceAttr("data.alicloud_disks.disks", "disks.0.instance_id", ""),
+					resource.TestCheckResourceAttrSet("data.alicloud_disks.disks", "disks.0.creation_time"),
+					resource.TestCheckResourceAttr("data.alicloud_disks.disks", "disks.0.attached_time", ""),
+					resource.TestCheckResourceAttr("data.alicloud_disks.disks", "disks.0.detached_time", ""),
+					resource.TestCheckResourceAttrSet("data.alicloud_disks.disks", "disks.0.expiration_time"),
+					resource.TestCheckResourceAttr("data.alicloud_disks.disks", "disks.0.tags.%", "2"),
+					resource.TestCheckResourceAttr("data.alicloud_disks.disks", "disks.0.tags.Name", "TerraformTest"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAlicloudDisksDataSource_filterByAllFields(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCheckAlicloudDisksDataSourceFilterByAllFields,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAlicloudDataSourceID("data.alicloud_disks.disks"),
+					resource.TestCheckResourceAttr("data.alicloud_disks.disks", "disks.#", "1"),
+					resource.TestCheckResourceAttr("data.alicloud_disks.disks", "disks.0.name", "tf-testAccCheckAlicloudDisksDataSourceFilterByAllFields"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAlicloudDisksDataSource_filterByInstanceId(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCheckAlicloudDisksDataSourceFilterByInstanceId,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAlicloudDataSourceID("data.alicloud_disks.disks"),
+					resource.TestCheckResourceAttr("data.alicloud_disks.disks", "disks.#", "1"),
+					resource.TestCheckResourceAttr("data.alicloud_disks.disks", "disks.0.name", "tf-testAccCheckAlicloudDisksDataSourceFilterByInstanceId"),
+					resource.TestCheckResourceAttr("data.alicloud_disks.disks", "disks.0.status", "In_use"),
+					resource.TestCheckResourceAttrSet("data.alicloud_disks.disks", "disks.0.instance_id"),
+					resource.TestCheckResourceAttrSet("data.alicloud_disks.disks", "disks.0.creation_time"),
+					resource.TestCheckResourceAttrSet("data.alicloud_disks.disks", "disks.0.attached_time"),
+				),
+			},
+		},
+	})
+}
+
+const testAccCheckAlicloudDisksDataSourceBasic = `
+variable "name" {
+	default = "tf-testAccCheckAlicloudDisksDataSourceBasic"
+}
+
+data "alicloud_zones" "az" {
+	"available_resource_creation"= "VSwitch"
+}
+
+resource "alicloud_disk" "sample_disk" {
+	availability_zone = "${data.alicloud_zones.az.zones.0.id}"
+	category = "cloud_efficiency"
+	name = "${var.name}"
+    description = "${var.name}_description"
+	size = "20"
+	tags {
+	    Name = "TerraformTest"
+	    Name1 = "TerraformTest"
+	}
+}
+
+data "alicloud_disks" "disks" {
+    name_regex = "${alicloud_disk.sample_disk.name}"
+}
+`
+
+const testAccCheckAlicloudDisksDataSourceFilterByAllFields = `
+variable "name" {
+	default = "tf-testAccCheckAlicloudDisksDataSourceFilterByAllFields"
+}
+
+data "alicloud_zones" "az" {
+	"available_resource_creation"= "VSwitch"
+}
+
+resource "alicloud_disk" "sample_disk" {
+	availability_zone = "${data.alicloud_zones.az.zones.0.id}"
+	category = "cloud_efficiency"
+	name = "${var.name}"
+    description = "${var.name}_description"
+	size = "20"
+	tags {
+	    Name = "TerraformTest"
+	    Name1 = "TerraformTest"
+	}
+}
+
+data "alicloud_disks" "disks" {
+    ids = ["${alicloud_disk.sample_disk.id}"]
+    name_regex = "${alicloud_disk.sample_disk.name}"
+    type = "data"
+    category = "cloud_efficiency"
+    encrypted = "off"
+    tags = {
+        Name = "TerraformTest"
+    }
+}
+`
+
+const testAccCheckAlicloudDisksDataSourceFilterByInstanceId = `
+variable "name" {
+	default = "tf-testAccCheckAlicloudDisksDataSourceFilterByInstanceId"
+}
+
+data "alicloud_zones" "az" {
+	"available_resource_creation"= "VSwitch"
+}
+data "alicloud_images" "images" {
+	name_regex = "ubuntu*"
+}
+data "alicloud_instance_types" "default" {
+ 	availability_zone = "${data.alicloud_zones.az.zones.0.id}"
+	cpu_core_count = 1
+	memory_size = 2
+}
+
+resource "alicloud_disk" "sample_disk" {
+	availability_zone = "${data.alicloud_zones.az.zones.0.id}"
+	category = "cloud_efficiency"
+	name = "${var.name}"
+    description = "${var.name}_description"
+	size = "20"
+}
+
+resource "alicloud_vpc" "sample_vpc" {
+	name = "${var.name}"
+  	cidr_block = "172.16.0.0/12"
+}
+
+resource "alicloud_vswitch" "sample_vswitch" {
+	name = "${var.name}"
+  	vpc_id = "${alicloud_vpc.sample_vpc.id}"
+  	cidr_block = "172.16.0.0/16"
+  	availability_zone = "${data.alicloud_zones.az.zones.0.id}"
+}
+
+resource "alicloud_security_group" "sample_security_group" {
+	name = "${var.name}"
+	vpc_id = "${alicloud_vpc.sample_vpc.id}"
+}
+
+resource "alicloud_instance" "sample_instance" {
+	vswitch_id = "${alicloud_vswitch.sample_vswitch.id}"
+	private_ip = "172.16.10.10"
+	image_id = "${data.alicloud_images.images.images.0.id}"
+	instance_type = "${data.alicloud_instance_types.default.instance_types.0.id}"
+  	instance_name = "${var.name}"
+	system_disk_category = "cloud_efficiency"
+	security_groups = ["${alicloud_security_group.sample_security_group.id}"]
+}
+
+resource "alicloud_disk_attachment" "sample_disk_attachment" {
+  disk_id = "${alicloud_disk.sample_disk.id}"
+  instance_id = "${alicloud_instance.sample_instance.id}"
+}
+
+data "alicloud_disks" "disks" {
+    instance_id = "${alicloud_disk_attachment.sample_disk_attachment.instance_id}"
+    type = "data"
+}
+`

--- a/alicloud/data_source_alicloud_fc_functions.go
+++ b/alicloud/data_source_alicloud_fc_functions.go
@@ -1,0 +1,179 @@
+package alicloud
+
+import (
+	"fmt"
+	"log"
+	"regexp"
+
+	"github.com/aliyun/fc-go-sdk"
+	"github.com/hashicorp/terraform/helper/schema"
+)
+
+func dataSourceAlicloudFcFunctions() *schema.Resource {
+	return &schema.Resource{
+		Read: dataSourceAlicloudFcFunctionsRead,
+
+		Schema: map[string]*schema.Schema{
+			"service_name": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"name_regex": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ValidateFunc: validateNameRegex,
+				ForceNew:     true,
+			},
+			"output_file": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+
+			// Computed values
+			"functions": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"name": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"description": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"runtime": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"handler": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"timeout": {
+							Type:     schema.TypeInt,
+							Computed: true,
+						},
+						"memory_size": {
+							Type:     schema.TypeInt,
+							Computed: true,
+						},
+						"code_size": {
+							Type:     schema.TypeInt,
+							Computed: true,
+						},
+						"code_checksum": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"creation_time": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"last_modification_time": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func dataSourceAlicloudFcFunctionsRead(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*AliyunClient)
+
+	fcconn, err := client.Fcconn()
+	if err != nil {
+		return err
+	}
+
+	serviceName := d.Get("service_name").(string)
+
+	var ids []string
+	var functionMappings []map[string]interface{}
+	nextToken := ""
+	for {
+		args := fc.NewListFunctionsInput(serviceName)
+		if nextToken != "" {
+			args.NextToken = &nextToken
+		}
+
+		resp, err := fcconn.ListFunctions(args)
+		if err != nil {
+			return err
+		}
+
+		if resp.Functions == nil || len(resp.Functions) < 1 {
+			break
+		}
+
+		for _, function := range resp.Functions {
+			mapping := map[string]interface{}{
+				"id":                     *function.FunctionID,
+				"name":                   *function.FunctionName,
+				"description":            *function.Description,
+				"runtime":                *function.Runtime,
+				"handler":                *function.Handler,
+				"timeout":                *function.Timeout,
+				"memory_size":            *function.MemorySize,
+				"code_size":              *function.CodeSize,
+				"code_checksum":          *function.CodeChecksum,
+				"creation_time":          *function.CreatedTime,
+				"last_modification_time": *function.LastModifiedTime,
+			}
+
+			functionMappings = append(functionMappings, mapping)
+			log.Printf("[DEBUG] alicloud_fc_functions - adding function mapping: %v", mapping)
+			ids = append(ids, *function.FunctionID)
+		}
+
+		nextToken = ""
+		if resp.NextToken != nil {
+			nextToken = *resp.NextToken
+		}
+		if nextToken == "" {
+			break
+		}
+	}
+
+	var filteredFunctionMappings []map[string]interface{}
+	nameRegex, ok := d.GetOk("name_regex")
+	if ok && nameRegex.(string) != "" {
+		var r *regexp.Regexp
+		if nameRegex != "" {
+			r = regexp.MustCompile(nameRegex.(string))
+		}
+		for _, mapping := range functionMappings {
+			if r != nil && !r.MatchString(mapping["name"].(string)) {
+				continue
+			}
+			filteredFunctionMappings = append(filteredFunctionMappings, mapping)
+		}
+	} else {
+		filteredFunctionMappings = functionMappings
+	}
+
+	if len(filteredFunctionMappings) < 1 {
+		return fmt.Errorf("your query returned no results. Please change your search criteria and try again")
+	}
+
+	log.Printf("[DEBUG] alicloud_fc_functions - Functions found: %#v", filteredFunctionMappings)
+	d.SetId(dataResourceIdHash(ids))
+	if err := d.Set("functions", filteredFunctionMappings); err != nil {
+		return err
+	}
+
+	// create a json file in current directory and write data source to it.
+	if output, ok := d.GetOk("output_file"); ok && output.(string) != "" {
+		writeToFile(output.(string), filteredFunctionMappings)
+	}
+	return nil
+}

--- a/alicloud/data_source_alicloud_fc_functions_test.go
+++ b/alicloud/data_source_alicloud_fc_functions_test.go
@@ -1,0 +1,81 @@
+package alicloud
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform/helper/acctest"
+	"github.com/hashicorp/terraform/helper/resource"
+)
+
+func TestAccAlicloudFcFunctionsDataSource_basic(t *testing.T) {
+	randInt := acctest.RandInt()
+	functionName := fmt.Sprintf("tf-testacc-fc-function-ds-basic-%d", randInt)
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCheckAlicloudFcFunctionsDataSourceBasic(randInt),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAlicloudDataSourceID("data.alicloud_fc_functions.functions"),
+					resource.TestCheckResourceAttr("data.alicloud_fc_functions.functions", "functions.#", "1"),
+					resource.TestCheckResourceAttrSet("data.alicloud_fc_functions.functions", "functions.0.id"),
+					resource.TestCheckResourceAttr("data.alicloud_fc_functions.functions", "functions.0.name", functionName),
+					resource.TestCheckResourceAttr("data.alicloud_fc_functions.functions", "functions.0.description", functionName+"-description"),
+					resource.TestCheckResourceAttr("data.alicloud_fc_functions.functions", "functions.0.runtime", "python2.7"),
+					resource.TestCheckResourceAttr("data.alicloud_fc_functions.functions", "functions.0.handler", "hello.handler"),
+					resource.TestCheckResourceAttr("data.alicloud_fc_functions.functions", "functions.0.timeout", "120"),
+					resource.TestCheckResourceAttr("data.alicloud_fc_functions.functions", "functions.0.memory_size", "512"),
+					resource.TestCheckResourceAttr("data.alicloud_fc_functions.functions", "functions.0.code_size", "105"),
+					resource.TestCheckResourceAttr("data.alicloud_fc_functions.functions", "functions.0.code_checksum", "5237022206872530469"),
+					resource.TestCheckResourceAttrSet("data.alicloud_fc_functions.functions", "functions.0.creation_time"),
+					resource.TestCheckResourceAttrSet("data.alicloud_fc_functions.functions", "functions.0.last_modification_time"),
+				),
+			},
+		},
+	})
+}
+func testAccCheckAlicloudFcFunctionsDataSourceBasic(randInt int) string {
+	return fmt.Sprintf(`
+variable "name" {
+	default = "tf-testacc-fc-function-ds-basic-%d"
+}
+
+resource "alicloud_fc_service" "sample_service" {
+    name = "${var.name}"
+}
+
+resource "alicloud_oss_bucket" "sample_bucket" {
+	bucket = "${var.name}"
+}
+
+resource "alicloud_oss_bucket_object" "sample_object" {
+	bucket = "${alicloud_oss_bucket.sample_bucket.id}"
+	key = "fc/hello.zip"
+	content = <<EOF
+		# -*- coding: utf-8 -*-
+		def handler(event, context):
+			print "hello world"
+			return 'hello world'
+	EOF
+}
+
+resource "alicloud_fc_function" "sample_function" {
+	service = "${alicloud_fc_service.sample_service.name}"
+	name = "${var.name}"
+	description = "${var.name}-description"
+	oss_bucket = "${alicloud_oss_bucket.sample_bucket.id}"
+	oss_key = "${alicloud_oss_bucket_object.sample_object.key}"
+	memory_size = "512"
+	runtime = "python2.7"
+	handler = "hello.handler"
+	timeout = "120"
+}
+
+data "alicloud_fc_functions" "functions" {
+	service_name = "${alicloud_fc_service.sample_service.name}"
+    name_regex = "${alicloud_fc_function.sample_function.name}"
+}
+`, randInt)
+}

--- a/alicloud/data_source_alicloud_fc_services.go
+++ b/alicloud/data_source_alicloud_fc_services.go
@@ -1,0 +1,216 @@
+package alicloud
+
+import (
+	"fmt"
+	"log"
+	"regexp"
+
+	"github.com/aliyun/fc-go-sdk"
+	"github.com/hashicorp/terraform/helper/schema"
+)
+
+func dataSourceAlicloudFcServices() *schema.Resource {
+	return &schema.Resource{
+		Read: dataSourceAlicloudFcServicesRead,
+
+		Schema: map[string]*schema.Schema{
+			"name_regex": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ValidateFunc: validateNameRegex,
+				ForceNew:     true,
+			},
+			"output_file": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+
+			// Computed values
+			"services": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"name": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"description": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"role": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"internet_access": {
+							Type:     schema.TypeBool,
+							Computed: true,
+						},
+						"creation_time": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"last_modification_time": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"log_config": {
+							Type:     schema.TypeList,
+							Computed: true,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"project": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+
+									"logstore": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+								},
+							},
+							MaxItems: 1,
+						},
+						"vpc_config": {
+							Type:     schema.TypeList,
+							Computed: true,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"vpc_id": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+
+									"vswitch_ids": {
+										Type:     schema.TypeList,
+										Computed: true,
+										Elem:     &schema.Schema{Type: schema.TypeString},
+									},
+
+									"security_group_id": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+								},
+							},
+							MaxItems: 1,
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func dataSourceAlicloudFcServicesRead(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*AliyunClient)
+
+	fcconn, err := client.Fcconn()
+	if err != nil {
+		return err
+	}
+
+	var ids []string
+	var serviceMappings []map[string]interface{}
+	nextToken := ""
+	for {
+		args := fc.NewListServicesInput()
+		if nextToken != "" {
+			args.NextToken = &nextToken
+		}
+
+		resp, err := fcconn.ListServices(args)
+		if err != nil {
+			return err
+		}
+
+		if resp.Services == nil || len(resp.Services) < 1 {
+			break
+		}
+
+		for _, service := range resp.Services {
+			mapping := map[string]interface{}{
+				"id":                     *service.ServiceID,
+				"name":                   *service.ServiceName,
+				"description":            *service.Description,
+				"role":                   *service.Role,
+				"internet_access":        *service.InternetAccess,
+				"creation_time":          *service.CreatedTime,
+				"last_modification_time": *service.LastModifiedTime,
+			}
+
+			var logConfigMappings []map[string]interface{}
+			if service.LogConfig != nil {
+				logConfigMappings = append(logConfigMappings, map[string]interface{}{
+					"project":  *service.LogConfig.Project,
+					"logstore": *service.LogConfig.Logstore,
+				})
+			}
+			mapping["log_config"] = logConfigMappings
+
+			var vpcConfigMappings []map[string]interface{}
+			if service.VPCConfig != nil &&
+				(service.VPCConfig.VPCID != nil || service.VPCConfig.SecurityGroupID != nil) {
+				vpcConfigMappings = append(vpcConfigMappings, map[string]interface{}{
+					"vpc_id":            *service.VPCConfig.VPCID,
+					"vswitch_ids":       service.VPCConfig.VSwitchIDs,
+					"security_group_id": *service.VPCConfig.SecurityGroupID,
+				})
+			}
+			mapping["vpc_config"] = vpcConfigMappings
+
+			serviceMappings = append(serviceMappings, mapping)
+
+			log.Printf("[DEBUG] alicloud_fc_services - adding service mapping: %v", mapping)
+			ids = append(ids, *service.ServiceID)
+		}
+
+		nextToken = ""
+		if resp.NextToken != nil {
+			nextToken = *resp.NextToken
+		}
+		if nextToken == "" {
+			break
+		}
+	}
+
+	var filteredServiceMappings []map[string]interface{}
+	nameRegex, ok := d.GetOk("name_regex")
+	if ok && nameRegex.(string) != "" {
+		var r *regexp.Regexp
+		if nameRegex != "" {
+			r = regexp.MustCompile(nameRegex.(string))
+		}
+		for _, mapping := range serviceMappings {
+			if r != nil && !r.MatchString(mapping["name"].(string)) {
+				continue
+			}
+			filteredServiceMappings = append(filteredServiceMappings, mapping)
+		}
+	} else {
+		filteredServiceMappings = serviceMappings
+	}
+
+	if len(filteredServiceMappings) < 1 {
+		return fmt.Errorf("your query returned no results. Please change your search criteria and try again")
+	}
+
+	log.Printf("[DEBUG] alicloud_fc_services - Services found: %#v", filteredServiceMappings)
+
+	d.SetId(dataResourceIdHash(ids))
+	if err := d.Set("services", filteredServiceMappings); err != nil {
+		return err
+	}
+
+	// create a json file in current directory and write data source to it.
+	if output, ok := d.GetOk("output_file"); ok && output.(string) != "" {
+		writeToFile(output.(string), filteredServiceMappings)
+	}
+	return nil
+}

--- a/alicloud/data_source_alicloud_fc_services_test.go
+++ b/alicloud/data_source_alicloud_fc_services_test.go
@@ -1,0 +1,156 @@
+package alicloud
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform/helper/acctest"
+	"github.com/hashicorp/terraform/helper/resource"
+)
+
+func TestAccAlicloudFcServicesDataSource_basic(t *testing.T) {
+	randInt := acctest.RandInt()
+	serviceName := fmt.Sprintf("tf-testacc-fc-service-ds-basic-%d", randInt)
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCheckAlicloudFcServicesDataSourceBasic(randInt),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAlicloudDataSourceID("data.alicloud_fc_services.services"),
+					resource.TestCheckResourceAttr("data.alicloud_fc_services.services", "services.#", "1"),
+					resource.TestCheckResourceAttrSet("data.alicloud_fc_services.services", "services.0.id"),
+					resource.TestCheckResourceAttr("data.alicloud_fc_services.services", "services.0.name", serviceName),
+					resource.TestCheckResourceAttr("data.alicloud_fc_services.services", "services.0.description", serviceName+"-description"),
+					resource.TestCheckResourceAttrSet("data.alicloud_fc_services.services", "services.0.role"),
+					resource.TestCheckResourceAttr("data.alicloud_fc_services.services", "services.0.internet_access", "true"),
+					resource.TestCheckResourceAttrSet("data.alicloud_fc_services.services", "services.0.creation_time"),
+					resource.TestCheckResourceAttrSet("data.alicloud_fc_services.services", "services.0.last_modification_time"),
+					resource.TestCheckResourceAttr("data.alicloud_fc_services.services", "services.0.log_config.#", "1"),
+					resource.TestCheckResourceAttr("data.alicloud_fc_services.services", "services.0.log_config.0.project", serviceName+"-project"),
+					resource.TestCheckResourceAttr("data.alicloud_fc_services.services", "services.0.log_config.0.logstore", serviceName+"-store"),
+					resource.TestCheckResourceAttr("data.alicloud_fc_services.services", "services.0.vpc_config.#", "1"),
+					resource.TestCheckResourceAttrSet("data.alicloud_fc_services.services", "services.0.vpc_config.0.vpc_id"),
+					resource.TestCheckResourceAttr("data.alicloud_fc_services.services", "services.0.vpc_config.0.vswitch_ids.#", "1"),
+					resource.TestCheckResourceAttrSet("data.alicloud_fc_services.services", "services.0.vpc_config.0.security_group_id"),
+				),
+			},
+		},
+	})
+}
+
+func testAccCheckAlicloudFcServicesDataSourceBasic(randInt int) string {
+	return fmt.Sprintf(`
+variable "name" {
+	default = "tf-testacc-fc-service-ds-basic-%d"
+}
+
+data "alicloud_zones" "zones" {
+    available_resource_creation = "VSwitch"
+}
+
+resource "alicloud_vpc" "sample_vpc" {
+	name = "${var.name}"
+	cidr_block = "172.16.0.0/16"
+}
+
+resource "alicloud_vswitch" "sample_vswitch" {
+	name = "${var.name}"
+	cidr_block = "172.16.0.0/24"
+	availability_zone = "${data.alicloud_zones.zones.zones.0.id}"
+	vpc_id = "${alicloud_vpc.sample_vpc.id}"
+}
+
+resource "alicloud_security_group" "sample_group" {
+	name = "${var.name}"
+	vpc_id = "${alicloud_vpc.sample_vpc.id}"
+}
+
+resource "alicloud_log_project" "sample_log_project" {
+    name = "${var.name}-project"
+}
+
+resource "alicloud_log_store" "sample_log_store" {
+    project = "${alicloud_log_project.sample_log_project.name}"
+    name = "${var.name}-store"
+}
+
+resource "alicloud_ram_role" "sample_role" {
+    name = "${var.name}"
+    document = <<DEFINITION
+    {
+        "Statement": [
+            {
+                "Action": "sts:AssumeRole",
+                "Effect": "Allow",
+                "Principal": {
+                    "Service": [
+                        "fc.aliyuncs.com"
+                    ]
+                }
+            }
+        ],
+        "Version": "1"
+    }
+    DEFINITION
+    description = "this is a test"
+    force = true
+}
+
+resource "alicloud_ram_policy" "sample_vpc_policy" {
+    name = "${var.name}"
+    document = <<DEFINITION
+    {
+  "Version": "1",
+  "Statement": [
+    {
+      "Action": "vpc:*",
+      "Resource": "*",
+      "Effect": "Allow"
+    },
+    {
+      "Action": [
+        "ecs:*NetworkInterface*"
+      ],
+      "Resource": "*",
+      "Effect": "Allow"
+    }
+  ]
+}
+    DEFINITION
+}
+
+resource "alicloud_ram_role_policy_attachment" "sample_attachment" {
+    role_name = "${alicloud_ram_role.sample_role.name}"
+    policy_name = "AliyunLogFullAccess"
+    policy_type = "System"
+}
+
+resource "alicloud_ram_role_policy_attachment" "sample_attachment_vpc" {
+    role_name = "${alicloud_ram_role.sample_role.name}"
+    policy_name = "${alicloud_ram_policy.sample_vpc_policy.name}"
+    policy_type = "Custom"
+}
+
+resource "alicloud_fc_service" "sample_service" {
+    name = "${var.name}"
+    description = "${var.name}-description"
+    log_config {
+	    project = "${alicloud_log_project.sample_log_project.name}"
+	    logstore = "${alicloud_log_store.sample_log_store.name}"
+    }
+    vpc_config {
+        vswitch_ids = ["${alicloud_vswitch.sample_vswitch.id}"]
+        security_group_id = "${alicloud_security_group.sample_group.id}"
+    }
+    role = "${alicloud_ram_role.sample_role.arn}"
+    depends_on = ["alicloud_ram_role_policy_attachment.sample_attachment", "alicloud_ram_role_policy_attachment.sample_attachment_vpc"]
+    internet_access = true
+}
+
+data "alicloud_fc_services" "services" {
+    name_regex = "${alicloud_fc_service.sample_service.name}"
+}
+`, randInt)
+}

--- a/alicloud/data_source_alicloud_oss_bucket_objects.go
+++ b/alicloud/data_source_alicloud_oss_bucket_objects.go
@@ -1,0 +1,215 @@
+package alicloud
+
+import (
+	"fmt"
+	"log"
+	"regexp"
+	"strings"
+	"time"
+
+	"github.com/aliyun/aliyun-oss-go-sdk/oss"
+	"github.com/hashicorp/terraform/helper/schema"
+)
+
+func dataSourceAlicloudOssBucketObjects() *schema.Resource {
+	return &schema.Resource{
+		Read: dataSourceAlicloudOssBucketObjectsRead,
+
+		Schema: map[string]*schema.Schema{
+			"bucket_name": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"key_prefix": {
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: true,
+			},
+			"key_regex": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ValidateFunc: validateNameRegex,
+				ForceNew:     true,
+			},
+
+			// Computed values
+			"objects": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"key": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"acl": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"content_type": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"content_length": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"cache_control": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"content_disposition": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"content_encoding": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"content_md5": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"expires": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"server_side_encryption": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"etag": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"storage_class": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"last_modification_time": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func dataSourceAlicloudOssBucketObjectsRead(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*AliyunClient)
+
+	// Get the bucket
+	bucketName := d.Get("bucket_name").(string)
+	bucket, err := client.ossconn.Bucket(bucketName)
+	if err != nil {
+		return fmt.Errorf("unable to get the bucket %s: %#v", bucketName, err)
+	}
+
+	// List bucket objects
+	var initialOptions []oss.Option
+	if v, ok := d.GetOk("key_prefix"); ok && v.(string) != "" {
+		keyPrefix := v.(string)
+		initialOptions = append(initialOptions, oss.Prefix(keyPrefix))
+	}
+
+	var allObjects []oss.ObjectProperties
+	nextMarker := ""
+	for {
+		var options []oss.Option
+		options = append(options, initialOptions...)
+		if nextMarker != "" {
+			options = append(options, oss.Marker(nextMarker))
+		}
+
+		resp, err := bucket.ListObjects(options...)
+		if err != nil {
+			return err
+		}
+
+		if resp.Objects == nil || len(resp.Objects) < 1 {
+			break
+		}
+
+		allObjects = append(allObjects, resp.Objects...)
+
+		nextMarker = resp.NextMarker
+		if nextMarker == "" {
+			break
+		}
+	}
+
+	var filteredObjectsTemp []oss.ObjectProperties
+	keyRegex, ok := d.GetOk("key_regex")
+	if ok && keyRegex.(string) != "" {
+		var r *regexp.Regexp
+		if keyRegex != "" {
+			r = regexp.MustCompile(keyRegex.(string))
+		}
+		for _, object := range allObjects {
+			if r != nil && !r.MatchString(object.Key) {
+				continue
+			}
+			filteredObjectsTemp = append(filteredObjectsTemp, object)
+		}
+	} else {
+		filteredObjectsTemp = allObjects
+	}
+
+	if len(filteredObjectsTemp) < 1 {
+		return fmt.Errorf("your query returned no results, please change your search criteria and try again")
+	}
+	log.Printf("[DEBUG] alicloud_oss_bucket_objects - Bucket objects found: %#v", filteredObjectsTemp)
+	return bucketObjectsDescriptionAttributes(d, bucket, filteredObjectsTemp, meta)
+}
+
+func bucketObjectsDescriptionAttributes(d *schema.ResourceData, bucket *oss.Bucket, objects []oss.ObjectProperties, meta interface{}) error {
+	var ids []string
+	var s []map[string]interface{}
+	for _, object := range objects {
+		mapping := map[string]interface{}{
+			"key":                    object.Key,
+			"etag":                   strings.Trim(object.ETag, `"`),
+			"storage_class":          object.StorageClass,
+			"last_modification_time": object.LastModified.Format(time.RFC3339),
+		}
+
+		// Add metadata information
+		objectHeader, err := bucket.GetObjectDetailedMeta(object.Key)
+		if err != nil {
+			log.Printf("[ERROR] Unable to get metadata for the object %s: %v", object.Key, err)
+		} else {
+			mapping["content_type"] = objectHeader.Get("Content-Type")
+			mapping["content_length"] = objectHeader.Get("Content-Length")
+			mapping["cache_control"] = objectHeader.Get("Cache-Control")
+			mapping["content_disposition"] = objectHeader.Get("Content-Disposition")
+			mapping["content_encoding"] = objectHeader.Get("Content-Encoding")
+			mapping["content_md5"] = objectHeader.Get("Content-Md5")
+			mapping["expires"] = objectHeader.Get("Expires")
+			mapping["server_side_encryption"] = objectHeader.Get("ServerSideEncryption")
+		}
+		// Add ACL information
+		objectACL, err := bucket.GetObjectACL(object.Key)
+		if err != nil {
+			log.Printf("[ERROR] Unable to get ACL for the object %s: %v", object.Key, err)
+		} else {
+			mapping["acl"] = objectACL.ACL
+		}
+
+		log.Printf("[DEBUG] alicloud_oss_bucket_objects - adding bucket object mapping: %v", mapping)
+		ids = append(ids, object.Key)
+		s = append(s, mapping)
+	}
+
+	d.SetId(dataResourceIdHash(ids))
+	if err := d.Set("objects", s); err != nil {
+		return err
+	}
+	// create a json file in current directory and write data source to it.
+	if output, ok := d.GetOk("output_file"); ok && output.(string) != "" {
+		writeToFile(output.(string), s)
+	}
+	return nil
+}

--- a/alicloud/data_source_alicloud_oss_bucket_objects_test.go
+++ b/alicloud/data_source_alicloud_oss_bucket_objects_test.go
@@ -1,0 +1,118 @@
+package alicloud
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform/helper/acctest"
+	"github.com/hashicorp/terraform/helper/resource"
+)
+
+func TestAccAlicloudOssBucketObjectsDataSource_basic(t *testing.T) {
+	randInt := acctest.RandInt()
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCheckAlicloudOssBucketObjectsDataSourceBasic(randInt),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAlicloudDataSourceID("data.alicloud_oss_bucket_objects.objects"),
+					resource.TestCheckResourceAttr("data.alicloud_oss_bucket_objects.objects", "objects.#", "1"),
+					resource.TestCheckResourceAttr("data.alicloud_oss_bucket_objects.objects", "objects.0.key", fmt.Sprintf("tf-sample/tf-testacc-bucket-object-ds-basic-%d-object", randInt)),
+					resource.TestCheckResourceAttr("data.alicloud_oss_bucket_objects.objects", "objects.0.acl", "default"),
+					resource.TestCheckResourceAttr("data.alicloud_oss_bucket_objects.objects", "objects.0.content_type", "text/plain"),
+					resource.TestCheckResourceAttr("data.alicloud_oss_bucket_objects.objects", "objects.0.content_length", "14"),
+					resource.TestCheckResourceAttr("data.alicloud_oss_bucket_objects.objects", "objects.0.cache_control", "max-age=0"),
+					resource.TestCheckResourceAttr("data.alicloud_oss_bucket_objects.objects", "objects.0.content_disposition", "attachment; filename=\"my-object\""),
+					resource.TestCheckResourceAttr("data.alicloud_oss_bucket_objects.objects", "objects.0.content_encoding", "gzip"),
+					resource.TestCheckResourceAttr("data.alicloud_oss_bucket_objects.objects", "objects.0.content_md5", "1STMBJqp4X5QEQsYTbRmkQ=="),
+					resource.TestCheckResourceAttr("data.alicloud_oss_bucket_objects.objects", "objects.0.expires", "Wed, 06 May 2020 00:00:00 GMT"),
+					resource.TestCheckResourceAttrSet("data.alicloud_oss_bucket_objects.objects", "objects.0.etag"),
+					resource.TestCheckResourceAttr("data.alicloud_oss_bucket_objects.objects", "objects.0.storage_class", "Standard"),
+					resource.TestCheckResourceAttrSet("data.alicloud_oss_bucket_objects.objects", "objects.0.last_modification_time"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAlicloudOssBucketObjectsDataSource_filterByPrefix(t *testing.T) {
+	randInt := acctest.RandInt()
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCheckAlicloudOssBucketObjectsDataSourceFilterByPrefix(randInt),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAlicloudDataSourceID("data.alicloud_oss_bucket_objects.objects"),
+					resource.TestCheckResourceAttr("data.alicloud_oss_bucket_objects.objects", "objects.#", "1"),
+					resource.TestCheckResourceAttr("data.alicloud_oss_bucket_objects.objects", "objects.0.key", fmt.Sprintf("tf-prefix1/tf-testacc-bucket-object-ds-prefix-%d-object", randInt)),
+				),
+			},
+		},
+	})
+}
+
+func testAccCheckAlicloudOssBucketObjectsDataSourceBasic(randInt int) string {
+	return fmt.Sprintf(`
+variable "name" {
+	default = "tf-testacc-bucket-object-ds-basic-%d"
+}
+
+resource "alicloud_oss_bucket" "sample_bucket" {
+	bucket = "${var.name}"
+	acl = "private"
+}
+
+resource "alicloud_oss_bucket_object" "sample_object" {
+	bucket = "${alicloud_oss_bucket.sample_bucket.bucket}"
+	key = "tf-sample/${var.name}-object"
+	content = "sample content"
+	content_type = "text/plain"
+	cache_control = "max-age=0"
+	content_disposition = "attachment; filename=\"my-object\""
+	content_encoding = "gzip"
+	expires = "Wed, 06 May 2020 00:00:00 GMT"
+}
+
+data "alicloud_oss_bucket_objects" "objects" {
+	bucket_name = "${var.name}"
+    key_regex = "${alicloud_oss_bucket_object.sample_object.key}"
+}
+`, randInt)
+}
+
+func testAccCheckAlicloudOssBucketObjectsDataSourceFilterByPrefix(randInt int) string {
+	return fmt.Sprintf(`
+variable "name" {
+	default = "tf-testacc-bucket-object-ds-prefix-%d"
+}
+
+resource "alicloud_oss_bucket" "sample_bucket" {
+	bucket = "${var.name}"
+	acl = "private"
+}
+
+resource "alicloud_oss_bucket_object" "sample_prefix1_object" {
+	bucket = "${alicloud_oss_bucket.sample_bucket.bucket}"
+	key = "tf-prefix1/${var.name}-object"
+	content = "sample content"
+	content_type = "text/plain"
+}
+
+resource "alicloud_oss_bucket_object" "sample_prefix2_object" {
+	bucket = "${alicloud_oss_bucket.sample_bucket.bucket}"
+	key = "tf-prefix2/${var.name}-object"
+	content = "sample content"
+	content_type = "text/plain"
+}
+
+data "alicloud_oss_bucket_objects" "objects" {
+	bucket_name = "${var.name}"
+    key_regex = "(${alicloud_oss_bucket_object.sample_prefix1_object.key}|${alicloud_oss_bucket_object.sample_prefix2_object.key})"
+    key_prefix = "tf-prefix1/"
+}
+`, randInt)
+}

--- a/alicloud/data_source_alicloud_oss_buckets.go
+++ b/alicloud/data_source_alicloud_oss_buckets.go
@@ -1,0 +1,386 @@
+package alicloud
+
+import (
+	"fmt"
+	"log"
+	"regexp"
+
+	"github.com/aliyun/aliyun-oss-go-sdk/oss"
+	"github.com/hashicorp/terraform/helper/schema"
+)
+
+func dataSourceAlicloudOssBuckets() *schema.Resource {
+	return &schema.Resource{
+		Read: dataSourceAlicloudOssBucketsRead,
+
+		Schema: map[string]*schema.Schema{
+			"name_regex": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ValidateFunc: validateNameRegex,
+				ForceNew:     true,
+			},
+			"output_file": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+
+			// Computed values
+			"buckets": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"name": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"acl": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"extranet_endpoint": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"intranet_endpoint": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"location": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"owner": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"storage_class": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"creation_date": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+
+						"cors_rules": {
+							Type:     schema.TypeList,
+							Computed: true,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"allowed_headers": {
+										Type:     schema.TypeList,
+										Computed: true,
+										Elem:     &schema.Schema{Type: schema.TypeString},
+									},
+									"allowed_methods": {
+										Type:     schema.TypeList,
+										Computed: true,
+										Elem:     &schema.Schema{Type: schema.TypeString},
+									},
+									"allowed_origins": {
+										Type:     schema.TypeList,
+										Computed: true,
+										Elem:     &schema.Schema{Type: schema.TypeString},
+									},
+									"expose_headers": {
+										Type:     schema.TypeList,
+										Computed: true,
+										Elem:     &schema.Schema{Type: schema.TypeString},
+									},
+									"max_age_seconds": {
+										Type:     schema.TypeInt,
+										Computed: true,
+									},
+								},
+							},
+						},
+
+						"website": {
+							Type:     schema.TypeList,
+							Computed: true,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"index_document": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+
+									"error_document": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+								},
+							},
+							MaxItems: 1,
+						},
+
+						"logging": {
+							Type:     schema.TypeList,
+							Computed: true,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"target_bucket": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+									"target_prefix": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+								},
+							},
+							MaxItems: 1,
+						},
+
+						"referer_config": {
+							Type:     schema.TypeList,
+							Computed: true,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"allow_empty": {
+										Type:     schema.TypeBool,
+										Computed: true,
+									},
+									"referers": {
+										Type:     schema.TypeList,
+										Computed: true,
+										Elem:     &schema.Schema{Type: schema.TypeString},
+									},
+								},
+							},
+							MaxItems: 1,
+						},
+
+						"lifecycle_rule": {
+							Type:     schema.TypeList,
+							Computed: true,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"id": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+									"prefix": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+									"enabled": {
+										Type:     schema.TypeBool,
+										Computed: true,
+									},
+									"expiration": {
+										Type:     schema.TypeList,
+										Computed: true,
+										Elem: &schema.Resource{
+											Schema: map[string]*schema.Schema{
+												"date": {
+													Type:     schema.TypeString,
+													Optional: true,
+												},
+												"days": {
+													Type:     schema.TypeInt,
+													Optional: true,
+												},
+											},
+										},
+										MaxItems: 1,
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func dataSourceAlicloudOssBucketsRead(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*AliyunClient)
+
+	var allBuckets []oss.BucketProperties
+	nextMarker := ""
+	for {
+		var options []oss.Option
+		if nextMarker != "" {
+			options = append(options, oss.Marker(nextMarker))
+		}
+
+		resp, err := client.ossconn.ListBuckets(options...)
+		if err != nil {
+			return err
+		}
+
+		if resp.Buckets == nil || len(resp.Buckets) < 1 {
+			break
+		}
+
+		allBuckets = append(allBuckets, resp.Buckets...)
+
+		nextMarker = resp.NextMarker
+		if nextMarker == "" {
+			break
+		}
+	}
+
+	var filteredBucketsTemp []oss.BucketProperties
+	nameRegex, ok := d.GetOk("name_regex")
+	if ok && nameRegex.(string) != "" {
+		var r *regexp.Regexp
+		if nameRegex != "" {
+			r = regexp.MustCompile(nameRegex.(string))
+		}
+		for _, bucket := range allBuckets {
+			if r != nil && !r.MatchString(bucket.Name) {
+				continue
+			}
+			filteredBucketsTemp = append(filteredBucketsTemp, bucket)
+		}
+	} else {
+		filteredBucketsTemp = allBuckets
+	}
+
+	if len(filteredBucketsTemp) < 1 {
+		return fmt.Errorf("Your query returned no results. Please change your search criteria and try again.")
+	}
+
+	log.Printf("[DEBUG] alicloud_oss_buckets - Bucket found: %#v", filteredBucketsTemp)
+
+	return bucketsDescriptionAttributes(d, filteredBucketsTemp, meta)
+}
+
+func bucketsDescriptionAttributes(d *schema.ResourceData, buckets []oss.BucketProperties, meta interface{}) error {
+	client := meta.(*AliyunClient)
+
+	var ids []string
+	var s []map[string]interface{}
+	for _, bucket := range buckets {
+		mapping := map[string]interface{}{
+			"name":          bucket.Name,
+			"location":      bucket.Location,
+			"storage_class": bucket.StorageClass,
+			"creation_date": bucket.CreationDate.Format("2006-01-02"),
+		}
+
+		// Add additional information
+		resp, err := client.ossconn.GetBucketInfo(bucket.Name)
+		if err == nil {
+			mapping["acl"] = resp.BucketInfo.ACL
+			mapping["extranet_endpoint"] = resp.BucketInfo.ExtranetEndpoint
+			mapping["intranet_endpoint"] = resp.BucketInfo.IntranetEndpoint
+			mapping["owner"] = resp.BucketInfo.Owner.ID
+		} else {
+			log.Printf("[WARN] Unable to get additional information for the bucket %s: %v", bucket.Name, err)
+		}
+
+		// Add CORS rule information
+		var ruleMappings []map[string]interface{}
+		cors, err := client.ossconn.GetBucketCORS(bucket.Name)
+		if err != nil && !IsExceptedErrors(err, []string{NoSuchCORSConfiguration}) {
+			log.Printf("[WARN] Unable to get CORS information for the bucket %s: %v", bucket.Name, err)
+		} else if err == nil && cors.CORSRules != nil {
+			for _, rule := range cors.CORSRules {
+				ruleMapping := make(map[string]interface{})
+				ruleMapping["allowed_headers"] = rule.AllowedHeader
+				ruleMapping["allowed_methods"] = rule.AllowedMethod
+				ruleMapping["allowed_origins"] = rule.AllowedOrigin
+				ruleMapping["expose_headers"] = rule.ExposeHeader
+				ruleMapping["max_age_seconds"] = rule.MaxAgeSeconds
+				ruleMappings = append(ruleMappings, ruleMapping)
+			}
+		}
+		mapping["cors_rules"] = ruleMappings
+
+		// Add website configuration
+		var websiteMappings []map[string]interface{}
+		ws, err := client.ossconn.GetBucketWebsite(bucket.Name)
+		if err != nil && !IsExceptedErrors(err, []string{NoSuchWebsiteConfiguration}) {
+			log.Printf("[WARN] Unable to get website information for the bucket %s: %v", bucket.Name, err)
+		} else if err == nil && &ws != nil {
+			websiteMapping := make(map[string]interface{})
+			if v := &ws.IndexDocument; v != nil {
+				websiteMapping["index_document"] = v.Suffix
+			}
+			if v := &ws.ErrorDocument; v != nil {
+				websiteMapping["error_document"] = v.Key
+			}
+			websiteMappings = append(websiteMappings, websiteMapping)
+		}
+		mapping["website"] = websiteMappings
+
+		// Add logging information
+		var loggingMappings []map[string]interface{}
+		logging, err := client.ossconn.GetBucketLogging(bucket.Name)
+		if err != nil {
+			log.Printf("[WARN] Unable to get logging information for the bucket %s: %v", bucket.Name, err)
+		} else if logging.LoggingEnabled.TargetBucket != "" || logging.LoggingEnabled.TargetPrefix != "" {
+			loggingMapping := map[string]interface{}{
+				"target_bucket": logging.LoggingEnabled.TargetBucket,
+				"target_prefix": logging.LoggingEnabled.TargetPrefix,
+			}
+			loggingMappings = append(loggingMappings, loggingMapping)
+		}
+		mapping["logging"] = loggingMappings
+
+		// Add referer information
+		var refererMappings []map[string]interface{}
+		referer, err := client.ossconn.GetBucketReferer(bucket.Name)
+		if err != nil {
+			log.Printf("[WARN] Unable to get referer information for the bucket %s: %v", bucket.Name, err)
+		} else {
+			refererMapping := map[string]interface{}{
+				"allow_empty": referer.AllowEmptyReferer,
+				"referers":    referer.RefererList,
+			}
+			refererMappings = append(refererMappings, refererMapping)
+		}
+		mapping["referer_config"] = refererMappings
+
+		// Add lifecycle information
+		var lifecycleRuleMappings []map[string]interface{}
+		lifecycle, err := client.ossconn.GetBucketLifecycle(bucket.Name)
+		if err != nil {
+			log.Printf("[WARN] Unable to get lifecycle information for the bucket %s: %v", bucket.Name, err)
+		} else if len(lifecycle.Rules) > 0 {
+			for _, lifecycleRule := range lifecycle.Rules {
+				ruleMapping := make(map[string]interface{})
+				ruleMapping["id"] = lifecycleRule.ID
+				ruleMapping["prefix"] = lifecycleRule.Prefix
+				if LifecycleRuleStatus(lifecycleRule.Status) == ExpirationStatusEnabled {
+					ruleMapping["enabled"] = true
+				} else {
+					ruleMapping["enabled"] = false
+				}
+
+				// Expiration
+				expirationMapping := make(map[string]interface{})
+				if !lifecycleRule.Expiration.Date.IsZero() {
+					expirationMapping["date"] = (lifecycleRule.Expiration.Date).Format("2006-01-02")
+				}
+				if &lifecycleRule.Expiration.Days != nil {
+					expirationMapping["days"] = int(lifecycleRule.Expiration.Days)
+				}
+				ruleMapping["expiration"] = []map[string]interface{}{expirationMapping}
+				lifecycleRuleMappings = append(lifecycleRuleMappings, ruleMapping)
+			}
+		}
+		mapping["lifecycle_rule"] = lifecycleRuleMappings
+
+		log.Printf("[DEBUG] alicloud_oss_buckets - adding bucket mapping: %v", mapping)
+		ids = append(ids, bucket.Name)
+		s = append(s, mapping)
+	}
+
+	d.SetId(dataResourceIdHash(ids))
+	if err := d.Set("buckets", s); err != nil {
+		return err
+	}
+
+	// create a json file in current directory and write data source to it.
+	if output, ok := d.GetOk("output_file"); ok && output.(string) != "" {
+		writeToFile(output.(string), s)
+	}
+	return nil
+}

--- a/alicloud/data_source_alicloud_oss_buckets_test.go
+++ b/alicloud/data_source_alicloud_oss_buckets_test.go
@@ -1,0 +1,200 @@
+package alicloud
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform/helper/acctest"
+	"github.com/hashicorp/terraform/helper/resource"
+)
+
+func TestAccAlicloudOssBucketsDataSource_basic(t *testing.T) {
+	randInt := acctest.RandInt()
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCheckAlicloudOssBucketsDataSourceBasic(randInt),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAlicloudDataSourceID("data.alicloud_oss_buckets.buckets"),
+					resource.TestCheckResourceAttr("data.alicloud_oss_buckets.buckets", "buckets.#", "1"),
+					resource.TestCheckResourceAttr("data.alicloud_oss_buckets.buckets", "buckets.0.name", fmt.Sprintf("tf-testacc-bucket-ds-basic-%d", randInt)),
+					resource.TestCheckResourceAttr("data.alicloud_oss_buckets.buckets", "buckets.0.acl", "public-read"),
+					resource.TestCheckResourceAttrSet("data.alicloud_oss_buckets.buckets", "buckets.0.extranet_endpoint"),
+					resource.TestCheckResourceAttrSet("data.alicloud_oss_buckets.buckets", "buckets.0.intranet_endpoint"),
+					resource.TestCheckResourceAttrSet("data.alicloud_oss_buckets.buckets", "buckets.0.location"),
+					resource.TestCheckResourceAttrSet("data.alicloud_oss_buckets.buckets", "buckets.0.owner"),
+					resource.TestCheckResourceAttr("data.alicloud_oss_buckets.buckets", "buckets.0.storage_class", "Standard"),
+					resource.TestCheckResourceAttrSet("data.alicloud_oss_buckets.buckets", "buckets.0.creation_date"),
+					resource.TestCheckResourceAttr("data.alicloud_oss_buckets.buckets", "buckets.0.cors_rules.#", "0"),
+					resource.TestCheckResourceAttr("data.alicloud_oss_buckets.buckets", "buckets.0.website.#", "0"),
+					resource.TestCheckResourceAttr("data.alicloud_oss_buckets.buckets", "buckets.0.logging.#", "0"),
+					resource.TestCheckResourceAttr("data.alicloud_oss_buckets.buckets", "buckets.0.referer_config.#", "1"),
+					resource.TestCheckResourceAttr("data.alicloud_oss_buckets.buckets", "buckets.0.referer_config.0.allow_empty", "true"),
+					resource.TestCheckResourceAttr("data.alicloud_oss_buckets.buckets", "buckets.0.referer_config.0.referers.#", "0"),
+					resource.TestCheckResourceAttr("data.alicloud_oss_buckets.buckets", "buckets.0.lifecycle_rule.#", "0"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAlicloudOssBucketsDataSource_full(t *testing.T) {
+	randInt := acctest.RandInt()
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCheckAlicloudOssBucketsDataSourceFull(randInt),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAlicloudDataSourceID("data.alicloud_oss_buckets.buckets"),
+					resource.TestCheckResourceAttr("data.alicloud_oss_buckets.buckets", "buckets.#", "1"),
+					resource.TestCheckResourceAttr("data.alicloud_oss_buckets.buckets", "buckets.0.name", fmt.Sprintf("tf-testacc-bucket-ds-full-%d-sample", randInt)),
+					resource.TestCheckResourceAttr("data.alicloud_oss_buckets.buckets", "buckets.0.acl", "public-read"),
+					resource.TestCheckResourceAttrSet("data.alicloud_oss_buckets.buckets", "buckets.0.extranet_endpoint"),
+					resource.TestCheckResourceAttrSet("data.alicloud_oss_buckets.buckets", "buckets.0.intranet_endpoint"),
+					resource.TestCheckResourceAttrSet("data.alicloud_oss_buckets.buckets", "buckets.0.location"),
+					resource.TestCheckResourceAttrSet("data.alicloud_oss_buckets.buckets", "buckets.0.owner"),
+					resource.TestCheckResourceAttr("data.alicloud_oss_buckets.buckets", "buckets.0.storage_class", "Standard"),
+					resource.TestCheckResourceAttrSet("data.alicloud_oss_buckets.buckets", "buckets.0.creation_date"),
+
+					resource.TestCheckResourceAttr("data.alicloud_oss_buckets.buckets", "buckets.0.cors_rules.#", "2"),
+					resource.TestCheckResourceAttr("data.alicloud_oss_buckets.buckets", "buckets.0.cors_rules.0.allowed_headers.#", "1"),
+					resource.TestCheckResourceAttr("data.alicloud_oss_buckets.buckets", "buckets.0.cors_rules.0.allowed_headers.0", "authorization"),
+					resource.TestCheckResourceAttr("data.alicloud_oss_buckets.buckets", "buckets.0.cors_rules.0.allowed_methods.#", "2"),
+					resource.TestCheckResourceAttr("data.alicloud_oss_buckets.buckets", "buckets.0.cors_rules.0.allowed_methods.0", "PUT"),
+					resource.TestCheckResourceAttr("data.alicloud_oss_buckets.buckets", "buckets.0.cors_rules.0.allowed_methods.1", "GET"),
+					resource.TestCheckResourceAttr("data.alicloud_oss_buckets.buckets", "buckets.0.cors_rules.0.allowed_origins.#", "1"),
+					resource.TestCheckResourceAttr("data.alicloud_oss_buckets.buckets", "buckets.0.cors_rules.0.allowed_origins.0", "*"),
+					resource.TestCheckResourceAttr("data.alicloud_oss_buckets.buckets", "buckets.0.cors_rules.0.expose_headers.#", "0"),
+					resource.TestCheckResourceAttr("data.alicloud_oss_buckets.buckets", "buckets.0.cors_rules.0.max_age_seconds", "0"),
+
+					resource.TestCheckResourceAttr("data.alicloud_oss_buckets.buckets", "buckets.0.cors_rules.1.allowed_headers.#", "1"),
+					resource.TestCheckResourceAttr("data.alicloud_oss_buckets.buckets", "buckets.0.cors_rules.1.allowed_headers.0", "authorization"),
+					resource.TestCheckResourceAttr("data.alicloud_oss_buckets.buckets", "buckets.0.cors_rules.1.allowed_methods.#", "1"),
+					resource.TestCheckResourceAttr("data.alicloud_oss_buckets.buckets", "buckets.0.cors_rules.1.allowed_methods.0", "GET"),
+					resource.TestCheckResourceAttr("data.alicloud_oss_buckets.buckets", "buckets.0.cors_rules.1.allowed_origins.#", "1"),
+					resource.TestCheckResourceAttr("data.alicloud_oss_buckets.buckets", "buckets.0.cors_rules.1.allowed_origins.0", "http://www.a.com"),
+					resource.TestCheckResourceAttr("data.alicloud_oss_buckets.buckets", "buckets.0.cors_rules.1.expose_headers.#", "1"),
+					resource.TestCheckResourceAttr("data.alicloud_oss_buckets.buckets", "buckets.0.cors_rules.1.expose_headers.0", "x-oss-test"),
+					resource.TestCheckResourceAttr("data.alicloud_oss_buckets.buckets", "buckets.0.cors_rules.1.max_age_seconds", "100"),
+
+					resource.TestCheckResourceAttr("data.alicloud_oss_buckets.buckets", "buckets.0.website.#", "1"),
+					resource.TestCheckResourceAttr("data.alicloud_oss_buckets.buckets", "buckets.0.website.0.index_document", "index.html"),
+					resource.TestCheckResourceAttr("data.alicloud_oss_buckets.buckets", "buckets.0.website.0.error_document", "error.html"),
+
+					resource.TestCheckResourceAttr("data.alicloud_oss_buckets.buckets", "buckets.0.logging.#", "1"),
+					resource.TestCheckResourceAttr("data.alicloud_oss_buckets.buckets", "buckets.0.logging.0.target_bucket", fmt.Sprintf("tf-testacc-bucket-ds-full-%d-log", randInt)),
+					resource.TestCheckResourceAttr("data.alicloud_oss_buckets.buckets", "buckets.0.logging.0.target_prefix", "log/"),
+
+					resource.TestCheckResourceAttr("data.alicloud_oss_buckets.buckets", "buckets.0.referer_config.#", "1"),
+					resource.TestCheckResourceAttr("data.alicloud_oss_buckets.buckets", "buckets.0.referer_config.0.allow_empty", "false"),
+					resource.TestCheckResourceAttr("data.alicloud_oss_buckets.buckets", "buckets.0.referer_config.0.referers.#", "1"),
+					resource.TestCheckResourceAttr("data.alicloud_oss_buckets.buckets", "buckets.0.referer_config.0.referers.0", "http://www.aliyun.com"),
+
+					resource.TestCheckResourceAttr("data.alicloud_oss_buckets.buckets", "buckets.0.lifecycle_rule.#", "2"),
+					resource.TestCheckResourceAttr("data.alicloud_oss_buckets.buckets", "buckets.0.lifecycle_rule.0.id", "rule1"),
+					resource.TestCheckResourceAttr("data.alicloud_oss_buckets.buckets", "buckets.0.lifecycle_rule.0.prefix", "path1/"),
+					resource.TestCheckResourceAttr("data.alicloud_oss_buckets.buckets", "buckets.0.lifecycle_rule.0.enabled", "true"),
+					resource.TestCheckResourceAttr("data.alicloud_oss_buckets.buckets", "buckets.0.lifecycle_rule.0.expiration.#", "1"),
+					resource.TestCheckResourceAttr("data.alicloud_oss_buckets.buckets", "buckets.0.lifecycle_rule.0.expiration.0.days", "365"),
+
+					resource.TestCheckResourceAttr("data.alicloud_oss_buckets.buckets", "buckets.0.lifecycle_rule.1.id", "rule2"),
+					resource.TestCheckResourceAttr("data.alicloud_oss_buckets.buckets", "buckets.0.lifecycle_rule.1.prefix", "path2/"),
+					resource.TestCheckResourceAttr("data.alicloud_oss_buckets.buckets", "buckets.0.lifecycle_rule.1.enabled", "true"),
+					resource.TestCheckResourceAttr("data.alicloud_oss_buckets.buckets", "buckets.0.lifecycle_rule.1.expiration.#", "1"),
+					resource.TestCheckResourceAttr("data.alicloud_oss_buckets.buckets", "buckets.0.lifecycle_rule.1.expiration.0.date", "2018-01-12"),
+				),
+			},
+		},
+	})
+}
+
+func testAccCheckAlicloudOssBucketsDataSourceBasic(randInt int) string {
+	return fmt.Sprintf(`
+variable "name" {
+	default = "tf-testacc-bucket-ds-basic-%d"
+}
+
+resource "alicloud_oss_bucket" "sample_bucket" {
+	bucket = "${var.name}"
+	acl = "public-read"
+}
+
+data "alicloud_oss_buckets" "buckets" {
+    name_regex = "${alicloud_oss_bucket.sample_bucket.bucket}"
+}
+`, randInt)
+}
+
+func testAccCheckAlicloudOssBucketsDataSourceFull(randInt int) string {
+	return fmt.Sprintf(`
+variable "name" {
+	default = "tf-testacc-bucket-ds-full-%d"
+}
+
+resource "alicloud_oss_bucket" "log_bucket"{
+	bucket = "${var.name}-log"
+}
+
+resource "alicloud_oss_bucket" "sample_bucket" {
+	bucket = "${var.name}-sample"
+	acl = "public-read"
+
+    cors_rule = [
+    	{
+			allowed_origins=["*"]
+			allowed_methods=["PUT","GET"]
+			allowed_headers=["authorization"]
+		},
+		{
+			allowed_origins=["http://www.a.com"]
+			allowed_methods=["GET"]
+			allowed_headers=["authorization"]
+			expose_headers=["x-oss-test"]
+			max_age_seconds=100
+		}
+    ]
+
+	website = {
+		index_document = "index.html"
+		error_document = "error.html"
+	}
+
+	logging {
+		target_bucket = "${alicloud_oss_bucket.log_bucket.id}"
+		target_prefix = "log/"
+	}
+
+	referer_config {
+		allow_empty = false
+		referers = ["http://www.aliyun.com"]
+	}
+
+	lifecycle_rule = [
+		{
+			id = "rule1"
+			prefix = "path1/"
+			enabled = true
+			expiration {
+				days = 365
+			}
+		},
+		{
+			id = "rule2"
+			prefix = "path2/"
+			enabled = true
+			expiration {
+				date = "2018-01-12"
+			}
+		}
+	]
+}
+
+data "alicloud_oss_buckets" "buckets" {
+    name_regex = "${alicloud_oss_bucket.sample_bucket.bucket}"
+}
+`, randInt)
+}

--- a/alicloud/provider.go
+++ b/alicloud/provider.go
@@ -71,6 +71,7 @@ func Provider() terraform.ResourceProvider {
 			"alicloud_zones":          dataSourceAlicloudZones(),
 			"alicloud_instance_types": dataSourceAlicloudInstanceTypes(),
 			"alicloud_instances":      dataSourceAlicloudInstances(),
+			"alicloud_disks":          dataSourceAlicloudDisks(),
 			"alicloud_vpcs":           dataSourceAlicloudVpcs(),
 			"alicloud_vswitches":      dataSourceAlicloudVSwitches(),
 			"alicloud_eips":           dataSourceAlicloudEips(),

--- a/alicloud/provider.go
+++ b/alicloud/provider.go
@@ -97,6 +97,7 @@ func Provider() terraform.ResourceProvider {
 			"alicloud_slb_listeners":        dataSourceAlicloudSlbListeners(),
 			"alicloud_slb_rules":            dataSourceAlicloudSlbRules(),
 			"alicloud_slb_server_groups":    dataSourceAlicloudSlbServerGroups(),
+			"alicloud_oss_buckets":          dataSourceAlicloudOssBuckets(),
 			"alicloud_db_instances":         dataSourceAlicloudDBInstances(),
 			"alicloud_pvtz_zones":           dataSourceAlicloudPvtzZones(),
 			"alicloud_pvtz_zone_records":    dataSourceAlicloudPvtzZoneRecords(),

--- a/alicloud/provider.go
+++ b/alicloud/provider.go
@@ -98,6 +98,7 @@ func Provider() terraform.ResourceProvider {
 			"alicloud_slb_rules":            dataSourceAlicloudSlbRules(),
 			"alicloud_slb_server_groups":    dataSourceAlicloudSlbServerGroups(),
 			"alicloud_oss_buckets":          dataSourceAlicloudOssBuckets(),
+			"alicloud_fc_functions":         dataSourceAlicloudFcFunctions(),
 			"alicloud_fc_services":          dataSourceAlicloudFcServices(),
 			"alicloud_db_instances":         dataSourceAlicloudDBInstances(),
 			"alicloud_pvtz_zones":           dataSourceAlicloudPvtzZones(),

--- a/alicloud/provider.go
+++ b/alicloud/provider.go
@@ -97,6 +97,7 @@ func Provider() terraform.ResourceProvider {
 			"alicloud_slb_listeners":        dataSourceAlicloudSlbListeners(),
 			"alicloud_slb_rules":            dataSourceAlicloudSlbRules(),
 			"alicloud_slb_server_groups":    dataSourceAlicloudSlbServerGroups(),
+			"alicloud_oss_bucket_objects":   dataSourceAlicloudOssBucketObjects(),
 			"alicloud_oss_buckets":          dataSourceAlicloudOssBuckets(),
 			"alicloud_fc_functions":         dataSourceAlicloudFcFunctions(),
 			"alicloud_fc_services":          dataSourceAlicloudFcServices(),

--- a/alicloud/provider.go
+++ b/alicloud/provider.go
@@ -98,6 +98,7 @@ func Provider() terraform.ResourceProvider {
 			"alicloud_slb_rules":            dataSourceAlicloudSlbRules(),
 			"alicloud_slb_server_groups":    dataSourceAlicloudSlbServerGroups(),
 			"alicloud_oss_buckets":          dataSourceAlicloudOssBuckets(),
+			"alicloud_fc_services":          dataSourceAlicloudFcServices(),
 			"alicloud_db_instances":         dataSourceAlicloudDBInstances(),
 			"alicloud_pvtz_zones":           dataSourceAlicloudPvtzZones(),
 			"alicloud_pvtz_zone_records":    dataSourceAlicloudPvtzZoneRecords(),

--- a/alicloud/resource_alicloud_oss_bucket_object.go
+++ b/alicloud/resource_alicloud_oss_bucket_object.go
@@ -236,7 +236,12 @@ func buildObjectHeaderOptions(d *schema.ResourceData) (options []oss.Option, err
 	}
 
 	if v, ok := d.GetOk("expires"); ok {
-		options = append(options, oss.Expires(v.(time.Time)))
+		expires := v.(string)
+		expiresTime, err := time.Parse(time.RFC1123, expires)
+		if err != nil {
+			return nil, fmt.Errorf("expires format must respect the RFC1123 standard (current value: %s)", expires)
+		}
+		options = append(options, oss.Expires(expiresTime))
 	}
 
 	if v, ok := d.GetOk("server_side_encryption"); ok {

--- a/examples/kubernetes/main.tf
+++ b/examples/kubernetes/main.tf
@@ -1,10 +1,3 @@
-// Provider specific configs
-provider "alicloud" {
-  access_key = "${var.alicloud_access_key}"
-  secret_key = "${var.alicloud_secret_key}"
-  region = "${var.region}"
-}
-
 // Instance_types data source for instance_type
 data "alicloud_instance_types" "default" {
   cpu_core_count = "${var.cpu_core_count}"
@@ -59,11 +52,11 @@ resource "alicloud_snat_entry" "default"{
 resource "alicloud_cs_kubernetes" "k8s" {
   count = "${var.k8s_number}"
   name = "${var.k8s_name_prefix == "" ? format("%s-%s", var.example_name, format(var.number_format, count.index+1)) : format("%s-%s", var.k8s_name_prefix, format(var.number_format, count.index+1))}"
-  vswitch_id = "${length(var.vswitch_ids) > 0 ? element(split(",", join(",", var.vswitch_ids)), count.index%length(split(",", join(",", var.vswitch_ids)))) : length(var.vswitch_cidrs) < 1 ? "" : element(split(",", join(",", alicloud_vswitch.vswitches.*.id)), count.index%length(split(",", join(",", alicloud_vswitch.vswitches.*.id))))}"
+  vswitch_ids = ["${length(var.vswitch_ids) > 0 ? element(split(",", join(",", var.vswitch_ids)), count.index%length(split(",", join(",", var.vswitch_ids)))) : length(var.vswitch_cidrs) < 1 ? "" : element(split(",", join(",", alicloud_vswitch.vswitches.*.id)), count.index%length(split(",", join(",", alicloud_vswitch.vswitches.*.id))))}"]
   new_nat_gateway = false
-  master_instance_type = "${var.master_instance_type == "" ? data.alicloud_instance_types.default.instance_types.0.id : var.master_instance_type}"
-  worker_instance_type = "${var.worker_instance_type == "" ? data.alicloud_instance_types.default.instance_types.0.id : var.worker_instance_type}"
-  worker_number = "${var.k8s_worker_number}"
+  master_instance_types = ["${var.master_instance_type == "" ? data.alicloud_instance_types.default.instance_types.0.id : var.master_instance_type}"]
+  worker_instance_types = ["${var.worker_instance_type == "" ? data.alicloud_instance_types.default.instance_types.0.id : var.worker_instance_type}"]
+  worker_numbers = ["${var.k8s_worker_number}"]
   master_disk_category = "${var.master_disk_category}"
   worker_disk_category = "${var.worker_disk_category}"
   master_disk_size = "${var.master_disk_size}"

--- a/examples/kubernetes/outputs.tf
+++ b/examples/kubernetes/outputs.tf
@@ -6,7 +6,7 @@ output "vpc_id" {
 
 output "vswitch_ids" {
   description = "List ID of the VSwitches."
-  value = ["${alicloud_cs_kubernetes.k8s.*.vswitch_id}"]
+  value = ["${alicloud_cs_kubernetes.k8s.*.vswitch_ids}"]
 }
 
 output "nat_gateway_id" {

--- a/examples/kubernetes/variables.tf
+++ b/examples/kubernetes/variables.tf
@@ -1,14 +1,4 @@
-# common variables
-variable "alicloud_access_key" {
-  description = "The Alicloud Access Key ID to launch resources."
-}
-variable "alicloud_secret_key" {
-  description = "The Alicloud Access Secret Key to launch resources."
-}
-variable "region" {
-  description = "The region to launch resources."
-  default = "cn-hangzhou"
-}
+//# common variables
 variable "availability_zone" {
   description = "The available zone to launch ecs instance and other resources."
   default = ""

--- a/website/alicloud.erb
+++ b/website/alicloud.erb
@@ -73,6 +73,8 @@
                         <li<%= sidebar_current("docs-alicloud-datasource-slb-server-groups") %>>
                           <a href="/docs/providers/alicloud/d/slb_server_groups.html">alicloud_slb_server_groups</a>
                         </li>
+                        <li<%= sidebar_current("docs-alicloud-datasource-oss-bucket-objects") %>>
+                          <a href="/docs/providers/alicloud/d/oss_bucket_objects.html">alicloud_oss_bucket_objects</a>
                         <li<%= sidebar_current("docs-alicloud-datasource-oss-buckets") %>>
                           <a href="/docs/providers/alicloud/d/oss_buckets.html">alicloud_oss_buckets</a>
                         </li>

--- a/website/alicloud.erb
+++ b/website/alicloud.erb
@@ -37,6 +37,9 @@
                         <li<%= sidebar_current("docs-alicloud-datasource-instances") %>>
                             <a href="/docs/providers/alicloud/d/instances.html">alicloud_instances</a>
                         </li>
+                        <li<%= sidebar_current("docs-alicloud-datasource-disks") %>>
+                            <a href="/docs/providers/alicloud/d/disks.html">alicloud_disks</a>
+                        </li>
                         <li<%= sidebar_current("docs-alicloud-datasource-vpcs") %>>
                             <a href="/docs/providers/alicloud/d/vpcs.html">alicloud_vpcs</a>
                         </li>

--- a/website/alicloud.erb
+++ b/website/alicloud.erb
@@ -73,6 +73,9 @@
                         <li<%= sidebar_current("docs-alicloud-datasource-slb-server-groups") %>>
                           <a href="/docs/providers/alicloud/d/slb_server_groups.html">alicloud_slb_server_groups</a>
                         </li>
+                        <li<%= sidebar_current("docs-alicloud-datasource-oss-buckets") %>>
+                          <a href="/docs/providers/alicloud/d/oss_buckets.html">alicloud_oss_buckets</a>
+                        </li>
                         <li<%= sidebar_current("docs-alicloud-datasource-db-instances") %>>
                             <a href="/docs/providers/alicloud/d/db_instances.html">alicloud_db_instances</a>
                         </li>

--- a/website/alicloud.erb
+++ b/website/alicloud.erb
@@ -76,6 +76,9 @@
                         <li<%= sidebar_current("docs-alicloud-datasource-oss-buckets") %>>
                           <a href="/docs/providers/alicloud/d/oss_buckets.html">alicloud_oss_buckets</a>
                         </li>
+                        <li<%= sidebar_current("docs-alicloud-datasource-fc-services") %>>
+                          <a href="/docs/providers/alicloud/d/fc_services.html">alicloud_fc_services</a>
+                        </li>
                         <li<%= sidebar_current("docs-alicloud-datasource-db-instances") %>>
                             <a href="/docs/providers/alicloud/d/db_instances.html">alicloud_db_instances</a>
                         </li>

--- a/website/alicloud.erb
+++ b/website/alicloud.erb
@@ -76,6 +76,8 @@
                         <li<%= sidebar_current("docs-alicloud-datasource-oss-buckets") %>>
                           <a href="/docs/providers/alicloud/d/oss_buckets.html">alicloud_oss_buckets</a>
                         </li>
+                        <li<%= sidebar_current("docs-alicloud-datasource-fc-functions") %>>
+                          <a href="/docs/providers/alicloud/d/fc_functions.html">alicloud_fc_functions</a>
                         <li<%= sidebar_current("docs-alicloud-datasource-fc-services") %>>
                           <a href="/docs/providers/alicloud/d/fc_services.html">alicloud_fc_services</a>
                         </li>

--- a/website/docs/d/disks.html.markdown
+++ b/website/docs/d/disks.html.markdown
@@ -1,0 +1,68 @@
+---
+layout: "alicloud"
+page_title: "Alicloud: alicloud_disks"
+sidebar_current: "docs-alicloud-datasource-disks"
+description: |-
+    Provides a list of disks to the user.
+---
+
+# alicloud\_disks
+
+This data source provides the disks of the current Alibaba Cloud user.
+
+## Example Usage
+
+```
+data "alicloud_disks" "disks_ds" {
+  name_regex = "sample_disk"
+}
+
+output "first_disk_id" {
+  value = "${data.alicloud_disks.disks_ds.disks.0.id}"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `ids` - (Optional) A list of disks IDs.
+* `name_regex` - (Optional) A regex string to filter results by disk name.
+* `type` - (Optional) Disk type. Possible values: `system` and `data`.
+* `category` - (Optional) Disk category. Possible values: `cloud` (basic cloud disk), `cloud_efficiency` (ultra cloud disk), `cloud_ssd` (SSD cloud disk), `ephemeral_ssd` (ephemeral SSD) and `ephemeral` (ephemeral disk).
+* `encrypted` - (Optional) Indicate whether the disk is encrypted or not. Possible values: `on` and `off`.
+* `instance_id` - (Optional) Filter the results by the specified ECS instance ID.
+* `tags` - (Optional) A map of tags assigned to the disks. It must be in the format:
+  ```
+  data "alicloud_disks" "disks_ds" {
+    tags = {
+      tagKey1 = "tagValue1",
+      tagKey2 = "tagValue2"
+    }
+  }
+  ```
+* `output_file` - (Optional) File name where to save data source results (after running `terraform plan`).
+
+## Attributes Reference
+
+The following attributes are exported in addition to the arguments listed above:
+
+* `disks` - A list of disks. Each element contains the following attributes:
+  * `id` - ID of the disk.
+  * `name` - Disk name.
+  * `description` - Disk description.
+  * `region_id` - Region ID the disk belongs to.
+  * `availability_zone` - Availability zone of the disk.
+  * `status` - Current status. Possible values: `In_use`, `Available`, `Attaching`, `Detaching`, `Creating` and `ReIniting`.
+  * `type` - Disk type. Possible values: `system` and `data`.
+  * `category` - Disk category. Possible values: `cloud` (basic cloud disk), `cloud_efficiency` (ultra cloud disk), `cloud_ssd` (SSD cloud disk), `ephemeral_ssd` (ephemeral SSD) and `ephemeral` (ephemeral disk).
+  * `encrypted` - Indicate whether the disk is encrypted or not. Possible values: `on` and `off`.
+  * `size` - Disk size in GiB.
+  * `image_id` - ID of the image from which the disk is created. It is null unless the disk is created using an image.
+  * `snapshot_id` - Snapshot used to create the disk. It is null if no snapshot is used to create the disk.
+  * `instance_id` - ID of the related instance. It is `null` unless the `status` is `In_use`.
+  * `creation_time` - Disk creation time.
+  * `attached_time` - Disk attachment time.
+  * `detached_time` - Disk detachment time.
+  * `expiration_time` - Disk expiration time.
+  * `tags` - A map of tags assigned to the disk.

--- a/website/docs/d/fc_functions.html.markdown
+++ b/website/docs/d/fc_functions.html.markdown
@@ -1,0 +1,49 @@
+---
+layout: "alicloud"
+page_title: "Alicloud: alicloud_fc_functions"
+sidebar_current: "docs-alicloud-datasource-fc-functions"
+description: |-
+    Provides a list of FC functions to the user.
+---
+
+# alicloud\_fc_functions
+
+This data source provides the Function Compute functions of the current Alibaba Cloud user.
+
+## Example Usage
+
+```
+data "alicloud_fc_functions" "functions_ds" {
+  service_name = "sample_service"
+  name_regex = "sample_fc_function"
+}
+
+output "first_fc_function_name" {
+  value = "${data.alicloud_fc_functions.functions_ds.functions.0.name}"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `service_name` - Name of the service that contains the functions to find.
+* `name_regex` - (Optional) A regex string to filter results by function name.
+* `output_file` - (Optional) File name where to save data source results (after running `terraform plan`).
+
+## Attributes Reference
+
+The following attributes are exported in addition to the arguments listed above:
+
+* `functions` - A list of functions. Each element contains the following attributes:
+  * `id` - Function ID.
+  * `name` - Function name.
+  * `description` - Function description.
+  * `runtime` - Function runtime. The list of possible values is [available here](https://www.alibabacloud.com/help/doc-detail/52077.htm).
+  * `handler` - Function [entry point](https://www.alibabacloud.com/help/doc-detail/62213.htm) in the code.
+  * `timeout` - Maximum amount of time the function can run in seconds.
+  * `memory_size` - Amount of memory in MB the function can use at runtime.
+  * `code_size` - Function code size in bytes.
+  * `code_checksum` - Checksum (crc64) of the function code.
+  * `creation_time` - Function creation time.
+  * `last_modification_time` - Function last modification time.

--- a/website/docs/d/fc_services.html.markdown
+++ b/website/docs/d/fc_services.html.markdown
@@ -1,0 +1,50 @@
+---
+layout: "alicloud"
+page_title: "Alicloud: alicloud_fc_services"
+sidebar_current: "docs-alicloud-datasource-fc-services"
+description: |-
+    Provides a list of FC services to the user.
+---
+
+# alicloud\_fc_services
+
+This data source provides the Function Compute services of the current Alibaba Cloud user.
+
+## Example Usage
+
+```
+data "alicloud_fc_services" "fc_services_ds" {
+  name_regex = "sample_fc_service"
+}
+
+output "first_fc_service_name" {
+  value = "${data.alicloud_fc_services.fc_services_ds.services.0.name}"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `name_regex` - (Optional) A regex string to filter results by FC service name.
+* `output_file` - (Optional) File name where to save data source results (after running `terraform plan`).
+
+## Attributes Reference
+
+The following attributes are exported in addition to the arguments listed above:
+
+* `services` - A list of FC services. Each element contains the following attributes:
+  * `id` - FC service ID.
+  * `name` - FC service name.
+  * `description` - FC service description.
+  * `role` - FC service role ARN.
+  * `internet_access` - Indicate whether the service can access to internet or not.
+  * `creation_time` - FC service creation time.
+  * `last_modification_time` - FC service last modification time.
+  * `log_config` - A list of one element containing information about the associated log store. It contains the following attributes:
+    * `project` - Log Service project name.
+    * `logstore` - Log Service store name.
+  * `vpc_config` - A list of one element containing information about accessible VPC resources. It contains the following attributes:
+    * `vpc_id` - Associated VPC ID.
+    * `vswitch_ids` - Associated VSwitch IDs.
+    * `security_group_id` - Associated security group ID.

--- a/website/docs/d/oss_bucket_objects.html.markdown
+++ b/website/docs/d/oss_bucket_objects.html.markdown
@@ -1,0 +1,52 @@
+---
+layout: "alicloud"
+page_title: "Alicloud: alicloud_oss_bucket_objects"
+sidebar_current: "docs-alicloud-datasource-oss-bucket-objects"
+description: |-
+    Provides a list of bucket objects to the user.
+---
+
+# alicloud\_oss_bucket_objects
+
+This data source provides the objects of an OSS bucket.
+
+## Example Usage
+
+```
+data "alicloud_oss_bucket_objects" "bucket_objects_ds" {
+  bucket_name = "sample_bucket"
+  key_regex = "sample/sample_object.txt"
+}
+
+output "first_object_key" {
+  value = "${data.alicloud_oss_bucket_objects.bucket_objects_ds.bucket_objects.0.key}"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `bucket_name` - Name of the bucket that contains the objects to find.
+* `key_regex` - (Optional) A regex string to filter results by key.
+* `key_prefix` - (Optional) Filter results by the given key prefix (such as "path/to/folder/logs-").
+* `output_file` - (Optional) File name where to save data source results (after running `terraform plan`).
+
+## Attributes Reference
+
+The following attributes are exported in addition to the arguments listed above:
+
+* `objects` - A list of bucket objects. Each element contains the following attributes:
+  * `key` - Object key.
+  * `acl` - Object access control list. Possible values: `default`, `private`, `public-read` and `public-read-write`.
+  * `content_type` - Standard MIME type describing the format of the object data, e.g. "application/octet-stream".
+  * `content_length` - Size of the object in bytes.
+  * `cache_control` - Caching behavior along the request/reply chain. Read [RFC2616 Cache-Control](https://www.ietf.org/rfc/rfc2616.txt) for further details.
+  * `content_disposition` - Presentational information for the object. Read [RFC2616 Content-Disposition](https://www.ietf.org/rfc/rfc2616.txt) for further details.
+  * `content_encoding` - Content encodings that have been applied to the object and thus what decoding mechanisms must be applied to obtain the media-type referenced by the Content-Type header field. Read [RFC2616 Content-Encoding](https://www.ietf.org/rfc/rfc2616.txt) for further details.
+  * `content_md5` - MD5 value of the content. Read [MD5](https://www.alibabacloud.com/help/doc-detail/31978.htm) for computing method.
+  * `expires` - Expiration date for the the request/response. Read [RFC2616 Expires](https://www.ietf.org/rfc/rfc2616.txt) for further details.
+  * `server_side_encryption` - Server-side encryption of the object in OSS. It can be empty or `AES256`.
+  * `etag` - ETag generated for the object (MD5 sum of the object content).
+  * `storage_class` - Object storage type. Possible values: `Standard`, `IA` and `Archive`.
+  * `last_modification_time` - Last modification time of the object.

--- a/website/docs/d/oss_buckets.html.markdown
+++ b/website/docs/d/oss_buckets.html.markdown
@@ -1,0 +1,66 @@
+---
+layout: "alicloud"
+page_title: "Alicloud: alicloud_oss_buckets"
+sidebar_current: "docs-alicloud-datasource-oss-buckets"
+description: |-
+    Provides a list of OSS buckets to the user.
+---
+
+# alicloud\_oss_buckets
+
+This data source provides the OSS buckets of the current Alibaba Cloud user.
+
+## Example Usage
+
+```
+data "alicloud_oss_buckets" "oss_buckets_ds" {
+  name_regex = "sample_oss_bucket"
+}
+
+output "first_oss_bucket_name" {
+  value = "${data.alicloud_oss_buckets.oss_buckets_ds.buckets.0.name}"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `name_regex` - (Optional) A regex string to filter results by bucket name.
+* `output_file` - (Optional) File name where to save data source results (after running `terraform plan`).
+
+## Attributes Reference
+
+The following attributes are exported in addition to the arguments listed above:
+
+* `buckets` - A list of buckets. Each element contains the following attributes:
+  * `name` - Bucket name.
+  * `acl` - Bucket access control list. Possible values: `private`, `public-read` and `public-read-write`.
+  * `extranet_endpoint` - Internet domain name for accessing the bucket from outside.
+  * `intranet_endpoint` - Intranet domain name for accessing the bucket from an ECS instance in the same region.
+  * `location` - Region of the data center where the bucket is located.
+  * `owner` - Bucket owner.
+  * `storage_class` - Object storage type. Possible values: `Standard`, `IA` and `Archive`.
+  * `creation_date` - Bucket creation date.
+  * `cors_rules` - A list of CORS rule configurations. Each element contains the following attributes:
+    * `allowed_origins` - The origins allowed for cross-domain requests. Multiple elements can be used to specify multiple allowed origins. Each rule allows up to one wildcard "\*". If "\*" is specified, cross-domain requests of all origins are allowed.
+    * `allowed_methods` - Specify the allowed methods for cross-domain requests. Possible values: `GET`, `PUT`, `DELETE`, `POST` and `HEAD`.
+    * `allowed_headers` - Control whether the headers specified by Access-Control-Request-Headers in the OPTIONS prefetch command are allowed. Each header specified by Access-Control-Request-Headers must match a value in AllowedHeader. Each rule allows up to one wildcard “*” .
+    * `expose_headers` - Specify the response headers allowing users to access from an application (for example, a Javascript XMLHttpRequest object). The wildcard "\*" is not allowed.
+    * `max_age_seconds` - Specify the cache time for the returned result of a browser prefetch (OPTIONS) request to a specific resource.
+  * `website` - A list of one element containing configuration parameters used when the bucket is used as a website. It contains the following attributes:
+    * `index_document` - Key of the HTML document containing the home page.
+    * `error_document` - Key of the HTML document containing the error page.
+  * `logging` - A list of one element containing configuration parameters used for storing access log information. It contains the following attributes:
+    * `target_bucket` - Bucket for storing access logs.
+    * `target_prefix` - Prefix of the saved access log file paths.
+  * `referer_config` - A list of one element containing referer configuration. It contains the following attributes:
+    * `allow_empty` - Indicate whether the access request referer field can be empty.
+    * `referers` - Referer access whitelist.
+  * `lifecycle_rule` - A list CORS of lifecycle configurations. When Lifecycle is enabled, OSS automatically deletes the objects or transitions the objects (to another storage class) corresponding the lifecycle rules on a regular basis. Each element contains the following attributes:
+    * `id` - Unique ID of the rule.
+    * `prefix` - Prefix applicable to a rule. Only those objects with a matching prefix can be affected by the rule.
+    * `enabled` - Indicate whether the rule is enabled or not.
+    * `expiration` - A list of one element containing expiration attributes of an object. It contains the following attributes:
+      * `date` - Date after which the rule to take effect. The format is like 2017-03-09.
+      * `days` - Indicate the number of days after the last object update until the rules take effect.

--- a/website/docs/r/oss_bucket.html.markdown
+++ b/website/docs/r/oss_bucket.html.markdown
@@ -103,13 +103,13 @@ resource "alicloud_oss_bucket" "bucket-lifecycle" {
 The following arguments are supported:
 
 * `bucket` - (Optional, Forces New Resorce) The name of the bucket. If omitted, Terraform will assign a random and unique name.
-* `acl` - (Optional) The [canned ACL](https://help.aliyun.com/document_detail/31843.html?spm=5176.doc31842.2.2.j7C2nn) to apply. Defaults to "private".
-* `core_rule` - (Optional) A rule of [Cross-Origin Resource Sharing](https://help.aliyun.com/document_detail/32001.html?spm=5176.doc32000.6.886.Hd5dYP) (documented below). The items of core rule are no more than 10 for every OSS bucket.
+* `acl` - (Optional) The [canned ACL](https://help.aliyun.com/document_detail/31843.html) to apply. Defaults to "private".
+* `core_rule` - (Optional) A rule of [Cross-Origin Resource Sharing](https://help.aliyun.com/document_detail/32001.html) (documented below). The items of core rule are no more than 10 for every OSS bucket.
 * `website` - (Optional) A website object(documented below).
-* `logging` - (Optional) A Settings of [bucket logging](https://help.aliyun.com/document_detail/31961.html?spm=5176.doc31868.2.4.jjuG5O) (documented below).
+* `logging` - (Optional) A Settings of [bucket logging](https://help.aliyun.com/document_detail/31961.html) (documented below).
 * `logging_isenable` - (Optional) The flag of using logging enable container. Defaults true.
-* `referer_config` - (Optional) The configuration of [referer](https://help.aliyun.com/document_detail/31869.html?spm=5176.doc31963.2.2.a3LZzH) (documented below).
-* `lifecycle_rule` - (Optional) A configuration of [object lifecycle management](https://help.aliyun.com/document_detail/31964.html?spm=5176.doc31869.6.846.ZxpE3x) (documented below).
+* `referer_config` - (Optional) The configuration of [referer](https://help.aliyun.com/document_detail/31869.html) (documented below).
+* `lifecycle_rule` - (Optional) A configuration of [object lifecycle management](https://help.aliyun.com/document_detail/31964.html) (documented below).
 
 ### Block core_rule
 

--- a/website/docs/r/oss_bucket_object.html.markdown
+++ b/website/docs/r/oss_bucket_object.html.markdown
@@ -47,13 +47,13 @@ The following arguments are supported:
 * `key` - (Required) The name of the object once it is in the bucket.
 * `source` - (Required) The path to the source file being uploaded to the bucket.
 * `content` - (Required unless `source` given) The literal content being uploaded to the bucket.
-* `acl` - (Optional) The [canned ACL](https://help.aliyun.com/document_detail/31843.html?spm=5176.doc31842.2.2.j7C2nn) to apply. Defaults to "private".
+* `acl` - (Optional) The [canned ACL](https://help.aliyun.com/document_detail/31843.html) to apply. Defaults to "private".
 * `content_type` - (Optional) A standard MIME type describing the format of the object data, e.g. application/octet-stream. All Valid MIME Types are valid for this input.
-* `cache_control` - (Optional) Specifies caching behavior along the request/reply chain. Read [RFC2616 Cache-Control](https://www.ietf.org/rfc/rfc2616.txt?spm=5176.doc31978.2.1.iLEoOM&file=rfc2616.txt) for further details.
-* `content_disposition` - (Optional) Specifies presentational information for the object. Read [RFC2616 Content-Disposition](https://www.ietf.org/rfc/rfc2616.txt?spm=5176.doc31978.2.1.iLEoOM&file=rfc2616.txt) for further details.
-* `content_encoding` - (Optional) Specifies what content encodings have been applied to the object and thus what decoding mechanisms must be applied to obtain the media-type referenced by the Content-Type header field. Read [RFC2616 Content-Encoding](https://www.ietf.org/rfc/rfc2616.txt?spm=5176.doc31978.2.1.iLEoOM&file=rfc2616.txt) for further details.
-* `content_md5` - (Optional) The MD5 value of the content. Read [MD5](https://help.aliyun.com/document_detail/31978.html?spm=5176.product31815.6.861.upTmI0) for computing method.
-* `expires` - (Optional) Specifies expire date for the the request/response. Read [RFC2616 Expires](https://www.ietf.org/rfc/rfc2616.txt?spm=5176.doc31978.2.1.iLEoOM&file=rfc2616.txt) for further details.
+* `cache_control` - (Optional) Specifies caching behavior along the request/reply chain. Read [RFC2616 Cache-Control](https://www.ietf.org/rfc/rfc2616.txt) for further details.
+* `content_disposition` - (Optional) Specifies presentational information for the object. Read [RFC2616 Content-Disposition](https://www.ietf.org/rfc/rfc2616.txt) for further details.
+* `content_encoding` - (Optional) Specifies what content encodings have been applied to the object and thus what decoding mechanisms must be applied to obtain the media-type referenced by the Content-Type header field. Read [RFC2616 Content-Encoding](https://www.ietf.org/rfc/rfc2616.txt) for further details.
+* `content_md5` - (Optional) The MD5 value of the content. Read [MD5](https://help.aliyun.com/document_detail/31978.html) for computing method.
+* `expires` - (Optional) Specifies expire date for the the request/response. Read [RFC2616 Expires](https://www.ietf.org/rfc/rfc2616.txt) for further details.
 * `server_side_encryption` - (Optional) Specifies server-side encryption of the object in OSS. At present, it valid value is "`AES256`".
 
 Either `source` or `content` must be provided to specify the bucket content.


### PR DESCRIPTION
Add a new data source alicloud_oss_bucket_objects.

Test results:
```
GOROOT=/usr/local/go #gosetup
GOPATH=/Users/marcplouhinec/go #gosetup
/usr/local/go/bin/go test -c -i -v -sweep=cn-beijing -o /private/var/folders/v1/jvjz3zmn64q0j34yc9m9n4w00000gn/T/___Test_in_Beijing__non_verbose_ github.com/alibaba/terraform-provider/alicloud #gosetup
github.com/alibaba/terraform-provider/alicloud
github.com/alibaba/terraform-provider/alicloud (testmain)
/usr/local/go/bin/go tool test2json -t /private/var/folders/v1/jvjz3zmn64q0j34yc9m9n4w00000gn/T/___Test_in_Beijing__non_verbose_ -test.v -test.run ^TestAccAlicloudOssBucketObjectsDataSource_ #gosetup
=== RUN   TestAccAlicloudOssBucketObjectsDataSource_basic
--- PASS: TestAccAlicloudOssBucketObjectsDataSource_basic (8.85s)
=== RUN   TestAccAlicloudOssBucketObjectsDataSource_filterByPrefix
--- PASS: TestAccAlicloudOssBucketObjectsDataSource_filterByPrefix (6.47s)
PASS
```