### PR TITLE
Fix cen instance and bandwidth multi regions test case bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ IMPROVEMENTS:
 
 - Improve kvstore client token [GH-585]
 
+BUG FIXES:
+
+- Fix cen instance and bandwidth multi regions test case bug [GH-586]
+
 ## 1.26.0 (December 20, 2018)
 
 FEATURES:

--- a/alicloud/data_source_alicloud_cen_bandwidth_limits_test.go
+++ b/alicloud/data_source_alicloud_cen_bandwidth_limits_test.go
@@ -4,14 +4,29 @@ import (
 	"testing"
 
 	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/helper/schema"
+	"github.com/hashicorp/terraform/terraform"
 )
 
 func TestAccAlicloudCenBandwidthLimitsDataSource_instance_id(t *testing.T) {
+	// multi provideris
+	var providers []*schema.Provider
+	providerFactories := map[string]terraform.ResourceProviderFactory{
+		"alicloud": func() (terraform.ResourceProvider, error) {
+			p := Provider()
+			providers = append(providers, p.(*schema.Provider))
+			return p, nil
+		},
+	}
+
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			testAccPreCheck(t)
 		},
-		Providers: testAccProviders,
+
+		// module name
+		ProviderFactories: providerFactories,
+		CheckDestroy:      testAccCheckCenBandwidthLimitDestroyWithProviders(&providers),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccCheckAlicloudCenInterRegionBandwidthLimitsDataSourceCenIdConfig,
@@ -29,11 +44,24 @@ func TestAccAlicloudCenBandwidthLimitsDataSource_instance_id(t *testing.T) {
 }
 
 func TestAccAlicloudCenBandwidthLimitsDataSource_empty(t *testing.T) {
+	// multi provideris
+	var providers []*schema.Provider
+	providerFactories := map[string]terraform.ResourceProviderFactory{
+		"alicloud": func() (terraform.ResourceProvider, error) {
+			p := Provider()
+			providers = append(providers, p.(*schema.Provider))
+			return p, nil
+		},
+	}
+
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			testAccPreCheck(t)
 		},
-		Providers: testAccProviders,
+
+		// module name
+		ProviderFactories: providerFactories,
+		CheckDestroy:      testAccCheckCenBandwidthLimitDestroyWithProviders(&providers),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccCheckAlicloudCenInterRegionBandwidthLimitsDataSourceEmpty,

--- a/alicloud/data_source_alicloud_cen_region_route_entries_test.go
+++ b/alicloud/data_source_alicloud_cen_region_route_entries_test.go
@@ -3,10 +3,13 @@ package alicloud
 import (
 	"testing"
 
+	"fmt"
+
 	"github.com/hashicorp/terraform/helper/resource"
 )
 
-func TestAccAlicloudCenRegionDomainRouteEntriesDataSource_basic(t *testing.T) {
+func TestAccAlicloudCenRegionRouteEntriesDataSource_basic(t *testing.T) {
+
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			testAccPreCheck(t)
@@ -14,14 +17,14 @@ func TestAccAlicloudCenRegionDomainRouteEntriesDataSource_basic(t *testing.T) {
 		Providers: testAccProviders,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccCheckCenRegionDomainRouteEntriesDataBasicConfig,
+				Config: testAccCheckCenRegionRouteEntriesDataSourceBasic(EcsInstanceCommonTestCase, defaultRegionToTest),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAlicloudDataSourceID("data.alicloud_cen_region_route_entries.entry"),
 					resource.TestCheckResourceAttr("data.alicloud_cen_region_route_entries.entry", "entries.0.cidr_block", "11.0.0.0/16"),
 					resource.TestCheckResourceAttr("data.alicloud_cen_region_route_entries.entry", "entries.0.type", "CBN"),
 					resource.TestCheckResourceAttr("data.alicloud_cen_region_route_entries.entry", "entries.0.next_hop_type", "VPC"),
 					resource.TestCheckResourceAttrSet("data.alicloud_cen_region_route_entries.entry", "entries.0.next_hop_id"),
-					resource.TestCheckResourceAttr("data.alicloud_cen_region_route_entries.entry", "entries.0.next_hop_region_id", "cn-beijing"),
+					resource.TestCheckResourceAttr("data.alicloud_cen_region_route_entries.entry", "entries.0.next_hop_region_id", defaultRegionToTest),
 					resource.TestCheckResourceAttr("data.alicloud_cen_region_route_entries.entry", "entries.#", "2"),
 				),
 			},
@@ -29,87 +32,55 @@ func TestAccAlicloudCenRegionDomainRouteEntriesDataSource_basic(t *testing.T) {
 	})
 }
 
