### PR TITLE
Fix pvtz resource priority bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,13 @@
 ## 1.25.0 (Unreleased)
+
+IMPROVEMENTS:
+
+- Add a docs guides/getting-account to help user learn alibaba cloud account [GH-510]
+
+BUG FIXES:
+
+- Fix pvtz resource priority bug [GH-511]
+
 ## 1.24.0 (November 21, 2018)
 
 FEATURES:

--- a/alicloud/extension_pvtz.go
+++ b/alicloud/extension_pvtz.go
@@ -1,0 +1,11 @@
+package alicloud
+
+type RecordType string
+
+const (
+	RecordA     = RecordType("A")
+	RecordCNAME = RecordType("CNAME")
+	RecordTXT   = RecordType("TXT")
+	RecordMX    = RecordType("MX")
+	RecordPTR   = RecordType("PTR")
+)

--- a/alicloud/resource_alicloud_pvtz_zone_record_test.go
+++ b/alicloud/resource_alicloud_pvtz_zone_record_test.go
@@ -11,6 +11,8 @@ import (
 	"github.com/terraform-providers/terraform-provider-alicloud/alicloud/connectivity"
 )
 
+// Only MX supports priority
+
 func TestAccAlicloudPvtzZoneRecord_Basic(t *testing.T) {
 	if !isRegionSupports(PrivateZone) {
 		logTestSkippedBecauseOfUnsupportedRegionalFeatures(t.Name(), PrivateZone)
@@ -33,7 +35,7 @@ func TestAccAlicloudPvtzZoneRecord_Basic(t *testing.T) {
 					resource.TestCheckResourceAttr("alicloud_pvtz_zone_record.foo", "resource_record", "www"),
 					resource.TestCheckResourceAttr("alicloud_pvtz_zone_record.foo", "value", "2.2.2.2"),
 					resource.TestCheckResourceAttr("alicloud_pvtz_zone_record.foo", "type", "A"),
-					resource.TestCheckResourceAttr("alicloud_pvtz_zone_record.foo", "priority", "5"),
+					resource.TestCheckResourceAttr("alicloud_pvtz_zone_record.foo", "priority", "0"),
 					resource.TestCheckResourceAttr("alicloud_pvtz_zone_record.foo", "ttl", "60"),
 				),
 			},
@@ -64,7 +66,7 @@ func TestAccAlicloudPvtzZoneRecord_updateRr(t *testing.T) {
 					resource.TestCheckResourceAttr("alicloud_pvtz_zone_record.foo", "resource_record", "www"),
 					resource.TestCheckResourceAttr("alicloud_pvtz_zone_record.foo", "value", "2.2.2.2"),
 					resource.TestCheckResourceAttr("alicloud_pvtz_zone_record.foo", "type", "A"),
-					resource.TestCheckResourceAttr("alicloud_pvtz_zone_record.foo", "priority", "5"),
+					resource.TestCheckResourceAttr("alicloud_pvtz_zone_record.foo", "priority", "0"),
 					resource.TestCheckResourceAttr("alicloud_pvtz_zone_record.foo", "ttl", "60"),
 				),
 			},
@@ -75,7 +77,7 @@ func TestAccAlicloudPvtzZoneRecord_updateRr(t *testing.T) {
 					resource.TestCheckResourceAttr("alicloud_pvtz_zone_record.foo", "resource_record", "@"),
 					resource.TestCheckResourceAttr("alicloud_pvtz_zone_record.foo", "value", "2.2.2.2"),
 					resource.TestCheckResourceAttr("alicloud_pvtz_zone_record.foo", "type", "A"),
-					resource.TestCheckResourceAttr("alicloud_pvtz_zone_record.foo", "priority", "5"),
+					resource.TestCheckResourceAttr("alicloud_pvtz_zone_record.foo", "priority", "0"),
 					resource.TestCheckResourceAttr("alicloud_pvtz_zone_record.foo", "ttl", "60"),
 				),
 			},
