### PR TITLE
bugfix for the input of cen bandwidth limit

### DIFF
--- a/alicloud/resource_alicloud_cen_bandwidth_limit.go
+++ b/alicloud/resource_alicloud_cen_bandwidth_limit.go
@@ -54,7 +54,12 @@ func resourceAlicloudCenBandwidthLimit() *schema.Resource {
 
 func resourceAlicloudCenBandwidthLimitCreate(d *schema.ResourceData, meta interface{}) error {
 	cenId := d.Get("instance_id").(string)
+
 	regionIds := d.Get("region_ids").(*schema.Set).List()
+	if len(regionIds) != 2 {
+		return fmt.Errorf("Two different region ids should be set for bandwidth limit")
+	}
+
 	localRegionId := regionIds[0].(string)
 	oppositeRegionId := regionIds[1].(string)
 
@@ -106,7 +111,12 @@ func resourceAlicloudCenBandwidthLimitUpdate(d *schema.ResourceData, meta interf
 	client := meta.(*connectivity.AliyunClient)
 	cenService := CenService{client}
 	cenId := d.Get("instance_id").(string)
+
 	regionIds := d.Get("region_ids").(*schema.Set).List()
+	if len(regionIds) != 2 {
+		return fmt.Errorf("Two different region ids should be set for bandwidth limit")
+	}
+
 	localRegionId := regionIds[0].(string)
 	oppositeRegionId := regionIds[1].(string)
 	var bandwidthLimit int
@@ -150,7 +160,12 @@ func resourceAlicloudCenBandwidthLimitDelete(d *schema.ResourceData, meta interf
 	client := meta.(*connectivity.AliyunClient)
 	cenService := CenService{client}
 	cenId := d.Get("instance_id").(string)
+
 	regionIds := d.Get("region_ids").(*schema.Set).List()
+	if len(regionIds) != 2 {
+		return fmt.Errorf("Two different region ids should be set for bandwidth limit")
+	}
+
 	localRegionId := regionIds[0].(string)
 	oppositeRegionId := regionIds[1].(string)
 


### PR DESCRIPTION
Bugfix for the input of cen bandwidth limit: the parameter region_ids is valid only when there are two different region ids set.

terraform-provider-alicloud chumo.yl$TF_ACC=1 go test ./alicloud -v -run=TestAccAlicloudCenBandwidthLimit
=== RUN   TestAccAlicloudCenBandwidthLimitsDataSource_instance_id
--- PASS: TestAccAlicloudCenBandwidthLimitsDataSource_instance_id (61.66s)
=== RUN   TestAccAlicloudCenBandwidthLimitsDataSource_empty
--- PASS: TestAccAlicloudCenBandwidthLimitsDataSource_empty (0.37s)
=== RUN   TestAccAlicloudCenBandwidthLimit_basic
--- PASS: TestAccAlicloudCenBandwidthLimit_basic (72.44s)
=== RUN   TestAccAlicloudCenBandwidthLimit_update
--- PASS: TestAccAlicloudCenBandwidthLimit_update (82.76s)
=== RUN   TestAccAlicloudCenBandwidthLimit_multi
--- PASS: TestAccAlicloudCenBandwidthLimit_multi (86.62s)
PASS
ok      github.com/terraform-providers/terraform-provider-alicloud/alicloud     303.913s


