### PR TITLE
Hide AliCloud HaVip Attachment resource docs because of it is not public totally

### DIFF
--- a/alicloud/errors.go
+++ b/alicloud/errors.go
@@ -228,6 +228,8 @@ const (
 	SubscriptionNotExist = "SubscriptionNotExist"
 	//HaVip
 	InvalidHaVipIdNotFound = "InvalidHaVipId.NotFound"
+	InvalidVipStatus       = "InvalidVip.Status"
+	IncorrectHaVipStatus   = "IncorrectHaVipStatus"
 )
 
 var SlbIsBusy = []string{"SystemBusy", "OperationBusy", "ServiceIsStopping", "BackendServer.configuring", "ServiceIsConfiguring"}

--- a/alicloud/resource_alicloud_havip_attachment.go
+++ b/alicloud/resource_alicloud_havip_attachment.go
@@ -42,7 +42,7 @@ func resourceAliyunHaVipAttachmentCreate(d *schema.ResourceData, meta interface{
 	if err := resource.Retry(5*time.Minute, func() *resource.RetryError {
 		ar := args
 		if _, err := client.vpcconn.AssociateHaVip(ar); err != nil {
-			if IsExceptedError(err, TaskConflict) {
+			if IsExceptedErrors(err, []string{TaskConflict, IncorrectHaVipStatus, InvalidVipStatus}) {
 				return resource.RetryableError(fmt.Errorf("AssociateHaVip got an error: %#v", err))
 			}
 			return resource.NonRetryableError(fmt.Errorf("AssociateHaVip got an error: %#v", err))

--- a/website/alicloud.erb
+++ b/website/alicloud.erb
@@ -235,12 +235,13 @@
                         <li<%= sidebar_current("docs-alicloud-resource-route-table") %>>
                             <a href="/docs/providers/alicloud/r/route_table.html">alicloud_route_table</a>
                         </li>
-                        <li<%= sidebar_current("docs-alicloud-resource-havip") %>>
-                            <a href="/docs/providers/alicloud/r/havip.html">alicloud_havip</a>
-                        </li>
-                        <li<%= sidebar_current("docs-alicloud-resource-havip-attachment") %>>
-                            <a href="/docs/providers/alicloud/r/havip_attachment.html">alicloud_havip_attachment</a>
-                        </li>
+                        <%# At present, only white list users can operate HaVip Resource. So close havip markdown file. %>
+                        <%#<li<%= sidebar_current("docs-alicloud-resource-havip") %>> %>
+                        <%#    <a href="/docs/providers/alicloud/r/havip.html">alicloud_havip</a> %>
+                        <%#</li> %>
+                        <%#<li<%= sidebar_current("docs-alicloud-resource-havip-attachment") %>> %>
+                        <%#    <a href="/docs/providers/alicloud/r/havip_attachment.html">alicloud_havip_attachment</a> %>
+                        <%#</li> %>
                         <li<%= sidebar_current("docs-alicloud-resource-route-table-attachment") %>>
                             <a href="/docs/providers/alicloud/r/route_table_attachment.html">alicloud_route_table_attachment</a>
                         </li>

--- a/website/docs/r/havip_attachment.html.markdown
+++ b/website/docs/r/havip_attachment.html.markdown
@@ -90,7 +90,7 @@ The following arguments are supported:
 
 The following attributes are exported:
 
-* `id` - The ID of the havip attachment id and formates as <havip_id>:<instance_id>
+* `id` - The ID of the havip attachment id and formates as `<havip_id>:<instance_id>`.
 
 ## Import
 
@@ -99,4 +99,3 @@ The havip attachemnt can be imported using the id, e.g.
 ```
 $ terraform import alicloud_havip_attachment.foo havip-abc123456:i-abc123456
 ```
-

--- a/website/docs/r/route_table_attachment.html.markdown
+++ b/website/docs/r/route_table_attachment.html.markdown
@@ -55,7 +55,7 @@ The following arguments are supported:
 
 The following attributes are exported:
 
-* `id` - The ID of the route table attachment id and formates as <route_table_id>:<vswitch_id>
+* `id` - The ID of the route table attachment id and formates as `<route_table_id>:<vswitch_id>`.
 
 ## Import
 


### PR DESCRIPTION
MacBook-Pro-2:terraform-provider-alicloud$ TF_ACC=1 go test ./alicloud -v -run=TestAccAlicloudHaVipAttachment -timeout=300m
=== RUN   TestAccAlicloudHaVipAttachment_importBasic
--- PASS: TestAccAlicloudHaVipAttachment_importBasic (152.32s)
=== RUN   TestAccAlicloudHaVipAttachment_basic
--- PASS: TestAccAlicloudHaVipAttachment_basic (155.52s)
PASS
ok  	github.com/terraform-providers/terraform-provider-alicloud/alicloud	307.889s