### PR TITLE
Fix table store describing no such host error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ IMPROVEMENTS:
 
 BUG FIXES:
 
+- Fix table store describing no such host error [GH-572]
 - Fix table store creating timeout error [GH-571]
 - Fix kvstore instance class update error [GH-570]
 - Fix ess_scaling_group import bugs and improve ess schedule testcase [GH-565]


### PR DESCRIPTION
```
TF_ACC=1 go test ./alicloud -v -run=TestAccAlicloudOtsTable  -timeout=240m
=== RUN   TestAccAlicloudOtsTableCapacity_import
--- PASS: TestAccAlicloudOtsTableCapacity_import (504.05s)
=== RUN   TestAccAlicloudOtsTableHighPerformance_import
--- SKIP: TestAccAlicloudOtsTableHighPerformance_import (0.00s)
	provider_test.go:75: Skipping unsupported region ap-south-1. Unsupported regions: [cn-qingdao cn-zhangjiakou cn-huhehaote cn-hongkong ap-southeast-2 ap-southeast-5 ap-northeast-1 eu-central-1 me-east-1 ap-south-1].
=== RUN   TestAccAlicloudOtsTableStoreCapatity
--- PASS: TestAccAlicloudOtsTableStoreCapatity (504.51s)
=== RUN   TestAccAlicloudOtsTableStoreCapatity_updateMaxVersion
--- PASS: TestAccAlicloudOtsTableStoreCapatity_updateMaxVersion (528.94s)
=== RUN   TestAccAlicloudOtsTableStoreCapatity_updateTimeToLive
--- PASS: TestAccAlicloudOtsTableStoreCapatity_updateTimeToLive (507.63s)
=== RUN   TestAccAlicloudOtsTableStoreCapatity_updateAll
--- PASS: TestAccAlicloudOtsTableStoreCapatity_updateAll (522.70s)
=== RUN   TestAccAlicloudOtsTableStoreHighPerformance
--- SKIP: TestAccAlicloudOtsTableStoreHighPerformance (0.00s)
	provider_test.go:75: Skipping unsupported region ap-south-1. Unsupported regions: [cn-qingdao cn-zhangjiakou cn-huhehaote cn-hongkong ap-southeast-2 ap-southeast-5 ap-northeast-1 eu-central-1 me-east-1 ap-south-1].
=== RUN   TestAccAlicloudOtsTableStoreHighPerformance_updateMaxVersion
--- SKIP: TestAccAlicloudOtsTableStoreHighPerformance_updateMaxVersion (0.00s)
	provider_test.go:75: Skipping unsupported region ap-south-1. Unsupported regions: [cn-qingdao cn-zhangjiakou cn-huhehaote cn-hongkong ap-southeast-2 ap-southeast-5 ap-northeast-1 eu-central-1 me-east-1 ap-south-1].
=== RUN   TestAccAlicloudOtsTableStoreHighPerformance_updateTimeToLive
--- SKIP: TestAccAlicloudOtsTableStoreHighPerformance_updateTimeToLive (0.00s)
	provider_test.go:75: Skipping unsupported region ap-south-1. Unsupported regions: [cn-qingdao cn-zhangjiakou cn-huhehaote cn-hongkong ap-southeast-2 ap-southeast-5 ap-northeast-1 eu-central-1 me-east-1 ap-south-1].
=== RUN   TestAccAlicloudOtsTableStoreHighPerformance_updateAll
--- SKIP: TestAccAlicloudOtsTableStoreHighPerformance_updateAll (0.00s)
	provider_test.go:75: Skipping unsupported region ap-south-1. Unsupported regions: [cn-qingdao cn-zhangjiakou cn-huhehaote cn-hongkong ap-southeast-2 ap-southeast-5 ap-northeast-1 eu-central-1 me-east-1 ap-south-1].
PASS
ok  	github.com/terraform-providers/terraform-provider-alicloud/alicloud	2567.887s
```