### PR TITLE
Fix router interface prepaid purchase

### DIFF
--- a/alicloud/service_alicloud_vpc.go
+++ b/alicloud/service_alicloud_vpc.go
@@ -351,10 +351,11 @@ func (s *VpcService) WaitForRouterInterface(regionId, interfaceId string, status
 		timeout = DefaultTimeout
 	}
 	for {
-		time.Sleep(DefaultIntervalShort * time.Second)
 		result, err := s.DescribeRouterInterface(regionId, interfaceId)
 		if err != nil {
-			return err
+			if !NotFoundError(err) {
+				return err
+			}
 		} else if result.Status == string(status) {
 			break
 		}


### PR DESCRIPTION
MacBook-Pro-2:terraform-provider-alicloud jince$ TF_ACC=1 go test ./alicloud -v -run=TestAccAlicloudRouterInterface -timeout=300m
=== RUN   TestAccAlicloudRouterInterfacesDataSource_oneRouter
--- PASS: TestAccAlicloudRouterInterfacesDataSource_oneRouter (11.84s)
=== RUN   TestAccAlicloudRouterInterfacesDataSource_twoRouters
--- PASS: TestAccAlicloudRouterInterfacesDataSource_twoRouters (81.11s)
=== RUN   TestAccAlicloudRouterInterface_import
--- PASS: TestAccAlicloudRouterInterface_import (16.31s)
=== RUN   TestAccAlicloudRouterInterfaceConnection_basic
--- PASS: TestAccAlicloudRouterInterfaceConnection_basic (80.58s)
=== RUN   TestAccAlicloudRouterInterface_basic
--- PASS: TestAccAlicloudRouterInterface_basic (19.13s)
PASS
ok  	github.com/terraform-providers/terraform-provider-alicloud/alicloud	209.008s
MacBook-Pro-2:terraform-provider-alicloud jince$ TF_ACC=1 go test ./alicloud -v -run=TestAccAlicloudCommonBandwidthPackage -timeout=300m
=== RUN   TestAccAlicloudCommonBandwidthPackage_importBasic
--- PASS: TestAccAlicloudCommonBandwidthPackage_importBasic (12.60s)
=== RUN   TestAccAlicloudCommonBandwidthPackageAttachment_basic
--- PASS: TestAccAlicloudCommonBandwidthPackageAttachment_basic (8.72s)
=== RUN   TestAccAlicloudCommonBandwidthPackage_basic
--- PASS: TestAccAlicloudCommonBandwidthPackage_basic (11.74s)
PASS
ok  	github.com/terraform-providers/terraform-provider-alicloud/alicloud	33.113s