### PR TITLE
resource alicloud_slb_listener tcp protocol support established_timeout parameter

### DIFF
--- a/alicloud/diff_suppress_funcs.go
+++ b/alicloud/diff_suppress_funcs.go
@@ -67,6 +67,14 @@ func healthCheckTypeDiffSuppressFunc(k, old, new string, d *schema.ResourceData)
 	}
 	return true
 }
+
+func establishedTimeoutDiffSuppressFunc(k, old, new string, d *schema.ResourceData) bool {
+	if protocol, ok := d.GetOk("protocol"); ok && Protocol(protocol.(string)) == Tcp {
+		return false
+	}
+	return true
+}
+
 func httpHttpsTcpDiffSuppressFunc(k, old, new string, d *schema.ResourceData) bool {
 	httpDiff := httpHttpsDiffSuppressFunc(k, old, new, d)
 	health, okHc := d.GetOk("health_check")

--- a/alicloud/resource_alicloud_slb_listener.go
+++ b/alicloud/resource_alicloud_slb_listener.go
@@ -262,6 +262,14 @@ func resourceAliyunSlbListener() *schema.Resource {
 				},
 				MaxItems: 1,
 			},
+			//tcp
+			"established_timeout": &schema.Schema{
+				Type:             schema.TypeInt,
+				ValidateFunc:     validateIntegerInRange(10, 900),
+				Optional:         true,
+				Default:          900,
+				DiffSuppressFunc: establishedTimeoutDiffSuppressFunc,
+			},
 		},
 	}
 }
@@ -513,6 +521,13 @@ func resourceAliyunSlbListenerUpdate(d *schema.ResourceData, meta interface{}) e
 		update = true
 	}
 
+	// tcp
+	if d.HasChange("established_timeout") {
+		tcpArgs.QueryParams["EstablishedTimeout"] = string(requests.NewInteger(d.Get("established_timeout").(int)))
+		d.SetPartial("established_timeout")
+		update = true
+	}
+
 	// https
 	httpsArgs := httpArgs
 	if protocol == Https {
@@ -746,6 +761,9 @@ func readListener(d *schema.ResourceData, listener map[string]interface{}) {
 	}
 	if val, ok := listener["HealthCheckType"]; ok {
 		d.Set("health_check_type", val.(string))
+	}
+	if val, ok := listener["EstablishedTimeout"]; ok {
+		d.Set("established_timeout", val.(float64))
 	}
 	if val, ok := listener["HealthCheckDomain"]; ok {
 		d.Set("health_check_domain", val.(string))

--- a/alicloud/resource_alicloud_slb_listener_test.go
+++ b/alicloud/resource_alicloud_slb_listener_test.go
@@ -82,6 +82,8 @@ func TestAccAlicloudSlbListener_tcp(t *testing.T) {
 						"alicloud_slb_listener.tcp", "acl_type", string(AclTypeWhite)),
 					resource.TestCheckResourceAttrSet(
 						"alicloud_slb_listener.tcp", "acl_id"),
+					resource.TestCheckResourceAttr(
+						"alicloud_slb_listener.tcp", "established_timeout", "600"),
 				),
 			},
 		},
