### PR TITLE
Add timeout and retry for tablestore client and Improve its testcases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 IMPROVEMENTS:
 
+- Add timeout and retry for tablestore client and Improve its testcases [GH-569]
 - Modify kvstore_instance password to Optional and improve its testcases [GH-567]
 - Improve datasource alicloud_vpcs testcase [GH-566]
 - Improve dns_domains testcase [GH-561]

--- a/alicloud.tf
+++ b/alicloud.tf
@@ -1,0 +1,14 @@
+resource "alicloud_ots_instance" "foo" {
+	name = "${var.name}"
+	description = "${var.name}"
+	accessed_by = "ConsoleOrVpc"
+	instance_type = "Capacity"
+	tags {
+		Updated = "TF"
+		For = "acceptance test"
+		From = "TF"
+	}
+}
+variable "name" {
+	default = "tf-testAcc12345"
+}

--- a/alicloud/connectivity/client.go
+++ b/alicloud/connectivity/client.go
@@ -708,7 +708,7 @@ func (client *AliyunClient) WithTableStoreClient(instanceName string, do func(*t
 		if !strings.HasPrefix(endpoint, "https") && !strings.HasPrefix(endpoint, "http") {
 			endpoint = "https://" + endpoint
 		}
-		tableStoreClient = tablestore.NewClient(endpoint, instanceName, client.AccessKey, client.SecretKey)
+		tableStoreClient = tablestore.NewClientWithConfig(endpoint, instanceName, client.AccessKey, client.SecretKey, client.SecurityToken, tablestore.NewDefaultTableStoreConfig())
 		client.tablestoreconnByInstanceName[instanceName] = tableStoreClient
 	}
 

--- a/alicloud/connectivity/regions.go
+++ b/alicloud/connectivity/regions.go
@@ -53,3 +53,5 @@ var DatahubSupportedRegions = []Region{Beijing, Hangzhou, Shanghai, Shenzhen, AP
 var RdsMultiAzNoSupportedRegions = []Region{Qingdao, APNorthEast1, APSouthEast5, MEEast1}
 var RouteTableNoSupportedRegions = []Region{Beijing, Hangzhou, Shenzhen}
 var ApiGatewayNoSupportedRegions = []Region{Zhangjiakou, Huhehaote, USEast1, USWest1, EUWest1, MEEast1}
+var OtsHighPerformanceNoSupportedRegions = []Region{Qingdao, Zhangjiakou, Huhehaote, Hongkong, APSouthEast2, APSouthEast5, APNorthEast1, EUCentral1, MEEast1, APSouth1}
+var OtsCapacityNoSupportedRegions = []Region{APSouthEast1, USWest1, USEast1}

--- a/alicloud/import_alicloud_ots_instance_test.go
+++ b/alicloud/import_alicloud_ots_instance_test.go
@@ -3,19 +3,41 @@ package alicloud
 import (
 	"testing"
 
+	"github.com/hashicorp/terraform/helper/acctest"
 	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/terraform-providers/terraform-provider-alicloud/alicloud/connectivity"
 )
 
-func TestAccAlicloudOtsInstance_import(t *testing.T) {
-	resourceName := "alicloud_ots_instance.basic"
+func TestAccAlicloudOtsInstanceCapacity_import(t *testing.T) {
+	resourceName := "alicloud_ots_instance.foo"
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { testAccPreCheckWithRegions(t, false, connectivity.OtsCapacityNoSupportedRegions) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckOtsInstanceDestroy,
 		Steps: []resource.TestStep{
 			resource.TestStep{
-				Config: testAccOtsInstance,
+				Config: testAccOtsInstance(string(OtsCapacity), acctest.RandIntRange(10000, 999999)),
+			},
+			resource.TestStep{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccAlicloudOtsInstanceHighPerformance_import(t *testing.T) {
+	resourceName := "alicloud_ots_instance.foo"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheckWithRegions(t, false, connectivity.OtsHighPerformanceNoSupportedRegions) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckOtsInstanceDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccOtsInstance(string(OtsHighPerformance), acctest.RandIntRange(10000, 999999)),
 			},
 			resource.TestStep{
 				ResourceName:      resourceName,

--- a/alicloud/import_alicloud_ots_table_test.go
+++ b/alicloud/import_alicloud_ots_table_test.go
@@ -3,19 +3,41 @@ package alicloud
 import (
 	"testing"
 
+	"github.com/hashicorp/terraform/helper/acctest"
 	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/terraform-providers/terraform-provider-alicloud/alicloud/connectivity"
 )
 
-func TestAccAlicloudOtsTable_importBasic(t *testing.T) {
+func TestAccAlicloudOtsTableCapacity_import(t *testing.T) {
 	resourceName := "alicloud_ots_table.basic"
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { testAccPreCheckWithRegions(t, false, connectivity.OtsCapacityNoSupportedRegions) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckOtsTableDestroy,
 		Steps: []resource.TestStep{
 			resource.TestStep{
-				Config: testAccOtsTable,
+				Config: testAccOtsTableStore(string(OtsCapacity), acctest.RandIntRange(10000, 999999)),
+			},
+			resource.TestStep{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccAlicloudOtsTableHighPerformance_import(t *testing.T) {
+	resourceName := "alicloud_ots_table.basic"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheckWithRegions(t, false, connectivity.OtsHighPerformanceNoSupportedRegions) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckOtsTableDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccOtsTableStore(string(OtsHighPerformance), acctest.RandIntRange(10000, 999999)),
 			},
 			resource.TestStep{
 				ResourceName:      resourceName,

--- a/alicloud/resource_alicloud_ots_table_test.go
+++ b/alicloud/resource_alicloud_ots_table_test.go
@@ -8,18 +8,19 @@ import (
 
 	"github.com/aliyun/alibaba-cloud-sdk-go/services/ots"
 	"github.com/aliyun/aliyun-tablestore-go-sdk/tablestore"
+	"github.com/hashicorp/terraform/helper/acctest"
 	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/terraform"
 	"github.com/terraform-providers/terraform-provider-alicloud/alicloud/connectivity"
 )
 
-func TestAccAlicloudOtsTable_Basic(t *testing.T) {
+func TestAccAlicloudOtsTableStoreCapatity(t *testing.T) {
 	var table tablestore.DescribeTableResponse
 	var instance ots.InstanceInfo
+	rand := acctest.RandIntRange(10000, 999999)
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
-
-			testAccPreCheck(t)
+			testAccPreCheckWithRegions(t, false, connectivity.OtsCapacityNoSupportedRegions)
 		},
 
 		// module name
@@ -28,15 +29,325 @@ func TestAccAlicloudOtsTable_Basic(t *testing.T) {
 		CheckDestroy:  testAccCheckOtsTableDestroy,
 		Steps: []resource.TestStep{
 			resource.TestStep{
-				Config: testAccOtsTable,
+				Config: testAccOtsTableStore(string(OtsCapacity), rand),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckOtsInstanceExist(
-						"alicloud_ots_instance.foo", &instance),
-					testAccCheckOtsTableExist(
-						"alicloud_ots_table.basic", &table),
-					resource.TestCheckResourceAttr(
-						"alicloud_ots_table.basic",
-						"table_name", "testAccOtsTable"),
+					testAccCheckOtsInstanceExist("alicloud_ots_instance.foo", &instance),
+					testAccCheckOtsTableExist("alicloud_ots_table.basic", &table),
+					resource.TestCheckResourceAttr("alicloud_ots_table.basic", "instance_name", fmt.Sprintf("tf-testAcc%d", rand)),
+					resource.TestCheckResourceAttr("alicloud_ots_table.basic", "table_name", fmt.Sprintf("testAcc%d", rand)),
+					resource.TestCheckResourceAttr("alicloud_ots_table.basic", "primary_key.#", "1"),
+					resource.TestCheckResourceAttr("alicloud_ots_table.basic", "primary_key.0.name", "pk1"),
+					resource.TestCheckResourceAttr("alicloud_ots_table.basic", "primary_key.0.type", "Integer"),
+					resource.TestCheckResourceAttr("alicloud_ots_table.basic", "time_to_live", "-1"),
+					resource.TestCheckResourceAttr("alicloud_ots_table.basic", "max_version", "1"),
+				),
+			},
+		},
+	})
+
+}
+func TestAccAlicloudOtsTableStoreCapatity_updateMaxVersion(t *testing.T) {
+	var table tablestore.DescribeTableResponse
+	var instance ots.InstanceInfo
+	rand := acctest.RandIntRange(10000, 999999)
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheckWithRegions(t, false, connectivity.OtsCapacityNoSupportedRegions)
+		},
+
+		// module name
+		IDRefreshName: "alicloud_ots_table.basic",
+		Providers:     testAccProviders,
+		CheckDestroy:  testAccCheckOtsTableDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccOtsTableStore(string(OtsCapacity), rand),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckOtsInstanceExist("alicloud_ots_instance.foo", &instance),
+					testAccCheckOtsTableExist("alicloud_ots_table.basic", &table),
+					resource.TestCheckResourceAttr("alicloud_ots_table.basic", "instance_name", fmt.Sprintf("tf-testAcc%d", rand)),
+					resource.TestCheckResourceAttr("alicloud_ots_table.basic", "table_name", fmt.Sprintf("testAcc%d", rand)),
+					resource.TestCheckResourceAttr("alicloud_ots_table.basic", "primary_key.#", "1"),
+					resource.TestCheckResourceAttr("alicloud_ots_table.basic", "primary_key.0.name", "pk1"),
+					resource.TestCheckResourceAttr("alicloud_ots_table.basic", "primary_key.0.type", "Integer"),
+					resource.TestCheckResourceAttr("alicloud_ots_table.basic", "time_to_live", "-1"),
+					resource.TestCheckResourceAttr("alicloud_ots_table.basic", "max_version", "1"),
+				),
+			},
+			resource.TestStep{
+				Config: testAccOtsTableStoreUpdateMaxVersion(string(OtsCapacity), rand),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckOtsInstanceExist("alicloud_ots_instance.foo", &instance),
+					testAccCheckOtsTableExist("alicloud_ots_table.basic", &table),
+					resource.TestCheckResourceAttr("alicloud_ots_table.basic", "instance_name", fmt.Sprintf("tf-testAcc%d", rand)),
+					resource.TestCheckResourceAttr("alicloud_ots_table.basic", "table_name", fmt.Sprintf("testAcc%d", rand)),
+					resource.TestCheckResourceAttr("alicloud_ots_table.basic", "primary_key.#", "1"),
+					resource.TestCheckResourceAttr("alicloud_ots_table.basic", "primary_key.0.name", "pk1"),
+					resource.TestCheckResourceAttr("alicloud_ots_table.basic", "primary_key.0.type", "Integer"),
+					resource.TestCheckResourceAttr("alicloud_ots_table.basic", "time_to_live", "-1"),
+					resource.TestCheckResourceAttr("alicloud_ots_table.basic", "max_version", "2"),
+				),
+			},
+		},
+	})
+
+}
+func TestAccAlicloudOtsTableStoreCapatity_updateTimeToLive(t *testing.T) {
+	var table tablestore.DescribeTableResponse
+	var instance ots.InstanceInfo
+	rand := acctest.RandIntRange(10000, 999999)
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheckWithRegions(t, false, connectivity.OtsCapacityNoSupportedRegions)
+		},
+
+		// module name
+		IDRefreshName: "alicloud_ots_table.basic",
+		Providers:     testAccProviders,
+		CheckDestroy:  testAccCheckOtsTableDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccOtsTableStore(string(OtsCapacity), rand),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckOtsInstanceExist("alicloud_ots_instance.foo", &instance),
+					testAccCheckOtsTableExist("alicloud_ots_table.basic", &table),
+					resource.TestCheckResourceAttr("alicloud_ots_table.basic", "instance_name", fmt.Sprintf("tf-testAcc%d", rand)),
+					resource.TestCheckResourceAttr("alicloud_ots_table.basic", "table_name", fmt.Sprintf("testAcc%d", rand)),
+					resource.TestCheckResourceAttr("alicloud_ots_table.basic", "primary_key.#", "1"),
+					resource.TestCheckResourceAttr("alicloud_ots_table.basic", "primary_key.0.name", "pk1"),
+					resource.TestCheckResourceAttr("alicloud_ots_table.basic", "primary_key.0.type", "Integer"),
+					resource.TestCheckResourceAttr("alicloud_ots_table.basic", "time_to_live", "-1"),
+					resource.TestCheckResourceAttr("alicloud_ots_table.basic", "max_version", "1"),
+				),
+			},
+			resource.TestStep{
+				Config: testAccOtsTableStoreUpdateTimeToLive(string(OtsCapacity), rand),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckOtsInstanceExist("alicloud_ots_instance.foo", &instance),
+					testAccCheckOtsTableExist("alicloud_ots_table.basic", &table),
+					resource.TestCheckResourceAttr("alicloud_ots_table.basic", "instance_name", fmt.Sprintf("tf-testAcc%d", rand)),
+					resource.TestCheckResourceAttr("alicloud_ots_table.basic", "table_name", fmt.Sprintf("testAcc%d", rand)),
+					resource.TestCheckResourceAttr("alicloud_ots_table.basic", "primary_key.#", "1"),
+					resource.TestCheckResourceAttr("alicloud_ots_table.basic", "primary_key.0.name", "pk1"),
+					resource.TestCheckResourceAttr("alicloud_ots_table.basic", "primary_key.0.type", "Integer"),
+					resource.TestCheckResourceAttr("alicloud_ots_table.basic", "time_to_live", "86401"),
+					resource.TestCheckResourceAttr("alicloud_ots_table.basic", "max_version", "1"),
+				),
+			},
+		},
+	})
+
+}
+func TestAccAlicloudOtsTableStoreCapatity_updateAll(t *testing.T) {
+	var table tablestore.DescribeTableResponse
+	var instance ots.InstanceInfo
+	rand := acctest.RandIntRange(10000, 999999)
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheckWithRegions(t, false, connectivity.OtsCapacityNoSupportedRegions)
+		},
+
+		// module name
+		IDRefreshName: "alicloud_ots_table.basic",
+		Providers:     testAccProviders,
+		CheckDestroy:  testAccCheckOtsTableDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccOtsTableStore(string(OtsCapacity), rand),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckOtsInstanceExist("alicloud_ots_instance.foo", &instance),
+					testAccCheckOtsTableExist("alicloud_ots_table.basic", &table),
+					resource.TestCheckResourceAttr("alicloud_ots_table.basic", "instance_name", fmt.Sprintf("tf-testAcc%d", rand)),
+					resource.TestCheckResourceAttr("alicloud_ots_table.basic", "table_name", fmt.Sprintf("testAcc%d", rand)),
+					resource.TestCheckResourceAttr("alicloud_ots_table.basic", "primary_key.#", "1"),
+					resource.TestCheckResourceAttr("alicloud_ots_table.basic", "primary_key.0.name", "pk1"),
+					resource.TestCheckResourceAttr("alicloud_ots_table.basic", "primary_key.0.type", "Integer"),
+					resource.TestCheckResourceAttr("alicloud_ots_table.basic", "time_to_live", "-1"),
+					resource.TestCheckResourceAttr("alicloud_ots_table.basic", "max_version", "1"),
+				),
+			},
+			resource.TestStep{
+				Config: testAccOtsTableStoreUpdateAll(string(OtsCapacity), rand),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckOtsInstanceExist("alicloud_ots_instance.foo", &instance),
+					testAccCheckOtsTableExist("alicloud_ots_table.basic", &table),
+					resource.TestCheckResourceAttr("alicloud_ots_table.basic", "instance_name", fmt.Sprintf("tf-testAcc%d", rand)),
+					resource.TestCheckResourceAttr("alicloud_ots_table.basic", "table_name", fmt.Sprintf("testAcc%d", rand)),
+					resource.TestCheckResourceAttr("alicloud_ots_table.basic", "primary_key.#", "1"),
+					resource.TestCheckResourceAttr("alicloud_ots_table.basic", "primary_key.0.name", "pk1"),
+					resource.TestCheckResourceAttr("alicloud_ots_table.basic", "primary_key.0.type", "Integer"),
+					resource.TestCheckResourceAttr("alicloud_ots_table.basic", "time_to_live", "86401"),
+					resource.TestCheckResourceAttr("alicloud_ots_table.basic", "max_version", "2"),
+				),
+			},
+		},
+	})
+
+}
+func TestAccAlicloudOtsTableStoreHighPerformance(t *testing.T) {
+	var table tablestore.DescribeTableResponse
+	var instance ots.InstanceInfo
+	rand := acctest.RandIntRange(10000, 999999)
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheckWithRegions(t, false, connectivity.OtsHighPerformanceNoSupportedRegions)
+		},
+
+		// module name
+		IDRefreshName: "alicloud_ots_table.basic",
+		Providers:     testAccProviders,
+		CheckDestroy:  testAccCheckOtsTableDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccOtsTableStore(string(OtsHighPerformance), rand),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckOtsInstanceExist("alicloud_ots_instance.foo", &instance),
+					testAccCheckOtsTableExist("alicloud_ots_table.basic", &table),
+					resource.TestCheckResourceAttr("alicloud_ots_table.basic", "instance_name", fmt.Sprintf("tf-testAcc%d", rand)),
+					resource.TestCheckResourceAttr("alicloud_ots_table.basic", "table_name", fmt.Sprintf("testAcc%d", rand)),
+					resource.TestCheckResourceAttr("alicloud_ots_table.basic", "primary_key.#", "1"),
+					resource.TestCheckResourceAttr("alicloud_ots_table.basic", "primary_key.0.name", "pk1"),
+					resource.TestCheckResourceAttr("alicloud_ots_table.basic", "primary_key.0.type", "Integer"),
+					resource.TestCheckResourceAttr("alicloud_ots_table.basic", "time_to_live", "-1"),
+					resource.TestCheckResourceAttr("alicloud_ots_table.basic", "max_version", "1"),
+				),
+			},
+		},
+	})
+
+}
+func TestAccAlicloudOtsTableStoreHighPerformance_updateMaxVersion(t *testing.T) {
+	var table tablestore.DescribeTableResponse
+	var instance ots.InstanceInfo
+	rand := acctest.RandIntRange(10000, 999999)
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheckWithRegions(t, false, connectivity.OtsHighPerformanceNoSupportedRegions)
+		},
+
+		// module name
+		IDRefreshName: "alicloud_ots_table.basic",
+		Providers:     testAccProviders,
+		CheckDestroy:  testAccCheckOtsTableDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccOtsTableStore(string(OtsHighPerformance), rand),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckOtsInstanceExist("alicloud_ots_instance.foo", &instance),
+					testAccCheckOtsTableExist("alicloud_ots_table.basic", &table),
+					resource.TestCheckResourceAttr("alicloud_ots_table.basic", "instance_name", fmt.Sprintf("tf-testAcc%d", rand)),
+					resource.TestCheckResourceAttr("alicloud_ots_table.basic", "table_name", fmt.Sprintf("testAcc%d", rand)),
+					resource.TestCheckResourceAttr("alicloud_ots_table.basic", "primary_key.#", "1"),
+					resource.TestCheckResourceAttr("alicloud_ots_table.basic", "primary_key.0.name", "pk1"),
+					resource.TestCheckResourceAttr("alicloud_ots_table.basic", "primary_key.0.type", "Integer"),
+					resource.TestCheckResourceAttr("alicloud_ots_table.basic", "time_to_live", "-1"),
+					resource.TestCheckResourceAttr("alicloud_ots_table.basic", "max_version", "1"),
+				),
+			},
+			resource.TestStep{
+				Config: testAccOtsTableStoreUpdateMaxVersion(string(OtsHighPerformance), rand),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckOtsInstanceExist("alicloud_ots_instance.foo", &instance),
+					testAccCheckOtsTableExist("alicloud_ots_table.basic", &table),
+					resource.TestCheckResourceAttr("alicloud_ots_table.basic", "instance_name", fmt.Sprintf("tf-testAcc%d", rand)),
+					resource.TestCheckResourceAttr("alicloud_ots_table.basic", "table_name", fmt.Sprintf("testAcc%d", rand)),
+					resource.TestCheckResourceAttr("alicloud_ots_table.basic", "primary_key.#", "1"),
+					resource.TestCheckResourceAttr("alicloud_ots_table.basic", "primary_key.0.name", "pk1"),
+					resource.TestCheckResourceAttr("alicloud_ots_table.basic", "primary_key.0.type", "Integer"),
+					resource.TestCheckResourceAttr("alicloud_ots_table.basic", "time_to_live", "-1"),
+					resource.TestCheckResourceAttr("alicloud_ots_table.basic", "max_version", "2"),
+				),
+			},
+		},
+	})
+
+}
+func TestAccAlicloudOtsTableStoreHighPerformance_updateTimeToLive(t *testing.T) {
+	var table tablestore.DescribeTableResponse
+	var instance ots.InstanceInfo
+	rand := acctest.RandIntRange(10000, 999999)
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheckWithRegions(t, false, connectivity.OtsHighPerformanceNoSupportedRegions)
+		},
+
+		// module name
+		IDRefreshName: "alicloud_ots_table.basic",
+		Providers:     testAccProviders,
+		CheckDestroy:  testAccCheckOtsTableDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccOtsTableStore(string(OtsHighPerformance), rand),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckOtsInstanceExist("alicloud_ots_instance.foo", &instance),
+					testAccCheckOtsTableExist("alicloud_ots_table.basic", &table),
+					resource.TestCheckResourceAttr("alicloud_ots_table.basic", "instance_name", fmt.Sprintf("tf-testAcc%d", rand)),
+					resource.TestCheckResourceAttr("alicloud_ots_table.basic", "table_name", fmt.Sprintf("testAcc%d", rand)),
+					resource.TestCheckResourceAttr("alicloud_ots_table.basic", "primary_key.#", "1"),
+					resource.TestCheckResourceAttr("alicloud_ots_table.basic", "primary_key.0.name", "pk1"),
+					resource.TestCheckResourceAttr("alicloud_ots_table.basic", "primary_key.0.type", "Integer"),
+					resource.TestCheckResourceAttr("alicloud_ots_table.basic", "time_to_live", "-1"),
+					resource.TestCheckResourceAttr("alicloud_ots_table.basic", "max_version", "1"),
+				),
+			},
+			resource.TestStep{
+				Config: testAccOtsTableStoreUpdateTimeToLive(string(OtsHighPerformance), rand),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckOtsInstanceExist("alicloud_ots_instance.foo", &instance),
+					testAccCheckOtsTableExist("alicloud_ots_table.basic", &table),
+					resource.TestCheckResourceAttr("alicloud_ots_table.basic", "instance_name", fmt.Sprintf("tf-testAcc%d", rand)),
+					resource.TestCheckResourceAttr("alicloud_ots_table.basic", "table_name", fmt.Sprintf("testAcc%d", rand)),
+					resource.TestCheckResourceAttr("alicloud_ots_table.basic", "primary_key.#", "1"),
+					resource.TestCheckResourceAttr("alicloud_ots_table.basic", "primary_key.0.name", "pk1"),
+					resource.TestCheckResourceAttr("alicloud_ots_table.basic", "primary_key.0.type", "Integer"),
+					resource.TestCheckResourceAttr("alicloud_ots_table.basic", "time_to_live", "86401"),
+					resource.TestCheckResourceAttr("alicloud_ots_table.basic", "max_version", "1"),
+				),
+			},
+		},
+	})
+
+}
+func TestAccAlicloudOtsTableStoreHighPerformance_updateAll(t *testing.T) {
+	var table tablestore.DescribeTableResponse
+	var instance ots.InstanceInfo
+	rand := acctest.RandIntRange(10000, 999999)
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheckWithRegions(t, false, connectivity.OtsHighPerformanceNoSupportedRegions)
+		},
+
+		// module name
+		IDRefreshName: "alicloud_ots_table.basic",
+		Providers:     testAccProviders,
+		CheckDestroy:  testAccCheckOtsTableDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccOtsTableStore(string(OtsHighPerformance), rand),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckOtsInstanceExist("alicloud_ots_instance.foo", &instance),
+					testAccCheckOtsTableExist("alicloud_ots_table.basic", &table),
+					resource.TestCheckResourceAttr("alicloud_ots_table.basic", "instance_name", fmt.Sprintf("tf-testAcc%d", rand)),
+					resource.TestCheckResourceAttr("alicloud_ots_table.basic", "table_name", fmt.Sprintf("testAcc%d", rand)),
+					resource.TestCheckResourceAttr("alicloud_ots_table.basic", "primary_key.#", "1"),
+					resource.TestCheckResourceAttr("alicloud_ots_table.basic", "primary_key.0.name", "pk1"),
+					resource.TestCheckResourceAttr("alicloud_ots_table.basic", "primary_key.0.type", "Integer"),
+					resource.TestCheckResourceAttr("alicloud_ots_table.basic", "time_to_live", "-1"),
+					resource.TestCheckResourceAttr("alicloud_ots_table.basic", "max_version", "1"),
+				),
+			},
+			resource.TestStep{
+				Config: testAccOtsTableStoreUpdateAll(string(OtsHighPerformance), rand),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckOtsInstanceExist("alicloud_ots_instance.foo", &instance),
+					testAccCheckOtsTableExist("alicloud_ots_table.basic", &table),
+					resource.TestCheckResourceAttr("alicloud_ots_table.basic", "instance_name", fmt.Sprintf("tf-testAcc%d", rand)),
+					resource.TestCheckResourceAttr("alicloud_ots_table.basic", "table_name", fmt.Sprintf("testAcc%d", rand)),
+					resource.TestCheckResourceAttr("alicloud_ots_table.basic", "primary_key.#", "1"),
+					resource.TestCheckResourceAttr("alicloud_ots_table.basic", "primary_key.0.name", "pk1"),
+					resource.TestCheckResourceAttr("alicloud_ots_table.basic", "primary_key.0.type", "Integer"),
+					resource.TestCheckResourceAttr("alicloud_ots_table.basic", "time_to_live", "86401"),
+					resource.TestCheckResourceAttr("alicloud_ots_table.basic", "max_version", "2"),
 				),
 			},
 		},
