### PR TITLE
fix a snat_entry bug without set id to empty

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ IMPROVEMENTS:
 
 BUG FIXES:
 
+- fix a snat_entry bug without set id to empty [GH-525]
 - fix a bug of ram_use display name [GH-519]
 - fix a bug of instance testcase [GH-513]
 - Fix pvtz resource priority bug [GH-511]

--- a/alicloud/resource_alicloud_snat.go
+++ b/alicloud/resource_alicloud_snat.go
@@ -75,6 +75,7 @@ func resourceAliyunSnatEntryRead(d *schema.ResourceData, meta interface{}) error
 
 	if err != nil {
 		if NotFoundError(err) {
+			d.SetId("")
 			return nil
 		}
 		return err


### PR DESCRIPTION
```
TF_ACC=1 go test ./alicloud -v -run=TestAccAlicloudSnat_multi -timeout=120m
=== RUN   TestAccAlicloudSnat_multi
--- PASS: TestAccAlicloudSnat_multi (260.06s)
PASS
ok      github.com/terraform-providers/terraform-provider-alicloud/alicloud     260.128s
```