### PR TITLE
Fix route_entry concurrence bug and improve it testcases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 IMPROVEMENTS:
 
+- Improve common bandwidth package test case and remove PayBy95 [GH-530]
 - Update resource drds supported regions [GH-534]
 - Remove DB instance engine_version limitation [GH-528]
 - Skip automatically the testcases which does not support route table and classic drds [GH-526]
@@ -17,6 +18,8 @@ IMPROVEMENTS:
 
 BUG FIXES:
 
+- Fix route_entry concurrence bug and improve it testcases [GH-537]
+- Fix router interface prepaid purchase [GH-529]
 - Fix fc_service sweeper test bug [GH-536]
 - Fix drds creating VPC instance bug by adding vpc_id [GH-531]
 - fix a snat_entry bug without set id to empty [GH-525]

--- a/alicloud/errors.go
+++ b/alicloud/errors.go
@@ -84,7 +84,7 @@ const (
 	// vswitch
 	VswitcInvalidRegionId    = "InvalidRegionId.NotFound"
 	InvalidVswitchIDNotFound = "InvalidVswitchID.NotFound"
-	//vroute entry
+	//route entry
 	IncorrectRouteEntryStatus            = "IncorrectRouteEntryStatus"
 	InvalidStatusRouteEntry              = "InvalidStatus.RouteEntry"
 	TaskConflict                         = "TaskConflict"
@@ -93,6 +93,7 @@ const (
 	InvalidCidrBlockOverlapped           = "InvalidCidrBlock.Overlapped"
 	IncorrectOppositeInterfaceInfoNotSet = "IncorrectOppositeInterfaceInfo.NotSet"
 	InvalidSnatTableIdNotFound           = "InvalidSnatTableId.NotFound"
+	InvalidRouteEntryNotFound            = "InvalidRouteEntry.NotFound"
 	// Forward
 	InvalidIpNotInNatgw           = "InvalidIp.NotInNatgw"
 	InvalidForwardTableIdNotFound = "InvalidForwardTableId.NotFound"

--- a/alicloud/extension_vpc.go
+++ b/alicloud/extension_vpc.go
@@ -45,11 +45,12 @@ const (
 type NextHopType string
 
 const (
-	NextHopIntance         = NextHopType("Instance") //Default
-	NextHopTunnel          = NextHopType("Tunnel")
-	NextHopRouterInterface = NextHopType("RouterInterface")
-	NextHopHaVip           = NextHopType("HaVip")
-	NextHopVpnGateway      = NextHopType("VpnGateway")
+	NextHopIntance          = NextHopType("Instance") //Default
+	NextHopTunnel           = NextHopType("Tunnel")
+	NextHopRouterInterface  = NextHopType("RouterInterface")
+	NextHopHaVip            = NextHopType("HaVip")
+	NextHopVpnGateway       = NextHopType("VpnGateway")
+	NextHopNetworkInterface = NextHopType("NetworkInterface")
 )
 
 func GetAllRouterInterfaceSpec() (specifications []string) {

--- a/alicloud/validators.go
+++ b/alicloud/validators.go
@@ -207,17 +207,6 @@ func validateIpAddress(v interface{}, k string) (ws []string, errors []error) {
 	return
 }
 
-func validateRouteEntryNextHopType(v interface{}, k string) (ws []string, errors []error) {
-	nht := NextHopType(v.(string))
-	if nht != NextHopIntance && nht != NextHopRouterInterface && nht != NextHopHaVip &&
-		nht != NextHopTunnel && nht != NextHopVpnGateway {
-		errors = append(errors, fmt.Errorf("%s must be one of %s %s %s %s %s", k,
-			NextHopIntance, NextHopRouterInterface, NextHopTunnel, NextHopHaVip, NextHopVpnGateway))
-	}
-
-	return
-}
-
 func validateSwitchCIDRNetworkAddress(v interface{}, k string) (ws []string, errors []error) {
 	value := v.(string)
 	_, ipnet, err := net.ParseCIDR(value)

--- a/alicloud/validators_test.go
+++ b/alicloud/validators_test.go
@@ -236,24 +236,6 @@ func TestValidateCIDRNetworkAddress(t *testing.T) {
 	}
 }
 
-func TestValidateRouteEntryNextHopType(t *testing.T) {
-	validNexthopType := []string{"Instance", "RouterInterface"}
-	for _, v := range validNexthopType {
-		_, errors := validateRouteEntryNextHopType(v, "route_entry_nexthop_type")
-		if len(errors) != 0 {
-			t.Fatalf("%q should be a valid route entry nexthop type: %q", v, errors)
-		}
-	}
-
-	invalidNexthopType := []string{"ri", "vpc"}
-	for _, v := range invalidNexthopType {
-		_, errors := validateRouteEntryNextHopType(v, "route_entry_nexthop_type")
-		if len(errors) == 0 {
-			t.Fatalf("%q should be an invalid route entry nexthop type", v)
-		}
-	}
-}
-
 func TestValidateSwitchCIDRNetworkAddress(t *testing.T) {
 	validSwitchCIDRNetworkAddress := []string{"192.168.10.0/24", "0.0.0.0/16", "127.0.0.0/29", "10.121.10.0/24"}
 	for _, v := range validSwitchCIDRNetworkAddress {

--- a/website/alicloud.erb
+++ b/website/alicloud.erb
@@ -269,7 +269,7 @@
                             <a href="/docs/providers/alicloud/r/vswitch.html">alicloud_vswitch</a>
                         </li>
                         <li<%= sidebar_current("docs-alicloud-resource-route-entry") %>>
-                            <a href="/docs/providers/alicloud/r/vroute_entry.html">alicloud_route_entry</a>
+                            <a href="/docs/providers/alicloud/r/route_entry.html">alicloud_route_entry</a>
                         </li>
                         <li<%= sidebar_current("docs-alicloud-resource-route-table") %>>
                             <a href="/docs/providers/alicloud/r/route_table.html">alicloud_route_table</a>

--- a/website/docs/r/route_entry.html.markdown
+++ b/website/docs/r/route_entry.html.markdown
@@ -43,6 +43,7 @@ The following arguments are supported:
     - `RouterInterface`: Route the traffic destined for the destination CIDR block to a router interface.
     - `VpnGateway`: Route the traffic destined for the destination CIDR block to a VPN Gateway.
     - `HaVip`: Route the traffic destined for the destination CIDR block to an HAVIP.
+    - `NetworkInterface`: Route the traffic destined for the destination CIDR block to an NetworkInterface.
 
 * `nexthop_id` - (Required, Forces new resource) The route entry's next hop. ECS instance ID or VPC router interface ID.
 


### PR DESCRIPTION
```
TF_ACC=1 go test ./alicloud -v -run=TestAccAlicloudRouteEntry -timeout=120m
=== RUN   TestAccAlicloudRouteEntry_importBasic
--- PASS: TestAccAlicloudRouteEntry_importBasic (187.13s)
=== RUN   TestAccAlicloudRouteEntry_Basic
--- PASS: TestAccAlicloudRouteEntry_Basic (190.97s)
=== RUN   TestAccAlicloudRouteEntry_RouteInterface
--- PASS: TestAccAlicloudRouteEntry_RouteInterface (71.02s)
=== RUN   TestAccAlicloudRouteEntry_Concurrence
--- PASS: TestAccAlicloudRouteEntry_Concurrence (110.13s)
ok
PASS    github.com/terraform-providers/terraform-provider-alicloud/alicloud     559.318s
```