@@ -92,28 +403,116 @@ func testAccCheckOtsTableDestroy(s *terraform.State) error {
 	return nil
 }
 
-const testAccOtsTable = `
-variable "name" {
-  default = "tf-testAccTable"
-}
-resource "alicloud_ots_instance" "foo" {
-  name = "${var.name}"
-  description = "${var.name}"
-  accessed_by = "Any"
-  tags {
-    Created = "TF"
-    For = "acceptance test"
-  }
+func testAccOtsTableStore(instanceType string, rand int) string {
+	return fmt.Sprintf(`
+	variable "name" {
+	  default = "testAcc%d"
+	}
+	resource "alicloud_ots_instance" "foo" {
+	  name = "tf-${var.name}"
+	  description = "${var.name}"
+	  accessed_by = "Any"
+	  instance_type = "%s"
+	  tags {
+	    Created = "TF"
+	    For = "acceptance test"
+	  }
+	}
+
+	resource "alicloud_ots_table" "basic" {
+	  instance_name = "${alicloud_ots_instance.foo.name}"
+	  table_name = "${var.name}"
+	  primary_key = {
+	    name = "pk1"
+	    type = "Integer"
+	  }
+	  time_to_live = -1
+	  max_version = 1
+	}
+	`, rand, instanceType)
 }
 
-resource "alicloud_ots_table" "basic" {
-  instance_name = "${alicloud_ots_instance.foo.name}"
-  table_name = "testAccOtsTable"
-  primary_key = {
-    name = "pk1"
-    type = "Integer"
-  }
-  time_to_live = -1
-  max_version = 1
+func testAccOtsTableStoreUpdateMaxVersion(instanceType string, rand int) string {
+	return fmt.Sprintf(`
+	variable "name" {
+	  default = "testAcc%d"
+	}
+	resource "alicloud_ots_instance" "foo" {
+	  name = "tf-${var.name}"
+	  description = "${var.name}"
+	  accessed_by = "Any"
+	  instance_type = "%s"
+	  tags {
+	    Created = "TF"
+	    For = "acceptance test"
+	  }
+	}
+
+	resource "alicloud_ots_table" "basic" {
+	  instance_name = "${alicloud_ots_instance.foo.name}"
+	  table_name = "${var.name}"
+	  primary_key = {
+	    name = "pk1"
+	    type = "Integer"
+	  }
+	  time_to_live = -1
+	  max_version = 2
+	}
+	`, rand, instanceType)
 }
-`
+func testAccOtsTableStoreUpdateTimeToLive(instanceType string, rand int) string {
+	return fmt.Sprintf(`
+	variable "name" {
+	  default = "testAcc%d"
+	}
+	resource "alicloud_ots_instance" "foo" {
+	  name = "tf-${var.name}"
+	  description = "${var.name}"
+	  accessed_by = "Any"
+	  instance_type = "%s"
+	  tags {
+	    Created = "TF"
+	    For = "acceptance test"
+	  }
+	}
+
+	resource "alicloud_ots_table" "basic" {
+	  instance_name = "${alicloud_ots_instance.foo.name}"
+	  table_name = "${var.name}"
+	  primary_key = {
+	    name = "pk1"
+	    type = "Integer"
+	  }
+	  time_to_live = 86401
+	  max_version = 1
+	}
+	`, rand, instanceType)
+}
+func testAccOtsTableStoreUpdateAll(instanceType string, rand int) string {
+	return fmt.Sprintf(`
+	variable "name" {
+	  default = "testAcc%d"
+	}
+	resource "alicloud_ots_instance" "foo" {
+	  name = "tf-${var.name}"
+	  description = "${var.name}"
+	  accessed_by = "Any"
+	  instance_type = "%s"
+	  tags {
+	    Created = "TF"
+	    For = "acceptance test"
+	  }
+	}
+
+	resource "alicloud_ots_table" "basic" {
+	  instance_name = "${alicloud_ots_instance.foo.name}"
+	  table_name = "${var.name}"
+	  primary_key = {
+	    name = "pk1"
+	    type = "Integer"
+	  }
+	  time_to_live = 86401
+	  max_version = 2
+	}
+	`, rand, instanceType)
+}

