### PR TITLE
Skip automatically the testcases which does not support classic regions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 IMPROVEMENTS:
 
+- Skip automatically the testcases which does not support classic regions [GH-524]
+- datasource alicloud_slbs support tags [GH-523]
+- resouce alicloud_slb support tags [GH-522]
 - Skip automatically the testcases which does not support multi az regions [GH-518]
 - Add some region limitation guide for sone resources [GH-517]
 - Skip automatically the testcases which does not support some known regions [GH-516]

--- a/alicloud/import_alicloud_security_group_test.go
+++ b/alicloud/import_alicloud_security_group_test.go
@@ -4,13 +4,14 @@ import (
 	"testing"
 
 	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/terraform-providers/terraform-provider-alicloud/alicloud/connectivity"
 )
 
 func TestAccAlicloudSecurityGroup_importBasic(t *testing.T) {
 	resourceName := "alicloud_security_group.foo"
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { testAccPreCheckWithRegions(t, true, connectivity.EcsClassicSupportedRegions) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckSecurityGroupDestroy,
 		Steps: []resource.TestStep{

--- a/alicloud/resource_alicloud_security_group_rule_test.go
+++ b/alicloud/resource_alicloud_security_group_rule_test.go
@@ -19,7 +19,7 @@ func TestAccAlicloudSecurityGroupRule_Ingress(t *testing.T) {
 
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
-			testAccPreCheck(t)
+			testAccPreCheckWithRegions(t, true, connectivity.EcsClassicSupportedRegions)
 		},
 
 		// module name
@@ -56,7 +56,7 @@ func TestAccAlicloudSecurityGroupRule_Egress(t *testing.T) {
 
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
-			testAccPreCheck(t)
+			testAccPreCheckWithRegions(t, true, connectivity.EcsClassicSupportedRegions)
 		},
 
 		// module name
@@ -109,7 +109,7 @@ func TestAccAlicloudSecurityGroupRule_EgressDefaultNicType(t *testing.T) {
 					resource.TestCheckResourceAttr(
 						"alicloud_security_group_rule.egress",
 						"nic_type",
-						"internet"),
+						"intranet"),
 				),
 			},
 		},
