### PR TITLE
Feature: add cen route entries data source.

### DIFF
--- a/alicloud/data_source_alicloud_cen_route_entries.go
+++ b/alicloud/data_source_alicloud_cen_route_entries.go
@@ -1,0 +1,214 @@
+package alicloud
+
+import (
+	"fmt"
+	"log"
+
+	"github.com/aliyun/alibaba-cloud-sdk-go/sdk/requests"
+	"github.com/aliyun/alibaba-cloud-sdk-go/services/cbn"
+	"github.com/hashicorp/terraform/helper/schema"
+)
+
+func dataSourceAlicloudCenRouteEntries() *schema.Resource {
+	return &schema.Resource{
+		Read: dataSourceAlicloudCenPublishedRouteEntriesRead,
+
+		Schema: map[string]*schema.Schema{
+			"instance_id": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"route_table_id": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"cidr_block": {
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: true,
+			},
+			"output_file": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+
+			// Computed values
+			"route_entries": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"route_table_id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"cidr_block": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"next_hop_id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"next_hop_type": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"route_type": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"operational_mode": {
+							Type:     schema.TypeBool,
+							Computed: true,
+						},
+						"publish_status": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						// Complex computed value
+						"conflicts": {
+							Type:     schema.TypeList,
+							Computed: true,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"cidr_block": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+									"region_id": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+									"instance_id": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+									"instance_type": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+									"status": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func dataSourceAlicloudCenPublishedRouteEntriesRead(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*AliyunClient)
+	conn := client.cenconn
+
+	args := cbn.CreateDescribePublishedRouteEntriesRequest()
+	if v, ok := d.GetOk("instance_id"); ok {
+		args.CenId = v.(string)
+	}
+	if v, ok := d.GetOk("route_table_id"); ok {
+		args.ChildInstanceRouteTableId = v.(string)
+	}
+	if v, ok := d.GetOk("cidr_block"); ok {
+		args.DestinationCidrBlock = v.(string)
+	}
+
+	childInstanceId, childInstanceType, err := client.createCenRouteEntryParas(args.ChildInstanceRouteTableId)
+	if err != nil {
+		return fmt.Errorf("Query route entry encounter an error, CEN %s vtb %s region_id %s, error info: %#v.",
+			args.CenId, args.ChildInstanceRouteTableId, client.RegionId, err)
+	}
+	args.ChildInstanceId = childInstanceId
+	args.ChildInstanceType = childInstanceType
+	args.ChildInstanceRegionId = client.RegionId
+
+	args.PageSize = requests.NewInteger(PageSizeLarge)
+
+	var allPublishedRouteEntries []cbn.PublishedRouteEntry
+	for pageNumber := 1; ; pageNumber++ {
+		args.PageNumber = requests.NewInteger(pageNumber)
+		resp, err := conn.DescribePublishedRouteEntries(args)
+
+		if err != nil {
+			return err
+		}
+
+		if resp == nil || len(resp.PublishedRouteEntries.PublishedRouteEntry) < 1 {
+			break
+		}
+		allPublishedRouteEntries = append(allPublishedRouteEntries, resp.PublishedRouteEntries.PublishedRouteEntry...)
+
+		if len(resp.PublishedRouteEntries.PublishedRouteEntry) < PageSizeLarge {
+			break
+		}
+	}
+
+	if len(allPublishedRouteEntries) < 1 {
+		return fmt.Errorf("Your query returned no results. Please change your search criteria and try again.")
+	}
+
+	log.Printf("[DEBUG] alicloud_cen_route_entries - PublishedRouteEntries found: %#v", allPublishedRouteEntries)
+
+	return cenPublishedRouteEntriesAttributes(d, allPublishedRouteEntries)
+}
+
+func cenPublishedRouteEntriesAttributes(d *schema.ResourceData, allPublishedRouteEntries []cbn.PublishedRouteEntry) error {
+	var ids []string
+	var s []map[string]interface{}
+
+	for _, routeEntry := range allPublishedRouteEntries {
+		mapping := map[string]interface{}{
+			"route_table_id":   routeEntry.ChildInstanceRouteTableId,
+			"cidr_block":       routeEntry.DestinationCidrBlock,
+			"next_hop_type":    routeEntry.NextHopType,
+			"next_hop_id":      routeEntry.NextHopId,
+			"operational_mode": routeEntry.OperationalMode,
+			"publish_status":   routeEntry.PublishStatus,
+			"route_type":       routeEntry.RouteType,
+			// Complex types get their own functions
+			"conflicts": routeConflictsMappings(routeEntry.Conflicts.Conflict),
+		}
+
+		id := routeEntry.ChildInstanceRouteTableId + COLON_SEPARATED + routeEntry.DestinationCidrBlock
+		ids = append(ids, id)
+		s = append(s, mapping)
+	}
+
+	d.SetId(dataResourceIdHash(ids))
+	if err := d.Set("route_entries", s); err != nil {
+		return err
+	}
+
+	// create a json file in current directory and write data source to it.
+	if output, ok := d.GetOk("output_file"); ok && output.(string) != "" {
+		writeToFile(output.(string), s)
+	}
+
+	return nil
+}
+
+// Returns a set of route conflicts mappings.
+func routeConflictsMappings(m []cbn.Conflict) []map[string]interface{} {
+	var s []map[string]interface{}
+
+	for _, v := range m {
+		mapping := map[string]interface{}{
+			"cidr_block":    v.DestinationCidrBlock,
+			"region_id":     v.RegionId,
+			"instance_id":   v.InstanceId,
+			"instance_type": v.InstanceType,
+			"status":        v.Status,
+		}
+
+		log.Printf("[DEBUG] alicloud_cen_route_entries - adding route conflicts mapping: %v", mapping)
+		s = append(s, mapping)
+	}
+
+	return s
+}

--- a/alicloud/data_source_alicloud_cen_route_entries_test.go
+++ b/alicloud/data_source_alicloud_cen_route_entries_test.go
@@ -1,0 +1,132 @@
+package alicloud
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform/helper/resource"
+)
+
+func TestAccAlicloudCenPublishedRouteEntriesDataSource_basic(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+		},
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCheckCenPublishedRouteEntriesDataSourceConfig,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAlicloudDataSourceID("data.alicloud_cen_route_entries.entry"),
+					resource.TestCheckResourceAttr("data.alicloud_cen_route_entries.entry", "route_entries.0.cidr_block", "11.0.0.0/16"),
+					resource.TestCheckResourceAttr("data.alicloud_cen_route_entries.entry", "route_entries.0.next_hop_type", "Instance"),
+					resource.TestCheckResourceAttr("data.alicloud_cen_route_entries.entry", "route_entries.0.route_type", "Custom"),
+					resource.TestCheckResourceAttrSet("data.alicloud_cen_route_entries.entry", "route_entries.0.route_table_id"),
+					resource.TestCheckResourceAttrSet("data.alicloud_cen_route_entries.entry", "route_entries.0.next_hop_id"),
+					resource.TestCheckResourceAttr("data.alicloud_cen_route_entries.entry", "route_entries.0.publish_status", "Published"),
+					resource.TestCheckResourceAttr("data.alicloud_cen_route_entries.entry", "route_entries.0.operational_mode", "true"),
+					resource.TestCheckNoResourceAttr("data.alicloud_cen_route_entries.entry", "route_entries.0.conflicts"),
+				),
+			},
+		},
+	})
+}
+
+const testAccCheckCenPublishedRouteEntriesDataSourceConfig = `
+provider "alicloud" {
+    alias = "bj"
+    region = "cn-beijing"
+}
+
+variable "name" {
+	default = "tf-testAccCenRoutes"
+}
+
+data "alicloud_zones" "default" {
+    provider = "alicloud.bj"
+	"available_disk_category"= "cloud_efficiency"
+	"available_resource_creation"= "VSwitch"
+}
+
+data "alicloud_instance_types" "default" {
+    provider = "alicloud.bj"
+ 	availability_zone = "${data.alicloud_zones.default.zones.0.id}"
+	cpu_core_count = 1
+	memory_size = 2
+}
+
+data "alicloud_images" "default" {
+    provider = "alicloud.bj"
+    name_regex = "^ubuntu_14.*_64"
+	most_recent = true
+	owners = "system"
+}
+
+resource "alicloud_vpc" "vpc" {
+    provider = "alicloud.bj"
+  	name = "${var.name}"
+  	cidr_block = "172.16.0.0/12"
+}
+
+resource "alicloud_vswitch" "default" {
+    provider = "alicloud.bj"
+ 	vpc_id = "${alicloud_vpc.vpc.id}"
+ 	cidr_block = "172.16.0.0/21"
+ 	availability_zone = "${data.alicloud_zones.default.zones.0.id}"
+ 	name = "${var.name}"
+}
+
+resource "alicloud_security_group" "default" {
+    provider = "alicloud.bj"
+	name = "${var.name}"
+	description = "foo"
+	vpc_id = "${alicloud_vpc.vpc.id}"
+}
+
+resource "alicloud_instance" "default" {
+    provider = "alicloud.bj"
+	vswitch_id = "${alicloud_vswitch.default.id}"
+	image_id = "${data.alicloud_images.default.images.0.id}"
+
+	instance_type = "${data.alicloud_instance_types.default.instance_types.0.id}"
+	system_disk_category = "cloud_efficiency"
+
+	internet_charge_type = "PayByTraffic"
+	internet_max_bandwidth_out = 5
+	security_groups = ["${alicloud_security_group.default.id}"]
+	instance_name = "${var.name}"
+}
+
+resource "alicloud_cen_instance" "cen" {
+	name = "${var.name}"
+	description = "terraform01"
+}
+
+resource "alicloud_cen_instance_attachment" "attach" {
+    instance_id = "${alicloud_cen_instance.cen.id}"
+    child_instance_id = "${alicloud_vpc.vpc.id}"
+    child_instance_region_id = "cn-beijing"
+}
+
+resource "alicloud_route_entry" "route" {
+    provider = "alicloud.bj"
+    route_table_id = "${alicloud_vpc.vpc.route_table_id}"
+    destination_cidrblock = "11.0.0.0/16"
+    nexthop_type = "Instance"
+    nexthop_id = "${alicloud_instance.default.id}"
+}
+
+resource "alicloud_cen_route_entry" "foo" {
+    provider = "alicloud.bj"
+    instance_id = "${alicloud_cen_instance.cen.id}"
+    route_table_id = "${alicloud_vpc.vpc.route_table_id}"
+    cidr_block = "${alicloud_route_entry.route.destination_cidrblock}"
+    depends_on = ["alicloud_cen_instance_attachment.attach"]
+}
+
+data "alicloud_cen_route_entries" "entry" {
+    provider = "alicloud.bj"
+	instance_id = "${alicloud_cen_route_entry.foo.instance_id}"
+	route_table_id = "${alicloud_cen_route_entry.foo.route_table_id}"
+ 	cidr_block = "11.0.0.0/16"
+}
+`