-const testAccCheckCenRegionDomainRouteEntriesDataBasicConfig = `
-data "alicloud_zones" "default" {
-	"available_disk_category"= "cloud_efficiency"
-	"available_resource_creation"= "VSwitch"
+func testAccCheckCenRegionRouteEntriesDataSourceBasic(common, region string) string {
+	return fmt.Sprintf(`
+	%s
+	variable "name" {
+		default = "tf-testAccRegionRouteEntriesDataSourceBasic"
+	}
+	
+	resource "alicloud_instance" "default" {
+		vswitch_id = "${alicloud_vswitch.default.id}"
+		image_id = "${data.alicloud_images.default.images.0.id}"
+	
+		instance_type = "${data.alicloud_instance_types.default.instance_types.0.id}"
+		system_disk_category = "cloud_efficiency"
+	
+		internet_charge_type = "PayByTraffic"
+		internet_max_bandwidth_out = 5
+		security_groups = ["${alicloud_security_group.default.id}"]
+		instance_name = "${var.name}-region-route-entry"
+	}
+	
+	resource "alicloud_cen_instance" "cen" {
+		name = "${var.name}-cen"
+		description = "terraform01"
+	}
+	
+	resource "alicloud_cen_instance_attachment" "attach" {
+	    instance_id = "${alicloud_cen_instance.cen.id}"
+	    child_instance_id = "${alicloud_vpc.default.id}"
+	    child_instance_region_id = "%s"
+	}
+	
+	resource "alicloud_route_entry" "route" {
+	    route_table_id = "${alicloud_vpc.default.route_table_id}"
+	    destination_cidrblock = "11.0.0.0/16"
+	    nexthop_type = "Instance"
+	    nexthop_id = "${alicloud_instance.default.id}"
+	}
+	
+	resource "alicloud_cen_route_entry" "foo" {
+	    instance_id = "${alicloud_cen_instance.cen.id}"
+	    route_table_id = "${alicloud_vpc.default.route_table_id}"
+	    cidr_block = "${alicloud_route_entry.route.destination_cidrblock}"
+	    depends_on = [
+			"alicloud_cen_instance_attachment.attach"]
+	}
+	
+	data "alicloud_cen_region_route_entries" "entry" {
+		instance_id = "${alicloud_cen_route_entry.foo.instance_id}"
+		region_id = "%s"
+	}
+	`, common, region, region)
 }
-
-data "alicloud_instance_types" "default" {
- 	availability_zone = "${data.alicloud_zones.default.zones.0.id}"
-	cpu_core_count = 1
-	memory_size = 2
-}
-
-data "alicloud_images" "default" {
-    name_regex = "^ubuntu_14.*_64"
-	most_recent = true
-	owners = "system"
-}
-
-variable "name" {
-	default = "tf-testAcc"
-}
-
-resource "alicloud_vpc" "vpc" {
-  	name = "${var.name}-vpc-region-route-entry"
-  	cidr_block = "172.16.0.0/12"
-}
-
-resource "alicloud_vswitch" "default" {
- 	vpc_id = "${alicloud_vpc.vpc.id}"
- 	cidr_block = "172.16.0.0/21"
- 	availability_zone = "${data.alicloud_zones.default.zones.0.id}"
- 	name = "${var.name}-vsw-region-route-entry"
-}
-
-resource "alicloud_security_group" "default" {
-	name = "${var.name}-sg-region-route-entry"
-	description = "foo"
-	vpc_id = "${alicloud_vpc.vpc.id}"
-}
-
-resource "alicloud_instance" "default" {
-	vswitch_id = "${alicloud_vswitch.default.id}"
-	image_id = "${data.alicloud_images.default.images.0.id}"
-
-	instance_type = "${data.alicloud_instance_types.default.instance_types.0.id}"
-	system_disk_category = "cloud_efficiency"
-
-	internet_charge_type = "PayByTraffic"
-	internet_max_bandwidth_out = 5
-	security_groups = ["${alicloud_security_group.default.id}"]
-	instance_name = "${var.name}-region-route-entry"
-}
-
-resource "alicloud_cen_instance" "cen" {
-	name = "${var.name}-cen"
-	description = "terraform01"
-}
-
-resource "alicloud_cen_instance_attachment" "attach" {
-    instance_id = "${alicloud_cen_instance.cen.id}"
-    child_instance_id = "${alicloud_vpc.vpc.id}"
-    child_instance_region_id = "cn-beijing"
-}
-
-resource "alicloud_route_entry" "route" {
-    route_table_id = "${alicloud_vpc.vpc.route_table_id}"
-    destination_cidrblock = "11.0.0.0/16"
-    nexthop_type = "Instance"
-    nexthop_id = "${alicloud_instance.default.id}"
-}
-
-resource "alicloud_cen_route_entry" "foo" {
-    instance_id = "${alicloud_cen_instance.cen.id}"
-    route_table_id = "${alicloud_vpc.vpc.route_table_id}"
-    cidr_block = "${alicloud_route_entry.route.destination_cidrblock}"
-    depends_on = [
-		"alicloud_cen_instance_attachment.attach"]
-}
-
-data "alicloud_cen_region_route_entries" "entry" {
-	instance_id = "${alicloud_cen_route_entry.foo.instance_id}"
-  	region_id = "cn-beijing"
-}
-`

--- a/alicloud/data_source_alicloud_cen_route_entries_test.go
+++ b/alicloud/data_source_alicloud_cen_route_entries_test.go
@@ -3,10 +3,12 @@ package alicloud
 import (
 	"testing"
 
+	"fmt"
+
 	"github.com/hashicorp/terraform/helper/resource"
 )
 
