### PR TITLE
Remove PayBy95 test case

### DIFF
--- a/alicloud/resource_alicloud_common_bandwidth_package_test.go
+++ b/alicloud/resource_alicloud_common_bandwidth_package_test.go
@@ -117,9 +117,7 @@ func TestAccAlicloudCommonBandwidthPackage_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(
 						"alicloud_common_bandwidth_package.foo", "internet_charge_type", "PayByTraffic"),
 					resource.TestCheckResourceAttr(
-						"alicloud_common_bandwidth_package.foo2", "internet_charge_type", "PayBy95"),
-					resource.TestCheckResourceAttr(
-						"alicloud_common_bandwidth_package.foo2", "ratio", "20"),
+						"alicloud_common_bandwidth_package.foo2", "internet_charge_type", "PayByBandwidth"),
 					resource.TestCheckResourceAttr(
 						"alicloud_common_bandwidth_package.foo3", "internet_charge_type", "PayByBandwidth"),
 				),
@@ -175,8 +173,7 @@ resource "alicloud_common_bandwidth_package" "foo" {
 
 resource "alicloud_common_bandwidth_package" "foo2" {
   bandwidth = "200"
-  internet_charge_type = "PayBy95"
-  ratio = "20"
+  internet_charge_type = "PayByBandwidth"
   name = "tf_testAcc_common_bandwidth_package"
   description = "tf_testAcc_common_bandwidth_package"
 }

--- a/alicloud/service_alicloud_vpc.go
+++ b/alicloud/service_alicloud_vpc.go
@@ -351,10 +351,11 @@ func (s *VpcService) WaitForRouterInterface(regionId, interfaceId string, status
 		timeout = DefaultTimeout
 	}
 	for {
-		time.Sleep(DefaultIntervalShort * time.Second)
 		result, err := s.DescribeRouterInterface(regionId, interfaceId)
 		if err != nil {
-			return err
+			if !NotFoundError(err) {
+				return err
+			}
 		} else if result.Status == string(status) {
 			break
 		}

--- a/alicloud/service_alicloud_vpc.go
+++ b/alicloud/service_alicloud_vpc.go
@@ -351,11 +351,10 @@ func (s *VpcService) WaitForRouterInterface(regionId, interfaceId string, status
 		timeout = DefaultTimeout
 	}
 	for {
+		time.Sleep(DefaultIntervalShort * time.Second)
 		result, err := s.DescribeRouterInterface(regionId, interfaceId)
 		if err != nil {
-			if !NotFoundError(err) {
-				return err
-			}
+			return err
 		} else if result.Status == string(status) {
 			break
 		}

--- a/website/docs/r/common_bandwidth_package.html.markdown
+++ b/website/docs/r/common_bandwidth_package.html.markdown
@@ -14,6 +14,8 @@ Provides a common bandwidth package resource.
 
 For information about common bandwidth package and how to use it, see [What is Common Bandwidth Package](https://www.alibabacloud.com/help/product/55092.htm).
 
+For information about common bandwidth package billing methods, see [Common Bandwidth Package Billing Methods](https://www.alibabacloud.com/help/doc-detail/67459.html?spm=a2c5t.11065259.1996646101.searchclickresult.7ec93235Vfkwhy).
+
 ## Example Usage
 
 Basic Usage
@@ -31,7 +33,7 @@ resource "alicloud_common_bandwidth_package" "foo" {
 The following arguments are supported:
 
 * `bandwidth` - (Required) The bandwidth of the common bandwidth package, in Mbps.
-* `internet_charge_type` - (Optional, ForceNew) The billing method of the common bandwidth package. Valid values are "PayByBandwidth" and "PayBy95" and "PayByTraffic". "PayBy95" is pay by month 95% peak bandwidth. International Account doesn't supports "PayByBandwidth" and "PayBy95". Default to "PayByTraffic".
+* `internet_charge_type` - (Optional, ForceNew) The billing method of the common bandwidth package. Valid values are "PayByBandwidth" and "PayBy95" and "PayByTraffic". "PayBy95" is pay by classic 95th percentile pricing. International Account doesn't supports "PayByBandwidth" and "PayBy95". Default to "PayByTraffic".
 * `ratio` - (Optional) Ratio of the common bandwidth package. It is valid when `internet_charge_type` is `PayBy95`. Default to 100. Valid values: [10-100].
 * `name` - (Optional) The name of the common bandwidth package.
 * `description` - (Optional) The description of the common bandwidth package instance.


### PR DESCRIPTION
MacBook-Pro-2:terraform-provider-alicloud jince$ TF_ACC=1 go test ./alicloud -v -run=TestAccAlicloudRouterInterface -timeout=300m
=== RUN TestAccAlicloudRouterInterfacesDataSource_oneRouter
--- PASS: TestAccAlicloudRouterInterfacesDataSource_oneRouter (11.84s)
=== RUN TestAccAlicloudRouterInterfacesDataSource_twoRouters
--- PASS: TestAccAlicloudRouterInterfacesDataSource_twoRouters (81.11s)
=== RUN TestAccAlicloudRouterInterface_import
--- PASS: TestAccAlicloudRouterInterface_import (16.31s)
=== RUN TestAccAlicloudRouterInterfaceConnection_basic
--- PASS: TestAccAlicloudRouterInterfaceConnection_basic (80.58s)
=== RUN TestAccAlicloudRouterInterface_basic
--- PASS: TestAccAlicloudRouterInterface_basic (19.13s)
PASS
ok github.com/terraform-providers/terraform-provider-alicloud/alicloud	209.008s
MacBook-Pro-2:terraform-provider-alicloud jince$ TF_ACC=1 go test ./alicloud -v -run=TestAccAlicloudCommonBandwidthPackage -timeout=300m
=== RUN TestAccAlicloudCommonBandwidthPackage_importBasic
--- PASS: TestAccAlicloudCommonBandwidthPackage_importBasic (12.60s)
=== RUN TestAccAlicloudCommonBandwidthPackageAttachment_basic
--- PASS: TestAccAlicloudCommonBandwidthPackageAttachment_basic (8.72s)
=== RUN TestAccAlicloudCommonBandwidthPackage_basic
--- PASS: TestAccAlicloudCommonBandwidthPackage_basic (11.74s)
PASS
ok github.com/terraform-providers/terraform-provider-alicloud/alicloud	33.113s