### PR TITLE
Fix a bug that caused the alicloud_dns_record.routing attribute to be…

### DIFF
--- a/alicloud/resource_alicloud_dns_record.go
+++ b/alicloud/resource_alicloud_dns_record.go
@@ -84,10 +84,11 @@ func resourceAlicloudDnsRecordCreate(d *schema.ResourceData, meta interface{}) e
 	}
 
 	if v, ok := d.GetOk("routing"); ok {
-		if v != "default" && args.Type == dns.ForwordURLRecord {
+		routing := v.(string)
+		if routing != "default" && args.Type == dns.ForwordURLRecord {
 			return fmt.Errorf("The ForwordURLRecord only support default line.")
 		}
-		args.Line = v.(string)
+		args.Line = routing
 	}
 
 	if err := resource.Retry(3*time.Minute, func() *resource.RetryError {

--- a/alicloud/resource_alicloud_dns_record.go
+++ b/alicloud/resource_alicloud_dns_record.go
@@ -87,6 +87,10 @@ func resourceAlicloudDnsRecordCreate(d *schema.ResourceData, meta interface{}) e
 		return fmt.Errorf("The ForwordURLRecord only support default line.")
 	}
 
+	if v, ok := d.GetOk("routing"); ok {
+		args.Line = v.(string)
+	}
+
 	if err := resource.Retry(3*time.Minute, func() *resource.RetryError {
 		raw, err := client.WithDnsClient(func(dnsClient *dns.Client) (interface{}, error) {
 			return dnsClient.AddDomainRecord(args)

--- a/alicloud/resource_alicloud_dns_record.go
+++ b/alicloud/resource_alicloud_dns_record.go
@@ -83,11 +83,10 @@ func resourceAlicloudDnsRecordCreate(d *schema.ResourceData, meta interface{}) e
 		return fmt.Errorf("'priority': required field when 'type' is MX.")
 	}
 
-	if v, ok := d.GetOk("routing"); ok && v != "default" && args.Type == dns.ForwordURLRecord {
-		return fmt.Errorf("The ForwordURLRecord only support default line.")
-	}
-
 	if v, ok := d.GetOk("routing"); ok {
+		if v != "default" && args.Type == dns.ForwordURLRecord {
+			return fmt.Errorf("The ForwordURLRecord only support default line.")
+		}
 		args.Line = v.(string)
 	}
 

--- a/alicloud/resource_alicloud_dns_record_test.go
+++ b/alicloud/resource_alicloud_dns_record_test.go
@@ -101,6 +101,36 @@ func TestAccAlicloudDnsRecord_multi(t *testing.T) {
 	})
 }
 
+func TestAccAlicloudDnsRecord_routing(t *testing.T) {
+	var v dns.RecordTypeNew
+
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+		},
+
+		// module name
+		IDRefreshName: "alicloud_dns_record.record",
+
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckDnsRecordDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccDnsRecordRouting(acctest.RandInt()),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckDnsRecordExists(
+						"alicloud_dns_record.record", &v),
+					resource.TestCheckResourceAttr(
+						"alicloud_dns_record.record",
+						"routing",
+						"oversea"),
+				),
+			},
+		},
+	})
+
+}
+
 func testAccCheckDnsRecordExists(n string, record *dns.RecordTypeNew) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[n]
@@ -209,6 +239,23 @@ resource "alicloud_dns_record" "record" {
   type = "CNAME"
   value = "mail.mxhichina${count.index}.com"
   count = 10
+}
+`, randInt)
+}
+
+func testAccDnsRecordRouting(randInt int) string {
+	return fmt.Sprintf(`
+resource "alicloud_dns" "dns" {
+  name = "testdnsrecordrouting%v.abc"
+}
+
+resource "alicloud_dns_record" "record" {
+  name = "${alicloud_dns.dns.name}"
+  host_record = "alimail"
+  type = "CNAME"
+  value = "mail.mxhichin.com"
+  routing = "oversea"
+  count = 1
 }
 `, randInt)
 }

--- a/alicloud/resource_alicloud_dns_record_test.go
+++ b/alicloud/resource_alicloud_dns_record_test.go
@@ -104,6 +104,9 @@ func TestAccAlicloudDnsRecord_multi(t *testing.T) {
 func TestAccAlicloudDnsRecord_routing(t *testing.T) {
 	var v dns.RecordTypeNew
 
+	randInt := acctest.RandInt()
+	dnsName := fmt.Sprintf("testdnsrecordrouting%v.abc", randInt)
+
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			testAccPreCheck(t)
@@ -116,19 +119,23 @@ func TestAccAlicloudDnsRecord_routing(t *testing.T) {
 		CheckDestroy: testAccCheckDnsRecordDestroy,
 		Steps: []resource.TestStep{
 			resource.TestStep{
-				Config: testAccDnsRecordRouting(acctest.RandInt()),
+				Config: testAccDnsRecordRouting(randInt),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckDnsRecordExists(
-						"alicloud_dns_record.record", &v),
-					resource.TestCheckResourceAttr(
-						"alicloud_dns_record.record",
-						"routing",
-						"oversea"),
+					testAccCheckDnsRecordExists("alicloud_dns_record.record", &v),
+					resource.TestCheckResourceAttrSet("alicloud_dns_record.record", "id"),
+					resource.TestCheckResourceAttr("alicloud_dns_record.record", "name", dnsName),
+					resource.TestCheckResourceAttr("alicloud_dns_record.record", "host_record", "alimail"),
+					resource.TestCheckResourceAttr("alicloud_dns_record.record", "type", "CNAME"),
+					resource.TestCheckResourceAttr("alicloud_dns_record.record", "value", "mail.mxhichin.com"),
+					resource.TestCheckResourceAttrSet("alicloud_dns_record.record", "ttl"),
+					resource.TestCheckResourceAttrSet("alicloud_dns_record.record", "priority"),
+					resource.TestCheckResourceAttr("alicloud_dns_record.record", "routing", "oversea"),
+					resource.TestCheckResourceAttrSet("alicloud_dns_record.record", "status"),
+					resource.TestCheckResourceAttrSet("alicloud_dns_record.record", "locked"),
 				),
 			},
 		},
 	})
-
 }
 
 func testAccCheckDnsRecordExists(n string, record *dns.RecordTypeNew) resource.TestCheckFunc {


### PR DESCRIPTION
… ignored during resource creation.

Related test results:
```
GOROOT=/usr/local/go #gosetup
GOPATH=/Users/marcplouhinec/go #gosetup
/usr/local/go/bin/go test -c -i -o /private/var/folders/v1/jvjz3zmn64q0j34yc9m9n4w00000gn/T/___Test_in_Singapore__non_verbose_ github.com/terraform-providers/terraform-provider-alicloud/alicloud #gosetup
/usr/local/go/bin/go tool test2json -t /private/var/folders/v1/jvjz3zmn64q0j34yc9m9n4w00000gn/T/___Test_in_Singapore__non_verbose_ -test.v -test.run ^TestAccAlicloudDnsRecord_ #gosetup
=== RUN   TestAccAlicloudDnsRecord_basic
--- PASS: TestAccAlicloudDnsRecord_basic (2.33s)
=== RUN   TestAccAlicloudDnsRecord_priority
--- PASS: TestAccAlicloudDnsRecord_priority (2.48s)
=== RUN   TestAccAlicloudDnsRecord_multi
--- PASS: TestAccAlicloudDnsRecord_multi (12.74s)
=== RUN   TestAccAlicloudDnsRecord_routing
--- PASS: TestAccAlicloudDnsRecord_routing (3.10s)
PASS
```