--- a/alicloud/service_alicloud_ots.go
+++ b/alicloud/service_alicloud_ots.go
@@ -5,6 +5,9 @@ import (
 
 	"time"
 
+	"fmt"
+
+	"github.com/aliyun/alibaba-cloud-sdk-go/sdk/requests"
 	"github.com/aliyun/alibaba-cloud-sdk-go/services/ots"
 	"github.com/aliyun/aliyun-tablestore-go-sdk/tablestore"
 	"github.com/terraform-providers/terraform-provider-alicloud/alicloud/connectivity"
@@ -149,4 +152,21 @@ func (s *OtsService) WaitForOtsInstance(name string, status Status, timeout int)
 		time.Sleep(DefaultIntervalShort * time.Second)
 	}
 	return nil
+}
+
+func (s *OtsService) DescribeOtsInstanceTypes() (types []string, err error) {
+	req := ots.CreateListClusterTypeRequest()
+	req.Method = requests.GET
+	raw, err := s.client.WithOtsClient(func(otsClient *ots.Client) (interface{}, error) {
+		return otsClient.ListClusterType(req)
+	})
+	if err != nil {
+		err = fmt.Errorf("Failed to list instance type with error: %#v", err)
+		return
+	}
+	resp, _ := raw.(*ots.ListClusterTypeResponse)
+	if resp != nil {
+		return resp.ClusterTypeInfos.ClusterType, nil
+	}
+	return
 }

