### PR TITLE
Fix deleting mns subscription bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ IMPROVEMENTS:
 
 BUG FIXES:
 
+- Fix deleting mns subscription bug [GH-601]
 - bug fix for the input of cen bandwidth limit [GH-598]
 - Fix log service timeout error [GH-594]
 - Fix record not found issue if pvtz records are more than 50 [GH-590]

--- a/alicloud/resource_alicloud_mns_topic_subscription_test.go
+++ b/alicloud/resource_alicloud_mns_topic_subscription_test.go
@@ -90,7 +90,7 @@ func testAccCheckMNSTopicSubscriptionDestroy(s *terraform.State) error {
 			return subscriptionManager.GetSubscriptionAttributes(name)
 		})
 		if err != nil {
-			if mnsService.SubscriptionNotExistFunc(err) {
+			if mnsService.TopicNotExistFunc(err) || mnsService.SubscriptionNotExistFunc(err) {
 				continue
 			}
 			return err


### PR DESCRIPTION
```
TF_ACC=1 go test ./alicloud -v -run=TestAccAlicloudMns  -timeout=240m
=== RUN   TestAccAlicloudMnsQueueDataSource
--- PASS: TestAccAlicloudMnsQueueDataSource (1.07s)
=== RUN   TestAccAlicloudMnsQueueDataSourceEmpty
--- PASS: TestAccAlicloudMnsQueueDataSourceEmpty (0.78s)
=== RUN   TestAccAlicloudMnsTopicSubscriptionDataSource
--- PASS: TestAccAlicloudMnsTopicSubscriptionDataSource (1.07s)
=== RUN   TestAccAlicloudMnsTopicSubscriptionDataSourceEmpty
--- PASS: TestAccAlicloudMnsTopicSubscriptionDataSourceEmpty (1.06s)
=== RUN   TestAccAlicloudMnsTopicDataSource
--- PASS: TestAccAlicloudMnsTopicDataSource (0.71s)
=== RUN   TestAccAlicloudMnsTopicDataSourceEmpty
--- PASS: TestAccAlicloudMnsTopicDataSourceEmpty (0.76s)
=== RUN   TestAccAlicloudMnsQueue_importBasic
--- PASS: TestAccAlicloudMnsQueue_importBasic (1.14s)
=== RUN   TestAccAlicloudMnsTopicSubscription_importBasic
--- PASS: TestAccAlicloudMnsTopicSubscription_importBasic (0.99s)
=== RUN   TestAccAlicloudMnsTopic_importBasic
--- PASS: TestAccAlicloudMnsTopic_importBasic (0.81s)
=== RUN   TestAccAlicloudMnsQueue_basic
--- PASS: TestAccAlicloudMnsQueue_basic (1.28s)
=== RUN   TestAccAlicloudMnsTopicSubscription_basic
--- PASS: TestAccAlicloudMnsTopicSubscription_basic (1.29s)
=== RUN   TestAccAlicloudMnsTopic_basic
--- PASS: TestAccAlicloudMnsTopic_basic (1.16s)
PASS
ok  	github.com/terraform-providers/terraform-provider-alicloud/alicloud	12.187s
```