### PR TITLE
fix listener deleted bug for resource alicloud_slb_listener.

### DIFF
--- a/alicloud/resource_alicloud_slb_listener.go
+++ b/alicloud/resource_alicloud_slb_listener.go
@@ -652,7 +652,6 @@ func resourceAliyunSlbListenerDelete(d *schema.ResourceData, meta interface{}) e
 		}
 		return fmt.Errorf("Get slb listener got an error: %#v", err)
 	}
-
 	req := slb.CreateDeleteLoadBalancerListenerRequest()
 	req.LoadBalancerId = lb_id
 	req.ListenerPort = requests.NewInteger(port)
@@ -768,7 +767,7 @@ func parseListenerId(d *schema.ResourceData, meta interface{}) (string, string, 
 			return loadBalancer.LoadBalancerId, portAndProtocol.ListenerProtocol, port, nil
 		}
 	}
-	return "", "", 0, nil
+	return "", "", 0, GetNotFoundErrorFromString(GetNotFoundMessage("Listener", d.Id()))
 }
 
 func readListenerAttribute(d *schema.ResourceData, protocol string, listen map[string]interface{}, err error) *resource.RetryError {


### PR DESCRIPTION
TF_ACC=1 go test ./alicloud -v -run=TestAccAlicloudSlbListener -timeout=300m count=1
=== RUN   TestAccAlicloudSlbListenersDataSource_http
--- PASS: TestAccAlicloudSlbListenersDataSource_http (34.24s)
=== RUN   TestAccAlicloudSlbListenersDataSource_https
--- PASS: TestAccAlicloudSlbListenersDataSource_https (15.09s)
=== RUN   TestAccAlicloudSlbListenersDataSource_tcp
--- PASS: TestAccAlicloudSlbListenersDataSource_tcp (32.13s)
=== RUN   TestAccAlicloudSlbListenersDataSource_udp
--- PASS: TestAccAlicloudSlbListenersDataSource_udp (35.64s)
=== RUN   TestAccAlicloudSlbListener_importHttp
--- PASS: TestAccAlicloudSlbListener_importHttp (16.62s)
=== RUN   TestAccAlicloudSlbListener_importHttps
--- PASS: TestAccAlicloudSlbListener_importHttps (15.00s)
=== RUN   TestAccAlicloudSlbListener_importTcp
--- PASS: TestAccAlicloudSlbListener_importTcp (13.81s)
=== RUN   TestAccAlicloudSlbListener_importUdp
--- PASS: TestAccAlicloudSlbListener_importUdp (12.14s)
=== RUN   TestAccAlicloudSlbListener_http
--- PASS: TestAccAlicloudSlbListener_http (13.04s)
=== RUN   TestAccAlicloudSlbListener_https
--- PASS: TestAccAlicloudSlbListener_https (21.42s)
=== RUN   TestAccAlicloudSlbListener_https_shared_performance
--- PASS: TestAccAlicloudSlbListener_https_shared_performance (14.84s)
=== RUN   TestAccAlicloudSlbListener_tcp
--- PASS: TestAccAlicloudSlbListener_tcp (10.46s)
=== RUN   TestAccAlicloudSlbListener_udp
--- PASS: TestAccAlicloudSlbListener_udp (10.91s)
