### PR TITLE
fixed bug in backup policy update

### DIFF
--- a/alicloud/resource_alicloud_kvstore_backup_policy.go
+++ b/alicloud/resource_alicloud_kvstore_backup_policy.go
@@ -94,24 +94,14 @@ func resourceAlicloudKVStoreBackupPolicyRead(d *schema.ResourceData, meta interf
 }
 
 func resourceAlicloudKVStoreBackupPolicyUpdate(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*connectivity.AliyunClient)
-	update := false
-	request := r_kvstore.CreateModifyBackupPolicyRequest()
-	request.InstanceId = d.Id()
-
-	if d.HasChange("backup_time") {
+	if d.HasChange("backup_time") || d.HasChange("backup_period") {
+		client := meta.(*connectivity.AliyunClient)
+		request := r_kvstore.CreateModifyBackupPolicyRequest()
+		request.InstanceId = d.Id()
 		request.PreferredBackupTime = d.Get("backup_time").(string)
-		update = true
-	}
-
-	if d.HasChange("backup_period") {
 		periodList := expandStringList(d.Get("backup_period").(*schema.Set).List())
 		backupPeriod := fmt.Sprintf("%s", strings.Join(periodList[:], COMMA_SEPARATED))
 		request.PreferredBackupPeriod = backupPeriod
-		update = true
-	}
-
-	if update {
 		_, err := client.WithRkvClient(func(rkvClient *r_kvstore.Client) (interface{}, error) {
 			return rkvClient.ModifyBackupPolicy(request)
 		})

--- a/website/docs/r/kvstore_backup_policy.html.markdown
+++ b/website/docs/r/kvstore_backup_policy.html.markdown
@@ -25,8 +25,8 @@ resource "alicloud_kvstore_backup_policy" "redisbackup" {
 The following arguments are supported:
 
 * `instance_id` - (Required) The id of ApsaraDB for Redis or Memcache intance.
-* `preferred_backup_time`- (Required) Backup time, in the format of HH:mmZ- HH:mm Z
-* `preferred_backup_period` - (Required) Backup Cycle. Allowed values: Monday, Tuesday, Wednesday, Thursday, Friday, Saturday, Sunday
+* `backup_time` - (Required) Backup time, in the format of HH:mmZ- HH:mm Z
+* `backup_period` - (Required) Backup Cycle. Allowed values: Monday, Tuesday, Wednesday, Thursday, Friday, Saturday, Sunday
 
 ## Attributes Reference
 
@@ -34,8 +34,8 @@ The following attributes are exported:
 
 * `id` - The id of the backup policy.
 * `instance_id` - The id of ApsaraDB for Redis or Memcache intance.
-* `preferred_backup_time`- Backup time, in the format of HH:mmZ- HH:mm Z
-* `preferred_backup_period` - Backup Cycle. Allowed values: Monday, Tuesday, Wednesday, Thursday, Friday, Saturday, Sunday
+* `backup_time` - Backup time, in the format of HH:mmZ- HH:mm Z
+* `backup_period` - Backup Cycle. Allowed values: Monday, Tuesday, Wednesday, Thursday, Friday, Saturday, Sunday
 
 ## Import
 


### PR DESCRIPTION
If backup policy is updated there was an error since required parameters where not set.
Also fixed docs: backup policy input parameters have been aligned with resource provider names. 