### PR TITLE
Improve dns_domains testcase

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 IMPROVEMENTS:
 
+- Improve dns_domains testcase [GH-561]
 - Improve ram_role_attachment testcase [GH-560]
 - Add retry and timemout for fc client [GH-557]
 - Datasource alicloud_zones supports filter FunctionCompute [GH-555]

--- a/alicloud/data_source_alicloud_dns_domains_test.go
+++ b/alicloud/data_source_alicloud_dns_domains_test.go
@@ -17,7 +17,7 @@ func TestAccAlicloudDnsDomainsDataSource_ali_domain(t *testing.T) {
 		Providers: testAccProviders,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccCheckAlicloudDomainsDataSourceAliDomainConfig(acctest.RandInt()),
+				Config: testAccCheckAlicloudDomainsDataSourceAliDomainConfig(acctest.RandIntRange(1000, 9999)),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAlicloudDataSourceID("data.alicloud_dns_domains.domain"),
 					resource.TestCheckResourceAttr("data.alicloud_dns_domains.domain", "domains.#", "1"),
@@ -36,7 +36,7 @@ func TestAccAlicloudDnsDomainsDataSource_name_regex(t *testing.T) {
 		Providers: testAccProviders,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccCheckAlicloudDomainsDataSourceNameRegexConfig(acctest.RandInt()),
+				Config: testAccCheckAlicloudDomainsDataSourceNameRegexConfig(acctest.RandIntRange(1000, 9999)),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAlicloudDataSourceID("data.alicloud_dns_domains.domain"),
 					resource.TestCheckResourceAttr("data.alicloud_dns_domains.domain", "domains.#", "1"),
@@ -75,28 +75,28 @@ func TestAccAlicloudDnsDomainsDataSource_empty(t *testing.T) {
 func testAccCheckAlicloudDomainsDataSourceAliDomainConfig(randInt int) string {
 	return fmt.Sprintf(`
 resource "alicloud_dns_group" "group" {
-  name = "testaccdnsalidomain%v"
+  name = "testaccdnsdomain%d"
 }
 
 resource "alicloud_dns" "dns" {
-  name = "testaccdnsalidomain%v.abc"
+  name = "testaccdnsalidomain%d.abc"
   group_id = "${alicloud_dns_group.group.id}"
 }
 
 data "alicloud_dns_domains" "domain" {
   ali_domain = "${alicloud_dns.dns.name == "" ? false : false}"
   group_name_regex = "${alicloud_dns_group.group.name}"
-}`, randInt%1000, randInt%1000)
+}`, randInt, randInt)
 }
 
 func testAccCheckAlicloudDomainsDataSourceNameRegexConfig(randInt int) string {
 	return fmt.Sprintf(`
 resource "alicloud_dns" "dns" {
-  name = "testaccdnsnameregex%v.abc"
+  name = "testaccdnsnameregex%d.abc"
 }
 data "alicloud_dns_domains" "domain" {
   domain_name_regex = "${alicloud_dns.dns.name}"
-}`, randInt%1000)
+}`, randInt)
 }
 
 const testAccCheckAlicloudDomainsDataSourceEmpty = `

--- a/alicloud/resource_alicloud_ram_role_attachment_test.go
+++ b/alicloud/resource_alicloud_ram_role_attachment_test.go
@@ -125,7 +125,7 @@ func testAccCheckRamRoleAttachmentDestroy(s *terraform.State) error {
 	return nil
 }
 
-func testAccRamRoleAttachmentConfig(common string) string{
+func testAccRamRoleAttachmentConfig(common string) string {
 	return fmt.Sprintf(`
 	%s
 	variable "name" {


### PR DESCRIPTION
```
TF_ACC=1 go test ./alicloud -v -run=TestAccAlicloudDns -timeout=180m
=== RUN   TestAccAlicloudDnsDomainsDataSource_ali_domain
--- PASS: TestAccAlicloudDnsDomainsDataSource_ali_domain (6.17s)
=== RUN   TestAccAlicloudDnsDomainsDataSource_name_regex
--- PASS: TestAccAlicloudDnsDomainsDataSource_name_regex (4.00s)
=== RUN   TestAccAlicloudDnsDomainsDataSource_empty
--- PASS: TestAccAlicloudDnsDomainsDataSource_empty (1.18s)
=== RUN   TestAccAlicloudDnsGroupsDataSource_name_regex
--- PASS: TestAccAlicloudDnsGroupsDataSource_name_regex (0.49s)
=== RUN   TestAccAlicloudDnsGroupsDataSource_empty
--- PASS: TestAccAlicloudDnsGroupsDataSource_empty (0.51s)
=== RUN   TestAccAlicloudDnsRecordsDataSource_host_record_regex
--- PASS: TestAccAlicloudDnsRecordsDataSource_host_record_regex (3.31s)
=== RUN   TestAccAlicloudDnsRecordsDataSource_type
--- PASS: TestAccAlicloudDnsRecordsDataSource_type (3.43s)
=== RUN   TestAccAlicloudDnsRecordsDataSource_value_regex
--- PASS: TestAccAlicloudDnsRecordsDataSource_value_regex (4.32s)
=== RUN   TestAccAlicloudDnsRecordsDataSource_line
--- PASS: TestAccAlicloudDnsRecordsDataSource_line (4.32s)
=== RUN   TestAccAlicloudDnsRecordsDataSource_status
--- PASS: TestAccAlicloudDnsRecordsDataSource_status (3.30s)
=== RUN   TestAccAlicloudDnsRecordsDataSource_is_locked
--- PASS: TestAccAlicloudDnsRecordsDataSource_is_locked (3.92s)
=== RUN   TestAccAlicloudDnsRecordsDataSource_empty
--- PASS: TestAccAlicloudDnsRecordsDataSource_empty (2.26s)
=== RUN   TestAccAlicloudDnsDomainRecord_importBasic
--- PASS: TestAccAlicloudDnsDomainRecord_importBasic (3.56s)
=== RUN   TestAccAlicloudDnsDomain_importBasic
--- PASS: TestAccAlicloudDnsDomain_importBasic (2.00s)
=== RUN   TestAccAlicloudDnsGroup_basic
--- PASS: TestAccAlicloudDnsGroup_basic (0.98s)
=== RUN   TestAccAlicloudDnsRecord_basic
--- PASS: TestAccAlicloudDnsRecord_basic (3.87s)
=== RUN   TestAccAlicloudDnsRecord_priority
--- PASS: TestAccAlicloudDnsRecord_priority (3.31s)
=== RUN   TestAccAlicloudDnsRecord_multi
--- PASS: TestAccAlicloudDnsRecord_multi (18.29s)
=== RUN   TestAccAlicloudDnsRecord_routing
--- PASS: TestAccAlicloudDnsRecord_routing (3.91s)
=== RUN   TestAccAlicloudDns_basic
--- PASS: TestAccAlicloudDns_basic (2.73s)
PASS
ok  	github.com/terraform-providers/terraform-provider-alicloud/alicloud	75.932s
```