### PR TITLE
fix the acceptance case that rely on the default provider

### DIFF
--- a/alicloud/data_source_alicloud_cen_region_route_entries_test.go
+++ b/alicloud/data_source_alicloud_cen_region_route_entries_test.go
@@ -30,18 +30,26 @@ func TestAccAlicloudCenRegionDomainRouteEntriesDataSource_basic(t *testing.T) {
 }
 
 const testAccCheckCenRegionDomainRouteEntriesDataBasicConfig = `
+provider "alicloud" {
+    alias = "bj"
+    region = "cn-beijing"
+}
+
 data "alicloud_zones" "default" {
+    provider = "alicloud.bj"
 	"available_disk_category"= "cloud_efficiency"
 	"available_resource_creation"= "VSwitch"
 }
 
 data "alicloud_instance_types" "default" {
+    provider = "alicloud.bj"
  	availability_zone = "${data.alicloud_zones.default.zones.0.id}"
 	cpu_core_count = 1
 	memory_size = 2
 }
 
 data "alicloud_images" "default" {
+    provider = "alicloud.bj"
     name_regex = "^ubuntu_14.*_64"
 	most_recent = true
 	owners = "system"
@@ -52,11 +60,13 @@ variable "name" {
 }
 
 resource "alicloud_vpc" "vpc" {
+    provider = "alicloud.bj"
   	name = "${var.name}-vpc-region-route-entry"
   	cidr_block = "172.16.0.0/12"
 }
 
 resource "alicloud_vswitch" "default" {
+    provider = "alicloud.bj"
  	vpc_id = "${alicloud_vpc.vpc.id}"
  	cidr_block = "172.16.0.0/21"
  	availability_zone = "${data.alicloud_zones.default.zones.0.id}"
@@ -64,12 +74,14 @@ resource "alicloud_vswitch" "default" {
 }
 
 resource "alicloud_security_group" "default" {
+    provider = "alicloud.bj"
 	name = "${var.name}-sg-region-route-entry"
 	description = "foo"
 	vpc_id = "${alicloud_vpc.vpc.id}"
 }
 
 resource "alicloud_instance" "default" {
+    provider = "alicloud.bj"
 	vswitch_id = "${alicloud_vswitch.default.id}"
 	image_id = "${data.alicloud_images.default.images.0.id}"
 
@@ -94,6 +106,7 @@ resource "alicloud_cen_instance_attachment" "attach" {
 }
 
 resource "alicloud_route_entry" "route" {
+    provider = "alicloud.bj"
     route_table_id = "${alicloud_vpc.vpc.route_table_id}"
     destination_cidrblock = "11.0.0.0/16"
     nexthop_type = "Instance"

--- a/alicloud/data_source_alicloud_cen_route_entries_test.go
+++ b/alicloud/data_source_alicloud_cen_route_entries_test.go
@@ -58,33 +58,43 @@ func TestAccAlicloudCenPublishedRouteEntriesDataSource_empty(t *testing.T) {
 }
 
 const testAccCheckCenPublishedRouteEntriesDataSourceConfig = `
