### PR TITLE
Fix pvtz_zone_record update bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ IMPROVEMENTS:
 
 BUG FIXES:
 
+- Fix pvtz_zone_record update bug [GH-503]
+- Fix network_interface_attachment docs error [GH-502]
 - fix fix datahub bug when visit region of ap-southeast-1 [GH-499]
 - Fix examples/mns-topic parameter error [GH-497]
 - Fix db_connection not found error when deleting [GH-495]

--- a/alicloud/resource_alicloud_pvtz_zone_record.go
+++ b/alicloud/resource_alicloud_pvtz_zone_record.go
@@ -100,7 +100,6 @@ func resourceAlicloudPvtzZoneRecordCreate(d *schema.ResourceData, meta interface
 }
 
 func resourceAlicloudPvtzZoneRecordUpdate(d *schema.ResourceData, meta interface{}) error {
-	d.Partial(true)
 
 	attributeUpdate := false
 
@@ -109,32 +108,28 @@ func resourceAlicloudPvtzZoneRecordUpdate(d *schema.ResourceData, meta interface
 	recordId, _ := strconv.Atoi(recordIdStr)
 	args.RecordId = requests.NewInteger(recordId)
 	args.Rr = d.Get("resource_record").(string)
+	args.Type = d.Get("type").(string)
+	args.Value = d.Get("value").(string)
+	args.Priority = requests.NewInteger(d.Get("priority").(int))
+	args.Ttl = requests.NewInteger(d.Get("ttl").(int))
+
+	if d.HasChange("resource_record") {
+		attributeUpdate = true
+	}
 
 	if d.HasChange("type") {
-		d.SetPartial("type")
-		args.Type = d.Get("type").(string)
-
 		attributeUpdate = true
 	}
 
 	if d.HasChange("value") {
-		d.SetPartial("value")
-		args.Value = d.Get("value").(string)
-
 		attributeUpdate = true
 	}
 
 	if d.HasChange("priority") {
-		d.SetPartial("priority")
-		args.Priority = requests.NewInteger(d.Get("priority").(int))
-
 		attributeUpdate = true
 	}
 
 	if d.HasChange("ttl") {
-		d.SetPartial("ttl")
-		args.Ttl = requests.NewInteger(d.Get("ttl").(int))
-
 		attributeUpdate = true
 	}
 
@@ -147,8 +142,6 @@ func resourceAlicloudPvtzZoneRecordUpdate(d *schema.ResourceData, meta interface
 			return err
 		}
 	}
-
-	d.Partial(false)
 
 	return resourceAlicloudPvtzZoneRecordRead(d, meta)
 

--- a/alicloud/resource_alicloud_pvtz_zone_record_test.go
+++ b/alicloud/resource_alicloud_pvtz_zone_record_test.go
@@ -31,7 +31,10 @@ func TestAccAlicloudPvtzZoneRecord_Basic(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccAlicloudPvtzZoneRecordExists("alicloud_pvtz_zone_record.foo", &record),
 					resource.TestCheckResourceAttr("alicloud_pvtz_zone_record.foo", "resource_record", "www"),
-					resource.TestCheckResourceAttrSet("alicloud_pvtz_zone_record.foo", "value"),
+					resource.TestCheckResourceAttr("alicloud_pvtz_zone_record.foo", "value", "2.2.2.2"),
+					resource.TestCheckResourceAttr("alicloud_pvtz_zone_record.foo", "type", "A"),
+					resource.TestCheckResourceAttr("alicloud_pvtz_zone_record.foo", "priority", "5"),
+					resource.TestCheckResourceAttr("alicloud_pvtz_zone_record.foo", "ttl", "60"),
 				),
 			},
 		},
@@ -39,7 +42,7 @@ func TestAccAlicloudPvtzZoneRecord_Basic(t *testing.T) {
 
 }
 
