### PR TITLE
Improve kvstore client token

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,9 @@
 ## 1.27.0 (Unreleased)
+
+IMPROVEMENTS:
+
+- Improve kvstore client token [GH-585]
+
 ## 1.26.0 (December 20, 2018)
 
 FEATURES:

--- a/alicloud/resource_alicloud_kvstore_backup_policy_test.go
+++ b/alicloud/resource_alicloud_kvstore_backup_policy_test.go
@@ -190,7 +190,7 @@ func TestAccAlicloudKVStoreMemcacheBackupPolicy_vpc(t *testing.T) {
 		CheckDestroy: testAccCheckKVStoreBackupPolicyDestroy,
 		Steps: []resource.TestStep{
 			resource.TestStep{
-				Config: testAccKVStoreBackupPolicy_vpc(DatabaseCommonTestCase, string(KVStoreMemcache), redisInstanceClassForTest, string(KVStore2Dot8)),
+				Config: testAccKVStoreBackupPolicy_vpc(DatabaseCommonTestCase, string(KVStoreMemcache), memcacheInstanceClassForTest, string(KVStore2Dot8)),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckKVStoreBackupPolicyExists("alicloud_kvstore_backup_policy.policy", &policy),
 					resource.TestCheckResourceAttrSet("alicloud_kvstore_backup_policy.policy", "instance_id"),
@@ -199,7 +199,7 @@ func TestAccAlicloudKVStoreMemcacheBackupPolicy_vpc(t *testing.T) {
 				),
 			},
 			resource.TestStep{
-				Config: testAccKVStoreBackupPolicy_vpcUpdatePeriod(DatabaseCommonTestCase, string(KVStoreMemcache), redisInstanceClassForTest, string(KVStore2Dot8)),
+				Config: testAccKVStoreBackupPolicy_vpcUpdatePeriod(DatabaseCommonTestCase, string(KVStoreMemcache), memcacheInstanceClassForTest, string(KVStore2Dot8)),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckKVStoreBackupPolicyExists("alicloud_kvstore_backup_policy.policy", &policy),
 					resource.TestCheckResourceAttrSet("alicloud_kvstore_backup_policy.policy", "instance_id"),
@@ -208,7 +208,7 @@ func TestAccAlicloudKVStoreMemcacheBackupPolicy_vpc(t *testing.T) {
 				),
 			},
 			resource.TestStep{
-				Config: testAccKVStoreBackupPolicy_vpcUpdateTime(DatabaseCommonTestCase, string(KVStoreMemcache), redisInstanceClassForTest, string(KVStore2Dot8)),
+				Config: testAccKVStoreBackupPolicy_vpcUpdateTime(DatabaseCommonTestCase, string(KVStoreMemcache), memcacheInstanceClassForTest, string(KVStore2Dot8)),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckKVStoreBackupPolicyExists("alicloud_kvstore_backup_policy.policy", &policy),
 					resource.TestCheckResourceAttrSet("alicloud_kvstore_backup_policy.policy", "instance_id"),
@@ -217,7 +217,7 @@ func TestAccAlicloudKVStoreMemcacheBackupPolicy_vpc(t *testing.T) {
 				),
 			},
 			resource.TestStep{
-				Config: testAccKVStoreBackupPolicy_vpcUpdateAll(DatabaseCommonTestCase, string(KVStoreMemcache), redisInstanceClassForTest, string(KVStore2Dot8)),
+				Config: testAccKVStoreBackupPolicy_vpcUpdateAll(DatabaseCommonTestCase, string(KVStoreMemcache), memcacheInstanceClassForTest, string(KVStore2Dot8)),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckKVStoreBackupPolicyExists("alicloud_kvstore_backup_policy.policy", &policy),
 					resource.TestCheckResourceAttrSet("alicloud_kvstore_backup_policy.policy", "instance_id"),

--- a/alicloud/resource_alicloud_kvstore_instance.go
+++ b/alicloud/resource_alicloud_kvstore_instance.go
@@ -356,7 +356,7 @@ func buildKVStoreCreateRequest(d *schema.ResourceData, meta interface{}) (*r_kvs
 		request.VpcId = vsw.VpcId
 	}
 
-	request.Token = buildClientToken("TF-CreateKVStoreInstance")
+	request.Token = buildClientToken(fmt.Sprintf("TF-Create%sInstance", request.InstanceType))
 
 	return request, nil
 }

--- a/alicloud/resource_alicloud_kvstore_instance_test.go
+++ b/alicloud/resource_alicloud_kvstore_instance_test.go
@@ -17,10 +17,10 @@ import (
 	"github.com/terraform-providers/terraform-provider-alicloud/alicloud/connectivity"
 )
 
-var redisInstanceConnectionDomainRegexp = regexp.MustCompile("^r-[a-z0-9]+.redis.[a-z-0-9]+.rds.aliyuncs.com")
+var redisInstanceConnectionDomainRegexp = regexp.MustCompile("^r-[a-z0-9]+.redis[.a-z-0-9]*.rds.aliyuncs.com")
 var redisInstanceClassForTest = "redis.master.small.default"
 var redisInstanceClassForTestUpdateClass = "redis.master.mid.default"
-var memcacheInstanceConnectionDomainRegexp = regexp.MustCompile("^m-[a-z0-9]+.memcache.[a-z-0-9]+.rds.aliyuncs.com")
+var memcacheInstanceConnectionDomainRegexp = regexp.MustCompile("^m-[a-z0-9]+.memcache[.a-z-0-9]*.rds.aliyuncs.com")
 var memcacheInstanceClassForTest = "memcache.master.small.default"
 var memcacheInstanceClassForTestUpdateClass = "memcache.master.mid.default"
 


### PR DESCRIPTION
```
TF_ACC=1 go test ./alicloud -v -run=TestAccAlicloudKVStoreRedisInstance_classic -timeout=240m
=== RUN   TestAccAlicloudKVStoreRedisInstance_classic
--- PASS: TestAccAlicloudKVStoreRedisInstance_classic (313.79s)
=== RUN   TestAccAlicloudKVStoreRedisInstance_classicUpdateSecurityIps
--- PASS: TestAccAlicloudKVStoreRedisInstance_classicUpdateSecurityIps (365.88s)
=== RUN   TestAccAlicloudKVStoreRedisInstance_classicUpdateClass
--- PASS: TestAccAlicloudKVStoreRedisInstance_classicUpdateClass (773.46s)
=== RUN   TestAccAlicloudKVStoreRedisInstance_classicUpdateAttr
--- PASS: TestAccAlicloudKVStoreRedisInstance_classicUpdateAttr (310.74s)
=== RUN   TestAccAlicloudKVStoreRedisInstance_classicUpdateAll
--- PASS: TestAccAlicloudKVStoreRedisInstance_classicUpdateAll (824.85s)
PASS
ok  	github.com/terraform-providers/terraform-provider-alicloud/alicloud	2588.782s
```