@@ -106,7 +108,7 @@ func TestAccAlicloudPvtzZoneRecord_updateType(t *testing.T) {
 					resource.TestCheckResourceAttr("alicloud_pvtz_zone_record.foo", "resource_record", "www"),
 					resource.TestCheckResourceAttr("alicloud_pvtz_zone_record.foo", "value", "2.2.2.2"),
 					resource.TestCheckResourceAttr("alicloud_pvtz_zone_record.foo", "type", "A"),
-					resource.TestCheckResourceAttr("alicloud_pvtz_zone_record.foo", "priority", "5"),
+					resource.TestCheckResourceAttr("alicloud_pvtz_zone_record.foo", "priority", "0"),
 					resource.TestCheckResourceAttr("alicloud_pvtz_zone_record.foo", "ttl", "60"),
 				),
 			},
@@ -117,7 +119,7 @@ func TestAccAlicloudPvtzZoneRecord_updateType(t *testing.T) {
 					resource.TestCheckResourceAttr("alicloud_pvtz_zone_record.foo", "resource_record", "www"),
 					resource.TestCheckResourceAttr("alicloud_pvtz_zone_record.foo", "value", "2.2.2.2"),
 					resource.TestCheckResourceAttr("alicloud_pvtz_zone_record.foo", "type", "TXT"),
-					resource.TestCheckResourceAttr("alicloud_pvtz_zone_record.foo", "priority", "5"),
+					resource.TestCheckResourceAttr("alicloud_pvtz_zone_record.foo", "priority", "0"),
 					resource.TestCheckResourceAttr("alicloud_pvtz_zone_record.foo", "ttl", "60"),
 				),
 			},
@@ -148,7 +150,7 @@ func TestAccAlicloudPvtzZoneRecord_updateValue(t *testing.T) {
 					resource.TestCheckResourceAttr("alicloud_pvtz_zone_record.foo", "resource_record", "www"),
 					resource.TestCheckResourceAttr("alicloud_pvtz_zone_record.foo", "value", "2.2.2.2"),
 					resource.TestCheckResourceAttr("alicloud_pvtz_zone_record.foo", "type", "A"),
-					resource.TestCheckResourceAttr("alicloud_pvtz_zone_record.foo", "priority", "5"),
+					resource.TestCheckResourceAttr("alicloud_pvtz_zone_record.foo", "priority", "0"),
 					resource.TestCheckResourceAttr("alicloud_pvtz_zone_record.foo", "ttl", "60"),
 				),
 			},
@@ -159,7 +161,7 @@ func TestAccAlicloudPvtzZoneRecord_updateValue(t *testing.T) {
 					resource.TestCheckResourceAttr("alicloud_pvtz_zone_record.foo", "resource_record", "www"),
 					resource.TestCheckResourceAttr("alicloud_pvtz_zone_record.foo", "value", "2.2.2.3"),
 					resource.TestCheckResourceAttr("alicloud_pvtz_zone_record.foo", "type", "A"),
-					resource.TestCheckResourceAttr("alicloud_pvtz_zone_record.foo", "priority", "5"),
+					resource.TestCheckResourceAttr("alicloud_pvtz_zone_record.foo", "priority", "0"),
 					resource.TestCheckResourceAttr("alicloud_pvtz_zone_record.foo", "ttl", "60"),
 				),
 			},
