### PR TITLE
Feature: add cen bandwdith limits data source

### DIFF
--- a/alicloud/data_source_alicloud_cen_bandwidth_limits.go
+++ b/alicloud/data_source_alicloud_cen_bandwidth_limits.go
@@ -61,13 +61,12 @@ func dataSourceAlicloudCenBandwidthLimits() *schema.Resource {
 func dataSourceAlicloudCenBandwidthLimitsRead(d *schema.ResourceData, meta interface{}) error {
 	conn := meta.(*AliyunClient).cenconn
 
-	cenId := d.Get("instance_id")
-
 	args := cbn.CreateDescribeCenInterRegionBandwidthLimitsRequest()
 	args.PageSize = requests.NewInteger(PageSizeLarge)
-	args.PageSize = requests.NewInteger(PageSizeLarge)
 	args.PageNumber = requests.NewInteger(1)
-	args.CenId = cenId.(string)
+	if v, ok := d.GetOk("instance_id"); ok && v.(string) != "" {
+		args.CenId = v.(string)
+	}
 
 	var allcenBwLimits []cbn.CenInterRegionBandwidthLimit
 

--- a/alicloud/data_source_alicloud_cen_bandwidth_limits.go
+++ b/alicloud/data_source_alicloud_cen_bandwidth_limits.go
@@ -1,0 +1,135 @@
+package alicloud
+
+import (
+	"fmt"
+
+	"log"
+
+	"github.com/aliyun/alibaba-cloud-sdk-go/sdk/requests"
+	"github.com/aliyun/alibaba-cloud-sdk-go/services/cbn"
+	"github.com/hashicorp/terraform/helper/schema"
+)
+
+func dataSourceAlicloudCenBandwidthLimits() *schema.Resource {
+	return &schema.Resource{
+		Read: dataSourceAlicloudCenBandwidthLimitsRead,
+
+		Schema: map[string]*schema.Schema{
+			"instance_id": {
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: true,
+			},
+			"output_file": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+
+			// Computed values
+			"bandwidth_limits": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"instance_id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"local_region_id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"opposite_region_id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"status": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"bandwidth_limit": {
+							Type:     schema.TypeInt,
+							Computed: true,
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func dataSourceAlicloudCenBandwidthLimitsRead(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AliyunClient).cenconn
+
+	cenId := d.Get("instance_id")
+
+	args := cbn.CreateDescribeCenInterRegionBandwidthLimitsRequest()
+	args.PageSize = requests.NewInteger(PageSizeLarge)
+	args.PageSize = requests.NewInteger(PageSizeLarge)
+	args.PageNumber = requests.NewInteger(1)
+	args.CenId = cenId.(string)
+
+	var allcenBwLimits []cbn.CenInterRegionBandwidthLimit
+
+	for {
+		resp, err := conn.DescribeCenInterRegionBandwidthLimits(args)
+		if err != nil {
+			return err
+		}
+
+		if resp == nil || len(resp.CenInterRegionBandwidthLimits.CenInterRegionBandwidthLimit) < 1 {
+			break
+		}
+		allcenBwLimits = append(allcenBwLimits, resp.CenInterRegionBandwidthLimits.CenInterRegionBandwidthLimit...)
+
+		if len(resp.CenInterRegionBandwidthLimits.CenInterRegionBandwidthLimit) < PageSizeLarge {
+			break
+		}
+
+		if page, err := getNextpageNumber(args.PageNumber); err != nil {
+			return err
+		} else {
+			args.PageNumber = page
+		}
+	}
+
+	if len(allcenBwLimits) < 1 {
+		return fmt.Errorf("Your query returned no results. Please change your search criteria and try again.")
+	}
+
+	log.Printf("[DEBUG] alicloud_cen_bandwidth_limits - CensBwLimits found: %#v", allcenBwLimits)
+
+	return cenInterRegionBandwidthLimitsAttributes(d, allcenBwLimits)
+
+}
+
+func cenInterRegionBandwidthLimitsAttributes(d *schema.ResourceData, allcenBwLimits []cbn.CenInterRegionBandwidthLimit) error {
+	var ids []string
+	var s []map[string]interface{}
+
+	for _, cenBwLimit := range allcenBwLimits {
+		mapping := map[string]interface{}{
+			"instance_id":        cenBwLimit.CenId,
+			"local_region_id":    cenBwLimit.LocalRegionId,
+			"opposite_region_id": cenBwLimit.OppositeRegionId,
+			"status":             cenBwLimit.Status,
+			"bandwidth_limit":    cenBwLimit.BandwidthLimit,
+		}
+
+		id := cenBwLimit.CenId + ":" + cenBwLimit.LocalRegionId + ":" + cenBwLimit.OppositeRegionId
+		ids = append(ids, id)
+		s = append(s, mapping)
+	}
+
+	d.SetId(dataResourceIdHash(ids))
+	if err := d.Set("bandwidth_limits", s); err != nil {
+		return err
+	}
+
+	// create a json file in current directory and write data source to it.
+	if output, ok := d.GetOk("output_file"); ok && output.(string) != "" {
+		writeToFile(output.(string), s)
+	}
+
+	return nil
+}

--- a/alicloud/data_source_alicloud_cen_bandwidth_limits.go
+++ b/alicloud/data_source_alicloud_cen_bandwidth_limits.go
@@ -27,7 +27,7 @@ func dataSourceAlicloudCenBandwidthLimits() *schema.Resource {
 			},
 
 			// Computed values
-			"bandwidth_limits": {
+			"limits": {
 				Type:     schema.TypeList,
 				Computed: true,
 				Elem: &schema.Resource{
@@ -138,13 +138,13 @@ func cenInterRegionBandwidthLimitsAttributes(d *schema.ResourceData, allCenBwLim
 			"bandwidth_limit":    cenBwLimit.BandwidthLimit,
 		}
 
-		id := cenBwLimit.CenId + ":" + cenBwLimit.LocalRegionId + ":" + cenBwLimit.OppositeRegionId
+		id := cenBwLimit.CenId + COLON_SEPARATED + cenBwLimit.LocalRegionId + COLON_SEPARATED + cenBwLimit.OppositeRegionId
 		ids = append(ids, id)
 		s = append(s, mapping)
 	}
 
 	d.SetId(dataResourceIdHash(ids))
-	if err := d.Set("bandwidth_limits", s); err != nil {
+	if err := d.Set("limits", s); err != nil {
 		return err
 	}
 

--- a/alicloud/data_source_alicloud_cen_bandwidth_limits_test.go
+++ b/alicloud/data_source_alicloud_cen_bandwidth_limits_test.go
@@ -1,0 +1,99 @@
+package alicloud
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform/helper/resource"
+)
+
+func TestAccAlicloudCenBandwidthLimitsDataSource_instance_id(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+		},
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCheckAlicloudCenInterRegionBandwidthLimitsDataSourceCenIdConfig,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAlicloudDataSourceID("data.alicloud_cen_bandwidth_limits.limit"),
+					resource.TestCheckResourceAttr("data.alicloud_cen_bandwidth_limits.limit", "bandwidth_limits.0.local_region_id", "cn-beijing"),
+					resource.TestCheckResourceAttr("data.alicloud_cen_bandwidth_limits.limit", "bandwidth_limits.0.opposite_region_id", "cn-shanghai"),
+					resource.TestCheckResourceAttr("data.alicloud_cen_bandwidth_limits.limit", "bandwidth_limits.0.status", "Active"),
+					resource.TestCheckResourceAttr("data.alicloud_cen_bandwidth_limits.limit", "bandwidth_limits.0.bandwidth_limit", "15"),
+					resource.TestCheckResourceAttrSet("data.alicloud_cen_bandwidth_limits.limit", "bandwidth_limits.0.instance_id"),
+				),
+			},
+		},
+	})
+}
+
+const testAccCheckAlicloudCenInterRegionBandwidthLimitsDataSourceCenIdConfig = `
+provider "alicloud" {
+  alias = "bj"
+  region = "cn-beijing"
+}
+
+provider "alicloud" {
+  alias = "sh"
+  region = "cn-shanghai"
+}
+
+resource "alicloud_vpc" "vpc1" {
+  provider = "alicloud.bj"
+  name = "tf-testAccTerraform-01"
+  cidr_block = "192.168.0.0/16"
+}
+
+resource "alicloud_vpc" "vpc2" {
+  provider = "alicloud.sh"
+  name = "tf-testAccTerraform-02"
+  cidr_block = "172.16.0.0/12"
+}
+
+resource "alicloud_cen_instance" "cen" {
+     name = "tf-testAccTerraform-01"
+     description = "tf-testAccTerraform01"
+}
+
+resource "alicloud_cen_bandwidth_package" "bwp" {
+    name = "tf-testAccCenBandwidthPackage"
+    bandwidth = 20
+    geographic_region_ids = [
+		"China",
+		"China"]
+}
+
+resource "alicloud_cen_bandwidth_package_attachment" "bwp_attach" {
+    instance_id = "${alicloud_cen_instance.cen.id}"
+    bandwidth_package_id = "${alicloud_cen_bandwidth_package.bwp.id}"
+}
+
+resource "alicloud_cen_instance_attachment" "vpc_attach_1" {
+    instance_id = "${alicloud_cen_instance.cen.id}"
+    child_instance_id = "${alicloud_vpc.vpc1.id}"
+    child_instance_region_id = "cn-beijing"
+}
+
+resource "alicloud_cen_instance_attachment" "vpc_attach_2" {
+    instance_id = "${alicloud_cen_instance.cen.id}"
+    child_instance_id = "${alicloud_vpc.vpc2.id}"
+    child_instance_region_id = "cn-shanghai"
+}
+
+resource "alicloud_cen_bandwidth_limit" "foo" {
+     instance_id = "${alicloud_cen_instance.cen.id}"
+     region_ids = [
+					"cn-beijing",
+					"cn-shanghai"]
+     bandwidth_limit = 15
+     depends_on = [
+        "alicloud_cen_bandwidth_package_attachment.bwp_attach",
+        "alicloud_cen_instance_attachment.vpc_attach_1",
+        "alicloud_cen_instance_attachment.vpc_attach_2"]
+}
+
+data "alicloud_cen_bandwidth_limits" "limit" {
+	instance_id = "${alicloud_cen_bandwidth_limit.foo.instance_id}"
+}
+`

