### PR TITLE
added need_slb attribute to cs swarm

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,12 +2,17 @@
 
 FEATURES:
 
+- **New Resource:** `alicloud_api_gateway_group` [GH-409]
 - **New Resource:** `alicloud_datahub_subscription` [GH-405]
 - **New Resource:** `alicloud_datahub_topic` [GH-404]
 - **New Resource:** `alicloud_datahub_project` [GH-403]
+- **New Data Source:** `alicloud_api_gateway_groups` [GH-412]
+- **New Data Source:** `alicloud_cen_bandwidth_limits` [GH-402]
 
 IMPROVEMENTS:
 
+- added need_slb attribute to cs swarm [GH-414]
+- Add new example/datahub [GH-407]
 - Add new example/datahub [GH-406]
 - Format examples [GH-397]
 - Add new example/kvstore [GH-396]
@@ -18,6 +23,7 @@ IMPROVEMENTS:
 
 BUG FIXES:
 
+- fix kubernetes's new_nat_gateway issue [GH-410]
 - modify the mns err info [GH-400]
 - Skip havip test case [GH-399]
 - modify the sweeptest nameprefix [GH-398]

--- a/alicloud/import_alicloud_cs_swarm_test.go
+++ b/alicloud/import_alicloud_cs_swarm_test.go
@@ -22,7 +22,29 @@ func TestAccAlicloudCSSwarm_importBasic(t *testing.T) {
 				ResourceName:            resourceName,
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"name_prefix", "cidr_block", "image_id", "password", "release_eip"},
+				ImportStateVerifyIgnore: []string{"name_prefix", "cidr_block", "image_id", "password", "release_eip", "need_slb"},
+			},
+		},
+	})
+}
+
+func TestAccAlicloudCSSwarm_importBasicNoSlb(t *testing.T) {
+	resourceName := "alicloud_cs_swarm.cs_vpc"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckSwarmClusterDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccCSSwarm_basic_noslb,
+			},
+
+			resource.TestStep{
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"name_prefix", "cidr_block", "image_id", "password", "release_eip", "need_slb"},
 			},
 		},
 	})

--- a/alicloud/resource_alicloud_cs_swarm.go
+++ b/alicloud/resource_alicloud_cs_swarm.go
@@ -100,7 +100,12 @@ func resourceAlicloudCSSwarm() *schema.Resource {
 				Type:     schema.TypeBool,
 				Optional: true,
 			},
-
+			"need_slb": &schema.Schema{
+				Type:     schema.TypeBool,
+				Optional: true,
+				Default:  true,
+				ForceNew: true,
+			},
 			"nodes": {
 				Type:     schema.TypeList,
 				Computed: true,
@@ -181,6 +186,7 @@ func resourceAlicloudCSSwarmCreate(d *schema.ResourceData, meta interface{}) err
 		VSwitchID:        d.Get("vswitch_id").(string),
 		SubnetCIDR:       d.Get("cidr_block").(string),
 		ReleaseEipFlag:   d.Get("release_eip").(bool),
+		NeedSLB:          d.Get("need_slb").(bool),
 	}
 
 	vsw, err := client.DescribeVswitch(args.VSwitchID)

--- a/website/docs/r/cs_swarm.html.markdown
+++ b/website/docs/r/cs_swarm.html.markdown
@@ -54,6 +54,7 @@ The following arguments are supported:
 * `disk_size` - (Force new resource) The data disk size of ECS instance node. Its valid value is 20~32768 GB. Default to 20.
 * `vswitch_id` - (Required, Force new resource) The password of ECS instance node. If it is not specified, the container cluster's network mode will be `Classic`.
 * `release_eip` - Whether to release EIP after creating swarm cluster successfully. Default to false.
+* `need_slb`- Whether to create the default simple routing Server Load Balancer instance for the cluster. The default value is true.
 
 
 ## Attributes Reference


### PR DESCRIPTION
```
go test -run TestAccAlicloudCSSwarm -v -timeout=120m                        
=== RUN   TestAccAlicloudCSSwarm_importBasic
--- PASS: TestAccAlicloudCSSwarm_importBasic (724.55s)
=== RUN   TestAccAlicloudCSSwarm_importBasicNoSlb
--- PASS: TestAccAlicloudCSSwarm_importBasicNoSlb (605.98s)
=== RUN   TestAccAlicloudCSSwarm_vpc
--- PASS: TestAccAlicloudCSSwarm_vpc (573.62s)
=== RUN   TestAccAlicloudCSSwarm_vpc_noslb
--- PASS: TestAccAlicloudCSSwarm_vpc_noslb (664.53s)
=== RUN   TestAccAlicloudCSSwarm_update
--- PASS: TestAccAlicloudCSSwarm_update (954.18s)
PASS
ok  	github.com/alibaba/terraform-provider/alicloud	3522.919s
```