### PR TITLE
Bugfix: set number of cen instances five for normal alicloud account testcases

### DIFF
--- a/alicloud/data_source_alicloud_cen_instances_test.go
+++ b/alicloud/data_source_alicloud_cen_instances_test.go
@@ -63,7 +63,7 @@ func TestAccAlicloudCenInstancesDataSource_multi_cen_ids(t *testing.T) {
 				Config: testAccCheckAlicloudCenInstancesDataSourceMultiCenIdsConfig,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAlicloudDataSourceID("data.alicloud_cen_instances.tf-testAccCen"),
-					resource.TestCheckResourceAttr("data.alicloud_cen_instances.tf-testAccCen", "instances.#", "6"),
+					resource.TestCheckResourceAttr("data.alicloud_cen_instances.tf-testAccCen", "instances.#", "5"),
 					resource.TestCheckResourceAttr("data.alicloud_cen_instances.tf-testAccCen", "instances.0.description", "tf-testAccCenConfigDescription"),
 					resource.TestCheckResourceAttr("data.alicloud_cen_instances.tf-testAccCen", "instances.1.status", "Active"),
 					resource.TestCheckResourceAttr("data.alicloud_cen_instances.tf-testAccCen", "instances.2.name", "tf-testAccCenConfig"),
@@ -92,7 +92,6 @@ resource "alicloud_cen_instance" "tf-testAccCen" {
 
 data "alicloud_cen_instances" "tf-testAccCen" {
 	name_regex = "${alicloud_cen_instance.tf-testAccCen.name}"
-
 }
 `
 
@@ -100,7 +99,7 @@ const testAccCheckAlicloudCenInstancesDataSourceMultiCenIdsConfig = `
 resource "alicloud_cen_instance" "tf-testAccCen" {
 	name = "tf-testAccCenConfig"
 	description = "tf-testAccCenConfigDescription"
-	count = 6
+	count = 5
 }
 
 data "alicloud_cen_instances" "tf-testAccCen" {


### PR DESCRIPTION
$TF_ACC=1 go test ./alicloud -v -run=TestAccAlicloudCenInstancesDataSource_multi_cen_ids -timeout=300m   
=== RUN   TestAccAlicloudCenInstancesDataSource_multi_cen_ids
--- PASS: TestAccAlicloudCenInstancesDataSource_multi_cen_ids (11.45s)
PASS
ok  	github.com/terraform-providers/terraform-provider-alicloud/alicloud	11.515s