### PR TITLE
Fix pvtz_record RecordInvalidConflict bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ FEATURES:
 
 IMPROVEMENTS:
 
-- Improve kvstore backup policy testcase [GH-579]
+- Improve kvstore backup policy testcase [GH-580]
 - Improve the describing endpoint [GH-579]
 - VPN gateway supports 200/500/1000M bandwidth [GH-577]
 - skip private ip test in some regions [GH-575]
@@ -26,6 +26,7 @@ IMPROVEMENTS:
 
 BUG FIXES:
 
+- Fix pvtz_record RecordInvalidConflict bug [GH-581]
 - fixed bug in backup policy update [GH-521]
 - Fix docs eip_association [GH-578]
 - Fix a bug about instance charge type change [GH-576]

--- a/alicloud/common.go
+++ b/alicloud/common.go
@@ -159,6 +159,7 @@ const (
 	PageSizeSmall  = 10
 	PageSizeMedium = 20
 	PageSizeLarge  = 50
+	PageSizeXLarge = 50
 )
 
 // Protocol represents network protocol

--- a/alicloud/errors.go
+++ b/alicloud/errors.go
@@ -196,8 +196,9 @@ const (
 	ApplicationConfirmConflict   = "Conflicts with unconfirmed updates for operation"
 
 	// privatezone
-	ZoneNotExists    = "Zone.NotExists"
-	ZoneVpcNotExists = "ZoneVpc.NotExists.VpcId"
+	ZoneNotExists         = "Zone.NotExists"
+	ZoneVpcNotExists      = "ZoneVpc.NotExists.VpcId"
+	RecordInvalidConflict = "Record.Invalid.Conflict"
 	// log
 	ProjectNotExist      = "ProjectNotExist"
 	IndexConfigNotExist  = "IndexConfigNotExist"


### PR DESCRIPTION
```
TF_ACC=1 go test ./alicloud -v -run=TestAccAlicloudPvtzZoneRecord -timeout=240m
=== RUN   TestAccAlicloudPvtzZoneRecordsDataSource_basic
--- PASS: TestAccAlicloudPvtzZoneRecordsDataSource_basic (6.10s)
=== RUN   TestAccAlicloudPvtzZoneRecordsDataSource_empty
--- PASS: TestAccAlicloudPvtzZoneRecordsDataSource_empty (2.37s)
=== RUN   TestAccAlicloudPvtzZoneRecord_importBasic
--- PASS: TestAccAlicloudPvtzZoneRecord_importBasic (3.64s)
=== RUN   TestAccAlicloudPvtzZoneRecord_Basic
--- PASS: TestAccAlicloudPvtzZoneRecord_Basic (3.89s)
=== RUN   TestAccAlicloudPvtzZoneRecord_updateRr
--- PASS: TestAccAlicloudPvtzZoneRecord_updateRr (6.00s)
=== RUN   TestAccAlicloudPvtzZoneRecord_updateType
--- PASS: TestAccAlicloudPvtzZoneRecord_updateType (5.88s)
=== RUN   TestAccAlicloudPvtzZoneRecord_updateValue
--- PASS: TestAccAlicloudPvtzZoneRecord_updateValue (5.80s)
=== RUN   TestAccAlicloudPvtzZoneRecord_updatePriority
--- PASS: TestAccAlicloudPvtzZoneRecord_updatePriority (5.61s)
=== RUN   TestAccAlicloudPvtzZoneRecord_updateTTL
--- PASS: TestAccAlicloudPvtzZoneRecord_updateTTL (5.46s)
=== RUN   TestAccAlicloudPvtzZoneRecord_updateAll
--- PASS: TestAccAlicloudPvtzZoneRecord_updateAll (5.57s)
=== RUN   TestAccAlicloudPvtzZoneRecord_multi
--- PASS: TestAccAlicloudPvtzZoneRecord_multi (7.91s)
PASS
ok  	github.com/terraform-providers/terraform-provider-alicloud/alicloud	58.265s
```