--- a/examples/ots-table/ots.json
+++ b/examples/ots-table/ots.json
@@ -1,0 +1,154 @@
+[
+	{
+		"id": "cn-qingdao",
+		"local_name": "华北 1",
+		"ots_instance_types": [
+			"HYBRID"
+		],
+		"region_id": "cn-qingdao"
+	},
+	{
+		"id": "cn-beijing",
+		"local_name": "华北 2",
+		"ots_instance_types": [
+			"HYBRID"
+		],
+		"region_id": "cn-beijing"
+	},
+	{
+		"id": "cn-zhangjiakou",
+		"local_name": "华北 3",
+		"ots_instance_types": [
+			"HYBRID"
+		],
+		"region_id": "cn-zhangjiakou"
+	},
+	{
+		"id": "cn-huhehaote",
+		"local_name": "华北 5",
+		"ots_instance_types": [
+			"HYBRID"
+		],
+		"region_id": "cn-huhehaote"
+	},
+	{
+		"id": "cn-hangzhou",
+		"local_name": "华东 1",
+		"ots_instance_types": [
+			"HYBRID"
+		],
+		"region_id": "cn-hangzhou"
+	},
+	{
+		"id": "cn-shanghai",
+		"local_name": "华东 2",
+		"ots_instance_types": [
+			"HYBRID"
+		],
+		"region_id": "cn-shanghai"
+	},
+	{
+		"id": "cn-shenzhen",
+		"local_name": "华南 1",
+		"ots_instance_types": [
+			"HYBRID"
+		],
+		"region_id": "cn-shenzhen"
+	},
+	{
+		"id": "cn-hongkong",
+		"local_name": "香港",
+		"ots_instance_types": [
+			"HYBRID"
+		],
+		"region_id": "cn-hongkong"
+	},
+	{
+		"id": "ap-northeast-1",
+		"local_name": "亚太东北 1 (东京)",
+		"ots_instance_types": [
+			"HYBRID"
+		],
+		"region_id": "ap-northeast-1"
+	},
+	{
+		"id": "ap-southeast-1",
+		"local_name": "亚太东南 1 (新加坡)",
+		"ots_instance_types": [
+			"HYBRID"
+		],
+		"region_id": "ap-southeast-1"
+	},
+	{
+		"id": "ap-southeast-2",
+		"local_name": "亚太东南 2 (悉尼)",
+		"ots_instance_types": [
+			"HYBRID"
+		],
+		"region_id": "ap-southeast-2"
+	},
+	{
+		"id": "ap-southeast-3",
+		"local_name": "亚太东南 3 (吉隆坡)",
+		"ots_instance_types": [
+			"HYBRID"
+		],
+		"region_id": "ap-southeast-3"
+	},
+	{
+		"id": "ap-southeast-5",
+		"local_name": "亚太东南 5 (雅加达)",
+		"ots_instance_types": [
+			"HYBRID"
+		],
+		"region_id": "ap-southeast-5"
+	},
+	{
+		"id": "ap-south-1",
+		"local_name": "亚太南部 1 (孟买)",
+		"ots_instance_types": [
+			"HYBRID"
+		],
+		"region_id": "ap-south-1"
+	},
+	{
+		"id": "us-east-1",
+		"local_name": "美国东部 1 (弗吉尼亚)",
+		"ots_instance_types": [
+			"HYBRID"
+		],
+		"region_id": "us-east-1"
+	},
+	{
+		"id": "us-west-1",
+		"local_name": "美国西部 1 (硅谷)",
+		"ots_instance_types": [
+			"HYBRID"
+		],
+		"region_id": "us-west-1"
+	},
+	{
+		"id": "eu-west-1",
+		"local_name": "英国 (伦敦)",
+		"ots_instance_types": [
+			"HYBRID"
+		],
+		"region_id": "eu-west-1"
+	},
+	{
+		"id": "me-east-1",
+		"local_name": "中东东部 1 (迪拜)",
+		"ots_instance_types": [
+			"HYBRID"
+		],
+		"region_id": "me-east-1"
+	},
+	{
+		"id": "eu-central-1",
+		"local_name": "欧洲中部 1 (法兰克福)",
+		"ots_instance_types": [
+			"HYBRID"
+		],
+		"region_id": "eu-central-1"
+	}
+]