+provider "alicloud" {
+    alias = "bj"
+    region = "cn-beijing"
+}
+
 variable "name" {
 	default = "tf-testAccCenRoutes"
 }
 
 data "alicloud_zones" "default" {
+    provider = "alicloud.bj"
 	"available_disk_category"= "cloud_efficiency"
 	"available_resource_creation"= "VSwitch"
 }
 
 data "alicloud_instance_types" "default" {
+    provider = "alicloud.bj"
  	availability_zone = "${data.alicloud_zones.default.zones.0.id}"
 	cpu_core_count = 1
 	memory_size = 2
 }
 
 data "alicloud_images" "default" {
+    provider = "alicloud.bj"
     name_regex = "^ubuntu_14.*_64"
 	most_recent = true
 	owners = "system"
 }
 
 resource "alicloud_vpc" "vpc" {
+    provider = "alicloud.bj"
   	name = "${var.name}"
   	cidr_block = "172.16.0.0/12"
 }
 
 resource "alicloud_vswitch" "default" {
+    provider = "alicloud.bj"
  	vpc_id = "${alicloud_vpc.vpc.id}"
  	cidr_block = "172.16.0.0/21"
  	availability_zone = "${data.alicloud_zones.default.zones.0.id}"
@@ -92,12 +102,14 @@ resource "alicloud_vswitch" "default" {
 }
 
 resource "alicloud_security_group" "default" {
+    provider = "alicloud.bj"
 	name = "${var.name}"
 	description = "foo"
 	vpc_id = "${alicloud_vpc.vpc.id}"
 }
 
 resource "alicloud_instance" "default" {
+    provider = "alicloud.bj"
 	vswitch_id = "${alicloud_vswitch.default.id}"
 	image_id = "${data.alicloud_images.default.images.0.id}"
 
@@ -122,6 +134,7 @@ resource "alicloud_cen_instance_attachment" "attach" {
 }
 
 resource "alicloud_route_entry" "route" {
+    provider = "alicloud.bj"
     route_table_id = "${alicloud_vpc.vpc.route_table_id}"
     destination_cidrblock = "11.0.0.0/16"
     nexthop_type = "Instance"
@@ -143,33 +156,43 @@ data "alicloud_cen_route_entries" "entry" {
 `
 
 const testAccCheckCenPublishedRouteEntriesDataSourceEmpty = `
+provider "alicloud" {
+    alias = "bj"
+    region = "cn-beijing"
+}
+
 variable "name" {
 	default = "tf-testAccCenRoutesEmpty"
 }
 
 data "alicloud_zones" "default" {
+    provider = "alicloud.bj"
 	"available_disk_category"= "cloud_efficiency"
 	"available_resource_creation"= "VSwitch"
 }
 
 data "alicloud_instance_types" "default" {
+    provider = "alicloud.bj"
  	availability_zone = "${data.alicloud_zones.default.zones.0.id}"
 	cpu_core_count = 1
 	memory_size = 2
 }
 
 data "alicloud_images" "default" {
+    provider = "alicloud.bj"
     name_regex = "^ubuntu_14.*_64"
 	most_recent = true
 	owners = "system"
 }
 
 resource "alicloud_vpc" "vpc" {
+    provider = "alicloud.bj"
   	name = "${var.name}"
   	cidr_block = "172.16.0.0/12"
 }
 
 resource "alicloud_vswitch" "default" {
+    provider = "alicloud.bj"
  	vpc_id = "${alicloud_vpc.vpc.id}"
  	cidr_block = "172.16.0.0/21"
  	availability_zone = "${data.alicloud_zones.default.zones.0.id}"
@@ -177,12 +200,14 @@ resource "alicloud_vswitch" "default" {
 }
 
 resource "alicloud_security_group" "default" {
+    provider = "alicloud.bj"
 	name = "${var.name}"
 	description = "foo"
 	vpc_id = "${alicloud_vpc.vpc.id}"
 }
 
 resource "alicloud_instance" "default" {
+    provider = "alicloud.bj"
 	vswitch_id = "${alicloud_vswitch.default.id}"
 	image_id = "${data.alicloud_images.default.images.0.id}"
 
@@ -207,6 +232,7 @@ resource "alicloud_cen_instance_attachment" "attach" {
 }
 
 resource "alicloud_route_entry" "route" {
+    provider = "alicloud.bj"
     route_table_id = "${alicloud_vpc.vpc.route_table_id}"
     destination_cidrblock = "11.0.0.0/16"
     nexthop_type = "Instance"

--- a/alicloud/resource_alicloud_cen_route_entry_test.go
+++ b/alicloud/resource_alicloud_cen_route_entry_test.go
@@ -92,33 +92,43 @@ func testAccCheckCenRouteEntryDestroy(s *terraform.State) error {
 }
 
 const testAccCenRouteEntryConfig = `
+provider "alicloud" {
+    alias = "bj"
+    region = "cn-beijing"
+}
+
 variable "name" {
     default = "tf-testAccCenRouteEntryConfig"
 }
 
 data "alicloud_zones" "default" {
+    provider = "alicloud.bj"
     available_disk_category = "cloud_efficiency"
     available_resource_creation = "VSwitch"
 }
 
 data "alicloud_instance_types" "default" {
+    provider = "alicloud.bj"
     availability_zone = "${data.alicloud_zones.default.zones.0.id}"
     cpu_core_count = 1
     memory_size = 2
 }
 
 data "alicloud_images" "default" {
+    provider = "alicloud.bj"
     name_regex = "^ubuntu_14.*_64"
     most_recent = true
     owners = "system"
 }
 
 resource "alicloud_vpc" "vpc" {
+    provider = "alicloud.bj"
     name = "${var.name}"
     cidr_block = "172.16.0.0/12"
 }
 
 resource "alicloud_vswitch" "default" {
+    provider = "alicloud.bj"
     vpc_id = "${alicloud_vpc.vpc.id}"
     cidr_block = "172.16.0.0/21"
     availability_zone = "${data.alicloud_zones.default.zones.0.id}"
@@ -126,12 +136,14 @@ resource "alicloud_vswitch" "default" {
 }
 
 resource "alicloud_security_group" "default" {
+    provider = "alicloud.bj"
     name = "${var.name}"
     description = "foo"
     vpc_id = "${alicloud_vpc.vpc.id}"
 }
 
 resource "alicloud_instance" "default" {
+    provider = "alicloud.bj"
     vswitch_id = "${alicloud_vswitch.default.id}"
     image_id = "${data.alicloud_images.default.images.0.id}"
     instance_type = "${data.alicloud_instance_types.default.instance_types.0.id}"
@@ -153,6 +165,7 @@ resource "alicloud_cen_instance_attachment" "attach" {
 }
 
 resource "alicloud_route_entry" "route" {
+    provider = "alicloud.bj"
     route_table_id = "${alicloud_vpc.vpc.route_table_id}"
     destination_cidrblock = "11.0.0.0/16"
     nexthop_type = "Instance"


### PR DESCRIPTION
Add provider to these cases.

$TF_ACC=1 go test ./alicloud -v -run=TestAccAlicloudCenRouteEntry
=== RUN   TestAccAlicloudCenRouteEntry_importBasic
--- PASS: TestAccAlicloudCenRouteEntry_importBasic (141.80s)
=== RUN   TestAccAlicloudCenRouteEntry_basic
--- PASS: TestAccAlicloudCenRouteEntry_basic (137.07s)
PASS
ok      github.com/terraform-providers/terraform-provider-alicloud/alicloud     278.929s
$TF_ACC=1 go test ./alicloud -v -run=TestAccAlicloudCenRegionDomainRouteEntriesDataSource
=== RUN   TestAccAlicloudCenRegionDomainRouteEntriesDataSource_basic
--- PASS: TestAccAlicloudCenRegionDomainRouteEntriesDataSource_basic (143.40s)
PASS
ok      github.com/terraform-providers/terraform-provider-alicloud/alicloud     143.463s
$TF_ACC=1 go test ./alicloud -v -run=TestAccAlicloudCenPublishedRouteEntriesDataSource
=== RUN   TestAccAlicloudCenPublishedRouteEntriesDataSource_basic
--- PASS: TestAccAlicloudCenPublishedRouteEntriesDataSource_basic (147.60s)
=== RUN   TestAccAlicloudCenPublishedRouteEntriesDataSource_empty
--- PASS: TestAccAlicloudCenPublishedRouteEntriesDataSource_empty (152.00s)
PASS
ok      github.com/terraform-providers/terraform-provider-alicloud/alicloud     299.667s