### PR TITLE
Improve apigateway testcase

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,8 @@
 
 IMPROVEMENTS:
 
-- Improve ram, ess schedule and cdn testcase [GH-591]
+- Improve apigateway testcase [GH-593]
+- Improve ram, ess schedule and cdn testcase [GH-592]
 - Improve kvstore client token [GH-586]
 
 BUG FIXES:

--- a/alicloud/data_source_alicloud_api_gateway_apis_test.go
+++ b/alicloud/data_source_alicloud_api_gateway_apis_test.go
@@ -3,6 +3,10 @@ package alicloud
 import (
 	"testing"
 
+	"fmt"
+	"regexp"
+
+	"github.com/hashicorp/terraform/helper/acctest"
 	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/terraform-providers/terraform-provider-alicloud/alicloud/connectivity"
 )
@@ -15,11 +19,11 @@ func TestAccAlicloudApigatewayApisDataSource_basic(t *testing.T) {
 		Providers: testAccProviders,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccCheckAlicloudApiGatewayApiDataSource,
+				Config: testAccCheckAlicloudApiGatewayApiDataSource(acctest.RandIntRange(10000, 999999)),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAlicloudDataSourceID("data.alicloud_api_gateway_apis.data_apis"),
 					resource.TestCheckResourceAttr("data.alicloud_api_gateway_apis.data_apis", "apis.0.name", "tf_testAcc_api"),
-					resource.TestCheckResourceAttr("data.alicloud_api_gateway_apis.data_apis", "apis.0.group_name", "tf_testAccApiGroupDataSource"),
+					resource.TestMatchResourceAttr("data.alicloud_api_gateway_apis.data_apis", "apis.0.group_name", regexp.MustCompile("^tf_testAccApiGroupDataSource_*")),
 					resource.TestCheckResourceAttr("data.alicloud_api_gateway_apis.data_apis", "apis.0.description", "tf_testAcc_api description"),
 				),
 			},
@@ -35,7 +39,7 @@ func TestAccAlicloudApigatewayApisDataSource_empty(t *testing.T) {
 		Providers: testAccProviders,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccCheckAlicloudApiGatewayApiDataSourceEmpty,
+				Config: testAccCheckAlicloudApiGatewayApiDataSourceEmpty(acctest.RandIntRange(10000, 999999)),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAlicloudDataSourceID("data.alicloud_api_gateway_apis.data_apis"),
 					resource.TestCheckResourceAttr("data.alicloud_api_gateway_apis.data_apis", "apis.#", "0"),
@@ -48,80 +52,84 @@ func TestAccAlicloudApigatewayApisDataSource_empty(t *testing.T) {
 	})
 }
 
-const testAccCheckAlicloudApiGatewayApiDataSource = `
+func testAccCheckAlicloudApiGatewayApiDataSource(rand int) string {
+	return fmt.Sprintf(`
 
