### PR TITLE
Increasing the min_size and max_size scaling group parameters to 1000

### DIFF
--- a/alicloud/resource_alicloud_ess_scalinggroup.go
+++ b/alicloud/resource_alicloud_ess_scalinggroup.go
@@ -28,12 +28,12 @@ func resourceAlicloudEssScalingGroup() *schema.Resource {
 			"min_size": &schema.Schema{
 				Type:         schema.TypeInt,
 				Required:     true,
-				ValidateFunc: validateIntegerInRange(0, 100),
+				ValidateFunc: validateIntegerInRange(0, 1000),
 			},
 			"max_size": &schema.Schema{
 				Type:         schema.TypeInt,
 				Required:     true,
-				ValidateFunc: validateIntegerInRange(0, 100),
+				ValidateFunc: validateIntegerInRange(0, 1000),
 			},
 			"scaling_group_name": &schema.Schema{
 				Type:     schema.TypeString,

--- a/website/docs/r/ess_scaling_group.html.markdown
+++ b/website/docs/r/ess_scaling_group.html.markdown
@@ -28,8 +28,8 @@ resource "alicloud_ess_scaling_group" "scaling" {
 
 The following arguments are supported:
 
-* `min_size` - (Required) Minimum number of ECS instances in the scaling group. Value range: [0, 100].
-* `max_size` - (Required) Maximum number of ECS instances in the scaling group. Value range: [0, 100].
+* `min_size` - (Required) Minimum number of ECS instances in the scaling group. Value range: [0, 1000].
+* `max_size` - (Required) Maximum number of ECS instances in the scaling group. Value range: [0, 1000].
 * `scaling_group_name` - (Optional) Name shown for the scaling group, which must contain 2-40 characters (English or Chinese). If this parameter is not specified, the default value is ScalingGroupId.
 * `default_cooldown` - (Optional) Default cool-down time (in seconds) of the scaling group. Value range: [0, 86400]. The default value is 300s.
 * `vswitch_id` - (Deprecated) It has been deprecated from version 1.7.1 and new field 'vswitch_ids' replaces it.


### PR DESCRIPTION
Currently the max capacity of auto scaling in ALI cloud is 1000 but terraform still points to old capacity of 100. Changing it