--- a/alicloud/provider.go
+++ b/alicloud/provider.go
@@ -119,6 +119,7 @@ func Provider() terraform.ResourceProvider {
 			"alicloud_cen_instances":           dataSourceAlicloudCenInstances(),
 			"alicloud_cen_bandwidth_packages":  dataSourceAlicloudCenBandwidthPackages(),
 			"alicloud_cen_bandwidth_limits":    dataSourceAlicloudCenBandwidthLimits(),
+			"alicloud_cen_route_entries":       dataSourceAlicloudCenRouteEntries(),
 			"alicloud_mns_queues":              dataSourceAlicloudMNSQueues(),
 			"alicloud_mns_topics":              dataSourceAlicloudMNSTopics(),
 			"alicloud_mns_topic_subscriptions": dataSourceAlicloudMNSTopicSubscriptions(),

--- a/alicloud/service_alicloud_route_table.go
+++ b/alicloud/service_alicloud_route_table.go
@@ -12,6 +12,7 @@ import (
 
 func (client *AliyunClient) DescribeRouteTable(routeTableId string) (v vpc.RouterTableListType, err error) {
 	request := vpc.CreateDescribeRouteTableListRequest()
+	request.RouteTableId = routeTableId
 
 	invoker := NewInvoker()
 	err = invoker.Run(func() error {

--- a/website/alicloud.erb
+++ b/website/alicloud.erb
@@ -154,6 +154,9 @@
                         <li<%= sidebar_current("docs-alicloud-datasource-cen-bandwidth-limits") %>>
                             <a href="/docs/providers/alicloud/d/cen_bandwidth_limits.html">alicloud_cen_bandwidth_limits</a>
                         </li>
+                        <li<%= sidebar_current("docs-alicloud-datasource-cen-route-entries") %>>
+                            <a href="/docs/providers/alicloud/d/cen_route_entries.html">alicloud_cen_route_entries</a>
+                        </li>
                         <li<%= sidebar_current("docs-alicloud-datasource-mns-queues") %>>
                             <a href="/docs/providers/alicloud/d/mns_queues.html">alicloud_mns_queues</a>
                         </li>

--- a/website/docs/d/cen_route_entries.html.markdown
+++ b/website/docs/d/cen_route_entries.html.markdown
@@ -1,0 +1,57 @@
+---
+layout: "alicloud"
+page_title: "Alicloud: alicloud_cen_route_entries"
+sidebar_current: "docs-alicloud-datasource-cen-route-entries"
+description: |-
+    Provides a list of CEN Route Entries owned by an Alibaba Cloud account.
+---
+
+# alicloud\_cen\_route\_entries
+
+This data source provides CEN Route Entries available to the user.
+
+## Example Usage
+
+```
+provider "alicloud" {
+    alias = "bj"
+    region = "cn-beijing"
+}
+data "alicloud_cen_route_entries" "entry"{
+    provider = "alicloud.bj"
+	instance_id = "cen-id1"
+	route_table_id = "vtb-id1"
+}
+
+output "first_route_entries_route_entry_cidr_block" {
+  value = "${data.alicloud_cen_bandwidth_packages.entry.route_entries.0.cidr_block}"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `instance_id` - (Required) ID of the CEN instance.
+* `route_table_id` - (Required) ID of the route table of the VPC or VBR.
+* `cidr_block` - (Optional) The destination CIDR block of the route entry to query.
+* `output_file` - (Optional) File name where to save data source results (after running `terraform plan`).
+
+## Attributes Reference
+
+The following attributes are exported in addition to the arguments listed above:
+
+* `route_entries` - A list of CEN Route Entries. Each element contains the following attributes:
+  * `route_table_id` - ID of the route table.
+  * `cidr_block` - The destination CIDR block of the route entry.
+  * `next_hop_id` - ID of the next hop.
+  * `next_hop_type` - Type of the next hop, including "Instance", "HaVip" and "RouterInterface".
+  * `route_type` - Type of the route entry, including "System", "Custom" and "BGP".
+  * `operational_mode` - Whether to allow the route entry to be published or removed to or from CEN.
+  * `publish_status` - The publish status of the route entry in CEN, including "Published" and "NonPublished".
+  * `conflicts` - A list of conflicted Route Entries. Each element contains the following attributes:
+    * `cidr_block` - The destination CIDR block of the conflicted route entry.
+    * `region_id` - ID of the region where the conflicted route entry is located.
+    * `instance_id` - ID of the CEN child instance.
+    * `instance_type` - The type of the CEN child instance.
+    * `status` - Reasons of exceptions.


### PR DESCRIPTION
Provides a list of CEN Route Entries owned by an Alibaba Cloud account.
$TF_ACC=1 go test ./alicloud -v -run=TestAccAlicloudCenPublishedRouteEntriesDataSource_basic -timeout=300m
=== RUN   TestAccAlicloudCenPublishedRouteEntriesDataSource_basic
--- PASS: TestAccAlicloudCenPublishedRouteEntriesDataSource_basic (153.22s)
PASS
ok  	github.com/terraform-providers/terraform-provider-alicloud/alicloud	153.273s