@@ -183,13 +185,13 @@ func TestAccAlicloudPvtzZoneRecord_updatePriority(t *testing.T) {
 		CheckDestroy: testAccAlicloudPvtzZoneRecordDestroy,
 		Steps: []resource.TestStep{
 			resource.TestStep{
-				Config: testAccPvtzZoneRecordConfig,
+				Config: testAccPvtzZoneRecordConfigPriority,
 				Check: resource.ComposeTestCheckFunc(
 					testAccAlicloudPvtzZoneRecordExists("alicloud_pvtz_zone_record.foo", &record),
 					resource.TestCheckResourceAttr("alicloud_pvtz_zone_record.foo", "resource_record", "www"),
-					resource.TestCheckResourceAttr("alicloud_pvtz_zone_record.foo", "value", "2.2.2.2"),
-					resource.TestCheckResourceAttr("alicloud_pvtz_zone_record.foo", "type", "A"),
-					resource.TestCheckResourceAttr("alicloud_pvtz_zone_record.foo", "priority", "5"),
+					resource.TestCheckResourceAttr("alicloud_pvtz_zone_record.foo", "value", "aaa.test.com"),
+					resource.TestCheckResourceAttr("alicloud_pvtz_zone_record.foo", "type", "MX"),
+					resource.TestCheckResourceAttr("alicloud_pvtz_zone_record.foo", "priority", "10"),
 					resource.TestCheckResourceAttr("alicloud_pvtz_zone_record.foo", "ttl", "60"),
 				),
 			},
@@ -198,9 +200,9 @@ func TestAccAlicloudPvtzZoneRecord_updatePriority(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccAlicloudPvtzZoneRecordExists("alicloud_pvtz_zone_record.foo", &record),
 					resource.TestCheckResourceAttr("alicloud_pvtz_zone_record.foo", "resource_record", "www"),
-					resource.TestCheckResourceAttr("alicloud_pvtz_zone_record.foo", "value", "2.2.2.2"),
-					resource.TestCheckResourceAttr("alicloud_pvtz_zone_record.foo", "type", "A"),
-					resource.TestCheckResourceAttr("alicloud_pvtz_zone_record.foo", "priority", "10"),
+					resource.TestCheckResourceAttr("alicloud_pvtz_zone_record.foo", "value", "aaa.test.com"),
+					resource.TestCheckResourceAttr("alicloud_pvtz_zone_record.foo", "type", "MX"),
+					resource.TestCheckResourceAttr("alicloud_pvtz_zone_record.foo", "priority", "20"),
 					resource.TestCheckResourceAttr("alicloud_pvtz_zone_record.foo", "ttl", "60"),
 				),
 			},
@@ -230,7 +232,7 @@ func TestAccAlicloudPvtzZoneRecord_updateTTL(t *testing.T) {
 					resource.TestCheckResourceAttr("alicloud_pvtz_zone_record.foo", "resource_record", "www"),
 					resource.TestCheckResourceAttr("alicloud_pvtz_zone_record.foo", "value", "2.2.2.2"),
 					resource.TestCheckResourceAttr("alicloud_pvtz_zone_record.foo", "type", "A"),
-					resource.TestCheckResourceAttr("alicloud_pvtz_zone_record.foo", "priority", "5"),
+					resource.TestCheckResourceAttr("alicloud_pvtz_zone_record.foo", "priority", "0"),
 					resource.TestCheckResourceAttr("alicloud_pvtz_zone_record.foo", "ttl", "60"),
 				),
 			},
@@ -241,7 +243,7 @@ func TestAccAlicloudPvtzZoneRecord_updateTTL(t *testing.T) {
 					resource.TestCheckResourceAttr("alicloud_pvtz_zone_record.foo", "resource_record", "www"),
 					resource.TestCheckResourceAttr("alicloud_pvtz_zone_record.foo", "value", "2.2.2.2"),
 					resource.TestCheckResourceAttr("alicloud_pvtz_zone_record.foo", "type", "A"),
-					resource.TestCheckResourceAttr("alicloud_pvtz_zone_record.foo", "priority", "5"),
+					resource.TestCheckResourceAttr("alicloud_pvtz_zone_record.foo", "priority", "0"),
 					resource.TestCheckResourceAttr("alicloud_pvtz_zone_record.foo", "ttl", "30"),
 				),
 			},
