### PR TITLE
Fix table store no such host error with deleting and updating

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ IMPROVEMENTS:
 
 BUG FIXES:
 
+- Fix table store no such host error with deleting and updating [GH-581]
 - Fix pvtz_record RecordInvalidConflict bug [GH-581]
 - fixed bug in backup policy update [GH-521]
 - Fix docs eip_association [GH-578]


### PR DESCRIPTION
```
TF_ACC=1 go test ./alicloud -v -run=TestAccAlicloudOtsTableStore -timeout=240m
=== RUN   TestAccAlicloudOtsTableStoreCapatity
--- PASS: TestAccAlicloudOtsTableStoreCapatity (498.86s)
=== RUN   TestAccAlicloudOtsTableStoreCapatity_updateMaxVersion
--- PASS: TestAccAlicloudOtsTableStoreCapatity_updateMaxVersion (520.38s)
=== RUN   TestAccAlicloudOtsTableStoreCapatity_updateTimeToLive
--- PASS: TestAccAlicloudOtsTableStoreCapatity_updateTimeToLive (500.08s)
=== RUN   TestAccAlicloudOtsTableStoreCapatity_updateAll
--- PASS: TestAccAlicloudOtsTableStoreCapatity_updateAll (520.23s)
=== RUN   TestAccAlicloudOtsTableStoreHighPerformance
--- SKIP: TestAccAlicloudOtsTableStoreHighPerformance (0.00s)
provider_test.go:75: Skipping unsupported region ap-south-1. Unsupported regions: [cn-qingdao cn-zhangjiakou cn-huhehaote cn-hongkong ap-southeast-2 ap-southeast-5 ap-northeast-1 eu-central-1 me-east-1 ap-south-1].
=== RUN   TestAccAlicloudOtsTableStoreHighPerformance_updateMaxVersion
--- SKIP: TestAccAlicloudOtsTableStoreHighPerformance_updateMaxVersion (0.00s)
provider_test.go:75: Skipping unsupported region ap-south-1. Unsupported regions: [cn-qingdao cn-zhangjiakou cn-huhehaote cn-hongkong ap-southeast-2 ap-southeast-5 ap-northeast-1 eu-central-1 me-east-1 ap-south-1].
=== RUN   TestAccAlicloudOtsTableStoreHighPerformance_updateTimeToLive
--- SKIP: TestAccAlicloudOtsTableStoreHighPerformance_updateTimeToLive (0.00s)
provider_test.go:75: Skipping unsupported region ap-south-1. Unsupported regions: [cn-qingdao cn-zhangjiakou cn-huhehaote cn-hongkong ap-southeast-2 ap-southeast-5 ap-northeast-1 eu-central-1 me-east-1 ap-south-1].
=== RUN   TestAccAlicloudOtsTableStoreHighPerformance_updateAll
--- SKIP: TestAccAlicloudOtsTableStoreHighPerformance_updateAll (0.00s)
provider_test.go:75: Skipping unsupported region ap-south-1. Unsupported regions: [cn-qingdao cn-zhangjiakou cn-huhehaote cn-hongkong ap-southeast-2 ap-southeast-5 ap-northeast-1 eu-central-1 me-east-1 ap-south-1].
PASS
ok  	github.com/terraform-providers/terraform-provider-alicloud/alicloud	2039.570s
```