### PR TITLE
Support managed kubernetes

### DIFF
--- a/alicloud/connectivity/regions.go
+++ b/alicloud/connectivity/regions.go
@@ -56,3 +56,4 @@ var ApiGatewayNoSupportedRegions = []Region{Zhangjiakou, Huhehaote, USEast1, USW
 var OtsHighPerformanceNoSupportedRegions = []Region{Qingdao, Zhangjiakou, Huhehaote, Hongkong, APSouthEast2, APSouthEast5, APNorthEast1, EUCentral1, MEEast1, APSouth1}
 var OtsCapacityNoSupportedRegions = []Region{APSouthEast1, USWest1, USEast1}
 var PrivateIpNoSupportedRegions = []Region{Beijing, Hangzhou, Shenzhen}
+var ManagedKubernetesSupportedRegions = []Region{Beijing, Hangzhou, Shanghai, APSouthEast1, APSouthEast3, APSouthEast5, APSouth1}

--- a/alicloud/import_alicloud_cs_managed_kubernetes_test.go
+++ b/alicloud/import_alicloud_cs_managed_kubernetes_test.go
@@ -1,0 +1,32 @@
+package alicloud
+
+import (
+	"testing"
+
+	"github.com/terraform-providers/terraform-provider-alicloud/alicloud/connectivity"
+
+	"github.com/hashicorp/terraform/helper/resource"
+)
+
+func TestAccAlicloudCSManagedKubernetes_import(t *testing.T) {
+	resourceName := "alicloud_cs_managed_kubernetes.k8s"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheckWithRegions(t, true, connectivity.ManagedKubernetesSupportedRegions) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckManagedKubernetesClusterDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccContainerManagedKubernetes_basic,
+			},
+
+			resource.TestStep{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{"name_prefix", "new_nat_gateway", "pod_cidr",
+					"service_cidr", "password", "install_cloud_monitor"},
+			},
+		},
+	})
+}