@@ -271,7 +273,7 @@ func TestAccAlicloudPvtzZoneRecord_updateAll(t *testing.T) {
 					resource.TestCheckResourceAttr("alicloud_pvtz_zone_record.foo", "resource_record", "www"),
 					resource.TestCheckResourceAttr("alicloud_pvtz_zone_record.foo", "value", "2.2.2.2"),
 					resource.TestCheckResourceAttr("alicloud_pvtz_zone_record.foo", "type", "A"),
-					resource.TestCheckResourceAttr("alicloud_pvtz_zone_record.foo", "priority", "5"),
+					resource.TestCheckResourceAttr("alicloud_pvtz_zone_record.foo", "priority", "0"),
 					resource.TestCheckResourceAttr("alicloud_pvtz_zone_record.foo", "ttl", "60"),
 				),
 			},
@@ -281,7 +283,7 @@ func TestAccAlicloudPvtzZoneRecord_updateAll(t *testing.T) {
 					testAccAlicloudPvtzZoneRecordExists("alicloud_pvtz_zone_record.foo", &record),
 					resource.TestCheckResourceAttr("alicloud_pvtz_zone_record.foo", "resource_record", "@"),
 					resource.TestCheckResourceAttr("alicloud_pvtz_zone_record.foo", "value", "bbb.test.com"),
-					resource.TestCheckResourceAttr("alicloud_pvtz_zone_record.foo", "type", "CNAME"),
+					resource.TestCheckResourceAttr("alicloud_pvtz_zone_record.foo", "type", "MX"),
 					resource.TestCheckResourceAttr("alicloud_pvtz_zone_record.foo", "priority", "10"),
 					resource.TestCheckResourceAttr("alicloud_pvtz_zone_record.foo", "ttl", "30"),
 				),
@@ -314,7 +316,7 @@ func TestAccAlicloudPvtzZoneRecord_multi(t *testing.T) {
 					resource.TestCheckResourceAttr(
 						"alicloud_pvtz_zone_record.bar_1", "type", "A"),
 					resource.TestCheckResourceAttr(
-						"alicloud_pvtz_zone_record.bar_1", "priority", "10"),
+						"alicloud_pvtz_zone_record.bar_1", "priority", "0"),
 					resource.TestCheckResourceAttr(
 						"alicloud_pvtz_zone_record.bar_1", "value", "2.2.2.2"),
 					testAccAlicloudPvtzZoneRecordExists("alicloud_pvtz_zone_record.bar_2", &record),
@@ -323,7 +325,7 @@ func TestAccAlicloudPvtzZoneRecord_multi(t *testing.T) {
 					resource.TestCheckResourceAttr(
 						"alicloud_pvtz_zone_record.bar_2", "type", "CNAME"),
 					resource.TestCheckResourceAttr(
-						"alicloud_pvtz_zone_record.bar_2", "priority", "5"),
+						"alicloud_pvtz_zone_record.bar_2", "priority", "0"),
 					resource.TestCheckResourceAttr(
 						"alicloud_pvtz_zone_record.bar_2", "value", "c.test.com"),
 					testAccAlicloudPvtzZoneRecordExists("alicloud_pvtz_zone_record.bar_3", &record),
@@ -332,7 +334,7 @@ func TestAccAlicloudPvtzZoneRecord_multi(t *testing.T) {
 					resource.TestCheckResourceAttr(
 						"alicloud_pvtz_zone_record.bar_3", "type", "A"),
 					resource.TestCheckResourceAttr(
-						"alicloud_pvtz_zone_record.bar_3", "priority", "3"),
+						"alicloud_pvtz_zone_record.bar_3", "priority", "0"),
 					resource.TestCheckResourceAttr(
 						"alicloud_pvtz_zone_record.bar_3", "value", "3.3.3.3"),
 				),
