### PR TITLE
 Add wait time to fix random detaching disk error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ IMPROVEMENTS:
 - Correct Function Compute conn [GH-371]
 - Improve datasource `images`'s docs [GH-370]
 
+BUG FIXES:
+
+- Add wait time to fix random detaching disk error [GH-373]
+
 ## 1.17.0 (September 22, 2018)
 
 FEATURES:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,8 @@
 
 IMPROVEMENTS:
 
-- Improve datasource `images`'s docs ([#370](https://github.com/terraform-providers/terraform-provider-alicloud/pull/370))
+- Correct Function Compute conn [GH-371]
+- Improve datasource `images`'s docs [GH-370]
 
 ## 1.17.0 (September 22, 2018)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,9 @@
 ## 1.18.0 (Unreleased)
+
+IMPROVEMENTS:
+
+- Improve datasource `images`'s docs ([#370](https://github.com/terraform-providers/terraform-provider-alicloud/pull/370))
+
 ## 1.17.0 (September 22, 2018)
 
 FEATURES:

--- a/alicloud/config.go
+++ b/alicloud/config.go
@@ -487,7 +487,7 @@ func (client *AliyunClient) Fcconn() (*fc.Client, error) {
 	defer client.fcconnMutex.Unlock()
 
 	if client.fcconn == nil {
-		endpoint := client.config.LogEndpoint
+		endpoint := client.config.FcEndpoint
 		if endpoint == "" {
 			endpoint = LoadEndpoint(client.config.RegionId, FCCode)
 			if endpoint == "" {

--- a/website/docs/d/images.html.markdown
+++ b/website/docs/d/images.html.markdown
@@ -33,6 +33,8 @@ The following arguments are supported:
 * `owners` - (Optional) Filter results by a specific image owner. Valid items are `system`, `self`, `others`, `marketplace`.
 * `output_file` - (Optional) File name where to save data source results (after running `terraform plan`).
 
+-> **NOTE:** At least one of the `name_regex`, `most_recent` and `owners` must be set.
+
 ## Attributes Reference
 
 The following attributes are exported in addition to the arguments listed above:


### PR DESCRIPTION
The result of running test case as follows:

```
TF_ACC=1 go test ./alicloud -v -run=TestAccAlicloudDiskAttachment -timeout=240m
=== RUN   TestAccAlicloudDiskAttachment
--- PASS: TestAccAlicloudDiskAttachment (171.28s)
PASS
ok  	github.com/terraform-providers/terraform-provider-alicloud/alicloud	171.332s
```