### PR TITLE
slb_rule name does not require ForceNew

### DIFF
--- a/alicloud/resource_alicloud_slb_rule.go
+++ b/alicloud/resource_alicloud_slb_rule.go
@@ -41,7 +41,7 @@ func resourceAliyunSlbRule() *schema.Resource {
 			"name": &schema.Schema{
 				Type:     schema.TypeString,
 				Optional: true,
-				ForceNew: true,
+				ForceNew: false,
 				Default:  "tf-slb-rule",
 			},
 			"domain": &schema.Schema{


### PR DESCRIPTION
I noticed that `name` of the SLB rule can be modified from the web console, thus `ForceNew` might not be needed here.

But I have not do a full cycle test yet.

-------

TF_ACC=1 go test ./alicloud -v -run=TestAccAlicloudSlbRule -timeout=120m
=== RUN   TestAccAlicloudSlbRulesDataSource_basic
--- PASS: TestAccAlicloudSlbRulesDataSource_basic (117.91s)
=== RUN   TestAccAlicloudSlbRulesDataSource_empty
--- PASS: TestAccAlicloudSlbRulesDataSource_empty (22.45s)
=== RUN   TestAccAlicloudSlbRule_import
--- PASS: TestAccAlicloudSlbRule_import (117.10s)
=== RUN   TestAccAlicloudSlbRule_basic
--- PASS: TestAccAlicloudSlbRule_basic (120.50s)
=== RUN   TestAccAlicloudSlbRule_url
--- PASS: TestAccAlicloudSlbRule_url (131.92s)
PASS
ok  	github.com/terraform-providers/terraform-provider-alicloud/alicloud	509.929s
