### PR TITLE
Datasource alicloud_zones supports filter FunctionCompute

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,12 +2,13 @@
 
 IMPROVEMENTS:
 
+- Datasource alicloud_zones supports filter FunctionCompute [GH-555]
 - Improve datahub project testcase [GH-548]
 - Improve ecs instance and disk testcase with common case [GH-544]
 
 BUG FIXES:
 
-- Fix oss bucket deleting failed error [GH-549]
+- Fix oss bucket deleting failed error [GH-550]
 - Fix potential bugs of datahub and ram when the resource has been deleted [GH-546]
 - Fix pvtz_record describing bug [GH-543]
 

--- a/alicloud/common.go
+++ b/alicloud/common.go
@@ -121,6 +121,7 @@ const (
 	ResourceTypeRds      = ResourceType("Rds")
 	IoOptimized          = ResourceType("IoOptimized")
 	ResourceTypeRkv      = ResourceType("KVStore")
+	ResourceTypeFC       = ResourceType("FunctionCompute")
 )
 
 type InternetChargeType string

--- a/website/docs/d/zones.html.markdown
+++ b/website/docs/d/zones.html.markdown
@@ -35,7 +35,8 @@ resource "alicloud_instance" "instance" {
 The following arguments are supported:
 
 * `available_instance_type` - (Optional) Filter the results by a specific instance type.
-* `available_resource_creation` - (Optional) Filter the results by a specific resource type. The following values are allowed: `Instance`, `Disk`, `VSwitch` and `Rds`.
+* `available_resource_creation` - (Optional) Filter the results by a specific resource type.
+Valid values: `Instance`, `Disk`, `VSwitch`, `Rds`, `KVStore`, `FunctionCompute`.
 * `available_disk_category` - (Optional) Filter the results by a specific disk category. Can be either `cloud`, `cloud_efficiency` or `cloud_ssd`.
 * `multi` - (Optional, type: bool) Indicate whether the zones can be used in a multi AZ configuration. Default to `false`. Multi AZ is usually used to launch RDS instances.
 * `instance_charge_type` - (Optional) Filter the results by a specific ECS instance charge type. Valid values: `PrePaid` and `PostPaid`. Default to `PostPaid`.


### PR DESCRIPTION
```
TF_ACC=1 go test ./alicloud -v -run=TestAccAlicloudZones -timeout=120m
=== RUN   TestAccAlicloudZonesDataSource_basic
--- PASS: TestAccAlicloudZonesDataSource_basic (2.07s)
=== RUN   TestAccAlicloudZonesDataSource_filter
--- PASS: TestAccAlicloudZonesDataSource_filter (4.05s)
=== RUN   TestAccAlicloudZonesDataSource_unitRegion
--- PASS: TestAccAlicloudZonesDataSource_unitRegion (1.61s)
=== RUN   TestAccAlicloudZonesDataSource_multiZone
--- PASS: TestAccAlicloudZonesDataSource_multiZone (0.52s)
=== RUN   TestAccAlicloudZonesDataSource_chargeType
--- PASS: TestAccAlicloudZonesDataSource_chargeType (0.50s)
=== RUN   TestAccAlicloudZonesDataSource_empty
--- PASS: TestAccAlicloudZonesDataSource_empty (0.98s)
PASS
ok      github.com/terraform-providers/terraform-provider-alicloud/alicloud     9.801s
```