@@ -261,6 +263,7 @@ resource "alicloud_slb_listener" "tcp" {
   acl_status = "on"
   acl_type   = "white"
   acl_id     = "${alicloud_slb_acl.acl.id}"
+  established_timeout = 600
 }
 variable "name" {
   default = "tf-testAcc-tcp-listener-acl"

--- a/examples/slb/README.md
+++ b/examples/slb/README.md
@@ -29,6 +29,7 @@ ssl_certificate_id | https |  |  |
 acl_status | http & https & tcp & udp | on or off | default to on |
 acl_type   | http & https & tcp & udp | white or black |  |
 acl_id     | http & https & tcp & udp | the id of resource alicloud_slb_acl|  |
+established_timeout | tcp       | 10-900|tcp listener's EstablishedTimeout for established connection idle timeout.|
 
 
 

--- a/examples/slb/main.tf
+++ b/examples/slb/main.tf
@@ -23,6 +23,7 @@ resource "alicloud_slb_listener" "tcp" {
   acl_status                = "off"
   acl_type                  = "white"
   acl_id                    = "${alicloud_slb_acl.acl.id}"
+  established_timeout       = 600
 }
 
 resource "alicloud_slb_listener" "udp" {

--- a/examples/slb/outputs.tf
+++ b/examples/slb/outputs.tf
@@ -17,3 +17,7 @@ output "slb_acl_id" {
 output "slb_acl_entry_list" {
   value = "${alicloud_slb_acl.acl.entry_list}"
 }
+
+output "slb_listener_tcp_established_timeout" {
+  value = "${alicloud_slb_listener.tcp.established_timeout}"
+}

--- a/website/docs/r/slb_listener.html.markdown
+++ b/website/docs/r/slb_listener.html.markdown
@@ -69,6 +69,7 @@ resource "alicloud_slb_listener" "tcp" {
   acl_status                = "on"
   acl_type                  = "black"
   acl_id                    = "${alicloud_slb_acl.acl.id}"
+  established_timeout       = 600
 }
 ```
 
@@ -103,6 +104,7 @@ The following arguments are supported:
 * `acl_status` - (Optinal) Whether to enable "acl(access control list)", the acl is specified by `acl_id`. Valid values are `on` and `off`. Default to `off`.
 * `acl_type` - (Optinal) Mode for handling the acl specified by acl_id. If `acl_status` is "on", it is mandatory. Otherwise, it will be ignored. Valid values are `white` and `black`. `white` means the Listener can only be accessed by client ip belongs to the acl; `black` means the Listener can not be accessed by client ip belongs to the acl;
 * `acl_id` - (Optinal) the id of access control list to be apply on the listener, is the id of resource alicloud_slb_acl. If `acl_status` is "on", it is mandatory. Otherwise, it will be ignored.
+* `established_timeout` - (Optinal) Timeout of tcp established connection idle timeout. Valid value range: [10-900] in seconds. Default to 900.
 
 ### Block x_forwarded_for
 
@@ -144,7 +146,7 @@ x_forwarded_for | http & https |  |
 acl_status | http & https & tcp & udp | on or off |
 acl_type   | http & https & tcp & udp | white or black |
 acl_id     | http & https & tcp & udp | the id of resource alicloud_slb_acl|
-
+established_timeout | tcp       | 10-900|
 
 The listener mapping supports the following:
 


### PR DESCRIPTION
…established_timeout for tcp listener connection  established idle timeout.  for issues/674.

https://github.com/alibaba/terraform-provider/issues/674



zhongbo.wzb@scala:~/go/src/github.com/terraform-providers/terraform-provider-alicloud% TF_ACC=1 go test ./alicloud -v  -sweep=cn-beijing -sweep-run=alicloud_slb_listener
2018/10/24 22:54:50 [DEBUG] Running Sweepers for region (cn-beijing):
2018/10/24 22:54:50 Sweeper Tests ran:
ok  	github.com/terraform-providers/terraform-provider-alicloud/alicloud	0.065s
zhongbo.wzb@scala:~/go/src/github.com/terraform-providers/terraform-provider-alicloud% TF_ACC=1 go test ./alicloud -v -run=TestAccAlicloudSlbListener -timeout=300m -count=1
=== RUN   TestAccAlicloudSlbListenersDataSource_http
^@^@--- PASS: TestAccAlicloudSlbListenersDataSource_http (37.09s)
=== RUN   TestAccAlicloudSlbListenersDataSource_tcp
^@^@^@--- PASS: TestAccAlicloudSlbListenersDataSource_tcp (31.40s)
=== RUN   TestAccAlicloudSlbListenersDataSource_udp
^@--- PASS: TestAccAlicloudSlbListenersDataSource_udp (31.59s)
=== RUN   TestAccAlicloudSlbListener_importHttp
^@--- PASS: TestAccAlicloudSlbListener_importHttp (13.13s)
=== RUN   TestAccAlicloudSlbListener_importTcp
^@--- PASS: TestAccAlicloudSlbListener_importTcp (11.24s)
=== RUN   TestAccAlicloudSlbListener_importUdp
^@^@--- PASS: TestAccAlicloudSlbListener_importUdp (13.81s)
=== RUN   TestAccAlicloudSlbListener_http
^@--- PASS: TestAccAlicloudSlbListener_http (13.98s)
=== RUN   TestAccAlicloudSlbListener_tcp
^@--- PASS: TestAccAlicloudSlbListener_tcp (10.91s)
=== RUN   TestAccAlicloudSlbListener_udp
^@--- PASS: TestAccAlicloudSlbListener_udp (10.59s)
PASS
ok  	github.com/terraform-providers/terraform-provider-alicloud/alicloud	173.833s