-func TestAccAlicloudPvtzZoneRecord_update(t *testing.T) {
+func TestAccAlicloudPvtzZoneRecord_updateRr(t *testing.T) {
 	if !isRegionSupports(PrivateZone) {
 		logTestSkippedBecauseOfUnsupportedRegionalFeatures(t.Name(), PrivateZone)
 		return
@@ -58,16 +61,22 @@ func TestAccAlicloudPvtzZoneRecord_update(t *testing.T) {
 				Config: testAccPvtzZoneRecordConfig,
 				Check: resource.ComposeTestCheckFunc(
 					testAccAlicloudPvtzZoneRecordExists("alicloud_pvtz_zone_record.foo", &record),
-					resource.TestCheckResourceAttr(
-						"alicloud_pvtz_zone_record.foo", "value", "2.2.2.2"),
+					resource.TestCheckResourceAttr("alicloud_pvtz_zone_record.foo", "resource_record", "www"),
+					resource.TestCheckResourceAttr("alicloud_pvtz_zone_record.foo", "value", "2.2.2.2"),
+					resource.TestCheckResourceAttr("alicloud_pvtz_zone_record.foo", "type", "A"),
+					resource.TestCheckResourceAttr("alicloud_pvtz_zone_record.foo", "priority", "5"),
+					resource.TestCheckResourceAttr("alicloud_pvtz_zone_record.foo", "ttl", "60"),
 				),
 			},
 			resource.TestStep{
-				Config: testAccPvtzZoneRecordConfigUpdate,
+				Config: testAccPvtzZoneRecordConfigUpdateResourceRecord,
 				Check: resource.ComposeTestCheckFunc(
 					testAccAlicloudPvtzZoneRecordExists("alicloud_pvtz_zone_record.foo", &record),
-					resource.TestCheckResourceAttr(
-						"alicloud_pvtz_zone_record.foo", "value", "bbb.test.com"),
+					resource.TestCheckResourceAttr("alicloud_pvtz_zone_record.foo", "resource_record", "@"),
+					resource.TestCheckResourceAttr("alicloud_pvtz_zone_record.foo", "value", "2.2.2.2"),
+					resource.TestCheckResourceAttr("alicloud_pvtz_zone_record.foo", "type", "A"),
+					resource.TestCheckResourceAttr("alicloud_pvtz_zone_record.foo", "priority", "5"),
+					resource.TestCheckResourceAttr("alicloud_pvtz_zone_record.foo", "ttl", "60"),
 				),
 			},
 		},
@@ -75,6 +84,212 @@ func TestAccAlicloudPvtzZoneRecord_update(t *testing.T) {
 
 }
 
+func TestAccAlicloudPvtzZoneRecord_updateType(t *testing.T) {
+	if !isRegionSupports(PrivateZone) {
+		logTestSkippedBecauseOfUnsupportedRegionalFeatures(t.Name(), PrivateZone)
+		return
+	}
+
+	var record pvtz.Record
+
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+		},
+		Providers:    testAccProviders,
+		CheckDestroy: testAccAlicloudPvtzZoneRecordDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccPvtzZoneRecordConfig,
+				Check: resource.ComposeTestCheckFunc(
+					testAccAlicloudPvtzZoneRecordExists("alicloud_pvtz_zone_record.foo", &record),
+					resource.TestCheckResourceAttr("alicloud_pvtz_zone_record.foo", "resource_record", "www"),
+					resource.TestCheckResourceAttr("alicloud_pvtz_zone_record.foo", "value", "2.2.2.2"),
+					resource.TestCheckResourceAttr("alicloud_pvtz_zone_record.foo", "type", "A"),
+					resource.TestCheckResourceAttr("alicloud_pvtz_zone_record.foo", "priority", "5"),
+					resource.TestCheckResourceAttr("alicloud_pvtz_zone_record.foo", "ttl", "60"),
+				),
+			},
+			resource.TestStep{
+				Config: testAccPvtzZoneRecordConfigUpdateType,
+				Check: resource.ComposeTestCheckFunc(
+					testAccAlicloudPvtzZoneRecordExists("alicloud_pvtz_zone_record.foo", &record),
+					resource.TestCheckResourceAttr("alicloud_pvtz_zone_record.foo", "resource_record", "www"),
+					resource.TestCheckResourceAttr("alicloud_pvtz_zone_record.foo", "value", "2.2.2.2"),
+					resource.TestCheckResourceAttr("alicloud_pvtz_zone_record.foo", "type", "TXT"),
+					resource.TestCheckResourceAttr("alicloud_pvtz_zone_record.foo", "priority", "5"),
+					resource.TestCheckResourceAttr("alicloud_pvtz_zone_record.foo", "ttl", "60"),
+				),
+			},
+		},
+	})
+
+}
+
+func TestAccAlicloudPvtzZoneRecord_updateValue(t *testing.T) {
+	if !isRegionSupports(PrivateZone) {
+		logTestSkippedBecauseOfUnsupportedRegionalFeatures(t.Name(), PrivateZone)
+		return
+	}
+
+	var record pvtz.Record
+
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+		},
+		Providers:    testAccProviders,
+		CheckDestroy: testAccAlicloudPvtzZoneRecordDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccPvtzZoneRecordConfig,
+				Check: resource.ComposeTestCheckFunc(
+					testAccAlicloudPvtzZoneRecordExists("alicloud_pvtz_zone_record.foo", &record),
+					resource.TestCheckResourceAttr("alicloud_pvtz_zone_record.foo", "resource_record", "www"),
+					resource.TestCheckResourceAttr("alicloud_pvtz_zone_record.foo", "value", "2.2.2.2"),
+					resource.TestCheckResourceAttr("alicloud_pvtz_zone_record.foo", "type", "A"),
+					resource.TestCheckResourceAttr("alicloud_pvtz_zone_record.foo", "priority", "5"),
+					resource.TestCheckResourceAttr("alicloud_pvtz_zone_record.foo", "ttl", "60"),
+				),
+			},
+			resource.TestStep{
+				Config: testAccPvtzZoneRecordConfigUpdateValue,
+				Check: resource.ComposeTestCheckFunc(
+					testAccAlicloudPvtzZoneRecordExists("alicloud_pvtz_zone_record.foo", &record),
+					resource.TestCheckResourceAttr("alicloud_pvtz_zone_record.foo", "resource_record", "www"),
+					resource.TestCheckResourceAttr("alicloud_pvtz_zone_record.foo", "value", "2.2.2.3"),
+					resource.TestCheckResourceAttr("alicloud_pvtz_zone_record.foo", "type", "A"),
+					resource.TestCheckResourceAttr("alicloud_pvtz_zone_record.foo", "priority", "5"),
+					resource.TestCheckResourceAttr("alicloud_pvtz_zone_record.foo", "ttl", "60"),
+				),
+			},
+		},
+	})
+
+}
+func TestAccAlicloudPvtzZoneRecord_updatePriority(t *testing.T) {
+	if !isRegionSupports(PrivateZone) {
+		logTestSkippedBecauseOfUnsupportedRegionalFeatures(t.Name(), PrivateZone)
+		return
+	}
+
+	var record pvtz.Record
+
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+		},
+		Providers:    testAccProviders,
+		CheckDestroy: testAccAlicloudPvtzZoneRecordDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccPvtzZoneRecordConfig,
+				Check: resource.ComposeTestCheckFunc(
+					testAccAlicloudPvtzZoneRecordExists("alicloud_pvtz_zone_record.foo", &record),
+					resource.TestCheckResourceAttr("alicloud_pvtz_zone_record.foo", "resource_record", "www"),
+					resource.TestCheckResourceAttr("alicloud_pvtz_zone_record.foo", "value", "2.2.2.2"),
+					resource.TestCheckResourceAttr("alicloud_pvtz_zone_record.foo", "type", "A"),
+					resource.TestCheckResourceAttr("alicloud_pvtz_zone_record.foo", "priority", "5"),
+					resource.TestCheckResourceAttr("alicloud_pvtz_zone_record.foo", "ttl", "60"),
+				),
+			},
+			resource.TestStep{
+				Config: testAccPvtzZoneRecordConfigUpdatePriority,
+				Check: resource.ComposeTestCheckFunc(
+					testAccAlicloudPvtzZoneRecordExists("alicloud_pvtz_zone_record.foo", &record),
+					resource.TestCheckResourceAttr("alicloud_pvtz_zone_record.foo", "resource_record", "www"),
+					resource.TestCheckResourceAttr("alicloud_pvtz_zone_record.foo", "value", "2.2.2.2"),
+					resource.TestCheckResourceAttr("alicloud_pvtz_zone_record.foo", "type", "A"),
+					resource.TestCheckResourceAttr("alicloud_pvtz_zone_record.foo", "priority", "10"),
+					resource.TestCheckResourceAttr("alicloud_pvtz_zone_record.foo", "ttl", "60"),
+				),
+			},
+		},
+	})
+
+}
+func TestAccAlicloudPvtzZoneRecord_updateTTL(t *testing.T) {
+	if !isRegionSupports(PrivateZone) {
+		logTestSkippedBecauseOfUnsupportedRegionalFeatures(t.Name(), PrivateZone)
+		return
+	}
+
+	var record pvtz.Record
+
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+		},
+		Providers:    testAccProviders,
+		CheckDestroy: testAccAlicloudPvtzZoneRecordDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccPvtzZoneRecordConfig,
+				Check: resource.ComposeTestCheckFunc(
+					testAccAlicloudPvtzZoneRecordExists("alicloud_pvtz_zone_record.foo", &record),
+					resource.TestCheckResourceAttr("alicloud_pvtz_zone_record.foo", "resource_record", "www"),
+					resource.TestCheckResourceAttr("alicloud_pvtz_zone_record.foo", "value", "2.2.2.2"),
+					resource.TestCheckResourceAttr("alicloud_pvtz_zone_record.foo", "type", "A"),
+					resource.TestCheckResourceAttr("alicloud_pvtz_zone_record.foo", "priority", "5"),
+					resource.TestCheckResourceAttr("alicloud_pvtz_zone_record.foo", "ttl", "60"),
+				),
+			},
+			resource.TestStep{
+				Config: testAccPvtzZoneRecordConfigUpdateTTl,
+				Check: resource.ComposeTestCheckFunc(
+					testAccAlicloudPvtzZoneRecordExists("alicloud_pvtz_zone_record.foo", &record),
+					resource.TestCheckResourceAttr("alicloud_pvtz_zone_record.foo", "resource_record", "www"),
+					resource.TestCheckResourceAttr("alicloud_pvtz_zone_record.foo", "value", "2.2.2.2"),
+					resource.TestCheckResourceAttr("alicloud_pvtz_zone_record.foo", "type", "A"),
+					resource.TestCheckResourceAttr("alicloud_pvtz_zone_record.foo", "priority", "5"),
+					resource.TestCheckResourceAttr("alicloud_pvtz_zone_record.foo", "ttl", "30"),
+				),
+			},
+		},
+	})
+
+}
+func TestAccAlicloudPvtzZoneRecord_updateAll(t *testing.T) {
+	if !isRegionSupports(PrivateZone) {
+		logTestSkippedBecauseOfUnsupportedRegionalFeatures(t.Name(), PrivateZone)
+		return
+	}
+
+	var record pvtz.Record
+
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+		},
+		Providers:    testAccProviders,
+		CheckDestroy: testAccAlicloudPvtzZoneRecordDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccPvtzZoneRecordConfig,
+				Check: resource.ComposeTestCheckFunc(
+					testAccAlicloudPvtzZoneRecordExists("alicloud_pvtz_zone_record.foo", &record),
+					resource.TestCheckResourceAttr("alicloud_pvtz_zone_record.foo", "resource_record", "www"),
+					resource.TestCheckResourceAttr("alicloud_pvtz_zone_record.foo", "value", "2.2.2.2"),
+					resource.TestCheckResourceAttr("alicloud_pvtz_zone_record.foo", "type", "A"),
+					resource.TestCheckResourceAttr("alicloud_pvtz_zone_record.foo", "priority", "5"),
+					resource.TestCheckResourceAttr("alicloud_pvtz_zone_record.foo", "ttl", "60"),
+				),
+			},
+			resource.TestStep{
+				Config: testAccPvtzZoneRecordConfigUpdateAll,
+				Check: resource.ComposeTestCheckFunc(
+					testAccAlicloudPvtzZoneRecordExists("alicloud_pvtz_zone_record.foo", &record),
+					resource.TestCheckResourceAttr("alicloud_pvtz_zone_record.foo", "resource_record", "@"),
+					resource.TestCheckResourceAttr("alicloud_pvtz_zone_record.foo", "value", "bbb.test.com"),
+					resource.TestCheckResourceAttr("alicloud_pvtz_zone_record.foo", "type", "CNAME"),
+					resource.TestCheckResourceAttr("alicloud_pvtz_zone_record.foo", "priority", "10"),
+					resource.TestCheckResourceAttr("alicloud_pvtz_zone_record.foo", "ttl", "30"),
+				),
+			},
+		},
+	})
+
+}
 func TestAccAlicloudPvtzZoneRecord_multi(t *testing.T) {
 	if !isRegionSupports(PrivateZone) {
 		logTestSkippedBecauseOfUnsupportedRegionalFeatures(t.Name(), PrivateZone)
@@ -95,11 +310,29 @@ func TestAccAlicloudPvtzZoneRecord_multi(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccAlicloudPvtzZoneRecordExists("alicloud_pvtz_zone_record.bar_1", &record),
 					resource.TestCheckResourceAttr(
+						"alicloud_pvtz_zone_record.bar_1", "resource_record", "aaa"),
+					resource.TestCheckResourceAttr(
+						"alicloud_pvtz_zone_record.bar_1", "type", "A"),
+					resource.TestCheckResourceAttr(
+						"alicloud_pvtz_zone_record.bar_1", "priority", "10"),
+					resource.TestCheckResourceAttr(
 						"alicloud_pvtz_zone_record.bar_1", "value", "2.2.2.2"),
 					testAccAlicloudPvtzZoneRecordExists("alicloud_pvtz_zone_record.bar_2", &record),
 					resource.TestCheckResourceAttr(
+						"alicloud_pvtz_zone_record.bar_2", "resource_record", "bbb"),
+					resource.TestCheckResourceAttr(
+						"alicloud_pvtz_zone_record.bar_2", "type", "CNAME"),
+					resource.TestCheckResourceAttr(
+						"alicloud_pvtz_zone_record.bar_2", "priority", "5"),
+					resource.TestCheckResourceAttr(
 						"alicloud_pvtz_zone_record.bar_2", "value", "c.test.com"),
 					testAccAlicloudPvtzZoneRecordExists("alicloud_pvtz_zone_record.bar_3", &record),
+					resource.TestCheckResourceAttr(
+						"alicloud_pvtz_zone_record.bar_3", "resource_record", "ccc"),
+					resource.TestCheckResourceAttr(
+						"alicloud_pvtz_zone_record.bar_3", "type", "A"),
+					resource.TestCheckResourceAttr(
+						"alicloud_pvtz_zone_record.bar_3", "priority", "3"),
 					resource.TestCheckResourceAttr(
 						"alicloud_pvtz_zone_record.bar_3", "value", "3.3.3.3"),
 				),
@@ -179,7 +412,21 @@ resource "alicloud_pvtz_zone_record" "foo" {
 	ttl = "60"
 }
 `
-const testAccPvtzZoneRecordConfigUpdate = `
+const testAccPvtzZoneRecordConfigUpdateResourceRecord = `
+resource "alicloud_pvtz_zone" "zone" {
+	name = "tf-testacc.test.com"
+}
+
+resource "alicloud_pvtz_zone_record" "foo" {
+	zone_id = "${alicloud_pvtz_zone.zone.id}"
+	resource_record = "@"
+	type = "A"
+	value = "2.2.2.2"
+	priority = "5"
+	ttl = "60"
+}
+`
+const testAccPvtzZoneRecordConfigUpdateType = `
 resource "alicloud_pvtz_zone" "zone" {
 	name = "tf-testacc.test.com"
 }
@@ -187,9 +434,70 @@ resource "alicloud_pvtz_zone" "zone" {
 resource "alicloud_pvtz_zone_record" "foo" {
 	zone_id = "${alicloud_pvtz_zone.zone.id}"
 	resource_record = "www"
+	type = "TXT"
+	value = "2.2.2.2"
+	priority = "5"
+	ttl = "60"
+}
+`
+
+const testAccPvtzZoneRecordConfigUpdateValue = `
+resource "alicloud_pvtz_zone" "zone" {
+	name = "tf-testacc.test.com"
+}
+
+resource "alicloud_pvtz_zone_record" "foo" {
+	zone_id = "${alicloud_pvtz_zone.zone.id}"
+	resource_record = "www"
+	type = "A"
+	value = "2.2.2.3"
+	priority = "5"
+	ttl = "60"
+}
+`
+
+const testAccPvtzZoneRecordConfigUpdatePriority = `
+resource "alicloud_pvtz_zone" "zone" {
+	name = "tf-testacc.test.com"
+}
+
+resource "alicloud_pvtz_zone_record" "foo" {
+	zone_id = "${alicloud_pvtz_zone.zone.id}"
+	resource_record = "www"
+	type = "A"
+	value = "2.2.2.2"
+	priority = "10"
+	ttl = "60"
+}
+`
+
+const testAccPvtzZoneRecordConfigUpdateTTl = `
+resource "alicloud_pvtz_zone" "zone" {
+	name = "tf-testacc.test.com"
+}
+
+resource "alicloud_pvtz_zone_record" "foo" {
+	zone_id = "${alicloud_pvtz_zone.zone.id}"
+	resource_record = "www"
+	type = "A"
+	value = "2.2.2.2"
+	priority = "5"
+	ttl = "30"
+}
+`
+
+const testAccPvtzZoneRecordConfigUpdateAll = `
+resource "alicloud_pvtz_zone" "zone" {
+	name = "tf-testacc.test.com"
+}
+
+resource "alicloud_pvtz_zone_record" "foo" {
+	zone_id = "${alicloud_pvtz_zone.zone.id}"
+	resource_record = "@"
 	type = "CNAME"
 	value = "bbb.test.com"
-	priority = "6"
+	priority = "10"
+	ttl = "30"
 }
 `
 
@@ -203,17 +511,20 @@ resource "alicloud_pvtz_zone_record" "bar_1" {
 	resource_record = "aaa"
 	type = "A"
 	value = "2.2.2.2"
+	priority = "10"
 }
 resource "alicloud_pvtz_zone_record" "bar_2" {
 	zone_id = "${alicloud_pvtz_zone.zone.id}"
 	resource_record = "bbb"
 	type = "CNAME"
 	value = "c.test.com"
+	priority = "5"
 }
 resource "alicloud_pvtz_zone_record" "bar_3" {
 	zone_id = "${alicloud_pvtz_zone.zone.id}"
 	resource_record = "ccc"
 	type = "A"
 	value = "3.3.3.3"
+	priority = "3"
 }
 `


### PR DESCRIPTION
The result of running test cases as follows:
```
TF_ACC=1 go test ./alicloud -v  -run=TestAccAlicloudPvtzZoneRecord_ -timeout=120m
=== RUN   TestAccAlicloudPvtzZoneRecord_importBasic
--- PASS: TestAccAlicloudPvtzZoneRecord_importBasic (1.63s)
=== RUN   TestAccAlicloudPvtzZoneRecord_Basic
--- PASS: TestAccAlicloudPvtzZoneRecord_Basic (1.63s)
=== RUN   TestAccAlicloudPvtzZoneRecord_updateRr
--- PASS: TestAccAlicloudPvtzZoneRecord_updateRr (2.35s)
=== RUN   TestAccAlicloudPvtzZoneRecord_updateType
--- PASS: TestAccAlicloudPvtzZoneRecord_updateType (2.29s)
=== RUN   TestAccAlicloudPvtzZoneRecord_updateValue
--- PASS: TestAccAlicloudPvtzZoneRecord_updateValue (2.33s)
=== RUN   TestAccAlicloudPvtzZoneRecord_updatePriority
--- PASS: TestAccAlicloudPvtzZoneRecord_updatePriority (2.28s)
=== RUN   TestAccAlicloudPvtzZoneRecord_updateTTL
--- PASS: TestAccAlicloudPvtzZoneRecord_updateTTL (2.29s)
=== RUN   TestAccAlicloudPvtzZoneRecord_updateAll
--- PASS: TestAccAlicloudPvtzZoneRecord_updateAll (2.29s)
=== RUN   TestAccAlicloudPvtzZoneRecord_multi
--- PASS: TestAccAlicloudPvtzZoneRecord_multi (3.40s)
PASS
ok      github.com/terraform-providers/terraform-provider-alicloud/alicloud     20.538s

```