### PR TITLE
Fix potential bugs of datahub and ram when the resource has been deleted

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ IMPROVEMENTS:
 
 BUG FIXES:
 
+- Fix potential bugs of datahub and ram when the resource has been deleted [GH-545]
 - Fix pvtz_record describing bug [GH-543]
 
 ## 1.25.0 (November 30, 2018)

--- a/alicloud/resource_alicloud_datahub_project.go
+++ b/alicloud/resource_alicloud_datahub_project.go
@@ -80,6 +80,7 @@ func resourceAliyunDatahubProjectRead(d *schema.ResourceData, meta interface{}) 
 	if err != nil {
 		if isDatahubNotExistError(err) {
 			d.SetId("")
+			return nil
 		}
 		return fmt.Errorf("failed to create project '%s' with error: %s", projectName, err)
 	}

--- a/alicloud/resource_alicloud_datahub_subscription.go
+++ b/alicloud/resource_alicloud_datahub_subscription.go
@@ -112,6 +112,7 @@ func resourceAliyunDatahubSubscriptionRead(d *schema.ResourceData, meta interfac
 	if err != nil {
 		if isDatahubNotExistError(err) {
 			d.SetId("")
+			return nil
 		}
 		return fmt.Errorf("failed to get subscription %s with error: %s", subId, err)
 	}

--- a/alicloud/resource_alicloud_datahub_topic.go
+++ b/alicloud/resource_alicloud_datahub_topic.go
@@ -149,6 +149,7 @@ func resourceAliyunDatahubTopicRead(d *schema.ResourceData, meta interface{}) er
 	if err != nil {
 		if isDatahubNotExistError(err) {
 			d.SetId("")
+			return nil
 		}
 		return fmt.Errorf("failed to access topic '%s/%s' with error: %s", projectName, topicName, err)
 	}

--- a/alicloud/resource_alicloud_ram_group.go
+++ b/alicloud/resource_alicloud_ram_group.go
@@ -110,6 +110,7 @@ func resourceAlicloudRamGroupRead(d *schema.ResourceData, meta interface{}) erro
 	if err != nil {
 		if RamEntityNotExist(err) {
 			d.SetId("")
+			return nil
 		}
 		return fmt.Errorf("GetGroup got an error: %#v", err)
 	}

--- a/alicloud/resource_alicloud_ram_group_membership.go
+++ b/alicloud/resource_alicloud_ram_group_membership.go
@@ -98,6 +98,7 @@ func resourceAlicloudRamGroupMembershipRead(d *schema.ResourceData, meta interfa
 	if err != nil {
 		if RamEntityNotExist(err) {
 			d.SetId("")
+			return nil
 		}
 		return fmt.Errorf("ListUsersForGroup got an error: %#v", err)
 	}

--- a/alicloud/resource_alicloud_ram_group_policy_attachment.go
+++ b/alicloud/resource_alicloud_ram_group_policy_attachment.go
@@ -74,6 +74,7 @@ func resourceAlicloudRamGroupPolicyAttachmentRead(d *schema.ResourceData, meta i
 	if err != nil {
 		if RamEntityNotExist(err) {
 			d.SetId("")
+			return nil
 		}
 		return fmt.Errorf("Get list policies for group got an error: %#v", err)
 	}

--- a/alicloud/resource_alicloud_ram_login_profile.go
+++ b/alicloud/resource_alicloud_ram_login_profile.go
@@ -121,6 +121,7 @@ func resourceAlicloudRamLoginProfileRead(d *schema.ResourceData, meta interface{
 	if err != nil {
 		if RamEntityNotExist(err) {
 			d.SetId("")
+			return nil
 		}
 		return fmt.Errorf("GetLoginProfile got an error: %#v", err)
 	}

--- a/alicloud/resource_alicloud_ram_policy.go
+++ b/alicloud/resource_alicloud_ram_policy.go
@@ -161,6 +161,7 @@ func resourceAlicloudRamPolicyRead(d *schema.ResourceData, meta interface{}) err
 	if err != nil {
 		if RamEntityNotExist(err) {
 			d.SetId("")
+			return nil
 		}
 		return fmt.Errorf("GetPolicy got an error: %#v", err)
 	}

--- a/alicloud/resource_alicloud_ram_role.go
+++ b/alicloud/resource_alicloud_ram_role.go
@@ -140,6 +140,7 @@ func resourceAlicloudRamRoleRead(d *schema.ResourceData, meta interface{}) error
 	if err != nil {
 		if RamEntityNotExist(err) {
 			d.SetId("")
+			return nil
 		}
 		return fmt.Errorf("GetRole got an error: %v", err)
 	}


### PR DESCRIPTION
```
TF_ACC=1 go test ./alicloud -v -run=TestAccAlicloudDatahub -timeout=120m
=== RUN   TestAccAlicloudDatahubProject_import
--- PASS: TestAccAlicloudDatahubProject_import (1.38s)
=== RUN   TestAccAlicloudDatahubSubscription_importBasic
--- PASS: TestAccAlicloudDatahubSubscription_importBasic (1.89s)
=== RUN   TestAccAlicloudDatahubTopic_importBasic
--- PASS: TestAccAlicloudDatahubTopic_importBasic (1.48s)
=== RUN   TestAccAlicloudDatahubProject_Basic
--- PASS: TestAccAlicloudDatahubProject_Basic (1.05s)
=== RUN   TestAccAlicloudDatahubProject_Update
--- PASS: TestAccAlicloudDatahubProject_Update (1.76s)
=== RUN   TestAccAlicloudDatahubSubscription_Basic
--- PASS: TestAccAlicloudDatahubSubscription_Basic (1.71s)
=== RUN   TestAccAlicloudDatahubSubscription_Update
--- PASS: TestAccAlicloudDatahubSubscription_Update (2.71s)
=== RUN   TestAccAlicloudDatahubTopic_Basic
--- PASS: TestAccAlicloudDatahubTopic_Basic (1.33s)
=== RUN   TestAccAlicloudDatahubTopic_Tuple
--- PASS: TestAccAlicloudDatahubTopic_Tuple (1.31s)
=== RUN   TestAccAlicloudDatahubTopic_Update
--- PASS: TestAccAlicloudDatahubTopic_Update (2.06s)
PASS
ok  	github.com/terraform-providers/terraform-provider-alicloud/alicloud	16.736s
```
```
 TF_ACC=1 go test ./alicloud -v -run=TestAccAlicloudRam -timeout=120m
=== RUN   TestAccAlicloudRamAccountAliasDataSource_basic
--- PASS: TestAccAlicloudRamAccountAliasDataSource_basic (1.43s)
=== RUN   TestAccAlicloudRamGroupsDataSource_for_user
--- PASS: TestAccAlicloudRamGroupsDataSource_for_user (5.45s)
=== RUN   TestAccAlicloudRamGroupsDataSource_for_policy
--- PASS: TestAccAlicloudRamGroupsDataSource_for_policy (5.62s)
=== RUN   TestAccAlicloudRamGroupsDataSource_for_all
--- PASS: TestAccAlicloudRamGroupsDataSource_for_all (1.25s)
=== RUN   TestAccAlicloudRamGroupsDataSource_group_name_regex
--- PASS: TestAccAlicloudRamGroupsDataSource_group_name_regex (2.48s)
=== RUN   TestAccAlicloudRamGroupsDataSource_Empty
--- PASS: TestAccAlicloudRamGroupsDataSource_Empty (1.26s)
=== RUN   TestAccAlicloudRamPoliciesDataSource_for_group
--- PASS: TestAccAlicloudRamPoliciesDataSource_for_group (7.25s)
=== RUN   TestAccAlicloudRamPoliciesDataSource_for_role
--- PASS: TestAccAlicloudRamPoliciesDataSource_for_role (7.08s)
=== RUN   TestAccAlicloudRamPoliciesDataSource_for_user
--- PASS: TestAccAlicloudRamPoliciesDataSource_for_user (7.68s)
=== RUN   TestAccAlicloudRamPoliciesDataSource_policy_name_regex
--- PASS: TestAccAlicloudRamPoliciesDataSource_policy_name_regex (4.46s)
=== RUN   TestAccAlicloudRamPoliciesDataSource_policy_type
--- PASS: TestAccAlicloudRamPoliciesDataSource_policy_type (4.44s)
=== RUN   TestAccAlicloudRamPoliciesDataSource_empty
--- PASS: TestAccAlicloudRamPoliciesDataSource_empty (2.92s)
=== RUN   TestAccAlicloudRamRolesDataSource_for_policy
--- PASS: TestAccAlicloudRamRolesDataSource_for_policy (5.84s)
=== RUN   TestAccAlicloudRamRolesDataSource_for_all
--- PASS: TestAccAlicloudRamRolesDataSource_for_all (5.85s)
=== RUN   TestAccAlicloudRamRolesDataSource_role_name_regex
--- PASS: TestAccAlicloudRamRolesDataSource_role_name_regex (2.65s)
=== RUN   TestAccAlicloudRamRolesDataSource_empty
--- PASS: TestAccAlicloudRamRolesDataSource_empty (1.25s)
=== RUN   TestAccAlicloudRamUsersDataSource_for_group
--- PASS: TestAccAlicloudRamUsersDataSource_for_group (5.91s)
=== RUN   TestAccAlicloudRamUsersDataSource_for_policy
--- PASS: TestAccAlicloudRamUsersDataSource_for_policy (6.29s)
=== RUN   TestAccAlicloudRamUsersDataSource_for_all
--- PASS: TestAccAlicloudRamUsersDataSource_for_all (1.29s)
=== RUN   TestAccAlicloudRamUsersDataSource_user_name_regex
--- PASS: TestAccAlicloudRamUsersDataSource_user_name_regex (2.78s)
=== RUN   TestAccAlicloudRamUsersDataSource_empty
--- PASS: TestAccAlicloudRamUsersDataSource_empty (1.29s)
=== RUN   TestAccAlicloudRamLoginProfile_importBasic
--- PASS: TestAccAlicloudRamLoginProfile_importBasic (3.78s)
=== RUN   TestAccAlicloudRamPolicy_importBasic
--- PASS: TestAccAlicloudRamPolicy_importBasic (2.81s)
=== RUN   TestAccAlicloudRamRole_importBasic
--- PASS: TestAccAlicloudRamRole_importBasic (2.01s)
=== RUN   TestAccAlicloudRamUser_importBasic
--- PASS: TestAccAlicloudRamUser_importBasic (2.57s)
=== RUN   TestAccAlicloudRamAccessKey_basic
--- PASS: TestAccAlicloudRamAccessKey_basic (3.91s)
=== RUN   TestAccAlicloudRamAccountAlias_basic
--- PASS: TestAccAlicloudRamAccountAlias_basic (1.89s)
=== RUN   TestAccAlicloudRamGroupMembership_basic
--- PASS: TestAccAlicloudRamGroupMembership_basic (6.83s)
=== RUN   TestAccAlicloudRamGroupPolicyAttachment_basic
--- PASS: TestAccAlicloudRamGroupPolicyAttachment_basic (5.44s)
=== RUN   TestAccAlicloudRamGroup_basic
--- PASS: TestAccAlicloudRamGroup_basic (2.15s)
=== RUN   TestAccAlicloudRamLoginProfile_basic
--- PASS: TestAccAlicloudRamLoginProfile_basic (4.13s)
=== RUN   TestAccAlicloudRamPolicy_basic
--- PASS: TestAccAlicloudRamPolicy_basic (2.50s)
=== RUN   TestAccAlicloudRamRoleAttachment_basic
--- PASS: TestAccAlicloudRamRoleAttachment_basic (126.07s)
=== RUN   TestAccAlicloudRamRolePolicyAttachment_basic
--- PASS: TestAccAlicloudRamRolePolicyAttachment_basic (4.86s)
=== RUN   TestAccAlicloudRamRole_basic
--- PASS: TestAccAlicloudRamRole_basic (2.06s)
=== RUN   TestAccAlicloudRamUserPolicyAttachment_basic
--- PASS: TestAccAlicloudRamUserPolicyAttachment_basic (5.26s)
=== RUN   TestAccAlicloudRamUser_basic
--- PASS: TestAccAlicloudRamUser_basic (2.23s)
PASS
ok	github.com/terraform-providers/terraform-provider-alicloud/alicloud	263.052s
```