--- a/alicloud/data_source_alicloud_cen_bandwidth_limits_test.go
+++ b/alicloud/data_source_alicloud_cen_bandwidth_limits_test.go
@@ -17,11 +17,11 @@ func TestAccAlicloudCenBandwidthLimitsDataSource_instance_id(t *testing.T) {
 				Config: testAccCheckAlicloudCenInterRegionBandwidthLimitsDataSourceCenIdConfig,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAlicloudDataSourceID("data.alicloud_cen_bandwidth_limits.limit"),
-					resource.TestCheckResourceAttr("data.alicloud_cen_bandwidth_limits.limit", "bandwidth_limits.0.local_region_id", "cn-beijing"),
-					resource.TestCheckResourceAttr("data.alicloud_cen_bandwidth_limits.limit", "bandwidth_limits.0.opposite_region_id", "cn-shanghai"),
-					resource.TestCheckResourceAttr("data.alicloud_cen_bandwidth_limits.limit", "bandwidth_limits.0.status", "Active"),
-					resource.TestCheckResourceAttr("data.alicloud_cen_bandwidth_limits.limit", "bandwidth_limits.0.bandwidth_limit", "15"),
-					resource.TestCheckResourceAttrSet("data.alicloud_cen_bandwidth_limits.limit", "bandwidth_limits.0.instance_id"),
+					resource.TestCheckResourceAttr("data.alicloud_cen_bandwidth_limits.limit", "limits.0.local_region_id", "cn-beijing"),
+					resource.TestCheckResourceAttr("data.alicloud_cen_bandwidth_limits.limit", "limits.0.opposite_region_id", "us-west-1"),
+					resource.TestCheckResourceAttr("data.alicloud_cen_bandwidth_limits.limit", "limits.0.status", "Active"),
+					resource.TestCheckResourceAttr("data.alicloud_cen_bandwidth_limits.limit", "limits.0.bandwidth_limit", "15"),
+					resource.TestCheckResourceAttrSet("data.alicloud_cen_bandwidth_limits.limit", "limits.0.instance_id"),
 				),
 			},
 		},
