### PR TITLE
add cen bandwidth limit resource

### DIFF
--- a/alicloud/import_alicloud_cen_bandwidth_limit_test.go
+++ b/alicloud/import_alicloud_cen_bandwidth_limit_test.go
@@ -1,0 +1,28 @@
+package alicloud
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform/helper/resource"
+)
+
+func TestAccAlicloudCenBandwidthLimit_importBasic(t *testing.T) {
+	resourceName := "alicloud_cen_bandwidth_limit.foo"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckCenBandwidthLimitDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccCenBandwidthLimitConfig,
+			},
+
+			resource.TestStep{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}

--- a/alicloud/provider.go
+++ b/alicloud/provider.go
@@ -205,6 +205,7 @@ func Provider() terraform.ResourceProvider {
 			"alicloud_cen_instance_attachment":          resourceAlicloudCenInstanceAttachment(),
 			"alicloud_cen_bandwidth_package":            resourceAlicloudCenBandwidthPackage(),
 			"alicloud_cen_bandwidth_package_attachment": resourceAlicloudCenBandwidthPackageAttachment(),
+			"alicloud_cen_bandwidth_limit":              resourceAlicloudCenBandwidthLimit(),
 			"alicloud_kvstore_instance":                 resourceAlicloudKVStoreInstance(),
 			"alicloud_kvstore_backup_policy":            resourceAlicloudKVStoreBackupPolicy(),
 			"alicloud_mns_queue":                        resourceAlicloudMNSQueue(),

--- a/alicloud/resource_alicloud_cen_bandwidth_limit.go
+++ b/alicloud/resource_alicloud_cen_bandwidth_limit.go
@@ -1,0 +1,173 @@
+package alicloud
+
+import (
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/helper/schema"
+)
+
+func resourceAlicloudCenBandwidthLimit() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceAlicloudCenBandwidthLimitCreate,
+		Read:   resourceAlicloudCenBandwidthLimitRead,
+		Update: resourceAlicloudCenBandwidthLimitUpdate,
+		Delete: resourceAlicloudCenBandwidthLimitDelete,
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
+
+		Schema: map[string]*schema.Schema{
+			"instance_id": &schema.Schema{
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"region_ids": &schema.Schema{
+				Type:     schema.TypeSet,
+				Required: true,
+				ForceNew: true,
+				Elem: &schema.Schema{
+					Type: schema.TypeString,
+				},
+				MaxItems: 2,
+				MinItems: 2,
+			},
+			"bandwidth_limit": &schema.Schema{
+				Type:     schema.TypeInt,
+				Required: true,
+				ValidateFunc: func(v interface{}, k string) (ws []string, errors []error) {
+					value := v.(int)
+					if value < 1 {
+						errors = append(errors, fmt.Errorf("%s should be at least than 1 Mbps", k))
+					}
+
+					return
+				},
+			},
+		},
+	}
+}
+
+func resourceAlicloudCenBandwidthLimitCreate(d *schema.ResourceData, meta interface{}) error {
+	cenId := d.Get("instance_id").(string)
+	regionIds := d.Get("region_ids").(*schema.Set).List()
+	localRegionId := regionIds[0].(string)
+	oppositeRegionId := regionIds[1].(string)
+
+	if strings.Compare(localRegionId, oppositeRegionId) <= 0 {
+		d.SetId(cenId + COLON_SEPARATED + localRegionId + COLON_SEPARATED + oppositeRegionId)
+	} else {
+		d.SetId(cenId + COLON_SEPARATED + oppositeRegionId + COLON_SEPARATED + localRegionId)
+	}
+
+	return resourceAlicloudCenBandwidthLimitUpdate(d, meta)
+}
+
+func resourceAlicloudCenBandwidthLimitRead(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*AliyunClient)
+	paras, err := getCenAndRegionIds(d.Id())
+	if err != nil {
+		return err
+	}
+
+	cenId := paras[0]
+	localRegionId := paras[1]
+	oppositeRegionId := paras[2]
+	if strings.Compare(localRegionId, oppositeRegionId) > 0 {
+		d.SetId(cenId + COLON_SEPARATED + oppositeRegionId + COLON_SEPARATED + localRegionId)
+	}
+
+	resp, err := client.DescribeCenBandwidthLimit(cenId, localRegionId, oppositeRegionId)
+	if err != nil {
+		if NotFoundError(err) {
+			d.SetId("")
+			return nil
+		}
+		return err
+	}
+
+	respRegionIds := make([]string, 0)
+	respRegionIds = append(respRegionIds, resp.LocalRegionId)
+	respRegionIds = append(respRegionIds, resp.OppositeRegionId)
+
+	d.Set("region_ids", respRegionIds)
+	d.Set("instance_id", resp.CenId)
+	d.Set("bandwidth_limit", resp.BandwidthLimit)
+
+	return nil
+}
+
+func resourceAlicloudCenBandwidthLimitUpdate(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*AliyunClient)
+	cenId := d.Get("instance_id").(string)
+	regionIds := d.Get("region_ids").(*schema.Set).List()
+	localRegionId := regionIds[0].(string)
+	oppositeRegionId := regionIds[1].(string)
+	var bandwidthLimit int
+
+	attributeUpdate := false
+	if d.HasChange("bandwidth_limit") {
+		attributeUpdate = true
+		d.SetPartial("bandwidth_limit")
+		bandwidthLimit = d.Get("bandwidth_limit").(int)
+		if bandwidthLimit == 0 {
+			return fmt.Errorf("the bandwidth limit should be at least than 1 Mbps")
+		}
+	}
+
+	if attributeUpdate {
+		err := resource.Retry(5*time.Minute, func() *resource.RetryError {
+			err := client.SetCenInterRegionBandwidthLimit(cenId, localRegionId, oppositeRegionId, bandwidthLimit)
+			if err != nil {
+				if IsExceptedError(err, InvalidCenInstanceStatus) {
+					return resource.RetryableError(err)
+				}
+				return resource.NonRetryableError(err)
+			}
+			return nil
+		})
+
+		if err != nil {
+			return fmt.Errorf("Create/Update bandwidth Limit CEN ID %s localRegionId %s oppositeRegionId %s got an error: %#v.",
+				cenId, localRegionId, oppositeRegionId, err)
+		}
+
+		if err = client.WaitForCenInterRegionBandwidthLimitActive(cenId, localRegionId, oppositeRegionId, DefaultCenTimeout); err != nil {
+			return err
+		}
+	}
+
+	return resourceAlicloudCenBandwidthLimitRead(d, meta)
+}
+
+func resourceAlicloudCenBandwidthLimitDelete(d *schema.ResourceData, meta interface{}) error {
+	client := (meta).(*AliyunClient)
+	cenId := d.Get("instance_id").(string)
+	regionIds := d.Get("region_ids").(*schema.Set).List()
+	localRegionId := regionIds[0].(string)
+	oppositeRegionId := regionIds[1].(string)
+
+	err := resource.Retry(5*time.Minute, func() *resource.RetryError {
+		err := client.SetCenInterRegionBandwidthLimit(cenId, localRegionId, oppositeRegionId, 0)
+		if err != nil {
+			if IsExceptedError(err, InvalidCenInstanceStatus) {
+				return resource.RetryableError(err)
+			}
+			return resource.NonRetryableError(err)
+		}
+		return nil
+	})
+	if err != nil {
+		return fmt.Errorf("delete bandwidth Limit CEN ID %s localRegionId %s oppositeRegionId %s got an error: %#v.",
+			cenId, localRegionId, oppositeRegionId, err)
+	}
+
+	if err := client.WaitForCenInterRegionBandwidthLimitDestroy(cenId, localRegionId, oppositeRegionId, DefaultCenTimeout); err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/alicloud/resource_alicloud_cen_bandwidth_limit_test.go
+++ b/alicloud/resource_alicloud_cen_bandwidth_limit_test.go
@@ -1,0 +1,417 @@
+package alicloud
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/aliyun/alibaba-cloud-sdk-go/services/cbn"
+	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/terraform"
+)
+
+func TestAccAlicloudCenBandwidthLimit_basic(t *testing.T) {
+	var cenBwpLimit cbn.CenInterRegionBandwidthLimit
+
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+		},
+
+		// module name
+		IDRefreshName: "alicloud_cen_bandwidth_limit.foo",
+		Providers:     testAccProviders,
+		CheckDestroy:  testAccCheckCenBandwidthLimitDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccCenBandwidthLimitConfig,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckCenBandwidthLimitExists("alicloud_cen_bandwidth_limit.foo", &cenBwpLimit),
+					resource.TestCheckResourceAttr(
+						"alicloud_cen_bandwidth_limit.foo", "bandwidth_limit", "4"),
+					resource.TestCheckResourceAttr(
+						"alicloud_cen_bandwidth_limit.foo", "region_ids.#", "2"),
+					testAccCheckCenBandwidthLimitRegionId(&cenBwpLimit, "eu-central-1", "cn-shanghai"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAlicloudCenBandwidthLimit_update(t *testing.T) {
+	var cenBwpLimit cbn.CenInterRegionBandwidthLimit
+
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+		},
+
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckCenBandwidthLimitDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccCenBandwidthLimitConfig,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckCenBandwidthLimitExists("alicloud_cen_bandwidth_limit.foo", &cenBwpLimit),
+					resource.TestCheckResourceAttr(
+						"alicloud_cen_bandwidth_limit.foo", "bandwidth_limit", "4"),
+					resource.TestCheckResourceAttr(
+						"alicloud_cen_bandwidth_limit.foo", "region_ids.#", "2"),
+					testAccCheckCenBandwidthLimitRegionId(&cenBwpLimit, "eu-central-1", "cn-shanghai"),
+				),
+			},
+			resource.TestStep{
+				Config: testAccCenBandwidthLimitUpdate,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckCenBandwidthLimitExists("alicloud_cen_bandwidth_limit.foo", &cenBwpLimit),
+					resource.TestCheckResourceAttr(
+						"alicloud_cen_bandwidth_limit.foo", "bandwidth_limit", "5"),
+					resource.TestCheckResourceAttr(
+						"alicloud_cen_bandwidth_limit.foo", "region_ids.#", "2"),
+					testAccCheckCenBandwidthLimitRegionId(&cenBwpLimit, "eu-central-1", "cn-shanghai"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAlicloudCenBandwidthLimit_multi(t *testing.T) {
+	var cenBwpLimit cbn.CenInterRegionBandwidthLimit
+
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+		},
+
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckCenBandwidthLimitDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccCenBandwidthLimitMulti,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckCenBandwidthLimitExists("alicloud_cen_bandwidth_limit.bar1", &cenBwpLimit),
+					resource.TestCheckResourceAttr(
+						"alicloud_cen_bandwidth_limit.bar1", "bandwidth_limit", "2"),
+					resource.TestCheckResourceAttr(
+						"alicloud_cen_bandwidth_limit.bar1", "region_ids.#", "2"),
+					testAccCheckCenBandwidthLimitRegionId(&cenBwpLimit, "eu-central-1", "cn-shanghai"),
+
+					testAccCheckCenBandwidthLimitExists("alicloud_cen_bandwidth_limit.bar2", &cenBwpLimit),
+					resource.TestCheckResourceAttr(
+						"alicloud_cen_bandwidth_limit.bar2", "bandwidth_limit", "3"),
+					resource.TestCheckResourceAttr(
+						"alicloud_cen_bandwidth_limit.bar2", "region_ids.#", "2"),
+					testAccCheckCenBandwidthLimitRegionId(&cenBwpLimit, "eu-central-1", "cn-hangzhou"),
+				),
+			},
+		},
+	})
+}
+
+func testAccCheckCenBandwidthLimitExists(n string, cenBwpLimit *cbn.CenInterRegionBandwidthLimit) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[n]
+		if !ok {
+			return fmt.Errorf("Not found: %s", n)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("No CEN bandwidth limit ID is set")
+		}
+
+		params, err := getCenAndRegionIds(rs.Primary.ID)
+		if err != nil {
+			return err
+		}
+		cenId := params[0]
+		localRegionId := params[1]
+		oppositeRegionId := params[2]
+
+		client := testAccProvider.Meta().(*AliyunClient)
+		instance, err := client.DescribeCenBandwidthLimit(cenId, localRegionId, oppositeRegionId)
+		if err != nil {
+			return err
+		}
+
+		*cenBwpLimit = instance
+		return nil
+	}
+}
+
+func testAccCheckCenBandwidthLimitDestroy(s *terraform.State) error {
+	client := testAccProvider.Meta().(*AliyunClient)
+
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "alicloud_cen_bandwidth_limit" {
+			continue
+		}
+
+		params, err := getCenAndRegionIds(rs.Primary.ID)
+		if err != nil {
+			return err
+		}
+		cenId := params[0]
+		localRegionId := params[1]
+		oppositeRegionId := params[2]
+
+		instance, err := client.DescribeCenBandwidthLimit(cenId, localRegionId, oppositeRegionId)
+		if err != nil {
+			if NotFoundError(err) {
+				continue
+			}
+			return err
+		} else {
+			return fmt.Errorf("CEN Bandwidth Limit still exist, CEN ID %s localRegionId %s oppositeRegionId %s",
+				instance.CenId, instance.LocalRegionId, instance.OppositeRegionId)
+		}
+	}
+
+	return nil
+}
+
+func testAccCheckCenBandwidthLimitRegionId(cenBwpLimit *cbn.CenInterRegionBandwidthLimit, regionAId string, regionBId string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		if (cenBwpLimit.LocalRegionId == regionAId && cenBwpLimit.OppositeRegionId == regionBId) ||
+			(cenBwpLimit.LocalRegionId == regionBId && cenBwpLimit.OppositeRegionId == regionAId) {
+			return nil
+		} else {
+			return fmt.Errorf("CEN %s BandwidthLimit Region ID error", cenBwpLimit.CenId)
+		}
+	}
+}
+
+const testAccCenBandwidthLimitConfig = `
+variable "name"{
+    default = "tf-testAccCenBandwidthLimitConfig"
+}
+
+provider "alicloud" {
+    alias = "fra"
+    region = "eu-central-1"
+}
+
+provider "alicloud" {
+    alias = "sh"
+    region = "cn-shanghai"
+}
+
+resource "alicloud_vpc" "vpc1" {
+  provider = "alicloud.fra"
+  name = "${var.name}"
+  cidr_block = "192.168.0.0/16"
+}
+
+resource "alicloud_vpc" "vpc2" {
+  provider = "alicloud.sh"
+  name = "${var.name}"
+  cidr_block = "172.16.0.0/12"
+}
+
+resource "alicloud_cen_instance" "cen" {
+     name = "${var.name}"
+     description = "tf-testAccCenBandwidthLimitConfigDescription"
+}
+
+resource "alicloud_cen_bandwidth_package" "bwp" {
+    bandwidth = 5
+    geographic_region_ids = [
+		"Europe",
+		"China"]
+}
+
+resource "alicloud_cen_bandwidth_package_attachment" "bwp_attach" {
+    instance_id = "${alicloud_cen_instance.cen.id}"
+    bandwidth_package_id = "${alicloud_cen_bandwidth_package.bwp.id}"
+}
+
+resource "alicloud_cen_instance_attachment" "vpc_attach_1" {
+    instance_id = "${alicloud_cen_instance.cen.id}"
+    child_instance_id = "${alicloud_vpc.vpc1.id}"
+    child_instance_region_id = "eu-central-1"
+}
+
+resource "alicloud_cen_instance_attachment" "vpc_attach_2" {
+    instance_id = "${alicloud_cen_instance.cen.id}"
+    child_instance_id = "${alicloud_vpc.vpc2.id}"
+    child_instance_region_id = "cn-shanghai"
+}
+
+resource "alicloud_cen_bandwidth_limit" "foo" {
+    instance_id = "${alicloud_cen_instance.cen.id}"
+    region_ids = [
+        "eu-central-1",
+        "cn-shanghai"]
+     bandwidth_limit = 4
+     depends_on = [
+        "alicloud_cen_bandwidth_package_attachment.bwp_attach",
+        "alicloud_cen_instance_attachment.vpc_attach_1",
+        "alicloud_cen_instance_attachment.vpc_attach_2"]
+}
+`
+
+const testAccCenBandwidthLimitUpdate = `
+variable "name"{
+    default = "tf-testAccCenBandwidthLimitConfig"
+}
+
+provider "alicloud" {
+    alias = "fra"
+    region = "eu-central-1"
+}
+
+provider "alicloud" {
+    alias = "sh"
+    region = "cn-shanghai"
+}
+
+resource "alicloud_vpc" "vpc1" {
+  provider = "alicloud.fra"
+  name = "${var.name}"
+  cidr_block = "192.168.0.0/16"
+}
+
+resource "alicloud_vpc" "vpc2" {
+  provider = "alicloud.sh"
+  name = "${var.name}"
+  cidr_block = "172.16.0.0/12"
+}
+
+resource "alicloud_cen_instance" "cen" {
+     name = "${var.name}"
+     description = "tf-testAccCenBandwidthLimitConfigDescription"
+}
+
+resource "alicloud_cen_bandwidth_package" "bwp" {
+    bandwidth = 5
+    geographic_region_ids = [
+		"Europe",
+		"China"]
+}
+
+resource "alicloud_cen_bandwidth_package_attachment" "bwp_attach" {
+    instance_id = "${alicloud_cen_instance.cen.id}"
+    bandwidth_package_id = "${alicloud_cen_bandwidth_package.bwp.id}"
+}
+
+resource "alicloud_cen_instance_attachment" "vpc_attach_1" {
+    instance_id = "${alicloud_cen_instance.cen.id}"
+    child_instance_id = "${alicloud_vpc.vpc1.id}"
+    child_instance_region_id = "eu-central-1"
+}
+
+resource "alicloud_cen_instance_attachment" "vpc_attach_2" {
+    instance_id = "${alicloud_cen_instance.cen.id}"
+    child_instance_id = "${alicloud_vpc.vpc2.id}"
+    child_instance_region_id = "cn-shanghai"
+}
+
+resource "alicloud_cen_bandwidth_limit" "foo" {
+    instance_id = "${alicloud_cen_instance.cen.id}"
+    region_ids = [
+        "eu-central-1",
+        "cn-shanghai"]
+     bandwidth_limit = 5
+     depends_on = [
+        "alicloud_cen_bandwidth_package_attachment.bwp_attach",
+        "alicloud_cen_instance_attachment.vpc_attach_1",
+        "alicloud_cen_instance_attachment.vpc_attach_2"]
+}
+`
+
+const testAccCenBandwidthLimitMulti = `
+variable "name"{
+    default = "tf-testAccCenBandwidthLimitMulti"
+}
+
+provider "alicloud" {
+    alias = "fra"
+    region = "eu-central-1"
+}
+
+provider "alicloud" {
+  alias = "sh"
+  region = "cn-shanghai"
+}
+
+provider "alicloud" {
+  alias = "hz"
+  region = "cn-hangzhou"
+}
+
+resource "alicloud_vpc" "vpc1" {
+  provider = "alicloud.fra"
+  name = "${var.name}"
+  cidr_block = "192.168.0.0/16"
+}
+
+resource "alicloud_vpc" "vpc2" {
+  provider = "alicloud.sh"
+  name = "${var.name}"
+  cidr_block = "172.16.0.0/12"
+}
+
+resource "alicloud_vpc" "vpc3" {
+  provider = "alicloud.hz"
+  name = "${var.name}"
+  cidr_block = "192.168.0.0/16"
+}
+
+resource "alicloud_cen_instance" "cen" {
+    name = "${var.name}"
+}
+
+resource "alicloud_cen_bandwidth_package" "bwp" {
+    bandwidth = 5
+    geographic_region_ids = [
+		"Europe",
+		"China"]
+}
+
+resource "alicloud_cen_bandwidth_package_attachment" "bwp_attach" {
+    instance_id = "${alicloud_cen_instance.cen.id}"
+    bandwidth_package_id = "${alicloud_cen_bandwidth_package.bwp.id}"
+}
+
+resource "alicloud_cen_instance_attachment" "vpc_attach_1" {
+    instance_id = "${alicloud_cen_instance.cen.id}"
+    child_instance_id = "${alicloud_vpc.vpc1.id}"
+    child_instance_region_id = "eu-central-1"
+}
+
+resource "alicloud_cen_instance_attachment" "vpc_attach_2" {
+    instance_id = "${alicloud_cen_instance.cen.id}"
+    child_instance_id = "${alicloud_vpc.vpc2.id}"
+    child_instance_region_id = "cn-shanghai"
+}
+
+resource "alicloud_cen_instance_attachment" "vpc_attach_3" {
+    instance_id = "${alicloud_cen_instance.cen.id}"
+    child_instance_id = "${alicloud_vpc.vpc3.id}"
+    child_instance_region_id = "cn-hangzhou"
+}
+
+resource "alicloud_cen_bandwidth_limit" "bar1" {
+	provider = "alicloud.fra"
+    instance_id = "${alicloud_cen_instance.cen.id}"
+    region_ids = [
+        "eu-central-1",
+        "cn-shanghai"]
+     bandwidth_limit = 2
+     depends_on = [
+        "alicloud_cen_bandwidth_package_attachment.bwp_attach",
+        "alicloud_cen_instance_attachment.vpc_attach_1",
+        "alicloud_cen_instance_attachment.vpc_attach_2"]
+}
+
+resource "alicloud_cen_bandwidth_limit" "bar2" {
+	provider = "alicloud.fra"
+    instance_id = "${alicloud_cen_instance.cen.id}"
+    region_ids = [
+        "eu-central-1",
+        "cn-hangzhou"]
+     bandwidth_limit = 3
+     depends_on = [
+        "alicloud_cen_bandwidth_package_attachment.bwp_attach",
+        "alicloud_cen_instance_attachment.vpc_attach_1",
+        "alicloud_cen_instance_attachment.vpc_attach_3"]
+}
+`