-func TestAccAlicloudCenPublishedRouteEntriesDataSource_basic(t *testing.T) {
+func TestAccAlicloudCenRouteEntriesDataSource_basic(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			testAccPreCheck(t)
@@ -14,7 +16,7 @@ func TestAccAlicloudCenPublishedRouteEntriesDataSource_basic(t *testing.T) {
 		Providers: testAccProviders,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccCheckCenPublishedRouteEntriesDataSourceConfig,
+				Config: testAccCheckCenRouteEntriesDataSourceConfig(EcsInstanceCommonTestCase, defaultRegionToTest),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAlicloudDataSourceID("data.alicloud_cen_route_entries.entry"),
 					resource.TestCheckResourceAttr("data.alicloud_cen_route_entries.entry", "entries.0.cidr_block", "11.0.0.0/16"),
@@ -31,7 +33,7 @@ func TestAccAlicloudCenPublishedRouteEntriesDataSource_basic(t *testing.T) {
 	})
 }
 
-func TestAccAlicloudCenPublishedRouteEntriesDataSource_empty(t *testing.T) {
+func TestAccAlicloudCenRouteEntriesDataSource_empty(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			testAccPreCheck(t)
@@ -39,7 +41,7 @@ func TestAccAlicloudCenPublishedRouteEntriesDataSource_empty(t *testing.T) {
 		Providers: testAccProviders,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccCheckCenPublishedRouteEntriesDataSourceEmpty,
+				Config: testAccCheckCenRouteEntriesDataSourceEmpty(EcsInstanceCommonTestCase, defaultRegionToTest),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAlicloudDataSourceID("data.alicloud_cen_route_entries.entry"),
 					resource.TestCheckResourceAttr("data.alicloud_cen_route_entries.entry", "entries.#", "0"),
@@ -57,172 +59,104 @@ func TestAccAlicloudCenPublishedRouteEntriesDataSource_empty(t *testing.T) {
 	})
 }
 
-const testAccCheckCenPublishedRouteEntriesDataSourceConfig = `
-variable "name" {
-	default = "tf-testAccCenRoutes"
+func testAccCheckCenRouteEntriesDataSourceConfig(common, region string) string {
+	return fmt.Sprintf(`
+	%s
+	variable "name" {
+	    default = "tf-testAccCenRouteEntries"
+	}
+
+	resource "alicloud_instance" "default" {
+	    vswitch_id = "${alicloud_vswitch.default.id}"
+	    image_id = "${data.alicloud_images.default.images.0.id}"
+	    instance_type = "${data.alicloud_instance_types.default.instance_types.0.id}"
+	    system_disk_category = "cloud_efficiency"
+	    internet_charge_type = "PayByTraffic"
+	    internet_max_bandwidth_out = 5
+	    security_groups = ["${alicloud_security_group.default.id}"]
+	    instance_name = "${var.name}"
+	}
+
+	resource "alicloud_cen_instance" "cen" {
+	    name = "${var.name}"
+	}
+
+	resource "alicloud_cen_instance_attachment" "attach" {
+	    instance_id = "${alicloud_cen_instance.cen.id}"
+	    child_instance_id = "${alicloud_vpc.default.id}"
+	    child_instance_region_id = "%s"
+	}
+
+	resource "alicloud_route_entry" "route" {
+	    route_table_id = "${alicloud_vpc.default.route_table_id}"
+	    destination_cidrblock = "11.0.0.0/16"
+	    nexthop_type = "Instance"
+	    nexthop_id = "${alicloud_instance.default.id}"
+	}
+
+	resource "alicloud_cen_route_entry" "foo" {
+	    instance_id = "${alicloud_cen_instance.cen.id}"
+	    route_table_id = "${alicloud_vpc.default.route_table_id}"
+	    cidr_block = "${alicloud_route_entry.route.destination_cidrblock}"
+	    depends_on = [
+		"alicloud_cen_instance_attachment.attach"]
+	}
+
+	data "alicloud_cen_route_entries" "entry" {
+		instance_id = "${alicloud_cen_route_entry.foo.instance_id}"
+		route_table_id = "${alicloud_cen_route_entry.foo.route_table_id}"
+		cidr_block = "11.0.0.0/16"
+	}
+	`, common, region)
 }
 
-data "alicloud_zones" "default" {
-	"available_disk_category"= "cloud_efficiency"
-	"available_resource_creation"= "VSwitch"
+func testAccCheckCenRouteEntriesDataSourceEmpty(common, region string) string {
+	return fmt.Sprintf(`
+	%s
+	variable "name" {
+	    default = "tf-testAccCenRouteEntries"
+	}
+
+	resource "alicloud_instance" "default" {
+	    vswitch_id = "${alicloud_vswitch.default.id}"
+	    image_id = "${data.alicloud_images.default.images.0.id}"
+	    instance_type = "${data.alicloud_instance_types.default.instance_types.0.id}"
+	    system_disk_category = "cloud_efficiency"
+	    internet_charge_type = "PayByTraffic"
+	    internet_max_bandwidth_out = 5
+	    security_groups = ["${alicloud_security_group.default.id}"]
+	    instance_name = "${var.name}"
+	}
+
+	resource "alicloud_cen_instance" "cen" {
+	    name = "${var.name}"
+	}
+
+	resource "alicloud_cen_instance_attachment" "attach" {
+	    instance_id = "${alicloud_cen_instance.cen.id}"
+	    child_instance_id = "${alicloud_vpc.default.id}"
+	    child_instance_region_id = "%s"
+	}
+
+	resource "alicloud_route_entry" "route" {
+	    route_table_id = "${alicloud_vpc.default.route_table_id}"
+	    destination_cidrblock = "11.0.0.0/16"
+	    nexthop_type = "Instance"
+	    nexthop_id = "${alicloud_instance.default.id}"
+	}
+
+	resource "alicloud_cen_route_entry" "foo" {
+	    instance_id = "${alicloud_cen_instance.cen.id}"
+	    route_table_id = "${alicloud_vpc.default.route_table_id}"
+	    cidr_block = "${alicloud_route_entry.route.destination_cidrblock}"
+	    depends_on = [
+		"alicloud_cen_instance_attachment.attach"]
+	}
+
+	data "alicloud_cen_route_entries" "entry" {
+		instance_id = "${alicloud_cen_route_entry.foo.instance_id}"
+		route_table_id = "${alicloud_cen_route_entry.foo.route_table_id}"
+		cidr_block = "11.1.0.0/16"
+	}
+	`, common, region)
 }
-
-data "alicloud_instance_types" "default" {
- 	availability_zone = "${data.alicloud_zones.default.zones.0.id}"
-	cpu_core_count = 1
-	memory_size = 2
-}
-
-data "alicloud_images" "default" {
-    name_regex = "^ubuntu_14.*_64"
-	most_recent = true
-	owners = "system"
-}
-
-resource "alicloud_vpc" "vpc" {
-  	name = "${var.name}"
-  	cidr_block = "172.16.0.0/12"
-}
-
-resource "alicloud_vswitch" "default" {
- 	vpc_id = "${alicloud_vpc.vpc.id}"
- 	cidr_block = "172.16.0.0/21"
- 	availability_zone = "${data.alicloud_zones.default.zones.0.id}"
- 	name = "${var.name}"
-}
-
-resource "alicloud_security_group" "default" {
-	name = "${var.name}"
-	description = "foo"
-	vpc_id = "${alicloud_vpc.vpc.id}"
-}
-
-resource "alicloud_instance" "default" {
-	vswitch_id = "${alicloud_vswitch.default.id}"
-	image_id = "${data.alicloud_images.default.images.0.id}"
-
-	instance_type = "${data.alicloud_instance_types.default.instance_types.0.id}"
-	system_disk_category = "cloud_efficiency"
-
-	internet_charge_type = "PayByTraffic"
-	internet_max_bandwidth_out = 5
-	security_groups = ["${alicloud_security_group.default.id}"]
-	instance_name = "${var.name}"
-}
-
-resource "alicloud_cen_instance" "cen" {
-	name = "${var.name}"
-	description = "terraform01"
-}
-
-resource "alicloud_cen_instance_attachment" "attach" {
-    instance_id = "${alicloud_cen_instance.cen.id}"
-    child_instance_id = "${alicloud_vpc.vpc.id}"
-    child_instance_region_id = "cn-beijing"
-}
-
-resource "alicloud_route_entry" "route" {
-    route_table_id = "${alicloud_vpc.vpc.route_table_id}"
-    destination_cidrblock = "11.0.0.0/16"
-    nexthop_type = "Instance"
-    nexthop_id = "${alicloud_instance.default.id}"
-}
-
-resource "alicloud_cen_route_entry" "foo" {
-    instance_id = "${alicloud_cen_instance.cen.id}"
-    route_table_id = "${alicloud_vpc.vpc.route_table_id}"
-    cidr_block = "${alicloud_route_entry.route.destination_cidrblock}"
-    depends_on = ["alicloud_cen_instance_attachment.attach"]
-}
-
-data "alicloud_cen_route_entries" "entry" {
-	instance_id = "${alicloud_cen_route_entry.foo.instance_id}"
-	route_table_id = "${alicloud_cen_route_entry.foo.route_table_id}"
- 	cidr_block = "11.0.0.0/16"
-}
-`
-
-const testAccCheckCenPublishedRouteEntriesDataSourceEmpty = `
-variable "name" {
-	default = "tf-testAccCenRoutesEmpty"
-}
-
-data "alicloud_zones" "default" {
-	"available_disk_category"= "cloud_efficiency"
-	"available_resource_creation"= "VSwitch"
-}
-
-data "alicloud_instance_types" "default" {
- 	availability_zone = "${data.alicloud_zones.default.zones.0.id}"
-	cpu_core_count = 1
-	memory_size = 2
-}
-
-data "alicloud_images" "default" {
-    name_regex = "^ubuntu_14.*_64"
-	most_recent = true
-	owners = "system"
-}
-
-resource "alicloud_vpc" "vpc" {
-  	name = "${var.name}"
-  	cidr_block = "172.16.0.0/12"
-}
-
-resource "alicloud_vswitch" "default" {
- 	vpc_id = "${alicloud_vpc.vpc.id}"
- 	cidr_block = "172.16.0.0/21"
- 	availability_zone = "${data.alicloud_zones.default.zones.0.id}"
- 	name = "${var.name}"
-}
-
-resource "alicloud_security_group" "default" {
-	name = "${var.name}"
-	description = "foo"
-	vpc_id = "${alicloud_vpc.vpc.id}"
-}
-
-resource "alicloud_instance" "default" {
-	vswitch_id = "${alicloud_vswitch.default.id}"
-	image_id = "${data.alicloud_images.default.images.0.id}"
-
-	instance_type = "${data.alicloud_instance_types.default.instance_types.0.id}"
-	system_disk_category = "cloud_efficiency"
-
-	internet_charge_type = "PayByTraffic"
-	internet_max_bandwidth_out = 5
-	security_groups = ["${alicloud_security_group.default.id}"]
-	instance_name = "${var.name}"
-}
-
-resource "alicloud_cen_instance" "cen" {
-	name = "${var.name}"
-	description = "terraform01"
-}
-
-resource "alicloud_cen_instance_attachment" "attach" {
-    instance_id = "${alicloud_cen_instance.cen.id}"
-    child_instance_id = "${alicloud_vpc.vpc.id}"
-    child_instance_region_id = "cn-beijing"
-}
-
-resource "alicloud_route_entry" "route" {
-    route_table_id = "${alicloud_vpc.vpc.route_table_id}"
-    destination_cidrblock = "11.0.0.0/16"
-    nexthop_type = "Instance"
-    nexthop_id = "${alicloud_instance.default.id}"
-}
-
-resource "alicloud_cen_route_entry" "foo" {
-    instance_id = "${alicloud_cen_instance.cen.id}"
-    route_table_id = "${alicloud_vpc.vpc.route_table_id}"
-    cidr_block = "${alicloud_route_entry.route.destination_cidrblock}"
-    depends_on = ["alicloud_cen_instance_attachment.attach"]
-}
-
-data "alicloud_cen_route_entries" "entry" {
-	instance_id = "${alicloud_cen_route_entry.foo.instance_id}"
-	route_table_id = "${alicloud_cen_route_entry.foo.route_table_id}"
- 	cidr_block = "11.1.0.0/16"
-}
-`

--- a/alicloud/import_alicloud_cen_bandwidth_limit_test.go
+++ b/alicloud/import_alicloud_cen_bandwidth_limit_test.go
@@ -4,15 +4,33 @@ import (
 	"testing"
 
 	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/helper/schema"
+	"github.com/hashicorp/terraform/terraform"
 )
 
-func TestAccAlicloudCenBandwidthLimit_importBasic(t *testing.T) {
+// This testcase can not work in the multi region.
+// The current resource does not need to support same region.
+func SkipTestAccAlicloudCenBandwidthLimit_importBasic(t *testing.T) {
 	resourceName := "alicloud_cen_bandwidth_limit.foo"
 
+	// multi provideris
+	var providers []*schema.Provider
+	providerFactories := map[string]terraform.ResourceProviderFactory{
+		"alicloud": func() (terraform.ResourceProvider, error) {
+			p := Provider()
+			providers = append(providers, p.(*schema.Provider))
+			return p, nil
+		},
+	}
+
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckCenBandwidthLimitDestroy,
+		PreCheck: func() {
+			testAccPreCheck(t)
+		},
+
+		// module name
+		ProviderFactories: providerFactories,
+		CheckDestroy:      testAccCheckCenBandwidthLimitDestroyWithProviders(&providers),
 		Steps: []resource.TestStep{
 			resource.TestStep{
 				Config: testAccCenBandwidthLimitConfig,

--- a/alicloud/import_alicloud_cen_route_entry_test.go
+++ b/alicloud/import_alicloud_cen_route_entry_test.go
@@ -15,7 +15,7 @@ func TestAccAlicloudCenRouteEntry_importBasic(t *testing.T) {
 		CheckDestroy: testAccCheckCenRouteEntryDestroy,
 		Steps: []resource.TestStep{
 			resource.TestStep{
-				Config: testAccCenRouteEntryConfig,
+				Config: testAccCenRouteEntryConfig(EcsInstanceCommonTestCase, defaultRegionToTest),
 			},
 
 			resource.TestStep{

--- a/alicloud/provider_test.go
+++ b/alicloud/provider_test.go
@@ -14,6 +14,7 @@ import (
 
 var testAccProviders map[string]terraform.ResourceProvider
 var testAccProvider *schema.Provider
+var defaultRegionToTest = os.Getenv("ALICLOUD_REGION")
 
 func init() {
 	testAccProvider = Provider().(*schema.Provider)

--- a/alicloud/resource_alicloud_cen_bandwidth_limit_test.go
+++ b/alicloud/resource_alicloud_cen_bandwidth_limit_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/aliyun/alibaba-cloud-sdk-go/services/cbn"
 	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/helper/schema"
 	"github.com/hashicorp/terraform/terraform"
 	"github.com/terraform-providers/terraform-provider-alicloud/alicloud/connectivity"
 )
@@ -13,20 +14,29 @@ import (
 func TestAccAlicloudCenBandwidthLimit_basic(t *testing.T) {
 	var cenBwpLimit cbn.CenInterRegionBandwidthLimit
 
+	// multi provideris
+	var providers []*schema.Provider
+	providerFactories := map[string]terraform.ResourceProviderFactory{
+		"alicloud": func() (terraform.ResourceProvider, error) {
+			p := Provider()
+			providers = append(providers, p.(*schema.Provider))
+			return p, nil
+		},
+	}
+
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			testAccPreCheck(t)
 		},
 
 		// module name
-		IDRefreshName: "alicloud_cen_bandwidth_limit.foo",
-		Providers:     testAccProviders,
-		CheckDestroy:  testAccCheckCenBandwidthLimitDestroy,
+		ProviderFactories: providerFactories,
+		CheckDestroy:      testAccCheckCenBandwidthLimitDestroyWithProviders(&providers),
 		Steps: []resource.TestStep{
 			resource.TestStep{
 				Config: testAccCenBandwidthLimitConfig,
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckCenBandwidthLimitExists("alicloud_cen_bandwidth_limit.foo", &cenBwpLimit),
+					testAccCheckCenBandwidthLimitExistsWithProviders("alicloud_cen_bandwidth_limit.foo", &cenBwpLimit, &providers),
 					resource.TestCheckResourceAttr(
 						"alicloud_cen_bandwidth_limit.foo", "bandwidth_limit", "4"),
 					resource.TestCheckResourceAttr(
@@ -41,18 +51,28 @@ func TestAccAlicloudCenBandwidthLimit_basic(t *testing.T) {
 func TestAccAlicloudCenBandwidthLimit_update(t *testing.T) {
 	var cenBwpLimit cbn.CenInterRegionBandwidthLimit
 
+	// multi provideris
+	var providers []*schema.Provider
+	providerFactories := map[string]terraform.ResourceProviderFactory{
+		"alicloud": func() (terraform.ResourceProvider, error) {
+			p := Provider()
+			providers = append(providers, p.(*schema.Provider))
+			return p, nil
+		},
+	}
+
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			testAccPreCheck(t)
 		},
 
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckCenBandwidthLimitDestroy,
+		ProviderFactories: providerFactories,
+		CheckDestroy:      testAccCheckCenBandwidthLimitDestroyWithProviders(&providers),
 		Steps: []resource.TestStep{
 			resource.TestStep{
 				Config: testAccCenBandwidthLimitConfig,
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckCenBandwidthLimitExists("alicloud_cen_bandwidth_limit.foo", &cenBwpLimit),
+					testAccCheckCenBandwidthLimitExistsWithProviders("alicloud_cen_bandwidth_limit.foo", &cenBwpLimit, &providers),
 					resource.TestCheckResourceAttr(
 						"alicloud_cen_bandwidth_limit.foo", "bandwidth_limit", "4"),
 					resource.TestCheckResourceAttr(
@@ -63,7 +83,7 @@ func TestAccAlicloudCenBandwidthLimit_update(t *testing.T) {
 			resource.TestStep{
 				Config: testAccCenBandwidthLimitUpdate,
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckCenBandwidthLimitExists("alicloud_cen_bandwidth_limit.foo", &cenBwpLimit),
+					testAccCheckCenBandwidthLimitExistsWithProviders("alicloud_cen_bandwidth_limit.foo", &cenBwpLimit, &providers),
 					resource.TestCheckResourceAttr(
 						"alicloud_cen_bandwidth_limit.foo", "bandwidth_limit", "5"),
 					resource.TestCheckResourceAttr(
@@ -78,25 +98,35 @@ func TestAccAlicloudCenBandwidthLimit_update(t *testing.T) {
 func TestAccAlicloudCenBandwidthLimit_multi(t *testing.T) {
 	var cenBwpLimit cbn.CenInterRegionBandwidthLimit
 
+	// multi provideris
+	var providers []*schema.Provider
+	providerFactories := map[string]terraform.ResourceProviderFactory{
+		"alicloud": func() (terraform.ResourceProvider, error) {
+			p := Provider()
+			providers = append(providers, p.(*schema.Provider))
+			return p, nil
+		},
+	}
+
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			testAccPreCheck(t)
 		},
 
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckCenBandwidthLimitDestroy,
+		ProviderFactories: providerFactories,
+		CheckDestroy:      testAccCheckCenBandwidthLimitDestroyWithProviders(&providers),
 		Steps: []resource.TestStep{
 			resource.TestStep{
 				Config: testAccCenBandwidthLimitMulti,
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckCenBandwidthLimitExists("alicloud_cen_bandwidth_limit.bar1", &cenBwpLimit),
+					testAccCheckCenBandwidthLimitExistsWithProviders("alicloud_cen_bandwidth_limit.bar1", &cenBwpLimit, &providers),
 					resource.TestCheckResourceAttr(
 						"alicloud_cen_bandwidth_limit.bar1", "bandwidth_limit", "2"),
 					resource.TestCheckResourceAttr(
 						"alicloud_cen_bandwidth_limit.bar1", "region_ids.#", "2"),
 					testAccCheckCenBandwidthLimitRegionId(&cenBwpLimit, "eu-central-1", "cn-shanghai"),
 
-					testAccCheckCenBandwidthLimitExists("alicloud_cen_bandwidth_limit.bar2", &cenBwpLimit),
+					testAccCheckCenBandwidthLimitExistsWithProviders("alicloud_cen_bandwidth_limit.bar2", &cenBwpLimit, &providers),
 					resource.TestCheckResourceAttr(
 						"alicloud_cen_bandwidth_limit.bar2", "bandwidth_limit", "3"),
 					resource.TestCheckResourceAttr(
@@ -108,7 +138,7 @@ func TestAccAlicloudCenBandwidthLimit_multi(t *testing.T) {
 	})
 }
 
-func testAccCheckCenBandwidthLimitExists(n string, cenBwpLimit *cbn.CenInterRegionBandwidthLimit) resource.TestCheckFunc {
+func testAccCheckCenBandwidthLimitExistsWithProviders(n string, cenBwpLimit *cbn.CenInterRegionBandwidthLimit, providers *[]*schema.Provider) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[n]
 		if !ok {
@@ -118,29 +148,50 @@ func testAccCheckCenBandwidthLimitExists(n string, cenBwpLimit *cbn.CenInterRegi
 		if rs.Primary.ID == "" {
 			return fmt.Errorf("No CEN bandwidth limit ID is set")
 		}
+		for _, provider := range *providers {
+			// Ignore if Meta is empty, this can happen for validation providers
+			if provider.Meta() == nil {
+				continue
+			}
 
-		client := testAccProvider.Meta().(*connectivity.AliyunClient)
-		cenService := CenService{client}
+			client := provider.Meta().(*connectivity.AliyunClient)
+			cenService := CenService{client}
 
-		params, err := cenService.GetCenAndRegionIds(rs.Primary.ID)
-		if err != nil {
-			return err
+			params, err := cenService.GetCenAndRegionIds(rs.Primary.ID)
+			if err != nil {
+				return err
+			}
+			cenId := params[0]
+			localRegionId := params[1]
+			oppositeRegionId := params[2]
+			instance, err := cenService.DescribeCenBandwidthLimit(cenId, localRegionId, oppositeRegionId)
+			if err != nil {
+				return err
+			}
+
+			*cenBwpLimit = instance
+			return nil
 		}
-		cenId := params[0]
-		localRegionId := params[1]
-		oppositeRegionId := params[2]
-		instance, err := cenService.DescribeCenBandwidthLimit(cenId, localRegionId, oppositeRegionId)
-		if err != nil {
-			return err
-		}
+		return fmt.Errorf("Cen bandwidth not found")
+	}
+}
 
-		*cenBwpLimit = instance
+func testAccCheckCenBandwidthLimitDestroyWithProviders(providers *[]*schema.Provider) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		for _, provider := range *providers {
+			if provider.Meta() == nil {
+				continue
+			}
+			if err := testAccCheckCenBandwidthLimitDestroyWithProvider(s, provider); err != nil {
+				return err
+			}
+		}
 		return nil
 	}
 }
 
-func testAccCheckCenBandwidthLimitDestroy(s *terraform.State) error {
-	client := testAccProvider.Meta().(*connectivity.AliyunClient)
+func testAccCheckCenBandwidthLimitDestroyWithProvider(s *terraform.State, provider *schema.Provider) error {
+	client := provider.Meta().(*connectivity.AliyunClient)
 	cenService := CenService{client}
 
 	for _, rs := range s.RootModule().Resources {

--- a/alicloud/resource_alicloud_cen_route_entry_test.go
+++ b/alicloud/resource_alicloud_cen_route_entry_test.go
@@ -24,7 +24,7 @@ func TestAccAlicloudCenRouteEntry_basic(t *testing.T) {
 		CheckDestroy:  testAccCheckCenRouteEntryDestroy,
 		Steps: []resource.TestStep{
 			resource.TestStep{
-				Config: testAccCenRouteEntryConfig,
+				Config: testAccCenRouteEntryConfig(EcsInstanceCommonTestCase, defaultRegionToTest),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckCenRouteEntryExists("alicloud_cen_route_entry.foo", &routeEntry),
 					resource.TestCheckResourceAttr("alicloud_cen_route_entry.foo", "cidr_block", "11.0.0.0/16"),
@@ -91,79 +91,47 @@ func testAccCheckCenRouteEntryDestroy(s *terraform.State) error {
 	return nil
 }
 
-const testAccCenRouteEntryConfig = `
-variable "name" {
-    default = "tf-testAccCenRouteEntryConfig"
-}
+func testAccCenRouteEntryConfig(common, region string) string {
+	return fmt.Sprintf(`
+	%s
+	variable "name" {
+	    default = "tf-testAccCenRouteEntryConfig"
+	}
 
-data "alicloud_zones" "default" {
-    available_disk_category = "cloud_efficiency"
-    available_resource_creation = "VSwitch"
-}
+	resource "alicloud_instance" "default" {
+	    vswitch_id = "${alicloud_vswitch.default.id}"
+	    image_id = "${data.alicloud_images.default.images.0.id}"
+	    instance_type = "${data.alicloud_instance_types.default.instance_types.0.id}"
+	    system_disk_category = "cloud_efficiency"
+	    internet_charge_type = "PayByTraffic"
+	    internet_max_bandwidth_out = 5
+	    security_groups = ["${alicloud_security_group.default.id}"]
+	    instance_name = "${var.name}"
+	}
 
-data "alicloud_instance_types" "default" {
-    availability_zone = "${data.alicloud_zones.default.zones.0.id}"
-    cpu_core_count = 1
-    memory_size = 2
-}
+	resource "alicloud_cen_instance" "cen" {
+	    name = "${var.name}"
+	}
 
-data "alicloud_images" "default" {
-    name_regex = "^ubuntu_14.*_64"
-    most_recent = true
-    owners = "system"
-}
+	resource "alicloud_cen_instance_attachment" "attach" {
+	    instance_id = "${alicloud_cen_instance.cen.id}"
+	    child_instance_id = "${alicloud_vpc.default.id}"
+	    child_instance_region_id = "%s"
+	}
 
-resource "alicloud_vpc" "vpc" {
-    name = "${var.name}"
-    cidr_block = "172.16.0.0/12"
-}
+	resource "alicloud_route_entry" "route" {
+	    route_table_id = "${alicloud_vpc.default.route_table_id}"
+	    destination_cidrblock = "11.0.0.0/16"
+	    nexthop_type = "Instance"
+	    nexthop_id = "${alicloud_instance.default.id}"
+	}
 
-resource "alicloud_vswitch" "default" {
-    vpc_id = "${alicloud_vpc.vpc.id}"
-    cidr_block = "172.16.0.0/21"
-    availability_zone = "${data.alicloud_zones.default.zones.0.id}"
-    name = "${var.name}"
+	resource "alicloud_cen_route_entry" "foo" {
+	    instance_id = "${alicloud_cen_instance.cen.id}"
+	    route_table_id = "${alicloud_vpc.default.route_table_id}"
+	    cidr_block = "${alicloud_route_entry.route.destination_cidrblock}"
+	    depends_on = [
+		"alicloud_cen_instance_attachment.attach"]
+	}
+	`, common, region)
 }
-
-resource "alicloud_security_group" "default" {
-    name = "${var.name}"
-    description = "foo"
-    vpc_id = "${alicloud_vpc.vpc.id}"
-}
-
-resource "alicloud_instance" "default" {
-    vswitch_id = "${alicloud_vswitch.default.id}"
-    image_id = "${data.alicloud_images.default.images.0.id}"
-    instance_type = "${data.alicloud_instance_types.default.instance_types.0.id}"
-    system_disk_category = "cloud_efficiency"
-    internet_charge_type = "PayByTraffic"
-    internet_max_bandwidth_out = 5
-    security_groups = ["${alicloud_security_group.default.id}"]
-    instance_name = "${var.name}"
-}
-
-resource "alicloud_cen_instance" "cen" {
-    name = "${var.name}"
-}
-
-resource "alicloud_cen_instance_attachment" "attach" {
-    instance_id = "${alicloud_cen_instance.cen.id}"
-    child_instance_id = "${alicloud_vpc.vpc.id}"
-    child_instance_region_id = "cn-beijing"
-}
-
-resource "alicloud_route_entry" "route" {
-    route_table_id = "${alicloud_vpc.vpc.route_table_id}"
-    destination_cidrblock = "11.0.0.0/16"
-    nexthop_type = "Instance"
-    nexthop_id = "${alicloud_instance.default.id}"
-}
-
-resource "alicloud_cen_route_entry" "foo" {
-    instance_id = "${alicloud_cen_instance.cen.id}"
-    route_table_id = "${alicloud_vpc.vpc.route_table_id}"
-    cidr_block = "${alicloud_route_entry.route.destination_cidrblock}"
-    depends_on = [
-        "alicloud_cen_instance_attachment.attach"]
-}
-`


### PR DESCRIPTION
```
TF_ACC=1 go test ./alicloud -v -run=TestAccAlicloudCen -timeout=240m
=== RUN   TestAccAlicloudCenBandwidthLimitsDataSource_instance_id
--- PASS: TestAccAlicloudCenBandwidthLimitsDataSource_instance_id (122.58s)
=== RUN   TestAccAlicloudCenBandwidthLimitsDataSource_empty
--- PASS: TestAccAlicloudCenBandwidthLimitsDataSource_empty (1.12s)
=== RUN   TestAccAlicloudCenBandwidthPackagesDataSource_instance_id
--- PASS: TestAccAlicloudCenBandwidthPackagesDataSource_instance_id (13.35s)
=== RUN   TestAccAlicloudCenBandwidthPackagesDataSource_bandwidth_package_nameRegex
--- PASS: TestAccAlicloudCenBandwidthPackagesDataSource_bandwidth_package_nameRegex (9.15s)
=== RUN   TestAccAlicloudCenBandwidthPackagesDataSource_multi_bandwith_packages
--- PASS: TestAccAlicloudCenBandwidthPackagesDataSource_multi_bandwith_packages (20.14s)
=== RUN   TestAccAlicloudCenBandwidthPackagesDataSource_empty
--- PASS: TestAccAlicloudCenBandwidthPackagesDataSource_empty (1.14s)
=== RUN   TestAccAlicloudCenInstancesDataSource_cen_id
--- PASS: TestAccAlicloudCenInstancesDataSource_cen_id (5.35s)
=== RUN   TestAccAlicloudCenInstancesDataSource_name_regex
--- PASS: TestAccAlicloudCenInstancesDataSource_name_regex (5.29s)
=== RUN   TestAccAlicloudCenInstancesDataSource_multi_cen_ids
--- PASS: TestAccAlicloudCenInstancesDataSource_multi_cen_ids (21.15s)
=== RUN   TestAccAlicloudCenInstancesDataSource_empty
--- PASS: TestAccAlicloudCenInstancesDataSource_empty (1.79s)
=== RUN   TestAccAlicloudCenRegionRouteEntriesDataSource_basic
--- PASS: TestAccAlicloudCenRegionRouteEntriesDataSource_basic (169.19s)
=== RUN   TestAccAlicloudCenRouteEntriesDataSource_basic
--- PASS: TestAccAlicloudCenRouteEntriesDataSource_basic (173.80s)
=== RUN   TestAccAlicloudCenRouteEntriesDataSource_empty
--- PASS: TestAccAlicloudCenRouteEntriesDataSource_empty (176.31s)
=== RUN   TestAccAlicloudCenBandwidthPackageAttachment_importBasic
--- PASS: TestAccAlicloudCenBandwidthPackageAttachment_importBasic (13.77s)
=== RUN   TestAccAlicloudCenBandwidthPackage_importBasic
--- PASS: TestAccAlicloudCenBandwidthPackage_importBasic (11.76s)
=== RUN   TestAccAlicloudCenInstanceAttachment_importBasic
--- PASS: TestAccAlicloudCenInstanceAttachment_importBasic (32.59s)
=== RUN   TestAccAlicloudCenInstance_importBasic
--- PASS: TestAccAlicloudCenInstance_importBasic (3.55s)
=== RUN   TestAccAlicloudCenRouteEntry_importBasic
--- PASS: TestAccAlicloudCenRouteEntry_importBasic (169.87s)
=== RUN   TestAccAlicloudCenBandwidthLimit_basic
--- PASS: TestAccAlicloudCenBandwidthLimit_basic (71.83s)
=== RUN   TestAccAlicloudCenBandwidthLimit_update
--- PASS: TestAccAlicloudCenBandwidthLimit_update (83.16s)
=== RUN   TestAccAlicloudCenBandwidthLimit_multi
--- PASS: TestAccAlicloudCenBandwidthLimit_multi (95.28s)
=== RUN   TestAccAlicloudCenBandwidthPackageAttachment_basic
--- PASS: TestAccAlicloudCenBandwidthPackageAttachment_basic (13.17s)
=== RUN   TestAccAlicloudCenBandwidthPackage_basic
--- PASS: TestAccAlicloudCenBandwidthPackage_basic (8.33s)
=== RUN   TestAccAlicloudCenBandwidthPackage_update
--- PASS: TestAccAlicloudCenBandwidthPackage_update (16.46s)
=== RUN   TestAccAlicloudCenBandwidthPackage_muti
--- PASS: TestAccAlicloudCenBandwidthPackage_muti (11.56s)
=== RUN   TestAccAlicloudCenInstanceAttachment_basic
--- PASS: TestAccAlicloudCenInstanceAttachment_basic (32.96s)
=== RUN   TestAccAlicloudCenInstanceAttachment_multi_same_regions
--- PASS: TestAccAlicloudCenInstanceAttachment_multi_same_regions (36.97s)
=== RUN   TestAccAlicloudCenInstanceAttachment_multi_different_regions
--- PASS: TestAccAlicloudCenInstanceAttachment_multi_different_regions (51.62s)
=== RUN   TestAccAlicloudCenInstance_basic
--- PASS: TestAccAlicloudCenInstance_basic (4.23s)
=== RUN   TestAccAlicloudCenInstance_update
--- PASS: TestAccAlicloudCenInstance_update (6.21s)
=== RUN   TestAccAlicloudCenInstance_multi
--- PASS: TestAccAlicloudCenInstance_multi (11.61s)
=== RUN   TestAccAlicloudCenRouteEntry_basic
--- PASS: TestAccAlicloudCenRouteEntry_basic (168.38s)
PASS
ok  	github.com/terraform-providers/terraform-provider-alicloud/alicloud	1563.704s
```