### PR TITLE
Modify router interface prepaid test case

### DIFF
--- a/alicloud/resource_alicloud_router_interface_test.go
+++ b/alicloud/resource_alicloud_router_interface_test.go
@@ -117,9 +117,7 @@ func TestAccAlicloudRouterInterface_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(
 						"alicloud_router_interface.interface", "role", "InitiatingSide"),
 					resource.TestCheckResourceAttr(
-						"alicloud_router_interface.interface", "instance_charge_type", "PrePaid"),
-					resource.TestCheckResourceAttr(
-						"alicloud_router_interface.interface", "period", "1"),
+						"alicloud_router_interface.interface", "instance_charge_type", "PostPaid"),
 				),
 			},
 		},
@@ -197,6 +195,5 @@ resource "alicloud_router_interface" "interface" {
   specification = "Large.2"
   name = "${var.name}"
   description = "testAccRouterInterfaceConfig"
-  instance_charge_type = "PrePaid"
-  period = "1"
+  instance_charge_type = "PostPaid"
 }`

--- a/website/docs/r/router_interface.html.markdown
+++ b/website/docs/r/router_interface.html.markdown
@@ -53,7 +53,7 @@ The following arguments are supported:
 * `description` - (Optional) Description of the router interface. It can be 2-256 characters long or left blank. It cannot start with http:// and https://.
 * `health_check_source_ip` - (Optional) Used as the Packet Source IP of health check for disaster recovery or ECMP. It is only valid when `router_type` is `VBR`. The IP must be an unused IP in the local VPC. It and `health_check_target_ip` must be specified at the same time.
 * `health_check_target_ip` - (Optional) Used as the Packet Target IP of health check for disaster recovery or ECMP. It is only valid when `router_type` is `VBR`. The IP must be an unused IP in the local VPC. It and `health_check_source_ip` must be specified at the same time.
-* `instance_charge_type` - (Optional, ForceNew) The billing method of the router interface. Valid values are "PrePaid" and "PostPaid". Default to "PostPaid".
+* `instance_charge_type` - (Optional, ForceNew) The billing method of the router interface. Valid values are "PrePaid" and "PostPaid". Default to "PostPaid". Router Interface doesn't support "PrePaid" when region and opposite_region are the same.
 * `period` - (Optional, ForceNew) The duration that you will buy the resource, in month. It is valid when `instance_charge_type` is `PrePaid`. Default to 1. Valid values: [1-9, 12, 24, 36]. At present, the provider does not support modify "period" and you can do that via web console.
 
 


### PR DESCRIPTION
MacBook-Pro-2:terraform-provider-alicloud jince$ TF_ACC=1 go test ./alicloud -v -run=TestAccAlicloudRouterInterface -timeout=300m
=== RUN   TestAccAlicloudRouterInterfacesDataSource_oneRouter
--- PASS: TestAccAlicloudRouterInterfacesDataSource_oneRouter (16.39s)
=== RUN   TestAccAlicloudRouterInterfacesDataSource_twoRouters
--- PASS: TestAccAlicloudRouterInterfacesDataSource_twoRouters (96.20s)
=== RUN   TestAccAlicloudRouterInterface_import
--- PASS: TestAccAlicloudRouterInterface_import (16.16s)
=== RUN   TestAccAlicloudRouterInterfaceConnection_basic
--- PASS: TestAccAlicloudRouterInterfaceConnection_basic (83.83s)
=== RUN   TestAccAlicloudRouterInterface_basic
--- PASS: TestAccAlicloudRouterInterface_basic (16.33s)
PASS
ok  	github.com/terraform-providers/terraform-provider-alicloud/alicloud	228.966s
