### PR TITLE
Improve kvstore and ess schedule testcase

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,12 +2,14 @@
 
 IMPROVEMENTS:
 
+- Improve kvstore and ess schedule testcase [GH-599]
 - Improve apigateway testcase [GH-593]
 - Improve ram, ess schedule and cdn testcase [GH-592]
 - Improve kvstore client token [GH-586]
 
 BUG FIXES:
 
+- bug fix for the input of cen bandwidth limit [GH-598]
 - Fix log service timeout error [GH-594]
 - Fix record not found issue if pvtz records are more than 50 [GH-590]
 - Fix cen instance and bandwidth multi regions test case bug [GH-588]

--- a/alicloud/import_alicloud_ess_schedule_test.go
+++ b/alicloud/import_alicloud_ess_schedule_test.go
@@ -10,6 +10,8 @@ import (
 
 func TestAccAlicloudEssSchedule_importBasic(t *testing.T) {
 	resourceName := "alicloud_ess_schedule.foo"
+	// Setting schedule time to more than one day
+	oneDay, _ := time.ParseDuration("24h")
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -17,7 +19,7 @@ func TestAccAlicloudEssSchedule_importBasic(t *testing.T) {
 		CheckDestroy: testAccCheckEssScheduleDestroy,
 		Steps: []resource.TestStep{
 			resource.TestStep{
-				Config: testAccEssScheduleConfig(time.Now().Format("2006-01-02T15:04Z")),
+				Config: testAccEssScheduleConfig(time.Now().Add(oneDay).Format("2006-01-02T15:04Z")),
 			},
 
 			resource.TestStep{


### PR DESCRIPTION
```
TF_ACC=1 go test ./alicloud -v -run=TestAccAlicloudEssSchedule -timeout=240m
=== RUN   TestAccAlicloudEssSchedule_importBasic
--- PASS: TestAccAlicloudEssSchedule_importBasic (38.76s)
=== RUN   TestAccAlicloudEssSchedule_basic
--- PASS: TestAccAlicloudEssSchedule_basic (35.74s)
PASS
ok  	github.com/terraform-providers/terraform-provider-alicloud/alicloud	74.602s
```