@@ -35,8 +35,8 @@ provider "alicloud" {
 }
 
 provider "alicloud" {
-  alias = "sh"
-  region = "cn-shanghai"
+  alias = "us"
+  region = "us-west-1"
 }
 
 resource "alicloud_vpc" "vpc1" {
@@ -46,7 +46,7 @@ resource "alicloud_vpc" "vpc1" {
 }
 
 resource "alicloud_vpc" "vpc2" {
-  provider = "alicloud.sh"
+  provider = "alicloud.us"
   name = "tf-testAccTerraform-02"
   cidr_block = "172.16.0.0/12"
 }
@@ -61,7 +61,7 @@ resource "alicloud_cen_bandwidth_package" "bwp" {
     bandwidth = 20
     geographic_region_ids = [
 		"China",
-		"China"]
+		"North-America"]
 }
 
 resource "alicloud_cen_bandwidth_package_attachment" "bwp_attach" {
@@ -78,14 +78,13 @@ resource "alicloud_cen_instance_attachment" "vpc_attach_1" {
 resource "alicloud_cen_instance_attachment" "vpc_attach_2" {
     instance_id = "${alicloud_cen_instance.cen.id}"
     child_instance_id = "${alicloud_vpc.vpc2.id}"
-    child_instance_region_id = "cn-shanghai"
+    child_instance_region_id = "us-west-1"
 }
 
 resource "alicloud_cen_bandwidth_limit" "foo" {
      instance_id = "${alicloud_cen_instance.cen.id}"
-     region_ids = [
-					"cn-beijing",
-					"cn-shanghai"]
+     region_ids = ["cn-beijing",
+                   "us-west-1"]
      bandwidth_limit = 15
      depends_on = [
         "alicloud_cen_bandwidth_package_attachment.bwp_attach",

--- a/alicloud/data_source_alicloud_cen_bandwidth_limits_test.go
+++ b/alicloud/data_source_alicloud_cen_bandwidth_limits_test.go
@@ -94,6 +94,6 @@ resource "alicloud_cen_bandwidth_limit" "foo" {
 }
 
 data "alicloud_cen_bandwidth_limits" "limit" {
-	instance_id = "${alicloud_cen_bandwidth_limit.foo.instance_id}"
+	instance_ids = ["${alicloud_cen_bandwidth_limit.foo.instance_id}"]
 }
 `

--- a/alicloud/provider.go
+++ b/alicloud/provider.go
@@ -118,6 +118,7 @@ func Provider() terraform.ResourceProvider {
 			"alicloud_kvstore_instances":       dataSourceAlicloudKVStoreInstances(),
 			"alicloud_cen_instances":           dataSourceAlicloudCenInstances(),
 			"alicloud_cen_bandwidth_packages":  dataSourceAlicloudCenBandwidthPackages(),
+			"alicloud_cen_bandwidth_limits":    dataSourceAlicloudCenBandwidthLimits(),
 			"alicloud_mns_queues":              dataSourceAlicloudMNSQueues(),
 			"alicloud_mns_topics":              dataSourceAlicloudMNSTopics(),
 			"alicloud_mns_topic_subscriptions": dataSourceAlicloudMNSTopicSubscriptions(),

--- a/website/alicloud.erb
+++ b/website/alicloud.erb
@@ -142,11 +142,14 @@
                         <li<%= sidebar_current("docs-alicloud-datasource-pvtz-zone-records") %>>
                             <a href="/docs/providers/alicloud/d/pvtz_zone_records.html">alicloud_pvtz_zone_records</a>
                         </li>
+                        <li<%= sidebar_current("docs-alicloud-datasource-cen-instances") %>>
+                            <a href="/docs/providers/alicloud/d/cen_instances.html">alicloud_cen_instances</a>
+                        </li>
                         <li<%= sidebar_current("docs-alicloud-datasource-cen-bandwidth-packages") %>>
                             <a href="/docs/providers/alicloud/d/cen_bandwidth_packages.html">alicloud_cen_bandwidth_packages</a>
                         </li>
-                        <li<%= sidebar_current("docs-alicloud-datasource-cen-instances") %>>
-                            <a href="/docs/providers/alicloud/d/cen_instances.html">alicloud_cen_instances</a>
+                        <li<%= sidebar_current("docs-alicloud-datasource-cen-bandwidth-limits") %>>
+                            <a href="/docs/providers/alicloud/d/cen_bandwidth_limits.html">alicloud_cen_bandwidth_limits</a>
                         </li>
                         <li<%= sidebar_current("docs-alicloud-datasource-mns-queues") %>>
                             <a href="/docs/providers/alicloud/d/mns_queues.html">alicloud_mns_queues</a>

--- a/website/docs/d/cen_bandwidth_limits.html.markdown
+++ b/website/docs/d/cen_bandwidth_limits.html.markdown
@@ -1,0 +1,41 @@
+---
+layout: "alicloud"
+page_title: "Alicloud: alicloud_cen_bandwidth_limits"
+sidebar_current: "docs-alicloud-datasource-cen-bandwidth-limits"
+description: |-
+    Provides a list of CEN Inter Region Bandwidth Limits owned by an Alibaba Cloud account.
+---
+
+# alicloud\_cen\_bandwidth\_limits
+
+This data source provides CEN Inter Region Bandwidth Limits available to the user.
+
+## Example Usage
+
+```
+data "alicloud_cen_bandwidth_limits" "bwl"{
+	instance_id = "cen-id1"
+}
+
+output "first_cen_bandwidth_limits_local_region_id" {
+  value = "${data.alicloud_cen_bandwidth_packages.bwl.bandwidth_limits.0.local_region_id}"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `instance_id` - (Optional) ID of a CEN instance.
+* `output_file` - (Optional) File name where to save data source results (after running `terraform plan`).
+
+## Attributes Reference
+
+The following attributes are exported in addition to the arguments listed above:
+
+* `bandwidth_limits` - A list of CEN Inter Region Bandwidth Limits. Each element contains the following attributes:
+  * `instance_id` - ID of the CEN instance.
+  * `local_region_id` - ID of local region.
+  * `opposite_region_id` - ID of opposite region.
+  * `status` - Status of the CEN Inter Region Bandwidth Limit, including "Active" and "Modifying".
+  * `bandwidth_limit` - The bandwidth limit configured for the interconnected regions communication.

--- a/website/docs/d/cen_bandwidth_limits.html.markdown
+++ b/website/docs/d/cen_bandwidth_limits.html.markdown
@@ -14,7 +14,7 @@ This data source provides CEN Inter Region Bandwidth Limits available to the use
 
 ```
 data "alicloud_cen_bandwidth_limits" "bwl"{
-	instance_id = "cen-id1"
+	instance_ids = ["cen-id1"]
 }
 
 output "first_cen_bandwidth_limits_local_region_id" {
@@ -26,7 +26,7 @@ output "first_cen_bandwidth_limits_local_region_id" {
 
 The following arguments are supported:
 
-* `instance_id` - (Optional) ID of a CEN instance.
+* `instance_ids` - (Optional) A list of CEN instances IDs.
 * `output_file` - (Optional) File name where to save data source results (after running `terraform plan`).
 
 ## Attributes Reference

--- a/website/docs/d/cen_bandwidth_limits.html.markdown
+++ b/website/docs/d/cen_bandwidth_limits.html.markdown
@@ -3,12 +3,12 @@ layout: "alicloud"
 page_title: "Alicloud: alicloud_cen_bandwidth_limits"
 sidebar_current: "docs-alicloud-datasource-cen-bandwidth-limits"
 description: |-
-    Provides a list of CEN Inter Region Bandwidth Limits owned by an Alibaba Cloud account.
+    Provides a list of CEN Bandwidth Limits owned by an Alibaba Cloud account.
 ---
 
 # alicloud\_cen\_bandwidth\_limits
 
-This data source provides CEN Inter Region Bandwidth Limits available to the user.
+This data source provides CEN Bandwidth Limits available to the user.
 
 ## Example Usage
 
@@ -33,9 +33,9 @@ The following arguments are supported:
 
 The following attributes are exported in addition to the arguments listed above:
 
-* `bandwidth_limits` - A list of CEN Inter Region Bandwidth Limits. Each element contains the following attributes:
+* `limits` - A list of CEN Bandwidth Limits. Each element contains the following attributes:
   * `instance_id` - ID of the CEN instance.
   * `local_region_id` - ID of local region.
   * `opposite_region_id` - ID of opposite region.
-  * `status` - Status of the CEN Inter Region Bandwidth Limit, including "Active" and "Modifying".
+  * `status` - Status of the CEN Bandwidth Limit, including "Active" and "Modifying".
   * `bandwidth_limit` - The bandwidth limit configured for the interconnected regions communication.


### PR DESCRIPTION
This data source provides CEN Inter Region Bandwidth Limits available to the user.
$TF_ACC=1 go test ./alicloud -v -run=TestAccAlicloudCenBandwidthLimitsDataSource_instance_id -timeout=300m      
=== RUN   TestAccAlicloudCenBandwidthLimitsDataSource_instance_id
--- PASS: TestAccAlicloudCenBandwidthLimitsDataSource_instance_id (46.46s)
PASS
ok  	github.com/terraform-providers/terraform-provider-alicloud/alicloud	46.510s