-variable "apigateway_group_name_test" {
-  default = "tf_testAccApiGroupDataSource"
+	variable "apigateway_group_name_test" {
+	  default = "tf_testAccApiGroupDataSource_%d"
+	}
+
+	variable "apigateway_group_description_test" {
+	  default = "tf_testAcc_api group description"
+	}
+
+	resource "alicloud_api_gateway_group" "apiGroupTest" {
+	  name = "${var.apigateway_group_name_test}"
+	  description = "${var.apigateway_group_description_test}"
+	}
+
+	resource "alicloud_api_gateway_api" "apiTest" {
+	  name = "tf_testAcc_api"
+	  group_id = "${alicloud_api_gateway_group.apiGroupTest.id}"
+	  description = "tf_testAcc_api description"
+	  auth_type = "APP"
+	  request_config = [
+	    {
+	      protocol = "HTTP"
+	      method = "GET"
+	      path = "/test/path"
+	      mode = "MAPPING"
+	    },
+	  ]
+	  service_type = "HTTP"
+	  http_service_config = [
+	    {
+	      address = "http://apigateway-backend.alicloudapi.com:8080"
+	      method = "GET"
+	      path = "/web/cloudapi"
+	      timeout = 20
+	      aone_name = "cloudapi-openapi"
+	    },
+	  ]
+
+	  request_parameters = [
+	    {
+	      name = "testparam"
+	      type = "STRING"
+	      required = "OPTIONAL"
+	      in = "QUERY"
+	      in_service = "QUERY"
+	      name_service = "testparams"
+	    },
+	  ]
+	}
+
+	data "alicloud_api_gateway_apis" "data_apis"{
+	  group_id = "${alicloud_api_gateway_group.apiGroupTest.id}"
+	  api_id = "${alicloud_api_gateway_api.apiTest.id}"
+	}
+
+	`, rand)
 }
 
-variable "apigateway_group_description_test" {
-  default = "tf_testAcc_api group description"
+func testAccCheckAlicloudApiGatewayApiDataSourceEmpty(rand int) string {
+	return fmt.Sprintf(`
+	variable "apigateway_group_name_test" {
+	  default = "tf_testAccApiGroupDataSourceEmpty_%d"
+	}
+
+	variable "apigateway_group_description_test" {
+	  default = "tf_testAcc_api group description"
+	}
+
+	resource "alicloud_api_gateway_group" "apiGroupTest" {
+	  name = "${var.apigateway_group_name_test}"
+	  description = "${var.apigateway_group_description_test}"
+	}
+
+
+	data "alicloud_api_gateway_apis" "data_apis"{
+	  group_id = "${alicloud_api_gateway_group.apiGroupTest.id}"
+	}
+	`, rand)
 }
-
-resource "alicloud_api_gateway_group" "apiGroupTest" {
-  name = "${var.apigateway_group_name_test}"
-  description = "${var.apigateway_group_description_test}"
-}
-
-resource "alicloud_api_gateway_api" "apiTest" {
-  name = "tf_testAcc_api"
-  group_id = "${alicloud_api_gateway_group.apiGroupTest.id}"
-  description = "tf_testAcc_api description"
-  auth_type = "APP"
-  request_config = [
-    {
-      protocol = "HTTP"
-      method = "GET"
-      path = "/test/path"
-      mode = "MAPPING"
-    },
-  ]
-  service_type = "HTTP"
-  http_service_config = [
-    {
-      address = "http://apigateway-backend.alicloudapi.com:8080"
-      method = "GET"
-      path = "/web/cloudapi"
-      timeout = 20
-      aone_name = "cloudapi-openapi"
-    },
-  ]
-
-  request_parameters = [
-    {
-      name = "testparam"
-      type = "STRING"
-      required = "OPTIONAL"
-      in = "QUERY"
-      in_service = "QUERY"
-      name_service = "testparams"
-    },
-  ]
-}
-
-data "alicloud_api_gateway_apis" "data_apis"{
-  group_id = "${alicloud_api_gateway_group.apiGroupTest.id}"
-  api_id = "${alicloud_api_gateway_api.apiTest.id}"
-}
-
-`
-
-const testAccCheckAlicloudApiGatewayApiDataSourceEmpty = `
-variable "apigateway_group_name_test" {
-  default = "tf_testAccApiGroupDataSourceEmpty"
-}
-
-variable "apigateway_group_description_test" {
-  default = "tf_testAcc_api group description"
-}
-
-resource "alicloud_api_gateway_group" "apiGroupTest" {
-  name = "${var.apigateway_group_name_test}"
-  description = "${var.apigateway_group_description_test}"
-}
-
-
-data "alicloud_api_gateway_apis" "data_apis"{
-  group_id = "${alicloud_api_gateway_group.apiGroupTest.id}"
-}
-`

--- a/alicloud/data_source_alicloud_api_gateway_groups_test.go
+++ b/alicloud/data_source_alicloud_api_gateway_groups_test.go
@@ -3,6 +3,10 @@ package alicloud
 import (
 	"testing"
 
+	"fmt"
+	"regexp"
+
+	"github.com/hashicorp/terraform/helper/acctest"
 	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/terraform-providers/terraform-provider-alicloud/alicloud/connectivity"
 )
@@ -15,10 +19,10 @@ func TestAccAlicloudApigatewayGroupsDataSource_basic(t *testing.T) {
 		Providers: testAccProviders,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccCheckAlicloudApiGatewayGroupDataSource,
+				Config: testAccCheckAlicloudApiGatewayGroupDataSource(acctest.RandIntRange(10000, 999999)),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAlicloudDataSourceID("data.alicloud_api_gateway_groups.data_apigatway_groups"),
-					resource.TestCheckResourceAttr("data.alicloud_api_gateway_groups.data_apigatway_groups", "groups.0.name", "tf_testAccGroupDataSource"),
+					resource.TestMatchResourceAttr("data.alicloud_api_gateway_groups.data_apigatway_groups", "groups.0.name", regexp.MustCompile("^tf_testAccGroupDataSource_*")),
 					resource.TestCheckResourceAttr("data.alicloud_api_gateway_groups.data_apigatway_groups", "groups.0.description", "tf_testAcc api gateway description"),
 				),
 			},