--- a/website/alicloud.erb
+++ b/website/alicloud.erb
@@ -259,14 +259,18 @@
                         <li<%= sidebar_current("docs-alicloud-resource-cen-instance") %>>
                             <a href="/docs/providers/alicloud/r/cen_instance.html">alicloud_cen_instance</a>
                         </li>
-                        <li<%= sidebar_current("docs-alicloud-cen-instance-attachment") %>>
+                        <li<%= sidebar_current("docs-alicloud-resource-cen-instance-attachment") %>>
                             <a href="/docs/providers/alicloud/r/cen_instance_attachment.html">alicloud_cen_instance_attachment</a>
                         </li>
-                        <li<%= sidebar_current("docs-alicloud-cen-bandwidth-package") %>>
+                        <li<%= sidebar_current("docs-alicloud-resource-cen-bandwidth-package") %>>
                         <a href="/docs/providers/alicloud/r/cen_bandwidth_package.html">alicloud_cen_bandwidth_package</a>
+                        </li>
                         <li<%= sidebar_current("docs-alicloud-resource-cen-bandwidth-package-attachment") %>>
                         <a href="/docs/providers/alicloud/r/cen_bandwidth_package_attachment.html">alicloud_cen_bandwidth_package_attachment</a>
-                    </li>
+                        </li>
+                        <li<%= sidebar_current("docs-alicloud-resource-cen-bandwidth-limi") %>>
+                        <a href="/docs/providers/alicloud/r/cen_bandwidth_limit.html">alicloud_cen_bandwidth_limit</a>
+                        </li>
                     </ul>
                 </li>
 