### PR DESCRIPTION
```
TF_ACC=1 go test ./alicloud -v -run=TestAccAlicloudOtsInstance  -timeout=240m
=== RUN   TestAccAlicloudOtsInstanceCapacity_import
--- PASS: TestAccAlicloudOtsInstanceCapacity_import (541.82s)
=== RUN   TestAccAlicloudOtsInstanceHighPerformance_import
--- SKIP: TestAccAlicloudOtsInstanceHighPerformance_import (0.00s)
	provider_test.go:75: Skipping unsupported region ap-south-1. Unsupported regions: [cn-qingdao cn-zhangjiakou cn-huhehaote cn-hongkong ap-southeast-2 ap-southeast-5 ap-northeast-1 eu-central-1 me-east-1 ap-south-1].
=== RUN   TestAccAlicloudOtsInstanceCapacityAttachment
--- PASS: TestAccAlicloudOtsInstanceCapacityAttachment (583.12s)
=== RUN   TestAccAlicloudOtsInstanceHighPerformanceAttachment
--- SKIP: TestAccAlicloudOtsInstanceHighPerformanceAttachment (0.00s)
	provider_test.go:75: Skipping unsupported region ap-south-1. Unsupported regions: [cn-qingdao cn-zhangjiakou cn-huhehaote cn-hongkong ap-southeast-2 ap-southeast-5 ap-northeast-1 eu-central-1 me-east-1 ap-south-1].
=== RUN   TestAccAlicloudOtsInstanceCapacity_basic
--- PASS: TestAccAlicloudOtsInstanceCapacity_basic (521.58s)
=== RUN   TestAccAlicloudOtsInstanceCapacity_updateAccessBy
--- PASS: TestAccAlicloudOtsInstanceCapacity_updateAccessBy (515.95s)
=== RUN   TestAccAlicloudOtsInstanceCapacity_updateTags
--- PASS: TestAccAlicloudOtsInstanceCapacity_updateTags (520.87s)
=== RUN   TestAccAlicloudOtsInstanceCapacity_updateAll
--- PASS: TestAccAlicloudOtsInstanceCapacity_updateAll (535.67s)
=== RUN   TestAccAlicloudOtsInstanceHighPerformance_basic
--- SKIP: TestAccAlicloudOtsInstanceHighPerformance_basic (0.00s)
	provider_test.go:75: Skipping unsupported region ap-south-1. Unsupported regions: [cn-qingdao cn-zhangjiakou cn-huhehaote cn-hongkong ap-southeast-2 ap-southeast-5 ap-northeast-1 eu-central-1 me-east-1 ap-south-1].
=== RUN   TestAccAlicloudOtsInstanceHighPerformance_updateAccessBy
--- SKIP: TestAccAlicloudOtsInstanceHighPerformance_updateAccessBy (0.00s)
	provider_test.go:75: Skipping unsupported region ap-south-1. Unsupported regions: [cn-qingdao cn-zhangjiakou cn-huhehaote cn-hongkong ap-southeast-2 ap-southeast-5 ap-northeast-1 eu-central-1 me-east-1 ap-south-1].
=== RUN   TestAccAlicloudOtsInstanceHighPerformance_updateTags
--- SKIP: TestAccAlicloudOtsInstanceHighPerformance_updateTags (0.00s)
	provider_test.go:75: Skipping unsupported region ap-south-1. Unsupported regions: [cn-qingdao cn-zhangjiakou cn-huhehaote cn-hongkong ap-southeast-2 ap-southeast-5 ap-northeast-1 eu-central-1 me-east-1 ap-south-1].
=== RUN   TestAccAlicloudOtsInstanceHighPerformance_updateAll
--- SKIP: TestAccAlicloudOtsInstanceHighPerformance_updateAll (0.00s)
	provider_test.go:75: Skipping unsupported region ap-south-1. Unsupported regions: [cn-qingdao cn-zhangjiakou cn-huhehaote cn-hongkong ap-southeast-2 ap-southeast-5 ap-northeast-1 eu-central-1 me-east-1 ap-south-1].
PASS
ok  	github.com/terraform-providers/terraform-provider-alicloud/alicloud	3219.062s
```