--- a/alicloud/provider.go
+++ b/alicloud/provider.go
@@ -199,6 +199,7 @@ func Provider() terraform.ResourceProvider {
 			"alicloud_cs_application":                      resourceAlicloudCSApplication(),
 			"alicloud_cs_swarm":                            resourceAlicloudCSSwarm(),
 			"alicloud_cs_kubernetes":                       resourceAlicloudCSKubernetes(),
+			"alicloud_cs_managed_kubernetes":               resourceAlicloudCSManagedKubernetes(),
 			"alicloud_cdn_domain":                          resourceAlicloudCdnDomain(),
 			"alicloud_router_interface":                    resourceAlicloudRouterInterface(),
 			"alicloud_router_interface_connection":         resourceAlicloudRouterInterfaceConnection(),

--- a/alicloud/resource_alicloud_cs_managed_kubernetes.go
+++ b/alicloud/resource_alicloud_cs_managed_kubernetes.go
@@ -286,6 +286,8 @@ func resourceAlicloudCSManagedKubernetesUpdate(d *schema.ResourceData, meta inte
 		workerNumbers := expandIntList(d.Get("worker_numbers").([]interface{}))
 		workerInstanceTypes := expandStringList(d.Get("worker_instance_types").([]interface{}))
 
+		// When cluster was created using keypair, LoginPassword will be ignored.
+		// When cluster was created using password, LoginPassword is required to resize.
 		args := &cs.KubernetesClusterResizeArgs{
 			DisableRollback: true,
 			TimeoutMins:     ManagedKubernetesCreationDefaultTimeoutInMinute,

--- a/alicloud/resource_alicloud_cs_managed_kubernetes.go
+++ b/alicloud/resource_alicloud_cs_managed_kubernetes.go
@@ -1,0 +1,656 @@
+package alicloud
+
+import (
+	"fmt"
+	"time"
+
+	"strconv"
+
+	"github.com/denverdino/aliyungo/common"
+	"github.com/denverdino/aliyungo/cs"
+	"github.com/denverdino/aliyungo/ecs"
+	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/helper/schema"
+	"github.com/terraform-providers/terraform-provider-alicloud/alicloud/connectivity"
+)
+
+const (
+	ManagedKubernetesClusterNetworkTypeFlannel      = "flannel"
+	ManagedKubernetesClusterNetworkTypeTerway       = "terway"
+	ManagedKubernetesCreationDefaultTimeoutInMinute = 60
+)
+
+func resourceAlicloudCSManagedKubernetes() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceAlicloudCSManagedKubernetesCreate,
+		Read:   resourceAlicloudCSManagedKubernetesRead,
+		Update: resourceAlicloudCSManagedKubernetesUpdate,
+		Delete: resourceAlicloudCSManagedKubernetesDelete,
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
+
+		Schema: map[string]*schema.Schema{
+			"name": &schema.Schema{
+				Type:          schema.TypeString,
+				Optional:      true,
+				Computed:      true,
+				ValidateFunc:  validateContainerName,
+				ConflictsWith: []string{"name_prefix"},
+			},
+			"name_prefix": &schema.Schema{
+				Type:          schema.TypeString,
+				Optional:      true,
+				Default:       "Terraform-Creation",
+				ValidateFunc:  validateContainerNamePrefix,
+				ConflictsWith: []string{"name"},
+			},
+			"availability_zone": &schema.Schema{
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: true,
+				Computed: true,
+			},
+			"vswitch_ids": &schema.Schema{
+				Type:     schema.TypeList,
+				Optional: true,
+				ForceNew: true,
+				Computed: true,
+				Elem: &schema.Schema{
+					Type: schema.TypeString,
+				},
+				MaxItems: 1,
+			},
+			"new_nat_gateway": &schema.Schema{
+				Type:     schema.TypeBool,
+				Optional: true,
+				Default:  true,
+			},
+			"worker_instance_types": &schema.Schema{
+				Type:     schema.TypeList,
+				Required: true,
+				ForceNew: true,
+				Elem: &schema.Schema{
+					Type: schema.TypeString,
+				},
+				MinItems: 1,
+				MaxItems: 1,
+			},
+			"worker_numbers": &schema.Schema{
+				Type:     schema.TypeList,
+				Optional: true,
+				Elem: &schema.Schema{
+					Type:    schema.TypeInt,
+					Default: 3,
+				},
+				MinItems: 1,
+				MaxItems: 1,
+			},
+			"password": &schema.Schema{
+				Type:          schema.TypeString,
+				Optional:      true,
+				ForceNew:      true,
+				Sensitive:     true,
+				ConflictsWith: []string{"key_name"},
+			},
+			"key_name": &schema.Schema{
+				Type:          schema.TypeString,
+				ForceNew:      true,
+				Optional:      true,
+				ConflictsWith: []string{"password"},
+			},
+			"pod_cidr": &schema.Schema{
+				Type:     schema.TypeString,
+				ForceNew: true,
+				Optional: true,
+			},
+			"service_cidr": &schema.Schema{
+				Type:     schema.TypeString,
+				ForceNew: true,
+				Optional: true,
+			},
+			"cluster_network_type": &schema.Schema{
+				Type:         schema.TypeString,
+				Optional:     true,
+				ForceNew:     true,
+				ValidateFunc: validateAllowedStringValue([]string{ManagedKubernetesClusterNetworkTypeFlannel, ManagedKubernetesClusterNetworkTypeTerway}),
+			},
+			"image_id": &schema.Schema{
+				Type:             schema.TypeString,
+				Optional:         true,
+				ForceNew:         true,
+				DiffSuppressFunc: imageIdSuppressFunc,
+			},
+			"worker_disk_size": &schema.Schema{
+				Type:         schema.TypeInt,
+				Optional:     true,
+				Default:      40,
+				ForceNew:     true,
+				ValidateFunc: validateIntegerInRange(20, 32768),
+			},
+			"worker_disk_category": &schema.Schema{
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: true,
+				Default:  DiskCloudEfficiency,
+				ValidateFunc: validateAllowedStringValue([]string{
+					string(DiskCloudEfficiency), string(DiskCloudSSD)}),
+			},
+			"worker_data_disk_size": &schema.Schema{
+				Type:             schema.TypeInt,
+				Optional:         true,
+				ForceNew:         true,
+				Default:          40,
+				ValidateFunc:     validateIntegerInRange(20, 32768),
+				DiffSuppressFunc: workerDataDiskSizeSuppressFunc,
+			},
+			"worker_data_disk_category": &schema.Schema{
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: true,
+				ValidateFunc: validateAllowedStringValue([]string{
+					string(DiskCloudEfficiency), string(DiskCloudSSD)}),
+			},
+			"worker_instance_charge_type": &schema.Schema{
+				Type:         schema.TypeString,
+				Optional:     true,
+				ForceNew:     true,
+				ValidateFunc: validateInstanceChargeType,
+				Default:      PostPaid,
+			},
+			"worker_period_unit": &schema.Schema{
+				Type:             schema.TypeString,
+				Optional:         true,
+				Default:          Month,
+				ValidateFunc:     validateInstanceChargeTypePeriodUnit,
+				DiffSuppressFunc: csKubernetesWorkerPostPaidDiffSuppressFunc,
+			},
+			"worker_period": &schema.Schema{
+				Type:             schema.TypeInt,
+				Optional:         true,
+				Default:          1,
+				ValidateFunc:     validateInstanceChargeTypePeriod,
+				DiffSuppressFunc: csKubernetesWorkerPostPaidDiffSuppressFunc,
+			},
+			"worker_auto_renew": &schema.Schema{
+				Type:             schema.TypeBool,
+				Default:          false,
+				Optional:         true,
+				DiffSuppressFunc: csKubernetesWorkerPostPaidDiffSuppressFunc,
+			},
+			"worker_auto_renew_period": &schema.Schema{
+				Type:             schema.TypeInt,
+				Optional:         true,
+				Default:          1,
+				ValidateFunc:     validateAllowedIntValue([]int{1, 2, 3, 6, 12}),
+				DiffSuppressFunc: csKubernetesWorkerPostPaidDiffSuppressFunc,
+			},
+			"install_cloud_monitor": &schema.Schema{
+				Type:     schema.TypeBool,
+				Optional: true,
+				Default:  false,
+			},
+			"kube_config": &schema.Schema{
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"client_cert": &schema.Schema{
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"client_key": &schema.Schema{
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"cluster_ca_cert": &schema.Schema{
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			// 'version' is a reserved parameter and it just is used to test. No Recommendation to expose it.
+			"version": &schema.Schema{
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"worker_nodes": &schema.Schema{
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"name": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"private_ip": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+					},
+				},
+			},
+			"security_group_id": &schema.Schema{
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"vpc_id": &schema.Schema{
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func resourceAlicloudCSManagedKubernetesCreate(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*connectivity.AliyunClient)
+	invoker := NewInvoker()
+
+	args, err := buildManagedKubernetesArgs(d, meta)
+	if err != nil {
+		return err
+	}
+	if err := invoker.Run(func() error {
+		raw, err := client.WithCsClient(func(csClient *cs.Client) (interface{}, error) {
+			return csClient.CreateKubernetesCluster(common.Region(client.RegionId), args)
+		})
+		if err != nil {
+			return err
+		}
+		cluster, _ := raw.(cs.ClusterCreationResponse)
+		d.SetId(cluster.ClusterID)
+		return nil
+	}); err != nil {
+		return fmt.Errorf("Creating ManagedKubernetes Cluster got an error: %#v", err)
+	}
+
+	if err := invoker.Run(func() error {
+		_, err := client.WithCsClient(func(csClient *cs.Client) (interface{}, error) {
+			return nil, csClient.WaitForClusterAsyn(d.Id(), cs.Running, 3600)
+		})
+		return err
+	}); err != nil {
+		return fmt.Errorf("Waitting for ManagedKubernetes cluster %#v got an error: %#v", cs.Running, err)
+	}
+
+	return resourceAlicloudCSManagedKubernetesRead(d, meta)
+}
+
+func resourceAlicloudCSManagedKubernetesUpdate(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*connectivity.AliyunClient)
+	d.Partial(true)
+	invoker := NewInvoker()
+	if d.HasChange("worker_numbers") {
+
+		workerNumbers := expandIntList(d.Get("worker_numbers").([]interface{}))
+		workerInstanceTypes := expandStringList(d.Get("worker_instance_types").([]interface{}))
+
+		args := &cs.KubernetesClusterResizeArgs{
+			DisableRollback: true,
+			TimeoutMins:     ManagedKubernetesCreationDefaultTimeoutInMinute,
+			LoginPassword:   d.Get("password").(string),
+		}
+
+		args.WorkerInstanceType = workerInstanceTypes[0]
+		args.NumOfNodes = int64(workerNumbers[0])
+		if err := invoker.Run(func() error {
+			_, err := client.WithCsClient(func(csClient *cs.Client) (interface{}, error) {
+				return nil, csClient.ResizeKubernetesCluster(d.Id(), args)
+			})
+			return err
+		}); err != nil {
+			return fmt.Errorf("Resize Cluster got an error: %#v", err)
+		}
+
+		if err := invoker.Run(func() error {
+			_, err := client.WithCsClient(func(csClient *cs.Client) (interface{}, error) {
+				return nil, csClient.WaitForClusterAsyn(d.Id(), cs.Running, 3600)
+			})
+			return err
+		}); err != nil {
+			return fmt.Errorf("Waitting for container Cluster %#v got an error: %#v", cs.Running, err)
+		}
+		d.SetPartial("worker_number")
+	}
+
+	if d.HasChange("name") || d.HasChange("name_prefix") {
+		var clusterName string
+		if v, ok := d.GetOk("name"); ok {
+			clusterName = v.(string)
+		} else {
+			clusterName = resource.PrefixedUniqueId(d.Get("name_prefix").(string))
+		}
+		if err := invoker.Run(func() error {
+			_, err := client.WithCsClient(func(csClient *cs.Client) (interface{}, error) {
+				return nil, csClient.ModifyClusterName(d.Id(), clusterName)
+			})
+			if err != nil && !IsExceptedError(err, ErrorClusterNameAlreadyExist) {
+				return err
+			}
+			return nil
+		}); err != nil {
+			return fmt.Errorf("Modify Cluster Name got an error: %#v", err)
+		}
+		d.SetPartial("name")
+		d.SetPartial("name_prefix")
+	}
+	d.Partial(false)
+
+	return resourceAlicloudCSManagedKubernetesRead(d, meta)
+}
+
+func resourceAlicloudCSManagedKubernetesRead(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*connectivity.AliyunClient)
+
+	var cluster cs.KubernetesCluster
+	invoker := NewInvoker()
+	if err := invoker.Run(func() error {
+		raw, e := client.WithCsClient(func(csClient *cs.Client) (interface{}, error) {
+			return csClient.DescribeKubernetesCluster(d.Id())
+		})
+		if e != nil {
+			return e
+		}
+		cluster, _ = raw.(cs.KubernetesCluster)
+		return nil
+	}); err != nil {
+		if NotFoundError(err) || IsExceptedError(err, ErrorClusterNotFound) {
+			d.SetId("")
+			return nil
+		}
+		return err
+	}
+
+	d.Set("name", cluster.Name)
+	if cluster.Parameters.ImageId != "" {
+		d.Set("image_id", cluster.Parameters.ImageId)
+	} else {
+		d.Set("image_id", cluster.Parameters.WorkerImageId)
+	}
+	d.Set("vpc_id", cluster.VPCID)
+	d.Set("security_group_id", cluster.SecurityGroupID)
+	d.Set("key_name", cluster.Parameters.KeyPair)
+	if size, err := strconv.Atoi(cluster.Parameters.WorkerSystemDiskSize); err != nil {
+		d.Set("worker_disk_size", size)
+	}
+	d.Set("worker_disk_category", cluster.Parameters.WorkerSystemDiskCategory)
+	d.Set("availability_zone", cluster.ZoneId)
+
+	if cluster.Parameters.WorkerInstanceChargeType == string(PrePaid) {
+		d.Set("worker_instance_charge_type", string(PrePaid))
+		d.Set("worker_period", cluster.Parameters.WorkerPeriod)
+		d.Set("worker_period_unit", cluster.Parameters.WorkerPeriodUnit)
+		d.Set("worker_auto_renew", cluster.Parameters.WorkerAutoRenew)
+		d.Set("worker_auto_renew_period", cluster.Parameters.WorkerAutoRenewPeriod)
+	} else {
+		d.Set("worker_instance_charge_type", string(PostPaid))
+	}
+
+	if cluster.Parameters.WorkerDataDisk {
+		d.Set("worker_data_disk_size", cluster.Parameters.WorkerDataDiskSize)
+		d.Set("worker_data_disk_category", cluster.Parameters.WorkerDataDiskCategory)
+	}
+
+	numOfNode, err := strconv.Atoi(cluster.Parameters.NumOfNodes)
+	if err != nil {
+		return fmt.Errorf("error convert NumOfNodes %s to int: %s", cluster.Parameters.NumOfNodes, err.Error())
+	}
+	d.Set("worker_numbers", []int{numOfNode})
+	d.Set("vswitch_ids", []string{cluster.Parameters.VSwitchID})
+	d.Set("worker_instance_types", []string{cluster.Parameters.WorkerInstanceType})
+
+	var workerNodes []map[string]interface{}
+
+	pageNumber := 1
+	for {
+		var result []cs.KubernetesNodeType
+		var pagination *cs.PaginationResult
+
+		if err := invoker.Run(func() error {
+			raw, e := client.WithCsClient(func(csClient *cs.Client) (interface{}, error) {
+				nodes, paginationResult, err := csClient.GetKubernetesClusterNodes(d.Id(), common.Pagination{PageNumber: pageNumber, PageSize: PageSizeLarge})
+				return []interface{}{nodes, paginationResult}, err
+			})
+			if e != nil {
+				return e
+			}
+			result, _ = raw.([]interface{})[0].([]cs.KubernetesNodeType)
+			pagination, _ = raw.([]interface{})[1].(*cs.PaginationResult)
+			return nil
+		}); err != nil {
+			return fmt.Errorf("[ERROR] GetManagedKubernetesClusterNodes got an error: %#v.", err)
+		}
+
+		if pageNumber == 1 && (len(result) == 0 || result[0].InstanceId == "") {
+			err := resource.Retry(5*time.Minute, func() *resource.RetryError {
+				if err := invoker.Run(func() error {
+					raw, e := client.WithCsClient(func(csClient *cs.Client) (interface{}, error) {
+						nodes, _, err := csClient.GetKubernetesClusterNodes(d.Id(), common.Pagination{PageNumber: pageNumber, PageSize: PageSizeLarge})
+						return nodes, err
+					})
+					if e != nil {
+						return e
+					}
+					tmp, _ := raw.([]cs.KubernetesNodeType)
+					if len(tmp) > 0 && tmp[0].InstanceId != "" {
+						result = tmp
+					}
+					return nil
+				}); err != nil {
+					return resource.NonRetryableError(fmt.Errorf("[ERROR] GetManagedKubernetesClusterNodes got an error: %#v.", err))
+				}
+				time.Sleep(5 * time.Second)
+				return resource.RetryableError(fmt.Errorf("[ERROR] There is no any nodes in ManagedKubernetes cluster %s.", d.Id()))
+			})
+			if err != nil {
+				return err
+			}
+
+		}
+
+		for _, node := range result {
+			mapping := map[string]interface{}{
+				"id":         node.InstanceId,
+				"name":       node.InstanceName,
+				"private_ip": node.IpAddress[0],
+			}
+			workerNodes = append(workerNodes, mapping)
+		}
+
+		if len(result) < pagination.PageSize {
+			break
+		}
+		pageNumber += 1
+	}
+	d.Set("worker_nodes", workerNodes)
+
+	if err := invoker.Run(func() error {
+		raw, err := client.WithCsClient(func(csClient *cs.Client) (interface{}, error) {
+			return csClient.GetClusterCerts(d.Id())
+		})
+		if err != nil {
+			return err
+		}
+		cert, _ := raw.(cs.ClusterCerts)
+		if ce, ok := d.GetOk("client_cert"); ok && ce.(string) != "" {
+			if err := writeToFile(ce.(string), cert.Cert); err != nil {
+				return err
+			}
+		}
+		if key, ok := d.GetOk("client_key"); ok && key.(string) != "" {
+			if err := writeToFile(key.(string), cert.Key); err != nil {
+				return err
+			}
+		}
+		if ca, ok := d.GetOk("cluster_ca_cert"); ok && ca.(string) != "" {
+			if err := writeToFile(ca.(string), cert.CA); err != nil {
+				return err
+			}
+		}
+		return nil
+	}); err != nil {
+		return fmt.Errorf("Get Cluster %s Certs got an error: %#v.", d.Id(), err)
+	}
+
+	var config cs.ClusterConfig
+	if file, ok := d.GetOk("kube_config"); ok && file.(string) != "" {
+		if err := invoker.Run(func() error {
+			raw, e := client.WithCsClient(func(csClient *cs.Client) (interface{}, error) {
+				return csClient.GetClusterConfig(d.Id())
+			})
+			if e != nil {
+				return e
+			}
+			config, _ = raw.(cs.ClusterConfig)
+			return nil
+		}); err != nil {
+			return fmt.Errorf("GetClusterConfig got an error: %#v.", err)
+		}
+		if err := writeToFile(file.(string), config.Config); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func resourceAlicloudCSManagedKubernetesDelete(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*connectivity.AliyunClient)
+	invoker := NewInvoker()
+	var cluster cs.ClusterType
+	return resource.Retry(5*time.Minute, func() *resource.RetryError {
+		if err := invoker.Run(func() error {
+			_, err := client.WithCsClient(func(csClient *cs.Client) (interface{}, error) {
+				return nil, csClient.DeleteCluster(d.Id())
+			})
+			return err
+		}); err != nil {
+			if NotFoundError(err) || IsExceptedError(err, ErrorClusterNotFound) {
+				return nil
+			}
+			return resource.RetryableError(fmt.Errorf("Delete ManagedKubernetes Cluster timeout and get an error: %#v.", err))
+		}
+
+		if err := invoker.Run(func() error {
+			raw, err := client.WithCsClient(func(csClient *cs.Client) (interface{}, error) {
+				return csClient.DescribeCluster(d.Id())
+			})
+			if err != nil {
+				return err
+			}
+			cluster, _ = raw.(cs.ClusterType)
+			return nil
+		}); err != nil {
+			if NotFoundError(err) || IsExceptedError(err, ErrorClusterNotFound) {
+				return nil
+			}
+			return resource.NonRetryableError(fmt.Errorf("Describing ManagedKubernetes Cluster got an error: %#v", err))
+		}
+		if cluster.ClusterID == "" {
+			return nil
+		}
+
+		if string(cluster.State) == string(Deleting) {
+			time.Sleep(5 * time.Second)
+		}
+
+		return resource.RetryableError(fmt.Errorf("Delete ManagedKubernetes Cluster timeout."))
+	})
+}
+
+func buildManagedKubernetesArgs(d *schema.ResourceData, meta interface{}) (*cs.KubernetesCreationArgs, error) {
+	client := meta.(*connectivity.AliyunClient)
+	ecsService := EcsService{client}
+	vpcService := VpcService{client}
+
+	// Ensure instance_type is valid
+	zoneId, validZones, err := ecsService.DescribeAvailableResources(d, meta, InstanceTypeResource)
+	if err != nil {
+		return nil, err
+	}
+
+	var workerInstanceType, vswitchID string
+	var workerNumber int
+
+	workerInstanceType = expandStringList(d.Get("worker_instance_types").([]interface{}))[0]
+
+	if list := expandStringList(d.Get("vswitch_ids").([]interface{})); len(list) > 0 {
+		vswitchID = list[0]
+	} else {
+		vswitchID = ""
+	}
+
+	if list := expandIntList(d.Get("worker_numbers").([]interface{})); len(list) > 0 {
+		workerNumber = list[0]
+	} else {
+		workerNumber = 3
+	}
+
+	if err := ecsService.InstanceTypeValidation(workerInstanceType, zoneId, validZones); err != nil {
+		return nil, err
+	}
+
+	var clusterName string
+	if v, ok := d.GetOk("name"); ok {
+		clusterName = v.(string)
+	} else {
+		clusterName = resource.PrefixedUniqueId(d.Get("name_prefix").(string))
+	}
+
+	var vpcId string
+	if vswitchID != "" {
+		vsw, err := vpcService.DescribeVswitch(vswitchID)
+		if err != nil {
+			return nil, err
+		}
+		vpcId = vsw.VpcId
+		if zoneId != "" && zoneId != vsw.ZoneId {
+			return nil, fmt.Errorf("The specified vswitch %s isn't in the zone %s.", vsw.VSwitchId, zoneId)
+		}
+		zoneId = vsw.ZoneId
+	} else if !d.Get("new_nat_gateway").(bool) {
+		return nil, fmt.Errorf("The automatic created VPC and VSwitch must set 'new_nat_gateway' to 'true'.")
+	}
+
+	creationArgs := &cs.KubernetesCreationArgs{
+		Name:                     clusterName,
+		ClusterType:              "ManagedKubernetes",
+		DisableRollback:          true,
+		TimeoutMins:              ManagedKubernetesCreationDefaultTimeoutInMinute,
+		WorkerInstanceType:       workerInstanceType,
+		VPCID:                    vpcId,
+		VSwitchId:                vswitchID,
+		LoginPassword:            d.Get("password").(string),
+		KeyPair:                  d.Get("key_name").(string),
+		ImageId:                  d.Get("image_id").(string),
+		Network:                  d.Get("cluster_network_type").(string),
+		NumOfNodes:               int64(workerNumber),
+		WorkerSystemDiskCategory: ecs.DiskCategory(d.Get("worker_disk_category").(string)),
+		WorkerSystemDiskSize:     int64(d.Get("worker_disk_size").(int)),
+		SNatEntry:                d.Get("new_nat_gateway").(bool),
+		KubernetesVersion:        d.Get("version").(string),
+		ContainerCIDR:            d.Get("pod_cidr").(string),
+		ServiceCIDR:              d.Get("service_cidr").(string),
+		CloudMonitorFlags:        d.Get("install_cloud_monitor").(bool),
+		ZoneId:                   zoneId,
+	}
+
+	if v, ok := d.GetOk("worker_data_disk_category"); ok {
+		creationArgs.WorkerDataDiskCategory = v.(string)
+		creationArgs.WorkerDataDisk = true
+		creationArgs.WorkerDataDiskSize = int64(d.Get("worker_data_disk_size").(int))
+	}
+
+	if v, ok := d.GetOk("worker_instance_charge_type"); ok {
+		creationArgs.WorkerInstanceChargeType = v.(string)
+		if creationArgs.WorkerInstanceChargeType == string(PrePaid) {
+			creationArgs.WorkerAutoRenew = d.Get("worker_auto_renew").(bool)
+			creationArgs.WorkerAutoRenewPeriod = d.Get("worker_auto_renew_period").(int)
+			creationArgs.WorkerPeriod = d.Get("worker_period").(int)
+			creationArgs.WorkerPeriodUnit = d.Get("worker_period_unit").(string)
+		}
+	}
+
+	return creationArgs, nil
+}

--- a/alicloud/resource_alicloud_cs_managed_kubernetes_test.go
+++ b/alicloud/resource_alicloud_cs_managed_kubernetes_test.go
@@ -1,0 +1,291 @@
+package alicloud
+
+import (
+	"fmt"
+	"github.com/hashicorp/terraform/terraform"
+	"testing"
+
+	"github.com/terraform-providers/terraform-provider-alicloud/alicloud/connectivity"
+
+	"github.com/denverdino/aliyungo/cs"
+	"github.com/hashicorp/terraform/helper/resource"
+)
+
+func TestAccAlicloudCSManagedKubernetes_basic(t *testing.T) {
+	var k8s cs.ClusterType
+
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() { testAccPreCheckWithRegions(t, true, connectivity.ManagedKubernetesSupportedRegions) },
+
+		IDRefreshName: "alicloud_cs_managed_kubernetes.k8s",
+
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckManagedKubernetesClusterDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccContainerManagedKubernetes_basic,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckContainerClusterExists("alicloud_cs_managed_kubernetes.k8s", &k8s),
+					resource.TestCheckResourceAttr("alicloud_cs_managed_kubernetes.k8s", "name", "tf-testAccContainerManagedKubernetes-basic"),
+					resource.TestCheckResourceAttr("alicloud_cs_managed_kubernetes.k8s", "worker_instance_charge_type", "PostPaid"),
+					resource.TestCheckResourceAttr("alicloud_cs_managed_kubernetes.k8s", "worker_numbers.#", "1"),
+					resource.TestCheckResourceAttr("alicloud_cs_managed_kubernetes.k8s", "worker_numbers.0", "2"),
+					resource.TestCheckResourceAttr("alicloud_cs_managed_kubernetes.k8s", "worker_disk_size", "50"),
+					resource.TestCheckResourceAttr("alicloud_cs_managed_kubernetes.k8s", "worker_disk_category", "cloud_ssd"),
+					resource.TestCheckResourceAttr("alicloud_cs_managed_kubernetes.k8s", "worker_instance_types.#", "1"),
+					resource.TestCheckResourceAttr("alicloud_cs_managed_kubernetes.k8s", "vswitch_ids.#", "1"),
+					resource.TestCheckResourceAttr("alicloud_cs_managed_kubernetes.k8s", "key_name", ""),
+
+					resource.TestCheckResourceAttrSet("alicloud_cs_managed_kubernetes.k8s", "image_id"),
+					resource.TestCheckResourceAttrSet("alicloud_cs_managed_kubernetes.k8s", "vpc_id"),
+					resource.TestCheckResourceAttrSet("alicloud_cs_managed_kubernetes.k8s", "security_group_id"),
+					resource.TestCheckResourceAttrSet("alicloud_cs_managed_kubernetes.k8s", "availability_zone"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAlicloudCSManagedKubernetes_autoVpc(t *testing.T) {
+	var k8s cs.ClusterType
+
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() { testAccPreCheckWithRegions(t, true, connectivity.ManagedKubernetesSupportedRegions) },
+
+		IDRefreshName: "alicloud_cs_managed_kubernetes.k8s",
+
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckManagedKubernetesClusterDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccContainerManagedKubernetes_autoVpc,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckContainerClusterExists("alicloud_cs_managed_kubernetes.k8s", &k8s),
+					resource.TestCheckResourceAttr("alicloud_cs_managed_kubernetes.k8s", "name", "tf-testAccContainerManagedKubernetes-autoVpc"),
+					resource.TestCheckResourceAttr("alicloud_cs_managed_kubernetes.k8s", "worker_numbers.#", "1"),
+					resource.TestCheckResourceAttr("alicloud_cs_managed_kubernetes.k8s", "worker_numbers.0", "2"),
+					resource.TestCheckResourceAttr("alicloud_cs_managed_kubernetes.k8s", "worker_disk_size", "40"),
+					resource.TestCheckResourceAttr("alicloud_cs_managed_kubernetes.k8s", "worker_disk_category", "cloud_efficiency"),
+					resource.TestCheckResourceAttr("alicloud_cs_managed_kubernetes.k8s", "worker_instance_charge_type", "PostPaid"),
+					resource.TestCheckResourceAttr("alicloud_cs_managed_kubernetes.k8s", "worker_instance_types.#", "1"),
+					resource.TestCheckResourceAttr("alicloud_cs_managed_kubernetes.k8s", "vswitch_ids.#", "1"),
+					resource.TestCheckResourceAttr("alicloud_cs_managed_kubernetes.k8s", "key_name", ""),
+
+					resource.TestCheckResourceAttrSet("alicloud_cs_managed_kubernetes.k8s", "image_id"),
+					resource.TestCheckResourceAttrSet("alicloud_cs_managed_kubernetes.k8s", "vpc_id"),
+					resource.TestCheckResourceAttrSet("alicloud_cs_managed_kubernetes.k8s", "security_group_id"),
+					resource.TestCheckResourceAttrSet("alicloud_cs_managed_kubernetes.k8s", "availability_zone"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAlicloudCSManagedKubernetes_update(t *testing.T) {
+	var k8s cs.ClusterType
+
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() { testAccPreCheckWithRegions(t, true, connectivity.ManagedKubernetesSupportedRegions) },
+
+		IDRefreshName: "alicloud_cs_managed_kubernetes.k8s",
+
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckManagedKubernetesClusterDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccContainerManagedKubernetes_update_before,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckContainerClusterExists("alicloud_cs_managed_kubernetes.k8s", &k8s),
+					resource.TestCheckResourceAttr("alicloud_cs_managed_kubernetes.k8s", "name", "tf-testAccContainerManagedKubernetes-update"),
+					resource.TestCheckResourceAttr("alicloud_cs_managed_kubernetes.k8s", "worker_numbers.#", "1"),
+					resource.TestCheckResourceAttr("alicloud_cs_managed_kubernetes.k8s", "worker_numbers.0", "2"),
+					resource.TestCheckResourceAttr("alicloud_cs_managed_kubernetes.k8s", "worker_disk_size", "40"),
+					resource.TestCheckResourceAttr("alicloud_cs_managed_kubernetes.k8s", "worker_disk_category", "cloud_efficiency"),
+					resource.TestCheckResourceAttr("alicloud_cs_managed_kubernetes.k8s", "worker_instance_charge_type", "PostPaid"),
+					resource.TestCheckResourceAttr("alicloud_cs_managed_kubernetes.k8s", "worker_instance_types.#", "1"),
+					resource.TestCheckResourceAttr("alicloud_cs_managed_kubernetes.k8s", "vswitch_ids.#", "1"),
+					resource.TestCheckResourceAttr("alicloud_cs_managed_kubernetes.k8s", "key_name", ""),
+
+					resource.TestCheckResourceAttrSet("alicloud_cs_managed_kubernetes.k8s", "image_id"),
+					resource.TestCheckResourceAttrSet("alicloud_cs_managed_kubernetes.k8s", "vpc_id"),
+					resource.TestCheckResourceAttrSet("alicloud_cs_managed_kubernetes.k8s", "security_group_id"),
+					resource.TestCheckResourceAttrSet("alicloud_cs_managed_kubernetes.k8s", "availability_zone"),
+				),
+			},
+			resource.TestStep{
+				Config: testAccContainerManagedKubernetes_update_after,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckContainerClusterExists("alicloud_cs_managed_kubernetes.k8s", &k8s),
+					resource.TestCheckResourceAttr("alicloud_cs_managed_kubernetes.k8s", "name", "tf-testAccContainerManagedKubernetes-update"),
+					resource.TestCheckResourceAttr("alicloud_cs_managed_kubernetes.k8s", "worker_numbers.#", "1"),
+					resource.TestCheckResourceAttr("alicloud_cs_managed_kubernetes.k8s", "worker_numbers.0", "4"),
+					resource.TestCheckResourceAttr("alicloud_cs_managed_kubernetes.k8s", "worker_disk_size", "40"),
+					resource.TestCheckResourceAttr("alicloud_cs_managed_kubernetes.k8s", "worker_disk_category", "cloud_efficiency"),
+					resource.TestCheckResourceAttr("alicloud_cs_managed_kubernetes.k8s", "worker_instance_charge_type", "PostPaid"),
+					resource.TestCheckResourceAttr("alicloud_cs_managed_kubernetes.k8s", "worker_instance_types.#", "1"),
+					resource.TestCheckResourceAttr("alicloud_cs_managed_kubernetes.k8s", "vswitch_ids.#", "1"),
+					resource.TestCheckResourceAttr("alicloud_cs_managed_kubernetes.k8s", "key_name", ""),
+
+					resource.TestCheckResourceAttrSet("alicloud_cs_managed_kubernetes.k8s", "image_id"),
+					resource.TestCheckResourceAttrSet("alicloud_cs_managed_kubernetes.k8s", "vpc_id"),
+					resource.TestCheckResourceAttrSet("alicloud_cs_managed_kubernetes.k8s", "security_group_id"),
+					resource.TestCheckResourceAttrSet("alicloud_cs_managed_kubernetes.k8s", "availability_zone"),
+				),
+			},
+		},
+	})
+}
+
+func testAccCheckManagedKubernetesClusterDestroy(s *terraform.State) error {
+	client := testAccProvider.Meta().(*connectivity.AliyunClient)
+
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "alicloud_cs_managed_kubernetes" {
+			continue
+		}
+
+		raw, err := client.WithCsClient(func(csClient *cs.Client) (interface{}, error) {
+			return csClient.DescribeCluster(rs.Primary.ID)
+		})
+
+		if err != nil {
+			if NotFoundError(err) || IsExceptedError(err, ErrorClusterNotFound) {
+				continue
+			}
+			return err
+		}
+		cluster, _ := raw.(cs.ClusterType)
+		if cluster.ClusterID != "" {
+			return fmt.Errorf("Error container cluster %s still exists.", rs.Primary.ID)
+		}
+	}
+
+	return nil
+}
+
+const testAccContainerManagedKubernetes_basic = `
+variable "name" {
+	default = "tf-testAccContainerManagedKubernetes-basic"
+}
+
+data "alicloud_zones" main {
+  available_resource_creation = "VSwitch"
+}
+
+data "alicloud_instance_types" "default" {
+	availability_zone = "${data.alicloud_zones.main.zones.0.id}"
+	cpu_core_count = 1
+	memory_size = 2
+}
+
+resource "alicloud_vpc" "foo" {
+  name = "${var.name}"
+  cidr_block = "10.1.0.0/21"
+}
+
+resource "alicloud_vswitch" "foo" {
+  name = "${var.name}"
+  vpc_id = "${alicloud_vpc.foo.id}"
+  cidr_block = "10.1.1.0/24"
+  availability_zone = "${data.alicloud_zones.main.zones.0.id}"
+}
+
+resource "alicloud_cs_managed_kubernetes" "k8s" {
+  name = "${var.name}"
+  availability_zone = "${data.alicloud_zones.main.zones.0.id}"
+  vswitch_ids = ["${alicloud_vswitch.foo.id}"]
+  new_nat_gateway = true
+  worker_instance_types = ["${data.alicloud_instance_types.default.instance_types.0.id}"]
+  worker_numbers = [2]
+  password = "Test12345"
+  pod_cidr = "172.20.0.0/16"
+  service_cidr = "172.21.0.0/20"
+  install_cloud_monitor = true
+  worker_disk_category  = "cloud_ssd"
+  worker_disk_size = 50
+}
+`
+
+const testAccContainerManagedKubernetes_autoVpc = `
+variable "name" {
+	default = "tf-testAccContainerManagedKubernetes-autoVpc"
+}
+data "alicloud_zones" main {
+  available_resource_creation = "VSwitch"
+}
+
+data "alicloud_instance_types" "default" {
+	availability_zone = "${data.alicloud_zones.main.zones.0.id}"
+	cpu_core_count = 1
+	memory_size = 2
+}
+
+resource "alicloud_cs_managed_kubernetes" "k8s" {
+  name = "${var.name}"
+  availability_zone = "${data.alicloud_zones.main.zones.0.id}"
+  new_nat_gateway = true
+  worker_instance_types = ["${data.alicloud_instance_types.default.instance_types.0.id}"]
+  worker_numbers = [2]
+  password = "Test12345"
+  pod_cidr = "172.20.0.0/16"
+  service_cidr = "172.21.0.0/20"
+  install_cloud_monitor = true
+  worker_disk_category  = "cloud_efficiency"
+}
+`
+
+const testAccContainerManagedKubernetes_update_before = `
+variable "name" {
+	default = "tf-testAccContainerManagedKubernetes-update"
+}
+data "alicloud_zones" main {
+  available_resource_creation = "VSwitch"
+}
+
+data "alicloud_instance_types" "default" {
+	availability_zone = "${data.alicloud_zones.main.zones.0.id}"
+	cpu_core_count = 1
+	memory_size = 2
+}
+
+resource "alicloud_cs_managed_kubernetes" "k8s" {
+  name = "${var.name}"
+  availability_zone = "${data.alicloud_zones.main.zones.0.id}"
+  new_nat_gateway = true
+  worker_instance_types = ["${data.alicloud_instance_types.default.instance_types.0.id}"]
+  worker_numbers = [2]
+  password = "Test12345"
+  pod_cidr = "172.20.0.0/16"
+  service_cidr = "172.21.0.0/20"
+  install_cloud_monitor = true
+  worker_disk_category  = "cloud_efficiency"
+}
+`
+
+const testAccContainerManagedKubernetes_update_after = `
+variable "name" {
+	default = "tf-testAccContainerManagedKubernetes-update"
+}
+data "alicloud_zones" main {
+  available_resource_creation = "VSwitch"
+}
+
+data "alicloud_instance_types" "default" {
+	availability_zone = "${data.alicloud_zones.main.zones.0.id}"
+	cpu_core_count = 1
+	memory_size = 2
+}
+
+resource "alicloud_cs_managed_kubernetes" "k8s" {
+  name = "${var.name}"
+  availability_zone = "${data.alicloud_zones.main.zones.0.id}"
+  new_nat_gateway = true
+  worker_instance_types = ["${data.alicloud_instance_types.default.instance_types.0.id}"]
+  worker_numbers = [4]
+  password = "Test12345"
+  pod_cidr = "172.20.0.0/16"
+  service_cidr = "172.21.0.0/20"
+  install_cloud_monitor = true
+  worker_disk_category  = "cloud_efficiency"
+}
+`

--- a/website/alicloud.erb
+++ b/website/alicloud.erb
@@ -445,6 +445,9 @@
                         <li<%= sidebar_current("docs-alicloud-resource-container") %>>
                             <a href="/docs/providers/alicloud/r/cs_kubernetes.html">alicloud_cs_kubernetes</a>
                         </li>
+                        <li<%= sidebar_current("docs-alicloud-resource-container") %>>
+                            <a href="/docs/providers/alicloud/r/cs_managed_kubernetes.html">alicloud_cs_managed_kubernetes</a>
+                        </li>
                     </ul>
                 </li>
 

--- a/website/docs/r/cs_managed_kubernetes.html.markdown
+++ b/website/docs/r/cs_managed_kubernetes.html.markdown
@@ -1,0 +1,127 @@
+---
+layout: "alicloud"
+page_title: "Alicloud: alicloud_cs_managed_kubernetes"
+sidebar_current: "docs-alicloud-resource-cs-managed-kubernetes"
+description: |-
+  Provides a Alicloud resource to manage container managed kubernetes cluster.
+---
+
+# alicloud\_cs\_managed\_kubernetes
+
+This resource will help you to manager a Managed Kubernetes Cluster. The cluster is same as container service created by web console.
+
+-> **NOTE:** Managed Kubernetes cluster only supports single availability zone currently. Arguments `vswitch_ids`, `worker_numbers`, `worker_instance_types` only accept one item.
+
+-> **NOTE:** Managed Kubernetes cluster only supports VPC network and it can access internet while creating kubernetes cluster.
+A Nat Gateway and configuring a SNAT for it can ensure one VPC network access internet. If there is no nat gateway in the
+VPC, you can set `new_nat_gateway` to "true" to create one automatically.
+
+-> **NOTE:** If there is no specified `vswitch_ids`, the resource will create a new VPC and VSwitch while creating managed kubernetes cluster.
+
+-> **NOTE:** Creating managed kubernetes cluster need to install several packages and it will cost about 10 minutes. Please be patient.
+
+-> **NOTE:** The provider supports to download kube config, client certificate, client key and cluster ca certificate
+after creating cluster successfully, and you can put them into the specified location, like '~/.kube/config'.
+
+-> **NOTE:** If you want to manage managed Kubernetes, you can use [Kubernetes Provider](https://www.terraform.io/docs/providers/kubernetes/index.html).
+
+## Example Usage
+
+Basic Usage
+
+```
+variable "name" {
+	default = "my-first-k8s"
+}
+data "alicloud_zones" main {
+  available_resource_creation = "VSwitch"
+}
+
+data "alicloud_instance_types" "default" {
+	availability_zone = "${data.alicloud_zones.main.zones.0.id}"
+	cpu_core_count = 1
+	memory_size = 2
+}
+
+resource "alicloud_cs_managed_kubernetes" "k8s" {
+  name = "${var.name}"
+  availability_zone = "${data.alicloud_zones.main.zones.0.id}"
+  new_nat_gateway = true
+  worker_instance_types = ["${data.alicloud_instance_types.default.instance_types.0.id}"]
+  worker_numbers = [2]
+  password = "Test12345"
+  pod_cidr = "172.20.0.0/16"
+  service_cidr = "172.21.0.0/20"
+  install_cloud_monitor = true
+  worker_disk_category  = "cloud_efficiency"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `name` - The kubernetes cluster's name. It is the only in one Alicloud account.
+* `name_prefix` - The kubernetes cluster name's prefix. It is conflict with `name`. If it is specified, terraform will using it to build the only cluster name. Default to "Terraform-Creation".
+* `availability_zone` - (Force new resource) The Zone where new kubernetes cluster will be located. If it is not be specified, the value will be vswitch's zone.
+* `vswitch_ids` - (Force new resource) The vswitch where new kubernetes cluster will be located. Specify one vswitch's id, if it is not specified, a new VPC and VSwicth will be built. It must be in the zone which `availability_zone` specified.
+* `new_nat_gateway` - (Force new resource) Whether to create a new nat gateway while creating kubernetes cluster. Default to true.
+* `password` - (Required, Force new resource) The password of ssh login cluster node. You have to specify one of `password` and `key_name` fields.
+* `key_name` - (Required, Force new resource) The keypair of ssh login cluster node, you have to create it first.
+* `pod_cidr` - (Required, Force new resource) The CIDR block for the pod network. It will be allocated automatically when `vswitch_ids` is not specified.
+It cannot be duplicated with the VPC CIDR and CIDR used by Kubernetes cluster in VPC, cannot be modified after creation.
+Maximum number of hosts allowed in the cluster: 256. Refer to [Plan Kubernetes CIDR blocks under VPC](https://www.alibabacloud.com/help/doc-detail/64530.htm).
+* `service_cidr` - (Required, Force new resource) The CIDR block for the service network.  It will be allocated automatically when `vswitch_id` is not specified.
+It cannot be duplicated with the VPC CIDR and CIDR used by Kubernetes cluster in VPC, cannot be modified after creation.
+* `install_cloud_monitor` - (Force new resource) Whether to install cloud monitor for the kubernetes' node.
+* `worker_disk_size` - (Force new resource) The system disk size of worker node. Its valid value range [20~32768] in GB. Default to 20.
+* `worker_disk_category` - (Force new resource) The system disk category of worker node. Its valid value are `cloud_ssd` and `cloud_efficiency`. Default to `cloud_efficiency`.
+* `worker_data_disk_size` - (Force new resource) The data disk size of worker node. Its valid value range [20~32768] in GB. When `worker_data_disk_category` is presented, it defaults to 40.
+* `worker_data_disk_category` - (Force new resource) The data disk category of worker node. Its valid value are `cloud_ssd` and `cloud_efficiency`, if not set, data disk will not be created.
+* `worker_numbers` - The worker node number of the kubernetes cluster. Default to [3]. It is limited up to 50 and if you want to enlarge it, please apply white list or contact with us.
+* `worker_instance_types` - (Required, Force new resource) The instance type of worker node. Specify one type for single AZ Cluster, three types for MultiAZ Cluster.
+* `worker_instance_charge_type` - (Optional, Force new resource) Worker payment type. `PrePaid` or `PostPaid`, defaults to `PostPaid`.
+* `worker_period_unit` - (Optional) Worker payment period unit. `Month` or `Week`, defaults to `Month`.
+* `worker_period` - (Optional) Worker payment period. When period unit is `Month`, it can be one of { “1”, “2”, “3”, “4”, “5”, “6”, “7”, “8”, “9”, “12”, “24”, “36”,”48”,”60”}.  When period unit is `Week`, it can be one of {“1”, “2”, “3”, “4”}.
+* `worker_auto_renew` - (Optional) Enable worker payment auto-renew, defaults to false.
+* `worker_auto_renew_period` - (Optional) Worker payment auto-renew period. When period unit is `Month`, it can be one of {“1”, “2”, “3”, “6”, “12”}.  When period unit is `Week`, it can be one of {“1”, “2”, “3”}.
+* `cluster_network_type` - (Optional, Force new resource) The network that cluster uses, use `flannel` or `terway`.
+* `kube_config` - (Optional) The path of kube config, like `~/.kube/config`.
+* `client_cert` - (Optional) The path of client certificate, like `~/.kube/client-cert.pem`.
+* `client_key` - (Optional) The path of client key, like `~/.kube/client-key.pem`.
+* `cluster_ca_cert` - (Optional) The path of cluster ca certificate, like `~/.kube/cluster-ca-cert.pem`
+
+## Attributes Reference
+
+The following attributes are exported:
+
+* `id` - The ID of the container cluster.
+* `name` - The name of the container cluster.
+* `availability_zone` - The ID of availability zone.
+* `key_name` - The keypair of ssh login cluster node, you have to create it first.
+* `worker_numbers` - The ECS instance node number in the current container cluster.
+* `vswitch_ids` - The ID of VSwitches where the current cluster is located.
+* `vpc_id` - The ID of VPC where the current cluster is located.
+* `security_group_id` - The ID of security group where the current cluster worker node is located.
+* `image_id` - The ID of node image.
+* `nat_gateway_id` - The ID of nat gateway used to launch kubernetes cluster.
+* `worker_instance_types` - The instance type of worker node.
+* `worker_disk_size` - The system disk size of worker node.
+* `worker_disk_category` - The system disk category of worker node.
+* `worker_data_disk_size` - The data disk category of worker node.
+* `worker_data_disk_category` - The data disk size of worker node.
+* `worker_nodes` - List of cluster worker nodes. It contains several attributes to `Block Nodes`.
+
+### Block Nodes
+
+* `id` - ID of the node.
+* `name` - Node name.
+* `private_ip` - The private IP address of node.
+
+## Import
+
+Managed Kubernetes cluster can be imported using the id, e.g.
+
+```
+$ terraform import alicloud_cs_managed_kubernetes.main ce4273f9156874b46bb
+```


### PR DESCRIPTION
* Managed Kubernetes Clusters have no masters, so there is no need to set master_instance_types, master_disk_category and other master-related arguments.

* Field `connections` is not applicable to Managed Kubernetes.

* Add NodeStableClusterState to cut time waiting for nodes when calling the read method. When cluster is in NodeStableClusterState, there is no node changes, so no need to poll the node api.