--- a/website/docs/r/cen_bandwidth_limit.html.markdown
+++ b/website/docs/r/cen_bandwidth_limit.html.markdown
@@ -1,0 +1,115 @@
+---
+layout: "alicloud"
+page_title: "Alicloud: alicloud_cen_bandwidth_limit"
+sidebar_current: "docs-alicloud-resource-cen-bandwidth-limit"
+description: |-
+  Provides a Alicloud CEN cross-regional interconnection bandwidth configuration resource.
+---
+
+# alicloud\_cen_bandwidth_limit
+
+Provides a CEN cross-regional interconnection bandwidth resource. To connect networks in different regions, you must set cross-region interconnection bandwidth after buying a bandwidth package. The total bandwidth set for all the interconnected regions of a bandwidth package cannot exceed the bandwidth of the bandwidth package. By default, 1 Kbps bandwidth is provided for connectivity test. To run normal business, you must buy a bandwidth package and set a proper interconnection bandwidth.
+
+For example, a CEN instance is bound to a bandwidth package of 20 Mbps and  the interconnection areas are Mainland China and North America. You can set the cross-region interconnection bandwidth between US West 1 and China East 1, China East 2, China South 1, and so on. However, the total bandwidth set for all the interconnected regions cannot exceed 20  Mbps.
+
+For information about CEN and how to use it, see [Cross-region interconnection bandwidth](https://www.alibabacloud.com/help/doc-detail/65983.htm)
+
+## Example Usage
+
+Basic Usage
+
+```
+variable "name"{
+    default = "tf-testAccCenBandwidthLimitConfig"
+}
+
+provider "alicloud" {
+    alias = "fra"
+    region = "eu-central-1"
+}
+
+provider "alicloud" {
+    alias = "sh"
+    region = "cn-shanghai"
+}
+
+resource "alicloud_vpc" "vpc1" {
+  provider = "alicloud.fra"
+  name = "${var.name}"
+  cidr_block = "192.168.0.0/16"
+}
+
+resource "alicloud_vpc" "vpc2" {
+  provider = "alicloud.sh"
+  name = "${var.name}"
+  cidr_block = "172.16.0.0/12"
+}
+
+resource "alicloud_cen_instance" "cen" {
+     name = "${var.name}"
+     description = "tf-testAccCenBandwidthLimitConfigDescription"
+}
+
+resource "alicloud_cen_bandwidth_package" "bwp" {
+    bandwidth = 5
+    geographic_region_ids = [
+		"Europe",
+		"China"]
+}
+
+resource "alicloud_cen_bandwidth_package_attachment" "bwp_attach" {
+    instance_id = "${alicloud_cen_instance.cen.id}"
+    bandwidth_package_id = "${alicloud_cen_bandwidth_package.bwp.id}"
+}
+
+resource "alicloud_cen_instance_attachment" "vpc_attach_1" {
+    instance_id = "${alicloud_cen_instance.cen.id}"
+    child_instance_id = "${alicloud_vpc.vpc1.id}"
+    child_instance_region_id = "eu-central-1"
+}
+
+resource "alicloud_cen_instance_attachment" "vpc_attach_2" {
+    instance_id = "${alicloud_cen_instance.cen.id}"
+    child_instance_id = "${alicloud_vpc.vpc2.id}"
+    child_instance_region_id = "cn-shanghai"
+}
+
+resource "alicloud_cen_bandwidth_limit" "foo" {
+    instance_id = "${alicloud_cen_instance.cen.id}"
+    region_ids = [
+        "eu-central-1",
+        "cn-shanghai"]
+     bandwidth_limit = 4
+     depends_on = [
+        "alicloud_cen_bandwidth_package_attachment.bwp_attach",
+        "alicloud_cen_instance_attachment.vpc_attach_1",
+        "alicloud_cen_instance_attachment.vpc_attach_2"]
+}
+```
+## Argument Reference
+
+The following arguments are supported:
+
+* `instance_id` - (Required) The ID of the CEN.
+* `region_ids` - (Required) List of the two regions to interconnect. 
+* `bandwidth_limit` - (Required) The bandwidth configured for the interconnected regions communication.
+
+~>**NOTE:** The "alicloud_cen_bandwidthlimit" resource depends on the related "alicloud_cen_bandwidth_package_attachment" resource and "alicloud_cen_instance_attachment" resource.
+
+## Attributes Reference
+
+The following attributes are exported:
+
+- `id` - ID of the resource, formatted as `<instance_id>:<region_id_1>:<region_id_2>`.
+
+~>**NOTE:** The region_id_1 and region_id_2 are sorted lexicographically.
+
+## Import
+
+CEN bandwidth limit can be imported using the id, e.g.
+
+```
+terraform import alicloud_cen_bandwidth_limit.example cen-abc123456:cn-beijing:eu-west-1
+```
+
+~>**NOTE:** The sequence of the region_id_1 and region_id_2 makes no difference when import. But the in the id of the resource, they are sorted lexicographically.

--- a/website/docs/r/cen_bandwidth_package.html.markdown
+++ b/website/docs/r/cen_bandwidth_package.html.markdown
@@ -1,7 +1,7 @@
 ---
 layout: "alicloud"
 page_title: "Alicloud: alicloud_cen_bandwidth_package"
-sidebar_current: "docs-alicloud-cen-bandwidth-package"
+sidebar_current: "docs-alicloud-resource-cen-bandwidth-package"
 description: |-
   Provides a Alicloud CEN bandwidth package resource.
 ---

--- a/website/docs/r/cen_instance_attachment.html.markdown
+++ b/website/docs/r/cen_instance_attachment.html.markdown
@@ -1,7 +1,7 @@
 ---
 layout: "alicloud"
 page_title: "Alicloud: alicloud_cen_instance_attachment"
-sidebar_current: "docs-alicloud-cen-instance-attachment"
+sidebar_current: "docs-alicloud-resource-cen-instance-attachment"
 description: |-
   Provides a Alicloud CEN child instance attachment resource.
 ---


### PR DESCRIPTION
Add resource cen_bandwidth_limit, which can be used to Set a cross-region interconnection bandwidth. The acceptance results are as below:
$TF_ACC=1 go test ./alicloud -v -run=TestAccAlicloudCenBandwidthLimit
=== RUN   TestAccAlicloudCenBandwidthLimit_importBasic
--- PASS: TestAccAlicloudCenBandwidthLimit_importBasic (80.69s)
=== RUN   TestAccAlicloudCenBandwidthLimit_basic
--- PASS: TestAccAlicloudCenBandwidthLimit_basic (110.94s)
=== RUN   TestAccAlicloudCenBandwidthLimit_update
--- PASS: TestAccAlicloudCenBandwidthLimit_update (147.01s)
=== RUN   TestAccAlicloudCenBandwidthLimit_multi
--- PASS: TestAccAlicloudCenBandwidthLimit_multi (146.87s)
PASS
ok      github.com/terraform-providers/terraform-provider-alicloud/alicloud     485.581s