### PR TITLE
Fix pvtz_record describing bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,9 @@
 ## 1.26.0 (Unreleased)
+
+BUG FIXES:
+
+- Fix pvtz_record describing bug [GH-543]
+
 ## 1.25.0 (November 30, 2018)
 
 IMPROVEMENTS:

--- a/alicloud/resource_alicloud_pvtz_zone_record.go
+++ b/alicloud/resource_alicloud_pvtz_zone_record.go
@@ -167,6 +167,7 @@ func resourceAlicloudPvtzZoneRecordRead(d *schema.ResourceData, meta interface{}
 	if err != nil {
 		if NotFoundError(e) {
 			d.SetId("")
+			return nil
 		}
 
 		return err


### PR DESCRIPTION
```
TF_ACC=1 go test ./alicloud -v -run=TestAccAlicloudPvtzZoneRecord -timeout=120m
=== RUN   TestAccAlicloudPvtzZoneRecordsDataSource_basic
--- PASS: TestAccAlicloudPvtzZoneRecordsDataSource_basic (2.44s)
=== RUN   TestAccAlicloudPvtzZoneRecordsDataSource_empty
--- PASS: TestAccAlicloudPvtzZoneRecordsDataSource_empty (0.95s)
=== RUN   TestAccAlicloudPvtzZoneRecord_importBasic
--- PASS: TestAccAlicloudPvtzZoneRecord_importBasic (1.60s)
=== RUN   TestAccAlicloudPvtzZoneRecord_Basic
--- PASS: TestAccAlicloudPvtzZoneRecord_Basic (1.56s)
=== RUN   TestAccAlicloudPvtzZoneRecord_updateRr
--- PASS: TestAccAlicloudPvtzZoneRecord_updateRr (2.40s)
=== RUN   TestAccAlicloudPvtzZoneRecord_updateType
--- PASS: TestAccAlicloudPvtzZoneRecord_updateType (2.42s)
=== RUN   TestAccAlicloudPvtzZoneRecord_updateValue
--- PASS: TestAccAlicloudPvtzZoneRecord_updateValue (2.41s)
=== RUN   TestAccAlicloudPvtzZoneRecord_updatePriority
--- PASS: TestAccAlicloudPvtzZoneRecord_updatePriority (2.36s)
=== RUN   TestAccAlicloudPvtzZoneRecord_updateTTL
--- PASS: TestAccAlicloudPvtzZoneRecord_updateTTL (2.39s)
=== RUN   TestAccAlicloudPvtzZoneRecord_updateAll
--- PASS: TestAccAlicloudPvtzZoneRecord_updateAll (2.34s)
=== RUN   TestAccAlicloudPvtzZoneRecord_multi
--- PASS: TestAccAlicloudPvtzZoneRecord_multi (3.44s)
PASS
ok      github.com/terraform-providers/terraform-provider-alicloud/alicloud     24.384s
```