@@ -408,7 +410,6 @@ resource "alicloud_pvtz_zone_record" "foo" {
 	resource_record = "www"
 	type = "A"
 	value = "2.2.2.2"
-	priority = "5"
 	ttl = "60"
 }
 `
@@ -422,7 +423,6 @@ resource "alicloud_pvtz_zone_record" "foo" {
 	resource_record = "@"
 	type = "A"
 	value = "2.2.2.2"
-	priority = "5"
 	ttl = "60"
 }
 `
@@ -436,11 +436,9 @@ resource "alicloud_pvtz_zone_record" "foo" {
 	resource_record = "www"
 	type = "TXT"
 	value = "2.2.2.2"
-	priority = "5"
 	ttl = "60"
 }
 `
-
 const testAccPvtzZoneRecordConfigUpdateValue = `
 resource "alicloud_pvtz_zone" "zone" {
 	name = "tf-testacc.test.com"
@@ -451,7 +449,21 @@ resource "alicloud_pvtz_zone_record" "foo" {
 	resource_record = "www"
 	type = "A"
 	value = "2.2.2.3"
-	priority = "5"
+	ttl = "60"
+}
+`
+
+const testAccPvtzZoneRecordConfigPriority = `
+resource "alicloud_pvtz_zone" "zone" {
+	name = "tf-testacc.test.com"
+}
+
+resource "alicloud_pvtz_zone_record" "foo" {
+	zone_id = "${alicloud_pvtz_zone.zone.id}"
+	resource_record = "www"
+	type = "MX"
+	value = "aaa.test.com"
+	priority = "10"
 	ttl = "60"
 }
 `
@@ -464,9 +476,9 @@ resource "alicloud_pvtz_zone" "zone" {
 resource "alicloud_pvtz_zone_record" "foo" {
 	zone_id = "${alicloud_pvtz_zone.zone.id}"
 	resource_record = "www"
-	type = "A"
-	value = "2.2.2.2"
-	priority = "10"
+	type = "MX"
+	value = "aaa.test.com"
+	priority = "20"
 	ttl = "60"
 }
 `
@@ -481,7 +493,6 @@ resource "alicloud_pvtz_zone_record" "foo" {
 	resource_record = "www"
 	type = "A"
 	value = "2.2.2.2"
-	priority = "5"
 	ttl = "30"
 }
 `
@@ -494,7 +505,7 @@ resource "alicloud_pvtz_zone" "zone" {
 resource "alicloud_pvtz_zone_record" "foo" {
 	zone_id = "${alicloud_pvtz_zone.zone.id}"
 	resource_record = "@"
-	type = "CNAME"
+	type = "MX"
 	value = "bbb.test.com"
 	priority = "10"
 	ttl = "30"

--- a/examples/pvtz/main.tf
+++ b/examples/pvtz/main.tf
@@ -1,5 +1,5 @@
 resource "alicloud_pvtz_zone" "main" {
-  zone_name = "${var.long_name}"
+  name = "${var.long_name}"
 }
 
 resource "alicloud_pvtz_zone_record" "main" {
@@ -7,7 +7,6 @@ resource "alicloud_pvtz_zone_record" "main" {
   resource_record = "${var.resource_record}"
   type            = "${var.type}"
   value           = "${var.value}"
-  status          = "ENABLE"
   priority        = "${var.priority}"
 }
 
@@ -16,7 +15,7 @@ resource "alicloud_vpc" "main" {
   cidr_block = "${var.vpc_cidr}"
 }
 
-resource "alicloud_pvtz_zone_bind_vpc" "main" {
+resource "alicloud_pvtz_zone_attachment" "main" {
   zone_id = "${alicloud_pvtz_zone.main.id}"
   vpc_ids = ["${alicloud_vpc.main.id}"]
 }

--- a/examples/pvtz/variables.tf
+++ b/examples/pvtz/variables.tf
@@ -1,7 +1,3 @@
-variable "region" {
-  default = "cn-hangzhou"
-}
-
 variable "zone_name" {
   default = "www.test.com"
 }
@@ -18,12 +14,13 @@ variable "value" {
   default = "1.1.1.1"
 }
 
+// Only MX supports priority
 variable "priority" {
-  default = "5"
+  default = "10"
 }
 
 variable "long_name" {
-  default = "alicloud"
+  default = "alicloud.com"
 }
 
 variable "vpc_cidr" {

--- a/website/docs/r/pvtz_zone_record.html.markdown
+++ b/website/docs/r/pvtz_zone_record.html.markdown
@@ -10,7 +10,7 @@ description: |-
 
 Provides a Private Zone Record resource.
 
-~> **NOTE:** Terraform will auto Create a Private Zone Record while it uses `alicloud_pvtz_zone_record` to build a Private Zone Record resource.
+-> **NOTE:** Terraform will auto Create a Private Zone Record while it uses `alicloud_pvtz_zone_record` to build a Private Zone Record resource.
 
 ## Example Usage
 
@@ -27,7 +27,6 @@ resource "alicloud_pvtz_zone_record" "foo" {
 	type = "CNAME"
 	value = "bbb.test.com"
 	ttl="60
-	priority = "6"
 }
 ```
 ## Argument Reference
@@ -36,11 +35,10 @@ The following arguments are supported:
 
 * `zone_id` - (Required, Forces new resource) The name of the Private Zone Record.
 * `resource_record` - (Required) The resource record of the Private Zone Record.
-* `type` - (Required) The type of the Private Zone Record.
+* `type` - (Required) The type of the Private Zone Record. Valid values: A, CNAME, TXT, MX, PTR.
 * `value` - (Required) The value of the Private Zone Record.
-* `status` - (Optional) The status of the Private Zone Record.
 * `ttl` - (Optional) The ttl of the Private Zone Record.
-* `priority` - (Optional) The priority of the Private Zone Record.
+* `priority` - (Optional) The priority of the Private Zone Record. At present, only can "MX" record support it. Valid values: [1-50]. Default to 1.
 
 ## Attributes Reference
 


### PR DESCRIPTION
```
TF_ACC=1 go test ./alicloud -v -run=TestAccAlicloudPvtzZoneRecord_ -timeout=120m
=== RUN   TestAccAlicloudPvtzZoneRecord_importBasic
--- PASS: TestAccAlicloudPvtzZoneRecord_importBasic (2.91s)
=== RUN   TestAccAlicloudPvtzZoneRecord_Basic
--- PASS: TestAccAlicloudPvtzZoneRecord_Basic (1.61s)
=== RUN   TestAccAlicloudPvtzZoneRecord_updateRr
--- PASS: TestAccAlicloudPvtzZoneRecord_updateRr (2.34s)
=== RUN   TestAccAlicloudPvtzZoneRecord_updateType
--- PASS: TestAccAlicloudPvtzZoneRecord_updateType (2.35s)
=== RUN   TestAccAlicloudPvtzZoneRecord_updateValue
--- PASS: TestAccAlicloudPvtzZoneRecord_updateValue (2.40s)
=== RUN   TestAccAlicloudPvtzZoneRecord_updatePriority
--- PASS: TestAccAlicloudPvtzZoneRecord_updatePriority (2.33s)
=== RUN   TestAccAlicloudPvtzZoneRecord_updateTTL
--- PASS: TestAccAlicloudPvtzZoneRecord_updateTTL (2.30s)
=== RUN   TestAccAlicloudPvtzZoneRecord_updateAll
--- PASS: TestAccAlicloudPvtzZoneRecord_updateAll (2.30s)
=== RUN   TestAccAlicloudPvtzZoneRecord_multi
--- PASS: TestAccAlicloudPvtzZoneRecord_multi (3.31s)
PASS
ok      github.com/terraform-providers/terraform-provider-alicloud/alicloud     21.914s

```