### PR TITLE
skip private ip test in some regions

### DIFF
--- a/alicloud/connectivity/regions.go
+++ b/alicloud/connectivity/regions.go
@@ -55,3 +55,4 @@ var RouteTableNoSupportedRegions = []Region{Beijing, Hangzhou, Shenzhen}
 var ApiGatewayNoSupportedRegions = []Region{Zhangjiakou, Huhehaote, USEast1, USWest1, EUWest1, MEEast1}
 var OtsHighPerformanceNoSupportedRegions = []Region{Qingdao, Zhangjiakou, Huhehaote, Hongkong, APSouthEast2, APSouthEast5, APNorthEast1, EUCentral1, MEEast1, APSouth1}
 var OtsCapacityNoSupportedRegions = []Region{APSouthEast1, USWest1, USEast1}
+var PrivateIpNoSupportedRegions = []Region{Beijing, Hangzhou, Shenzhen}

--- a/alicloud/resource_alicloud_network_interface_test.go
+++ b/alicloud/resource_alicloud_network_interface_test.go
@@ -167,7 +167,7 @@ func TestAccAlicloudNetworkInterfaceWithPrivateIpList(t *testing.T) {
 	var eni ecs.NetworkInterfaceSet
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
-			testAccPreCheck(t)
+			testAccPreCheckWithRegions(t, false, connectivity.PrivateIpNoSupportedRegions)
 		},
 
 		IDRefreshName: "alicloud_network_interface.eni",
@@ -212,7 +212,7 @@ func TestAccAlicloudNetworkInterfaceWithPrivateIpCount(t *testing.T) {
 	var eni ecs.NetworkInterfaceSet
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
-			testAccPreCheck(t)
+			testAccPreCheckWithRegions(t, false, connectivity.PrivateIpNoSupportedRegions)
 		},
 
 		IDRefreshName: "alicloud_network_interface.eni",

--- a/website/docs/r/network_interface.html.markdown
+++ b/website/docs/r/network_interface.html.markdown
@@ -17,14 +17,14 @@ For information about Elastic Network Interface and how to use it, see [Elastic 
 ## Example Usage
 
 ```
-resource "alicloud_networt_interface" "eni0" {
+resource "alicloud_network_interface" "eni0" {
     name = "terraform-test-eni0"
     vswitch_id = "${alicloud_vswith.vswith.id}"
     security_groups = [ "${alicloud_security_group.sg.id}" ]
     private_ips = [ "192.168.*.2", "192.168.*.3", "192.168.*.4" ]
 }
 
-resource "alicloud_networt_interface" "eni1" {
+resource "alicloud_network_interface" "eni1" {
     name = "terraform-test-eni1"
     vswitch_id = "{alicloud_vswith.vswith.id}"
     primary_ip_address = "192.168.*.8"
@@ -32,7 +32,7 @@ resource "alicloud_networt_interface" "eni1" {
     private_ips = [ "192.168.*.5", "192.168.*.6", "192.168.*.7" ]
 }
 
-resource "alicloud_networt_interface" "eni2" {
+resource "alicloud_network_interface" "eni2" {
     name = "terraform-test-eni2"
     vswitch_id = "{alicloud_vswith.vswith.id}"
     security_groups = [ "${alicloud_security_group.sg.id}" ]


### PR DESCRIPTION
env TF_DEBUG=debug TF_ACC=1 go test  -v -run=TestAccAlicloudNetworkInterface --timeout=600m
=== RUN   TestAccAlicloudNetworkInterfacesDataSourceBasic
--- PASS: TestAccAlicloudNetworkInterfacesDataSourceBasic (122.30s)
=== RUN   TestAccAlicloudNetworkInterfacesDataSourceWithId
--- PASS: TestAccAlicloudNetworkInterfacesDataSourceWithId (35.16s)
=== RUN   TestAccAlicloudNetworkInterfacesDataSourceWithAllFields
--- PASS: TestAccAlicloudNetworkInterfacesDataSourceWithAllFields (32.00s)
=== RUN   TestAccAlicloudNetworkInterfacesDataSourceEmpty
--- PASS: TestAccAlicloudNetworkInterfacesDataSourceEmpty (107.74s)
=== RUN   TestAccAlicloudNetworkInterfaceAttachment_importBasic
--- PASS: TestAccAlicloudNetworkInterfaceAttachment_importBasic (145.44s)
=== RUN   TestAccAlicloudNetworkInterface_importBasic
--- PASS: TestAccAlicloudNetworkInterface_importBasic (33.16s)
=== RUN   TestAccAlicloudNetworkInterfaceAttachment
--- PASS: TestAccAlicloudNetworkInterfaceAttachment (168.57s)
=== RUN   TestAccAlicloudNetworkInterfaceAttachmentWithMultiEni
--- PASS: TestAccAlicloudNetworkInterfaceAttachmentWithMultiEni (154.54s)
=== RUN   TestAccAlicloudNetworkInterfaceBasic
--- PASS: TestAccAlicloudNetworkInterfaceBasic (37.50s)
=== RUN   TestAccAlicloudNetworkInterfaceWithPrivateIpList
--- SKIP: TestAccAlicloudNetworkInterfaceWithPrivateIpList (0.00s)
	provider_test.go:75: Skipping unsupported region cn-beijing. Unsupported regions: [cn-beijing cn-hangzhou cn-shenzhen].
=== RUN   TestAccAlicloudNetworkInterfaceWithPrivateIpCount
--- SKIP: TestAccAlicloudNetworkInterfaceWithPrivateIpCount (0.00s)
	provider_test.go:75: Skipping unsupported region cn-beijing. Unsupported regions: [cn-beijing cn-hangzhou cn-shenzhen].
=== RUN   TestAccAlicloudNetworkInterfaceWithoutPrimaryIpAddress
--- PASS: TestAccAlicloudNetworkInterfaceWithoutPrimaryIpAddress (34.66s)
PASS
ok  	github.com/terraform-providers/terraform-provider-alicloud/alicloud	871.139s