### PR TITLE
Fix alicloud_fc_trigger's config diff bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,11 +3,14 @@
 IMPROVEMENTS:
 
 - Datasource alicloud_zones supports filter FunctionCompute [GH-555]
+- Resource alicloud_ess_scalingconfiguration supports system_disk_size [GH-551]
 - Improve datahub project testcase [GH-548]
+- resource alicloud_slb_listener support server group [GH-545]
 - Improve ecs instance and disk testcase with common case [GH-544]
 
 BUG FIXES:
 
+- Fix alicloud_fc_trigger's config diff bug [GH-556]
 - Fix oss bucket deleting failed error [GH-550]
 - Fix potential bugs of datahub and ram when the resource has been deleted [GH-546]
 - Fix pvtz_record describing bug [GH-543]

--- a/alicloud/import_alicloud_fc_service_test.go
+++ b/alicloud/import_alicloud_fc_service_test.go
@@ -3,6 +3,7 @@ package alicloud
 import (
 	"testing"
 
+	"github.com/hashicorp/terraform/helper/acctest"
 	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/terraform-providers/terraform-provider-alicloud/alicloud/connectivity"
 )
@@ -16,7 +17,7 @@ func TestAccAlicloudFCService_import(t *testing.T) {
 		CheckDestroy: testAccCheckAlicloudFCServiceDestroy,
 		Steps: []resource.TestStep{
 			resource.TestStep{
-				Config: testAlicloudFCServiceBasic("tf-testaccalicloudfcserviceimport", testFCRoleTemplate),
+				Config: testAlicloudFCServiceBasic(acctest.RandInt(), testFCRoleTemplate),
 			},
 
 			resource.TestStep{

--- a/alicloud/resource_alicloud_fc_service_test.go
+++ b/alicloud/resource_alicloud_fc_service_test.go
@@ -178,12 +178,12 @@ func TestAccAlicloudFCService_basic(t *testing.T) {
 		CheckDestroy: testAccCheckAlicloudFCServiceDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAlicloudFCServiceBasic("tf-testaccalicloudfcservicebasic", testFCRoleTemplate),
+				Config: testAlicloudFCServiceBasic(acctest.RandInt(), testFCRoleTemplate),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAlicloudLogProjectExists("alicloud_log_project.foo", &project),
 					testAccCheckAlicloudLogStoreExists("alicloud_log_store.foo", &store),
 					testAccCheckAlicloudFCServiceExists("alicloud_fc_service.foo", &service),
-					resource.TestCheckResourceAttr("alicloud_fc_service.foo", "name", "tf-testaccalicloudfcservicebasic"),
+					resource.TestMatchResourceAttr("alicloud_fc_service.foo", "name", regexp.MustCompile("^tf-testaccalicloudfcservice")),
 					resource.TestCheckResourceAttr("alicloud_fc_service.foo", "description", "tf unit test"),
 				),
 			},
@@ -282,10 +282,10 @@ func testAccCheckAlicloudFCServiceDestroy(s *terraform.State) error {
 	return nil
 }
 
-func testAlicloudFCServiceBasic(name, role string) string {
+func testAlicloudFCServiceBasic(rand int, role string) string {
 	return fmt.Sprintf(`
 variable "name" {
-    default = "%s"
+    default = "tf-testaccalicloudfcservice%d"
 }
 
 resource "alicloud_log_project" "foo" {
@@ -322,7 +322,7 @@ resource "alicloud_fc_service" "foo" {
     role = "${alicloud_ram_role.role.arn}"
     depends_on = ["alicloud_ram_role_policy_attachment.attac"]
 }
-`, name, role)
+`, rand, role)
 }
 
 func testAlicloudFCServiceUpdate(rand int) string {
@@ -349,7 +349,7 @@ resource "alicloud_vpc" "vpc" {
 }
 
 data "alicloud_zones" "zones" {
-    available_resource_creation = "VSwitch"
+    available_resource_creation = "FunctionCompute"
 }
 
 resource "alicloud_vswitch" "vsw" {

--- a/alicloud/resource_alicloud_fc_trigger_test.go
+++ b/alicloud/resource_alicloud_fc_trigger_test.go
@@ -300,7 +300,6 @@ resource "alicloud_ram_role_policy_attachment" "foo" {
 var testTriggerLogTemplate = `
     {
         "sourceConfig": {
-            "project": "${alicloud_log_project.foo.name}",
             "logstore": "${alicloud_log_store.bar.name}"
         },
         "jobConfig": {
@@ -322,7 +321,6 @@ var testTriggerLogTemplate = `
 var testTriggerLogTemplateUpdate = `
     {
         "sourceConfig": {
-            "project": "${alicloud_log_project.foo.name}",
             "logstore": "${alicloud_log_store.bar.name}"
         },
         "jobConfig": {

--- a/alicloud/service_alicloud_fc.go
+++ b/alicloud/service_alicloud_fc.go
@@ -3,6 +3,8 @@ package alicloud
 import (
 	"fmt"
 
+	"strings"
+
 	"github.com/aliyun/fc-go-sdk"
 	"github.com/terraform-providers/terraform-provider-alicloud/alicloud/connectivity"
 )
@@ -54,11 +56,7 @@ func (s *FcService) DescribeFcFunction(service, name string) (function *fc.GetFu
 
 func (s *FcService) DescribeFcTrigger(service, function, name string) (trigger *fc.GetTriggerOutput, err error) {
 	raw, err := s.client.WithFcClient(func(fcClient *fc.Client) (interface{}, error) {
-		return fcClient.GetTrigger(&fc.GetTriggerInput{
-			ServiceName:  &service,
-			FunctionName: &function,
-			TriggerName:  &name,
-		})
+		return fcClient.GetTrigger(fc.NewGetTriggerInput(service, function, name))
 	})
 	if err != nil {
 		if IsExceptedErrors(err, []string{ServiceNotFound, FunctionNotFound, TriggerNotFound}) {
@@ -73,4 +71,11 @@ func (s *FcService) DescribeFcTrigger(service, function, name string) (trigger *
 		err = GetNotFoundErrorFromString(GetNotFoundMessage("FC Trigger", name))
 	}
 	return
+}
+
+func removeSpaceAndEnter(s string) string {
+	if Trim(s) == "" {
+		return Trim(s)
+	}
+	return strings.Replace(strings.Replace(strings.Replace(s, " ", "", -1), "\n", "", -1), "\t", "", -1)
 }


### PR DESCRIPTION
```
TF_ACC=1 go test ./alicloud -v -run=TestAccAlicloudFC -timeout=120m
=== RUN   TestAccAlicloudFCFunction_import
--- PASS: TestAccAlicloudFCFunction_import (14.31s)
=== RUN   TestAccAlicloudFCService_import
--- PASS: TestAccAlicloudFCService_import (10.07s)
=== RUN   TestAccAlicloudFCTrigger_import
--- PASS: TestAccAlicloudFCTrigger_import (18.09s)
=== RUN   TestAccAlicloudFCFunction_basic
--- PASS: TestAccAlicloudFCFunction_basic (26.60s)
=== RUN   TestAccAlicloudFCService_basic
--- PASS: TestAccAlicloudFCService_basic (26.25s)
=== RUN   TestAccAlicloudFCService_update
--- PASS: TestAccAlicloudFCService_update (29.31s)
=== RUN   TestAccAlicloudFCTrigger_log
--- PASS: TestAccAlicloudFCTrigger_log (25.39s)
PASS
ok	github.com/terraform-providers/terraform-provider-alicloud/alicloud	150.090s
```