### PR TITLE
Fix ess_scaling_group import bugs and improve ess schedule testcase

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ IMPROVEMENTS:
 
 BUG FIXES:
 
+- Fix ess_scaling_group import bugs and improve ess schedule testcase [GH-565]
 - Fix alicloud rds related IncorrectStatus bug [GH-558]
 - Fix alicloud_fc_trigger's config diff bug [GH-556]
 - Fix oss bucket deleting failed error [GH-550]

--- a/alicloud/connectivity/client.go
+++ b/alicloud/connectivity/client.go
@@ -104,7 +104,9 @@ const businessInfoKey = "Terraform"
 const DefaultClientTimeout = 30000000000
 const DefaultEcsClientTimeout = 60000000000
 
-const DefaultClientRetryCount = 5
+const DefaultClientRetryCountSmall = 5
+const DefaultClientRetryCountMedium = 10
+const DefaultClientRetryCountLarge = 15
 
 var goSdkMutex = sync.RWMutex{} // The Go SDK is not thread-safe
 
@@ -277,7 +279,8 @@ func (client *AliyunClient) WithOssClient(do func(*oss.Client) (interface{}, err
 		}
 
 		log.Printf("[DEBUG] Instantiate OSS client using endpoint: %#v", endpoint)
-		clientOptions := []oss.ClientOption{oss.UserAgent(client.getUserAgent())}
+		clientOptions := []oss.ClientOption{oss.UserAgent(client.getUserAgent()),
+			oss.SecurityToken(client.config.SecurityToken)}
 		proxyUrl := client.getHttpProxyUrl()
 		if proxyUrl != nil {
 			clientOptions = append(clientOptions, oss.Proxy(proxyUrl.String()))
@@ -583,7 +586,7 @@ func (client *AliyunClient) WithFcClient(do func(*fc.Client) (interface{}, error
 			fc.WithSecurityToken(client.config.SecurityToken),
 			fc.WithTransport(config.HttpTransport),
 			fc.WithTimeout(DefaultClientTimeout),
-			fc.WithRetryCount(DefaultClientRetryCount))
+			fc.WithRetryCount(DefaultClientRetryCountSmall))
 		if err != nil {
 			return nil, fmt.Errorf("unable to initialize the FC client: %#v", err)
 		}
@@ -777,7 +780,7 @@ func (client *AliyunClient) getSdkConfig() *sdk.Config {
 		utils.LoadLocationFromTZData = time.LoadLocationFromTZData
 	}
 	return sdk.NewConfig().
-		WithMaxRetryTime(DefaultClientRetryCount).
+		WithMaxRetryTime(DefaultClientRetryCountSmall).
 		WithTimeout(time.Duration(DefaultClientTimeout)).
 		WithUserAgent(client.getUserAgent()).
 		WithGoRoutinePoolSize(10).

--- a/alicloud/resource_alicloud_ess_scalinggroup.go
+++ b/alicloud/resource_alicloud_ess_scalinggroup.go
@@ -136,6 +136,7 @@ func resourceAliyunEssScalingGroupRead(d *schema.ResourceData, meta interface{})
 	d.Set("max_size", scaling.MaxSize)
 	d.Set("scaling_group_name", scaling.ScalingGroupName)
 	d.Set("default_cooldown", scaling.DefaultCooldown)
+	d.Set("multi_az_policy", scaling.MultiAZPolicy)
 	var polices []string
 	if len(scaling.RemovalPolicies.RemovalPolicy) > 0 {
 		for _, v := range scaling.RemovalPolicies.RemovalPolicy {

--- a/alicloud/resource_alicloud_ess_schedule_test.go
+++ b/alicloud/resource_alicloud_ess_schedule_test.go
@@ -96,6 +96,7 @@ func testSweepEssSchedules(region string) error {
 
 func TestAccAlicloudEssSchedule_basic(t *testing.T) {
 	var sc ess.ScheduledTask
+	local, _ := time.LoadLocation("Asia/Shanghai")
 
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
@@ -109,7 +110,7 @@ func TestAccAlicloudEssSchedule_basic(t *testing.T) {
 		CheckDestroy: testAccCheckEssScheduleDestroy,
 		Steps: []resource.TestStep{
 			resource.TestStep{
-				Config: testAccEssScheduleConfig(time.Now().Format("2006-01-02T15:04Z")),
+				Config: testAccEssScheduleConfig(time.Now().In(local).Format("2006-01-02T15:04Z")),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckEssScheduleExists(
 						"alicloud_ess_schedule.foo", &sc),


### PR DESCRIPTION
```
TF_ACC=1 go test ./alicloud -v -run=TestAccAlicloudEssScalingGroup_importBasic  -timeout=240m
=== RUN   TestAccAlicloudEssScalingGroup_importBasic
--- PASS: TestAccAlicloudEssScalingGroup_importBasic (160.02s)
PASS
ok  	github.com/terraform-providers/terraform-provider-alicloud/alicloud	160.088s
TF_ACC=1 go test ./alicloud -v -run=TestAccAlicloudEssSchedule_basic -timeout=180m
=== RUN   TestAccAlicloudEssSchedule_basic
--- PASS: TestAccAlicloudEssSchedule_basic (78.33s)
PASS
```
ok  	github.com/terraform-providers/terraform-provider-alicloud/alicloud	78.392s