### PR TITLE
Fix table store creating timeout error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ IMPROVEMENTS:
 
 BUG FIXES:
 
+- Fix table store creating timeout error [GH-571]
 - Fix kvstore instance class update error [GH-570]
 - Fix ess_scaling_group import bugs and improve ess schedule testcase [GH-565]
 - Fix alicloud rds related IncorrectStatus bug [GH-558]

--- a/alicloud/errors.go
+++ b/alicloud/errors.go
@@ -209,6 +209,7 @@ const (
 
 	// OTS
 	OTSObjectNotExist = "OTSObjectNotExist"
+	SuffixNoSuchHost  = "no such host"
 
 	// FC
 	ServiceNotFound  = "ServiceNotFound"

--- a/alicloud/resource_alicloud_kvstore_instance.go
+++ b/alicloud/resource_alicloud_kvstore_instance.go
@@ -187,6 +187,7 @@ func resourceAlicloudKVStoreInstanceUpdate(d *schema.ResourceData, meta interfac
 		if err := kvstoreService.WaitForRKVInstance(d.Id(), Normal, DefaultLongTimeout); err != nil {
 			return fmt.Errorf("WaitForInstance %s got error: %#v", Normal, err)
 		}
+		// There needs more time to sync instance class update
 		if err = resource.Retry(1*time.Minute, func() *resource.RetryError {
 			instance, err := kvstoreService.DescribeRKVInstanceById(d.Id())
 			if err != nil {

--- a/alicloud/service_alicloud_ots.go
+++ b/alicloud/service_alicloud_ots.go
@@ -32,6 +32,9 @@ func (s *OtsService) getPrimaryKeyType(primaryKeyType string) tablestore.Primary
 }
 
 func (s *OtsService) DescribeOtsTable(instanceName, tableName string) (table *tablestore.DescribeTableResponse, err error) {
+	if _, err = s.DescribeOtsInstance(instanceName); err != nil {
+		return
+	}
 	describeTableReq := new(tablestore.DescribeTableRequest)
 	describeTableReq.TableName = tableName
 


### PR DESCRIPTION
```
TF_ACC=1 go test ./alicloud -v -run=TestAccAlicloudOtsTable -timeout=240m
=== RUN   TestAccAlicloudOtsTableCapacity_import
--- PASS: TestAccAlicloudOtsTableCapacity_import (500.92s)
=== RUN   TestAccAlicloudOtsTableHighPerformance_import
--- PASS: TestAccAlicloudOtsTableHighPerformance_import (515.30s)
=== RUN   TestAccAlicloudOtsTableStoreCapatity
--- PASS: TestAccAlicloudOtsTableStoreCapatity (504.65s)
=== RUN   TestAccAlicloudOtsTableStoreCapatity_updateMaxVersion
--- PASS: TestAccAlicloudOtsTableStoreCapatity_updateMaxVersion (524.51s)
=== RUN   TestAccAlicloudOtsTableStoreCapatity_updateTimeToLive
--- PASS: TestAccAlicloudOtsTableStoreCapatity_updateTimeToLive (507.53s)
=== RUN   TestAccAlicloudOtsTableStoreCapatity_updateAll
--- PASS: TestAccAlicloudOtsTableStoreCapatity_updateAll (522.43s)
=== RUN   TestAccAlicloudOtsTableStoreHighPerformance
--- PASS: TestAccAlicloudOtsTableStoreHighPerformance (497.41s)
=== RUN   TestAccAlicloudOtsTableStoreHighPerformance_updateMaxVersion
--- PASS: TestAccAlicloudOtsTableStoreHighPerformance_updateMaxVersion (508.53s)
=== RUN   TestAccAlicloudOtsTableStoreHighPerformance_updateTimeToLive
--- PASS: TestAccAlicloudOtsTableStoreHighPerformance_updateTimeToLive (515.32s)
=== RUN   TestAccAlicloudOtsTableStoreHighPerformance_updateAll
--- PASS: TestAccAlicloudOtsTableStoreHighPerformance_updateAll (813.02s)
PASS
ok	github.com/terraform-providers/terraform-provider-alicloud/alicloud	5409.665s
```
```
TF_ACC=1 go test ./alicloud -v -run=TestAccAlicloudOtsTable -timeout=240m
=== RUN   TestAccAlicloudOtsTableCapacity_import
--- PASS: TestAccAlicloudOtsTableCapacity_import (521.37s)
=== RUN   TestAccAlicloudOtsTableHighPerformance_import
--- SKIP: TestAccAlicloudOtsTableHighPerformance_import (0.00s)
	provider_test.go:75: Skipping unsupported region eu-central-1. Unsupported regions: [cn-qingdao cn-zhangjiakou cn-huhehaote cn-hongkong ap-southeast-2 ap-southeast-5 ap-northeast-1 eu-central-1 me-east-1 ap-south-1].
=== RUN   TestAccAlicloudOtsTableStoreCapatity
--- PASS: TestAccAlicloudOtsTableStoreCapatity (511.79s)
=== RUN   TestAccAlicloudOtsTableStoreCapatity_updateMaxVersion
--- PASS: TestAccAlicloudOtsTableStoreCapatity_updateMaxVersion (505.09s)
=== RUN   TestAccAlicloudOtsTableStoreCapatity_updateTimeToLive
--- PASS: TestAccAlicloudOtsTableStoreCapatity_updateTimeToLive (516.16s)
=== RUN   TestAccAlicloudOtsTableStoreCapatity_updateAll
--- PASS: TestAccAlicloudOtsTableStoreCapatity_updateAll (504.38s)
=== RUN   TestAccAlicloudOtsTableStoreHighPerformance
--- SKIP: TestAccAlicloudOtsTableStoreHighPerformance (0.00s)
	provider_test.go:75: Skipping unsupported region eu-central-1. Unsupported regions: [cn-qingdao cn-zhangjiakou cn-huhehaote cn-hongkong ap-southeast-2 ap-southeast-5 ap-northeast-1 eu-central-1 me-east-1 ap-south-1].
=== RUN   TestAccAlicloudOtsTableStoreHighPerformance_updateMaxVersion
--- SKIP: TestAccAlicloudOtsTableStoreHighPerformance_updateMaxVersion (0.00s)
	provider_test.go:75: Skipping unsupported region eu-central-1. Unsupported regions: [cn-qingdao cn-zhangjiakou cn-huhehaote cn-hongkong ap-southeast-2 ap-southeast-5 ap-northeast-1 eu-central-1 me-east-1 ap-south-1].
=== RUN   TestAccAlicloudOtsTableStoreHighPerformance_updateTimeToLive
--- SKIP: TestAccAlicloudOtsTableStoreHighPerformance_updateTimeToLive (0.00s)
	provider_test.go:75: Skipping unsupported region eu-central-1. Unsupported regions: [cn-qingdao cn-zhangjiakou cn-huhehaote cn-hongkong ap-southeast-2 ap-southeast-5 ap-northeast-1 eu-central-1 me-east-1 ap-south-1].
=== RUN   TestAccAlicloudOtsTableStoreHighPerformance_updateAll
--- SKIP: TestAccAlicloudOtsTableStoreHighPerformance_updateAll (0.00s)
	provider_test.go:75: Skipping unsupported region eu-central-1. Unsupported regions: [cn-qingdao cn-zhangjiakou cn-huhehaote cn-hongkong ap-southeast-2 ap-southeast-5 ap-northeast-1 eu-central-1 me-east-1 ap-south-1].
PASS
ok  	github.com/terraform-providers/terraform-provider-alicloud/alicloud	2558.852s
```