### PR TITLE
Improve ram, ess schedule and cdn testcase

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,11 +2,13 @@
 
 IMPROVEMENTS:
 
-- Improve kvstore client token [GH-585]
+- Improve ram, ess schedule and cdn testcase [GH-591]
+- Improve kvstore client token [GH-586]
 
 BUG FIXES:
 
-- Fix cen instance and bandwidth multi regions test case bug [GH-586]
+- Fix record not found issue if pvtz records are more than 50 [GH-590]
+- Fix cen instance and bandwidth multi regions test case bug [GH-588]
 
 ## 1.26.0 (December 20, 2018)
 

--- a/alicloud/import_alicloud_ram_group_test.go
+++ b/alicloud/import_alicloud_ram_group_test.go
@@ -3,6 +3,7 @@ package alicloud
 import (
 	"testing"
 
+	"github.com/hashicorp/terraform/helper/acctest"
 	"github.com/hashicorp/terraform/helper/resource"
 )
 
@@ -15,7 +16,7 @@ func TestAccAliclouTFdRamGroup_importBasic(t *testing.T) {
 		CheckDestroy: testAccCheckRamGroupDestroy,
 		Steps: []resource.TestStep{
 			resource.TestStep{
-				Config: testAccRamGroupConfig,
+				Config: testAccRamGroupConfig(acctest.RandInt()),
 			},
 
 			resource.TestStep{

--- a/alicloud/import_alicloud_ram_login_profile_test.go
+++ b/alicloud/import_alicloud_ram_login_profile_test.go
@@ -3,6 +3,7 @@ package alicloud
 import (
 	"testing"
 
+	"github.com/hashicorp/terraform/helper/acctest"
 	"github.com/hashicorp/terraform/helper/resource"
 )
 
@@ -15,7 +16,7 @@ func TestAccAlicloudRamLoginProfile_importBasic(t *testing.T) {
 		CheckDestroy: testAccCheckRamLoginProfileDestroy,
 		Steps: []resource.TestStep{
 			resource.TestStep{
-				Config: testAccRamLoginProfileConfig,
+				Config: testAccRamLoginProfileConfig(acctest.RandInt()),
 			},
 
 			resource.TestStep{

--- a/alicloud/import_alicloud_ram_policy_test.go
+++ b/alicloud/import_alicloud_ram_policy_test.go
@@ -3,6 +3,7 @@ package alicloud
 import (
 	"testing"
 
+	"github.com/hashicorp/terraform/helper/acctest"
 	"github.com/hashicorp/terraform/helper/resource"
 )
 
@@ -15,7 +16,7 @@ func TestAccAlicloudRamPolicy_importBasic(t *testing.T) {
 		CheckDestroy: testAccCheckRamPolicyDestroy,
 		Steps: []resource.TestStep{
 			resource.TestStep{
-				Config: testAccRamPolicyConfig,
+				Config: testAccRamPolicyConfig(acctest.RandInt()),
 			},
 
 			resource.TestStep{

--- a/alicloud/import_alicloud_ram_role_test.go
+++ b/alicloud/import_alicloud_ram_role_test.go
@@ -3,6 +3,7 @@ package alicloud
 import (
 	"testing"
 
+	"github.com/hashicorp/terraform/helper/acctest"
 	"github.com/hashicorp/terraform/helper/resource"
 )
 
@@ -15,7 +16,7 @@ func TestAccAlicloudRamRole_importBasic(t *testing.T) {
 		CheckDestroy: testAccCheckRamRoleDestroy,
 		Steps: []resource.TestStep{
 			resource.TestStep{
-				Config: testAccRamRoleConfig,
+				Config: testAccRamRoleConfig(acctest.RandInt()),
 			},
 
 			resource.TestStep{

--- a/alicloud/import_alicloud_ram_user_test.go
+++ b/alicloud/import_alicloud_ram_user_test.go
@@ -3,6 +3,7 @@ package alicloud
 import (
 	"testing"
 
+	"github.com/hashicorp/terraform/helper/acctest"
 	"github.com/hashicorp/terraform/helper/resource"
 )
 
@@ -15,7 +16,7 @@ func TestAccAlicloudRamUser_importBasic(t *testing.T) {
 		CheckDestroy: testAccCheckRamUserDestroy,
 		Steps: []resource.TestStep{
 			resource.TestStep{
-				Config: testAccRamUserConfig,
+				Config: testAccRamUserConfig(acctest.RandInt()),
 			},
 
 			resource.TestStep{

--- a/alicloud/resource_alicloud_ess_schedule_test.go
+++ b/alicloud/resource_alicloud_ess_schedule_test.go
@@ -96,7 +96,8 @@ func testSweepEssSchedules(region string) error {
 
 func TestAccAlicloudEssSchedule_basic(t *testing.T) {
 	var sc ess.ScheduledTask
-	local, _ := time.LoadLocation("Asia/Shanghai")
+	// Setting schedule time to more than one day
+	oneDay, _ := time.ParseDuration("24h")
 
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
@@ -110,7 +111,7 @@ func TestAccAlicloudEssSchedule_basic(t *testing.T) {
 		CheckDestroy: testAccCheckEssScheduleDestroy,
 		Steps: []resource.TestStep{
 			resource.TestStep{
-				Config: testAccEssScheduleConfig(time.Now().In(local).Format("2006-01-02T15:04Z")),
+				Config: testAccEssScheduleConfig(time.Now().Add(oneDay).Format("2006-01-02T15:04Z")),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckEssScheduleExists(
 						"alicloud_ess_schedule.foo", &sc),

--- a/alicloud/resource_alicloud_instance_test.go
+++ b/alicloud/resource_alicloud_instance_test.go
@@ -22,17 +22,13 @@ func init() {
 		F:    testSweepInstances,
 		// When implemented, these should be removed firstly
 		// Now, the resource alicloud_havip_attachment has been published.
-		//Dependencies: []string{
-		//	"alicloud_havip_attachment",
-		//},
+		Dependencies: []string{
+			"alicloud_havip_attachment",
+		},
 	})
 }
 
 func testSweepInstances(region string) error {
-	if testSweepPreCheckWithRegions(region, true, connectivity.EcsClassicSupportedRegions) {
-		log.Printf("[INFO] Skipping ECS Classic Instance unsupported region: %s", region)
-		return nil
-	}
 	rawClient, err := sharedClientForRegion(region)
 	if err != nil {
 		return fmt.Errorf("error getting Alicloud client: %s", err)

--- a/alicloud/resource_alicloud_ram_access_key_test.go
+++ b/alicloud/resource_alicloud_ram_access_key_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/denverdino/aliyungo/ram"
+	"github.com/hashicorp/terraform/helper/acctest"
 	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/terraform"
 	"github.com/terraform-providers/terraform-provider-alicloud/alicloud/connectivity"
@@ -26,7 +27,7 @@ func TestAccAlicloudRamAccessKey_basic(t *testing.T) {
 		CheckDestroy: testAccCheckRamAccessKeyDestroy,
 		Steps: []resource.TestStep{
 			resource.TestStep{
-				Config: testAccRamAccessKeyConfig,
+				Config: testAccRamAccessKeyConfig(acctest.RandIntRange(1000000, 99999999)),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckRamUserExists(
 						"alicloud_ram_user.user", &u),
@@ -113,17 +114,19 @@ func testAccCheckRamAccessKeyDestroy(s *terraform.State) error {
 	return nil
 }
 
-const testAccRamAccessKeyConfig = `
-resource "alicloud_ram_user" "user" {
-  name = "tf-testAccRamAccessKeyConfig"
-  display_name = "displayname"
-  mobile = "86-18888888888"
-  email = "hello.uuu@aaa.com"
-  comments = "yoyoyo"
-}
+func testAccRamAccessKeyConfig(rand int) string {
+	return fmt.Sprintf(`
+	resource "alicloud_ram_user" "user" {
+	  name = "tf-testAccRamAccessKeyConfig%d"
+	  display_name = "displayname"
+	  mobile = "86-18888888888"
+	  email = "hello.uuu@aaa.com"
+	  comments = "yoyoyo"
+	}
 
-resource "alicloud_ram_access_key" "ak" {
-  user_name = "${alicloud_ram_user.user.name}"
-  status = "Active"
-  secret_file = "/hello.txt"
-}`
+	resource "alicloud_ram_access_key" "ak" {
+	  user_name = "${alicloud_ram_user.user.name}"
+	  status = "Active"
+	  secret_file = "/hello.txt"
+	}`, rand)
+}

--- a/alicloud/resource_alicloud_ram_account_alias_test.go
+++ b/alicloud/resource_alicloud_ram_account_alias_test.go
@@ -8,7 +8,10 @@ import (
 	"strings"
 	"time"
 
+	"regexp"
+
 	"github.com/denverdino/aliyungo/ram"
+	"github.com/hashicorp/terraform/helper/acctest"
 	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/terraform"
 	"github.com/terraform-providers/terraform-provider-alicloud/alicloud/connectivity"
@@ -87,14 +90,14 @@ func TestAccAlicloudRamAccountAlias_basic(t *testing.T) {
 		CheckDestroy: testAccCheckRamAccountAliasDestroy,
 		Steps: []resource.TestStep{
 			resource.TestStep{
-				Config: testAccRamAccountAliasConfig,
+				Config: testAccRamAccountAliasConfig(acctest.RandIntRange(10000, 999999)),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckRamAccountAliasExists(
 						"alicloud_ram_account_alias.alias", &v),
-					resource.TestCheckResourceAttr(
+					resource.TestMatchResourceAttr(
 						"alicloud_ram_account_alias.alias",
 						"account_alias",
-						"testaccramaccountaliasconfig"),
+						regexp.MustCompile("^tf-testaccramaccountalias*")),
 				),
 			},
 		},
@@ -149,7 +152,9 @@ func testAccCheckRamAccountAliasDestroy(s *terraform.State) error {
 	return nil
 }
 
-const testAccRamAccountAliasConfig = `
-resource "alicloud_ram_account_alias" "alias" {
-  account_alias = "testaccramaccountaliasconfig"
-}`
+func testAccRamAccountAliasConfig(rand int) string {
+	return fmt.Sprintf(`
+	resource "alicloud_ram_account_alias" "alias" {
+	  account_alias = "tf-testaccramaccountalias%d"
+	}`, rand)
+}

--- a/alicloud/resource_alicloud_ram_group_membership_test.go
+++ b/alicloud/resource_alicloud_ram_group_membership_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/denverdino/aliyungo/ram"
+	"github.com/hashicorp/terraform/helper/acctest"
 	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/terraform"
 	"github.com/terraform-providers/terraform-provider-alicloud/alicloud/connectivity"
@@ -26,7 +27,7 @@ func TestAccAlicloudRamGroupMembership_basic(t *testing.T) {
 		CheckDestroy: testAccCheckRamGroupMembershipDestroy,
 		Steps: []resource.TestStep{
 			resource.TestStep{
-				Config: testAccRamGroupMembershipConfig,
+				Config: testAccRamGroupMembershipConfig(acctest.RandIntRange(1000000, 99999999)),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckRamUserExists(
 						"alicloud_ram_user.user", &u),
@@ -110,33 +111,35 @@ func testAccCheckRamGroupMembershipDestroy(s *terraform.State) error {
 	return nil
 }
 
-const testAccRamGroupMembershipConfig = `
-variable "name" {
-  default = "tf-testAccRamGroupMembershipConfig"
-}
-resource "alicloud_ram_user" "user" {
-  name = "${var.name}"
-  display_name = "displayname"
-  mobile = "86-18888888888"
-  email = "hello.uuu@aaa.com"
-  comments = "yoyoyo"
-}
+func testAccRamGroupMembershipConfig(rand int) string {
+	return fmt.Sprintf(`
+	variable "name" {
+	  default = "tf-testAccRamGroupMembershipConfig-%d"
+	}
+	resource "alicloud_ram_user" "user" {
+	  name = "${var.name}"
+	  display_name = "displayname"
+	  mobile = "86-18888888888"
+	  email = "hello.uuu@aaa.com"
+	  comments = "yoyoyo"
+	}
 
-resource "alicloud_ram_user" "user1" {
-  name = "${var.name}1"
-  display_name = "displayname1"
-  mobile = "86-18888888888"
-  email = "hello.uuuu@aaa.com"
-  comments = "yoyoyo1"
-}
+	resource "alicloud_ram_user" "user1" {
+	  name = "${var.name}1"
+	  display_name = "displayname1"
+	  mobile = "86-18888888888"
+	  email = "hello.uuuu@aaa.com"
+	  comments = "yoyoyo1"
+	}
 
-resource "alicloud_ram_group" "group" {
-  name = "${var.name}"
-  comments = "group comments"
-  force=true
-}
+	resource "alicloud_ram_group" "group" {
+	  name = "${var.name}"
+	  comments = "group comments"
+	  force=true
+	}
 
-resource "alicloud_ram_group_membership" "membership" {
-  group_name = "${alicloud_ram_group.group.name}"
-  user_names = ["${alicloud_ram_user.user.name}", "${alicloud_ram_user.user1.name}"]
-}`
+	resource "alicloud_ram_group_membership" "membership" {
+	  group_name = "${alicloud_ram_group.group.name}"
+	  user_names = ["${alicloud_ram_user.user.name}", "${alicloud_ram_user.user1.name}"]
+	}`, rand)
+}

--- a/alicloud/resource_alicloud_ram_group_test.go
+++ b/alicloud/resource_alicloud_ram_group_test.go
@@ -8,7 +8,10 @@ import (
 	"strings"
 	"time"
 
+	"regexp"
+
 	"github.com/denverdino/aliyungo/ram"
+	"github.com/hashicorp/terraform/helper/acctest"
 	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/terraform"
 	"github.com/terraform-providers/terraform-provider-alicloud/alicloud/connectivity"
@@ -132,14 +135,14 @@ func TestAccAlicloudRamGroup_basic(t *testing.T) {
 		CheckDestroy: testAccCheckRamGroupDestroy,
 		Steps: []resource.TestStep{
 			resource.TestStep{
-				Config: testAccRamGroupConfig,
+				Config: testAccRamGroupConfig(acctest.RandIntRange(1000000, 99999999)),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckRamGroupExists(
 						"alicloud_ram_group.group", &v),
-					resource.TestCheckResourceAttr(
+					resource.TestMatchResourceAttr(
 						"alicloud_ram_group.group",
 						"name",
-						"tf-testAccRamGroupConfig"),
+						regexp.MustCompile("^tf-testAccRamGroupConfig-*")),
 					resource.TestCheckResourceAttr(
 						"alicloud_ram_group.group",
 						"comments",
@@ -204,9 +207,11 @@ func testAccCheckRamGroupDestroy(s *terraform.State) error {
 	return nil
 }
 
-const testAccRamGroupConfig = `
-resource "alicloud_ram_group" "group" {
-  name = "tf-testAccRamGroupConfig"
-  comments = "group comments"
-  force=true
-}`
+func testAccRamGroupConfig(rand int) string {
+	return fmt.Sprintf(`
+	resource "alicloud_ram_group" "group" {
+	  name = "tf-testAccRamGroupConfig-%d"
+	  comments = "group comments"
+	  force=true
+	}`, rand)
+}

--- a/alicloud/resource_alicloud_ram_login_profile_test.go
+++ b/alicloud/resource_alicloud_ram_login_profile_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/denverdino/aliyungo/ram"
+	"github.com/hashicorp/terraform/helper/acctest"
 	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/terraform"
 	"github.com/terraform-providers/terraform-provider-alicloud/alicloud/connectivity"
@@ -26,7 +27,7 @@ func TestAccAlicloudRamLoginProfile_basic(t *testing.T) {
 		CheckDestroy: testAccCheckRamLoginProfileDestroy,
 		Steps: []resource.TestStep{
 			resource.TestStep{
-				Config: testAccRamLoginProfileConfig,
+				Config: testAccRamLoginProfileConfig(acctest.RandIntRange(1000000, 99999999)),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckRamUserExists(
 						"alicloud_ram_user.user", &u),
@@ -94,16 +95,18 @@ func testAccCheckRamLoginProfileDestroy(s *terraform.State) error {
 	return nil
 }
 
-const testAccRamLoginProfileConfig = `
-resource "alicloud_ram_user" "user" {
-  name = "tf-testAccRamLoginProfileConfig"
-  display_name = "displayname"
-  mobile = "86-18888888888"
-  email = "hello.uuu@aaa.com"
-  comments = "yoyoyo"
-}
+func testAccRamLoginProfileConfig(rand int) string {
+	return fmt.Sprintf(`
+	resource "alicloud_ram_user" "user" {
+	  name = "tf-testAccRamLoginProfileConfig-%d"
+	  display_name = "displayname"
+	  mobile = "86-18888888888"
+	  email = "hello.uuu@aaa.com"
+	  comments = "yoyoyo"
+	}
 
-resource "alicloud_ram_login_profile" "profile" {
-  user_name = "${alicloud_ram_user.user.name}"
-  password = "World.123456"
-}`
+	resource "alicloud_ram_login_profile" "profile" {
+	  user_name = "${alicloud_ram_user.user.name}"
+	  password = "World.123456"
+	}`, rand)
+}

--- a/alicloud/resource_alicloud_ram_role_attachment_test.go
+++ b/alicloud/resource_alicloud_ram_role_attachment_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/aliyun/alibaba-cloud-sdk-go/services/ecs"
 	"github.com/denverdino/aliyungo/ram"
+	"github.com/hashicorp/terraform/helper/acctest"
 	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/terraform"
 	"github.com/terraform-providers/terraform-provider-alicloud/alicloud/connectivity"
@@ -29,7 +30,7 @@ func TestAccAlicloudRamRoleAttachment_basic(t *testing.T) {
 		CheckDestroy: testAccCheckRamRoleAttachmentDestroy,
 		Steps: []resource.TestStep{
 			resource.TestStep{
-				Config: testAccRamRoleAttachmentConfig(EcsInstanceCommonTestCase),
+				Config: testAccRamRoleAttachmentConfig(EcsInstanceCommonTestCase, acctest.RandIntRange(1000000, 99999999)),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckRamRoleExists(
 						"alicloud_ram_role.role", &role),
@@ -125,11 +126,11 @@ func testAccCheckRamRoleAttachmentDestroy(s *terraform.State) error {
 	return nil
 }
 
-func testAccRamRoleAttachmentConfig(common string) string {
+func testAccRamRoleAttachmentConfig(common string, rand int) string {
 	return fmt.Sprintf(`
 	%s
 	variable "name" {
-		default = "tf-testAccRamRoleAttachmentConfig"
+		default = "tf-testAccRamRoleAttachmentConfig-%d"
 	}
 
 	resource "alicloud_instance" "instance" {
@@ -157,5 +158,5 @@ func testAccRamRoleAttachmentConfig(common string) string {
 	resource "alicloud_ram_role_attachment" "attach" {
 	  role_name = "${alicloud_ram_role.role.name}"
 	  instance_ids = ["${alicloud_instance.instance.*.id}"]
-	}`, common)
+	}`, common, rand)
 }

--- a/alicloud/resource_alicloud_ram_role_test.go
+++ b/alicloud/resource_alicloud_ram_role_test.go
@@ -8,7 +8,10 @@ import (
 	"strings"
 	"time"
 
+	"regexp"
+
 	"github.com/denverdino/aliyungo/ram"
+	"github.com/hashicorp/terraform/helper/acctest"
 	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/terraform"
 	"github.com/terraform-providers/terraform-provider-alicloud/alicloud/connectivity"
@@ -128,14 +131,14 @@ func TestAccAlicloudRamRole_basic(t *testing.T) {
 		CheckDestroy: testAccCheckRamRoleDestroy,
 		Steps: []resource.TestStep{
 			resource.TestStep{
-				Config: testAccRamRoleConfig,
+				Config: testAccRamRoleConfig(acctest.RandIntRange(1000000, 99999999)),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckRamRoleExists(
 						"alicloud_ram_role.role", &v),
-					resource.TestCheckResourceAttr(
+					resource.TestMatchResourceAttr(
 						"alicloud_ram_role.role",
 						"name",
-						"tf-testAccRamRoleConfig"),
+						regexp.MustCompile("^tf-testAccRamRoleConfig-*")),
 					resource.TestCheckResourceAttr(
 						"alicloud_ram_role.role",
 						"description",
@@ -203,10 +206,12 @@ func testAccCheckRamRoleDestroy(s *terraform.State) error {
 	return nil
 }
 
-const testAccRamRoleConfig = `
-resource "alicloud_ram_role" "role" {
-  name = "tf-testAccRamRoleConfig"
-  services = ["apigateway.aliyuncs.com", "ecs.aliyuncs.com"]
-  description = "this is a test"
-  force = true
-}`
+func testAccRamRoleConfig(rand int) string {
+	return fmt.Sprintf(`
+	resource "alicloud_ram_role" "role" {
+	  name = "tf-testAccRamRoleConfig-%d"
+	  services = ["apigateway.aliyuncs.com", "ecs.aliyuncs.com"]
+	  description = "this is a test"
+	  force = true
+	}`, rand)
+}

--- a/alicloud/resource_alicloud_ram_user_test.go
+++ b/alicloud/resource_alicloud_ram_user_test.go
@@ -8,7 +8,10 @@ import (
 	"strings"
 	"time"
 
+	"regexp"
+
 	"github.com/denverdino/aliyungo/ram"
+	"github.com/hashicorp/terraform/helper/acctest"
 	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/terraform"
 	"github.com/terraform-providers/terraform-provider-alicloud/alicloud/connectivity"
@@ -109,14 +112,14 @@ func TestAccAlicloudRamUser_basic(t *testing.T) {
 		CheckDestroy: testAccCheckRamUserDestroy,
 		Steps: []resource.TestStep{
 			resource.TestStep{
-				Config: testAccRamUserConfig,
+				Config: testAccRamUserConfig(acctest.RandIntRange(1000000, 99999999)),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckRamUserExists(
 						"alicloud_ram_user.user", &v),
-					resource.TestCheckResourceAttr(
+					resource.TestMatchResourceAttr(
 						"alicloud_ram_user.user",
 						"name",
-						"tf-testAccRamUserConfig"),
+						regexp.MustCompile("^tf-testAccRamUserConfig-*")),
 					resource.TestCheckResourceAttr(
 						"alicloud_ram_user.user",
 						"display_name",
@@ -188,11 +191,13 @@ func testAccCheckRamUserDestroy(s *terraform.State) error {
 	return nil
 }
 
-const testAccRamUserConfig = `
-resource "alicloud_ram_user" "user" {
-  name = "tf-testAccRamUserConfig"
-  display_name = "displayname"
-  mobile = "86-18888888888"
-  email = "hello.uuu@aaa.com"
-  comments = "yoyoyo"
-}`
+func testAccRamUserConfig(rand int) string {
+	return fmt.Sprintf(`
+	resource "alicloud_ram_user" "user" {
+	  name = "tf-testAccRamUserConfig-%d"
+	  display_name = "displayname"
+	  mobile = "86-18888888888"
+	  email = "hello.uuu@aaa.com"
+	  comments = "yoyoyo"
+	}`, rand)
+}


### PR DESCRIPTION
```
TF_ACC=1 go test ./alicloud -v -run=TestAccAlicloudRam  -timeout=240m
=== RUN   TestAccAlicloudRamAccountAliasDataSource_basic
--- PASS: TestAccAlicloudRamAccountAliasDataSource_basic (3.34s)
=== RUN   TestAccAlicloudRamGroupsDataSource_for_user
--- PASS: TestAccAlicloudRamGroupsDataSource_for_user (9.74s)
=== RUN   TestAccAlicloudRamGroupsDataSource_for_policy
--- PASS: TestAccAlicloudRamGroupsDataSource_for_policy (9.68s)
=== RUN   TestAccAlicloudRamGroupsDataSource_for_all
--- PASS: TestAccAlicloudRamGroupsDataSource_for_all (1.98s)
=== RUN   TestAccAlicloudRamGroupsDataSource_group_name_regex
--- PASS: TestAccAlicloudRamGroupsDataSource_group_name_regex (3.40s)
=== RUN   TestAccAlicloudRamGroupsDataSource_Empty
--- PASS: TestAccAlicloudRamGroupsDataSource_Empty (1.59s)
=== RUN   TestAccAlicloudRamPoliciesDataSource_for_group
--- PASS: TestAccAlicloudRamPoliciesDataSource_for_group (8.72s)
=== RUN   TestAccAlicloudRamPoliciesDataSource_for_role
--- PASS: TestAccAlicloudRamPoliciesDataSource_for_role (8.34s)
=== RUN   TestAccAlicloudRamPoliciesDataSource_for_user
--- PASS: TestAccAlicloudRamPoliciesDataSource_for_user (9.88s)
=== RUN   TestAccAlicloudRamPoliciesDataSource_policy_name_regex
--- PASS: TestAccAlicloudRamPoliciesDataSource_policy_name_regex (5.80s)
=== RUN   TestAccAlicloudRamPoliciesDataSource_policy_type
--- PASS: TestAccAlicloudRamPoliciesDataSource_policy_type (5.69s)
=== RUN   TestAccAlicloudRamPoliciesDataSource_empty
--- PASS: TestAccAlicloudRamPoliciesDataSource_empty (3.13s)
=== RUN   TestAccAlicloudRamRolesDataSource_for_policy
--- PASS: TestAccAlicloudRamRolesDataSource_for_policy (8.26s)
=== RUN   TestAccAlicloudRamRolesDataSource_for_all
--- PASS: TestAccAlicloudRamRolesDataSource_for_all (8.81s)
=== RUN   TestAccAlicloudRamRolesDataSource_role_name_regex
--- PASS: TestAccAlicloudRamRolesDataSource_role_name_regex (3.39s)
=== RUN   TestAccAlicloudRamRolesDataSource_empty
--- PASS: TestAccAlicloudRamRolesDataSource_empty (1.57s)
=== RUN   TestAccAlicloudRamUsersDataSource_for_group
--- PASS: TestAccAlicloudRamUsersDataSource_for_group (6.70s)
=== RUN   TestAccAlicloudRamUsersDataSource_for_policy
--- PASS: TestAccAlicloudRamUsersDataSource_for_policy (6.59s)
=== RUN   TestAccAlicloudRamUsersDataSource_for_all
--- PASS: TestAccAlicloudRamUsersDataSource_for_all (1.46s)
=== RUN   TestAccAlicloudRamUsersDataSource_user_name_regex
--- PASS: TestAccAlicloudRamUsersDataSource_user_name_regex (3.01s)
=== RUN   TestAccAlicloudRamUsersDataSource_empty
--- PASS: TestAccAlicloudRamUsersDataSource_empty (1.34s)
=== RUN   TestAccAlicloudRamLoginProfile_importBasic
--- PASS: TestAccAlicloudRamLoginProfile_importBasic (4.44s)
=== RUN   TestAccAlicloudRamPolicy_importBasic
--- PASS: TestAccAlicloudRamPolicy_importBasic (3.23s)
=== RUN   TestAccAlicloudRamRole_importBasic
--- PASS: TestAccAlicloudRamRole_importBasic (8.18s)
=== RUN   TestAccAlicloudRamUser_importBasic
--- PASS: TestAccAlicloudRamUser_importBasic (7.05s)
=== RUN   TestAccAlicloudRamAccessKey_basic
--- PASS: TestAccAlicloudRamAccessKey_basic (4.90s)
=== RUN   TestAccAlicloudRamAccountAlias_basic
--- PASS: TestAccAlicloudRamAccountAlias_basic (2.06s)
=== RUN   TestAccAlicloudRamGroupMembership_basic
--- PASS: TestAccAlicloudRamGroupMembership_basic (8.59s)
=== RUN   TestAccAlicloudRamGroupPolicyAttachment_basic
--- PASS: TestAccAlicloudRamGroupPolicyAttachment_basic (6.15s)
=== RUN   TestAccAlicloudRamGroup_basic
--- PASS: TestAccAlicloudRamGroup_basic (2.61s)
=== RUN   TestAccAlicloudRamLoginProfile_basic
--- PASS: TestAccAlicloudRamLoginProfile_basic (5.53s)
=== RUN   TestAccAlicloudRamPolicy_basic
--- PASS: TestAccAlicloudRamPolicy_basic (3.83s)
=== RUN   TestAccAlicloudRamRoleAttachment_basic
--- PASS: TestAccAlicloudRamRoleAttachment_basic (201.83s)
=== RUN   TestAccAlicloudRamRolePolicyAttachment_basic
--- PASS: TestAccAlicloudRamRolePolicyAttachment_basic (6.32s)
=== RUN   TestAccAlicloudRamRole_basic
--- PASS: TestAccAlicloudRamRole_basic (2.26s)
=== RUN   TestAccAlicloudRamUserPolicyAttachment_basic
--- PASS: TestAccAlicloudRamUserPolicyAttachment_basic (6.32s)
=== RUN   TestAccAlicloudRamUser_basic
--- PASS: TestAccAlicloudRamUser_basic (2.72s)
PASS
ok  	github.com/terraform-providers/terraform-provider-alicloud/alicloud	388.499s
```

```
TF_ACC=1 go test ./alicloud -v -run=TestAccAlicloudCdn  -timeout=240m
=== RUN   TestAccAlicloudCdnDomain_basic
--- PASS: TestAccAlicloudCdnDomain_basic (86.71s)
PASS
ok  	github.com/terraform-providers/terraform-provider-alicloud/alicloud	86.777s
```

```
TF_ACC=1 go test ./alicloud -v -run=TestAccAlicloudEssSchedule_basic  -timeout=240m
=== RUN   TestAccAlicloudEssSchedule_basic
--- PASS: TestAccAlicloudEssSchedule_basic (82.44s)
PASS
ok  	github.com/terraform-providers/terraform-provider-alicloud/alicloud	82.505s
```