@@ -175,7 +175,7 @@ func TestAccAlicloudSecurityGroupRule_MissParameterSourceCidrIp(t *testing.T) {
 					resource.TestCheckResourceAttr(
 						"alicloud_security_group_rule.egress",
 						"nic_type",
-						"internet"),
+						"intranet"),
 					resource.TestCheckResourceAttr(
 						"alicloud_security_group_rule.egress",
 						"ip_protocol",
@@ -414,8 +414,17 @@ resource "alicloud_security_group_rule" "egress" {
 `
 
 const testAccSecurityGroupRuleEgress_emptyNicType = `
+variable "name" {
+  default = "tf-testAccSecurityGroupRuleEgress_emptyNicType"
+}
+
+resource "alicloud_vpc" "vpc" {
+  name = "${var.name}"
+  cidr_block = "172.16.0.0/24"
+}
 resource "alicloud_security_group" "foo" {
-  name = "tf-testAccSecurityGroupRuleEgress_emptyNicType"
+  name = "${var.name}"
+  vpc_id = "${alicloud_vpc.vpc.id}"
 }
 
 resource "alicloud_security_group_rule" "egress" {
@@ -457,8 +466,17 @@ resource "alicloud_security_group_rule" "ingress" {
 
 `
 const testAccSecurityGroupRule_missingSourceCidrIp = `
+variable "name" {
+  default = "tf-testAccSecurityGroupRule_missingSourceCidrIp"
+}
 resource "alicloud_security_group" "foo" {
-  name = "tf-testAccSecurityGroupRule_missingSourceCidrIp"
+  name = "${var.name}"
+  vpc_id = "${alicloud_vpc.vpc.id}"
+}
+
+resource "alicloud_vpc" "vpc" {
+  name = "${var.name}"
+  cidr_block = "172.16.0.0/24"
 }
 
 resource "alicloud_security_group_rule" "egress" {
@@ -488,16 +506,6 @@ variable "cidr_ip_list_2" {
 resource "alicloud_vpc" "main" {
   name = "${var.name}"
   cidr_block = "10.1.0.0/21"
-}
-
-data "alicloud_zones" "main" {
-  	available_resource_creation = "VSwitch"
-}
-resource "alicloud_vswitch" "main" {
-  name = "${var.name}"
-  vpc_id = "${alicloud_vpc.main.id}"
-  cidr_block = "10.1.1.0/24"
-  availability_zone = "${data.alicloud_zones.main.zones.0.id}"
 }
 
 resource "alicloud_security_group" "foo" {
@@ -537,12 +545,18 @@ const testAccSecurityGroupRuleSourceSecurityGroup = `
 variable "name" {
   default = "tf-testAccSecurityGroupRuleSourceSecurityGroup"
 }
+resource "alicloud_vpc" "vpc" {
+  name = "${var.name}"
+  cidr_block = "172.16.0.0/24"
+}
 resource "alicloud_security_group" "foo" {
   name = "${var.name}-foo"
+  vpc_id = "${alicloud_vpc.vpc.id}"
 }
 
 resource "alicloud_security_group" "bar" {
   name = "${var.name}_bar"
+  vpc_id = "${alicloud_vpc.vpc.id}"
 }
 
 resource "alicloud_security_group_rule" "ingress" {

--- a/alicloud/resource_alicloud_security_group_test.go
+++ b/alicloud/resource_alicloud_security_group_test.go
@@ -103,7 +103,7 @@ func TestAccAlicloudSecurityGroup_basic(t *testing.T) {
 
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
-			testAccPreCheck(t)
+			testAccPreCheckWithRegions(t, true, connectivity.EcsClassicSupportedRegions)
 		},
 
 		// module name


### PR DESCRIPTION
```
TF_ACC=1 go test ./alicloud -v -run=TestAccAlicloudSecurityGroup -timeout=120m
=== RUN   TestAccAlicloudSecurityGroupRulesDataSource
--- PASS: TestAccAlicloudSecurityGroupRulesDataSource (58.92s)
=== RUN   TestAccAlicloudSecurityGroupsDataSource
--- PASS: TestAccAlicloudSecurityGroupsDataSource (40.95s)
=== RUN   TestAccAlicloudSecurityGroupsDataSource_tags
--- PASS: TestAccAlicloudSecurityGroupsDataSource_tags (36.97s)
=== RUN   TestAccAlicloudSecurityGroup_importBasic
--- SKIP: TestAccAlicloudSecurityGroup_importBasic (0.00s)
        provider_test.go:73: Skipping unsupported region ap-south-1. Supported regions: [cn-shenzhen cn-shanghai cn-beijing cn-qingdao cn-hangzhou cn-hongkong us-west-1 ap-southeast-1].
=== RUN   TestAccAlicloudSecurityGroup_importWithVpc
--- PASS: TestAccAlicloudSecurityGroup_importWithVpc (36.05s)
=== RUN   TestAccAlicloudSecurityGroupRule_Ingress
--- SKIP: TestAccAlicloudSecurityGroupRule_Ingress (0.00s)
        provider_test.go:73: Skipping unsupported region ap-south-1. Supported regions: [cn-shenzhen cn-shanghai cn-beijing cn-qingdao cn-hangzhou cn-hongkong us-west-1 ap-southeast-1].
=== RUN   TestAccAlicloudSecurityGroupRule_Egress
--- SKIP: TestAccAlicloudSecurityGroupRule_Egress (0.00s)
        provider_test.go:73: Skipping unsupported region ap-south-1. Supported regions: [cn-shenzhen cn-shanghai cn-beijing cn-qingdao cn-hangzhou cn-hongkong us-west-1 ap-southeast-1].
=== RUN   TestAccAlicloudSecurityGroupRule_EgressDefaultNicType
--- PASS: TestAccAlicloudSecurityGroupRule_EgressDefaultNicType (41.10s)
=== RUN   TestAccAlicloudSecurityGroupRule_Vpc_Ingress
--- PASS: TestAccAlicloudSecurityGroupRule_Vpc_Ingress (33.29s)
=== RUN   TestAccAlicloudSecurityGroupRule_MissParameterSourceCidrIp
--- PASS: TestAccAlicloudSecurityGroupRule_MissParameterSourceCidrIp (49.42s)
=== RUN   TestAccAlicloudSecurityGroupRule_SourceSecurityGroup
--- PASS: TestAccAlicloudSecurityGroupRule_SourceSecurityGroup (52.33s)
=== RUN   TestAccAlicloudSecurityGroupRule_Multi
--- PASS: TestAccAlicloudSecurityGroupRule_Multi (71.71s)
=== RUN   TestAccAlicloudSecurityGroupRule_MultiAttri
--- PASS: TestAccAlicloudSecurityGroupRule_MultiAttri (80.70s)
=== RUN   TestAccAlicloudSecurityGroup_basic
--- SKIP: TestAccAlicloudSecurityGroup_basic (0.00s)
        provider_test.go:73: Skipping unsupported region ap-south-1. Supported regions: [cn-shenzhen cn-shanghai cn-beijing cn-qingdao cn-hangzhou cn-hongkong us-west-1 ap-southeast-1].
=== RUN   TestAccAlicloudSecurityGroup_withVpc
--- PASS: TestAccAlicloudSecurityGroup_withVpc (33.52s)
=== RUN   TestAccAlicloudSecurityGroup_tags
--- PASS: TestAccAlicloudSecurityGroup_tags (48.27s)
PASS
ok      github.com/terraform-providers/terraform-provider-alicloud/alicloud     583.295s
```