@@ -46,25 +50,27 @@ func TestAccAlicloudApigatewayGroupsDataSource_empty(t *testing.T) {
 	})
 }
 
-const testAccCheckAlicloudApiGatewayGroupDataSource = `
+func testAccCheckAlicloudApiGatewayGroupDataSource(rand int) string {
+	return fmt.Sprintf(`
 
-variable "apigateway_group_name_test" {
-  default = "tf_testAccGroupDataSource"
-}
+	variable "apigateway_group_name_test" {
+	  default = "tf_testAccGroupDataSource_%d"
+	}
 
-variable "apigateway_group_description_test" {
-  default = "tf_testAcc api gateway description"
-}
+	variable "apigateway_group_description_test" {
+	  default = "tf_testAcc api gateway description"
+	}
 
-resource "alicloud_api_gateway_group" "apiGroupTest" {
-  name = "${var.apigateway_group_name_test}"
-  description = "${var.apigateway_group_description_test}"
-}
+	resource "alicloud_api_gateway_group" "apiGroupTest" {
+	  name = "${var.apigateway_group_name_test}"
+	  description = "${var.apigateway_group_description_test}"
+	}
 
-data "alicloud_api_gateway_groups" "data_apigatway_groups"{
-  name_regex = "${alicloud_api_gateway_group.apiGroupTest.name}"
+	data "alicloud_api_gateway_groups" "data_apigatway_groups"{
+	  name_regex = "${alicloud_api_gateway_group.apiGroupTest.name}"
+	}
+	`, rand)
 }
-`
 
 const testAccCheckAlicloudApiGatewayGroupDataSourceEmpty = `
 data "alicloud_api_gateway_groups" "data_apigatway_groups"{

--- a/alicloud/import_alicloud_api_gateway_api_test.go
+++ b/alicloud/import_alicloud_api_gateway_api_test.go
@@ -3,6 +3,7 @@ package alicloud
 import (
 	"testing"
 
+	"github.com/hashicorp/terraform/helper/acctest"
 	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/terraform-providers/terraform-provider-alicloud/alicloud/connectivity"
 )
@@ -16,7 +17,7 @@ func TestAccAlicloudApigatewayApi_importBasic(t *testing.T) {
 		CheckDestroy: testAccCheckAlicloudApigatewayApiDestroy,
 		Steps: []resource.TestStep{
 			resource.TestStep{
-				Config: testAccAlicloudApigatwayApiBasic,
+				Config: testAccAlicloudApigatwayApiBasic(acctest.RandIntRange(10000, 999999)),
 			},
 
 			resource.TestStep{

--- a/alicloud/import_alicloud_api_gateway_group_test.go
+++ b/alicloud/import_alicloud_api_gateway_group_test.go
@@ -3,6 +3,7 @@ package alicloud
 import (
 	"testing"
 
+	"github.com/hashicorp/terraform/helper/acctest"
 	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/terraform-providers/terraform-provider-alicloud/alicloud/connectivity"
 )
@@ -16,7 +17,7 @@ func TestAccAlicloudApigatewayGroup_importBasic(t *testing.T) {
 		CheckDestroy: testAccCheckAlicloudApigatewayGroupDestroy,
 		Steps: []resource.TestStep{
 			resource.TestStep{
-				Config: testAccAlicloudApigatwayGroupBasic,
+				Config: testAccAlicloudApigatwayGroupBasic(acctest.RandIntRange(10000, 999999)),
 			},
 
 			resource.TestStep{

--- a/alicloud/resource_alicloud_api_gateway_api_test.go
+++ b/alicloud/resource_alicloud_api_gateway_api_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/terraform-providers/terraform-provider-alicloud/alicloud/connectivity"
 
 	"github.com/aliyun/alibaba-cloud-sdk-go/services/cloudapi"
+	"github.com/hashicorp/terraform/helper/acctest"
 	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/terraform"
 )
@@ -93,7 +94,7 @@ func TestAccAlicloudApigatewayApi_basic(t *testing.T) {
 		CheckDestroy:  testAccCheckAlicloudApigatewayApiDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAlicloudApigatwayApiBasic,
+				Config: testAccAlicloudApigatwayApiBasic(acctest.RandIntRange(10000, 999999)),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAlicloudApigatewayApiExists("alicloud_api_gateway_api.apiTest", &api),
 					resource.TestCheckResourceAttr("alicloud_api_gateway_api.apiTest", "name", "tf_testAcc_api"),
@@ -123,7 +124,7 @@ func TestAccAlicloudApigatewayApi_basic(t *testing.T) {
 
 func TestAccAlicloudApigatewayApi_update(t *testing.T) {
 	var api cloudapi.DescribeApiResponse
-
+	rand := acctest.RandIntRange(10000, 999999)
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			testAccPreCheckWithRegions(t, false, connectivity.ApiGatewayNoSupportedRegions)
@@ -132,7 +133,7 @@ func TestAccAlicloudApigatewayApi_update(t *testing.T) {
 		CheckDestroy: testAccCheckAlicloudApigatewayApiDestroy,
 		Steps: []resource.TestStep{
 			resource.TestStep{
-				Config: testAccAlicloudApigatwayApiBasic,
+				Config: testAccAlicloudApigatwayApiBasic(rand),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAlicloudApigatewayApiExists("alicloud_api_gateway_api.apiTest", &api),
 					resource.TestCheckResourceAttr("alicloud_api_gateway_api.apiTest", "name", "tf_testAcc_api"),
@@ -151,7 +152,7 @@ func TestAccAlicloudApigatewayApi_update(t *testing.T) {
 				),
 			},
 			resource.TestStep{
-				Config: testAccAlicloudApigatwayApiUpdate,
+				Config: testAccAlicloudApigatwayApiUpdate(rand),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAlicloudApigatewayApiExists("alicloud_api_gateway_api.apiTest", &api),
 					resource.TestCheckResourceAttr("alicloud_api_gateway_api.apiTest", "name", "tf_testAcc_api_update"),
@@ -183,8 +184,6 @@ func testAccCheckAlicloudApigatewayApiExists(n string, d *cloudapi.DescribeApiRe
 		if rs.Primary.ID == "" {
 			return fmt.Errorf("No Api ID is set")
 		}
-
-		fmt.Println(rs.Primary.ID)
 
 		client := testAccProvider.Meta().(*connectivity.AliyunClient)
 		cloudApiService := CloudApiService{client}
@@ -223,108 +222,111 @@ func testAccCheckAlicloudApigatewayApiDestroy(s *terraform.State) error {
 	return nil
 }
 
-const testAccAlicloudApigatwayApiBasic = `
+func testAccAlicloudApigatwayApiBasic(rand int) string {
+	return fmt.Sprintf(`
 
-variable "apigateway_group_name_test" {
-  default = "tf_testAccApiGroupDataSource"
+	variable "apigateway_group_name_test" {
+	  default = "tf_testAccApiGroupResource_%d"
+	}
+
+	variable "apigateway_group_description_test" {
+	  default = "tf_testAcc_api group description"
+	}
+
+	resource "alicloud_api_gateway_group" "apiGroupTest" {
+	  name = "${var.apigateway_group_name_test}"
+	  description = "${var.apigateway_group_description_test}"
+	}
+
+	resource "alicloud_api_gateway_api" "apiTest" {
+	  name = "tf_testAcc_api"
+	  group_id = "${alicloud_api_gateway_group.apiGroupTest.id}"
+	  description = "tf_testAcc_api description"
+	  auth_type = "APP"
+	  request_config = [
+	    {
+	      protocol        = "HTTP"
+	      method = "GET"
+	      path = "/test/path"
+	      mode = "MAPPING"
+	    },
+	  ]
+	  service_type = "HTTP"
+	  http_service_config = [
+	    {
+	      address = "http://apigateway-backend.alicloudapi.com:8080"
+	      method = "GET"
+	      path = "/web/cloudapi"
+	      timeout = 20
+	      aone_name = "cloudapi-openapi"
+	    },
+	  ]
+
+	  request_parameters = [
+	    {
+	      name = "testparam"
+	      type = "STRING"
+	      required = "OPTIONAL"
+	      in = "QUERY"
+	      in_service = "QUERY"
+	      name_service = "testparams"
+	    },
+	  ]
+	}
+
+	`, rand)
 }
 
-variable "apigateway_group_description_test" {
-  default = "tf_testAcc_api group description"
+func testAccAlicloudApigatwayApiUpdate(rand int) string {
+	return fmt.Sprintf(`
+	variable "apigateway_group_name_test" {
+	  default = "tf_testAccApiGroupResource_%d"
+	}
+
+	variable "apigateway_group_description_test" {
+	  default = "tf_testAcc_api group description"
+	}
+
+	resource "alicloud_api_gateway_group" "apiGroupTest" {
+	  name = "${var.apigateway_group_name_test}"
+	  description = "${var.apigateway_group_description_test}"
+	}
+
+	resource "alicloud_api_gateway_api" "apiTest" {
+	  name = "tf_testAcc_api_update"
+	  group_id = "${alicloud_api_gateway_group.apiGroupTest.id}"
+	  description = "tf_testAcc_api description update"
+	  auth_type = "APP"
+	  request_config = [
+	    {
+	      protocol = "HTTP"
+	      method = "GET"
+	      path = "/test/path/test"
+	      mode = "MAPPING"
+	    },
+	  ]
+	  service_type = "HTTP"
+	  http_service_config = [
+	    {
+	      address = "http://apigateway-backend.alicloudapi.com:8080"
+	      method = "GET"
+	      path = "/web/cloudapi/update"
+	      timeout = 20
+	      aone_name = "cloudapi-openapi"
+	    },
+	  ]
+
+	  request_parameters = [
+	    {
+	      name = "testparam"
+	      type = "STRING"
+	      required = "OPTIONAL"
+	      in = "QUERY"
+	      in_service = "QUERY"
+	      name_service = "testparams"
+	    },
+	  ]
+	}
+
+	`, rand)
 }
-
-resource "alicloud_api_gateway_group" "apiGroupTest" {
-  name = "${var.apigateway_group_name_test}"
-  description = "${var.apigateway_group_description_test}"
-}
-
-resource "alicloud_api_gateway_api" "apiTest" {
-  name = "tf_testAcc_api"
-  group_id = "${alicloud_api_gateway_group.apiGroupTest.id}"
-  description = "tf_testAcc_api description"
-  auth_type = "APP"
-  request_config = [
-    {
-      protocol        = "HTTP"
-      method = "GET"
-      path = "/test/path"
-      mode = "MAPPING"
-    },
-  ]
-  service_type = "HTTP"
-  http_service_config = [
-    {
-      address = "http://apigateway-backend.alicloudapi.com:8080"
-      method = "GET"
-      path = "/web/cloudapi"
-      timeout = 20
-      aone_name = "cloudapi-openapi"
-    },
-  ]
-
-  request_parameters = [
-    {
-      name = "testparam"
-      type = "STRING"
-      required = "OPTIONAL"
-      in = "QUERY"
-      in_service = "QUERY"
-      name_service = "testparams"
-    },
-  ]
-}
-
-`
-
-const testAccAlicloudApigatwayApiUpdate = `
-
-variable "apigateway_group_name_test" {
-  default = "tf_testAccApiGroupDataSource"
-}
-
-variable "apigateway_group_description_test" {
-  default = "tf_testAcc_api group description"
-}
-
-resource "alicloud_api_gateway_group" "apiGroupTest" {
-  name = "${var.apigateway_group_name_test}"
-  description = "${var.apigateway_group_description_test}"
-}
-
-resource "alicloud_api_gateway_api" "apiTest" {
-  name = "tf_testAcc_api_update"
-  group_id = "${alicloud_api_gateway_group.apiGroupTest.id}"
-  description = "tf_testAcc_api description update"
-  auth_type = "APP"
-  request_config = [
-    {
-      protocol = "HTTP"
-      method = "GET"
-      path = "/test/path/test"
-      mode = "MAPPING"
-    },
-  ]
-  service_type = "HTTP"
-  http_service_config = [
-    {
-      address = "http://apigateway-backend.alicloudapi.com:8080"
-      method = "GET"
-      path = "/web/cloudapi/update"
-      timeout = 20
-      aone_name = "cloudapi-openapi"
-    },
-  ]
-
-  request_parameters = [
-    {
-      name = "testparam"
-      type = "STRING"
-      required = "OPTIONAL"
-      in = "QUERY"
-      in_service = "QUERY"
-      name_service = "testparams"
-    },
-  ]
-}
-
-`

--- a/alicloud/resource_alicloud_api_gateway_group_test.go
+++ b/alicloud/resource_alicloud_api_gateway_group_test.go
@@ -7,7 +7,10 @@ import (
 	"testing"
 	"time"
 
+	"regexp"
+
 	"github.com/aliyun/alibaba-cloud-sdk-go/services/cloudapi"
+	"github.com/hashicorp/terraform/helper/acctest"
 	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/terraform"
 	"github.com/terraform-providers/terraform-provider-alicloud/alicloud/connectivity"
@@ -92,10 +95,10 @@ func TestAccAlicloudApigatewayGroup_basic(t *testing.T) {
 		CheckDestroy: testAccCheckAlicloudApigatewayGroupDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAlicloudApigatwayGroupBasic,
+				Config: testAccAlicloudApigatwayGroupBasic(acctest.RandIntRange(10000, 999999)),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAlicloudApigatewayGroupExists("alicloud_api_gateway_group.apiGroupTest", &group),
-					resource.TestCheckResourceAttr("alicloud_api_gateway_group.apiGroupTest", "name", "tf_testAccGroupResource"),
+					resource.TestMatchResourceAttr("alicloud_api_gateway_group.apiGroupTest", "name", regexp.MustCompile("^tf_testAccGroupResource_*")),
 					resource.TestCheckResourceAttr("alicloud_api_gateway_group.apiGroupTest", "description", "tf_testAcc api gateway description"),
 				),
 			},
@@ -148,18 +151,19 @@ func testAccCheckAlicloudApigatewayGroupDestroy(s *terraform.State) error {
 	return nil
 }
 
-const testAccAlicloudApigatwayGroupBasic = `
+func testAccAlicloudApigatwayGroupBasic(rand int) string {
+	return fmt.Sprintf(`
+	variable "apigateway_group_name_test" {
+	  default = "tf_testAccGroupResource_%d"
+	}
 
-variable "apigateway_group_name_test" {
-  default = "tf_testAccGroupResource"
-}
+	variable "apigateway_group_description_test" {
+	  default = "tf_testAcc api gateway description"
+	}
 
-variable "apigateway_group_description_test" {
-  default = "tf_testAcc api gateway description"
+	resource "alicloud_api_gateway_group" "apiGroupTest" {
+	  name = "${var.apigateway_group_name_test}"
+	  description = "${var.apigateway_group_description_test}"
+	}
+	`, rand)
 }
-
-resource "alicloud_api_gateway_group" "apiGroupTest" {
-  name = "${var.apigateway_group_name_test}"
-  description = "${var.apigateway_group_description_test}"
-}
-`


### PR DESCRIPTION
```
TF_ACC=1 go test ./alicloud -v -run=TestAccAlicloudApi -timeout=240m
=== RUN   TestAccAlicloudApigatewayApisDataSource_basic
--- PASS: TestAccAlicloudApigatewayApisDataSource_basic (19.24s)
=== RUN   TestAccAlicloudApigatewayApisDataSource_empty
--- PASS: TestAccAlicloudApigatewayApisDataSource_empty (7.61s)
=== RUN   TestAccAlicloudApigatewayAppsDataSource_empty
--- PASS: TestAccAlicloudApigatewayAppsDataSource_empty (3.10s)
=== RUN   TestAccAlicloudApigatewayGroupsDataSource_basic
--- PASS: TestAccAlicloudApigatewayGroupsDataSource_basic (7.44s)
=== RUN   TestAccAlicloudApigatewayGroupsDataSource_empty
--- PASS: TestAccAlicloudApigatewayGroupsDataSource_empty (3.03s)
=== RUN   TestAccAlicloudApigatewayApi_importBasic
--- PASS: TestAccAlicloudApigatewayApi_importBasic (17.85s)
=== RUN   TestAccAlicloudApigatewayGroup_importBasic
--- PASS: TestAccAlicloudApigatewayGroup_importBasic (8.31s)
=== RUN   TestAccAlicloudApigatewayVpc_importBasic
--- PASS: TestAccAlicloudApigatewayVpc_importBasic (172.09s)
=== RUN   TestAccAlicloudApigatewayApi_basic
--- PASS: TestAccAlicloudApigatewayApi_basic (16.99s)
=== RUN   TestAccAlicloudApigatewayApi_update
--- PASS: TestAccAlicloudApigatewayApi_update (24.50s)
=== RUN   TestAccAlicloudApigatewayGroup_basic
--- PASS: TestAccAlicloudApigatewayGroup_basic (7.39s)
=== RUN   TestAccAlicloudApigatewayVpc_basic
--- PASS: TestAccAlicloudApigatewayVpc_basic (175.85s)
PASS
ok  	github.com/terraform-providers/terraform-provider-alicloud/alicloud	463.458s
```