### PR TITLE
Bugfix/kvstore charge type

### DIFF
--- a/alicloud/resource_alicloud_kvstore_instance.go
+++ b/alicloud/resource_alicloud_kvstore_instance.go
@@ -2,6 +2,7 @@ package alicloud
 
 import (
 	"fmt"
+	"github.com/aliyun/alibaba-cloud-sdk-go/sdk/requests"
 	"strings"
 	"time"
 
@@ -49,7 +50,7 @@ func resourceAlicloudKVStoreInstance() *schema.Resource {
 				Type:         schema.TypeString,
 				ValidateFunc: validateInstanceChargeType,
 				Optional:     true,
-				ForceNew:     true,
+				ForceNew:     false,
 				Default:      PostPaid,
 			},
 			"period": &schema.Schema{
@@ -191,8 +192,10 @@ func resourceAlicloudKVStoreInstanceUpdate(d *schema.ResourceData, meta interfac
 	}
 
 	request := r_kvstore.CreateModifyInstanceAttributeRequest()
+	prePaidRequest := r_kvstore.CreateTransformToPrePaidRequest()
 	request.InstanceId = d.Id()
 	update := false
+	changePayType := false
 	if d.HasChange("instance_name") {
 		request.InstanceName = d.Get("instance_name").(string)
 		update = true
@@ -206,6 +209,24 @@ func resourceAlicloudKVStoreInstanceUpdate(d *schema.ResourceData, meta interfac
 		d.SetPartial("password")
 	}
 
+	if d.HasChange("instance_charge_type") {
+		prePaidRequest.InstanceId = d.Id()
+		prePaidRequest.Period = requests.Integer(strconv.Itoa(d.Get("period").(int)))
+		update = true
+		changePayType = true
+		d.SetPartial("instance_charge_type")
+		d.SetPartial("period")
+	}
+
+	if d.HasChange("period") {
+		prePaidRequest.InstanceId = d.Id()
+		prePaidRequest.Period = requests.Integer(strconv.Itoa(d.Get("period").(int)))
+		update = true
+		changePayType = true
+		d.SetPartial("instance_charge_type")
+		d.SetPartial("period")
+	}
+
 	if update {
 		// wait instance status is Normal before modifying
 		if err := kvstoreService.WaitForRKVInstance(d.Id(), Normal, DefaultLongTimeout); err != nil {
@@ -216,6 +237,21 @@ func resourceAlicloudKVStoreInstanceUpdate(d *schema.ResourceData, meta interfac
 		})
 		if err != nil {
 			return fmt.Errorf("ModifyRKVInstanceDescription got an error: %#v", err)
+		}
+		// wait instance status is Normal after modifying
+		if err := kvstoreService.WaitForRKVInstance(d.Id(), Normal, DefaultLongTimeout); err != nil {
+			return fmt.Errorf("WaitForInstance %s got error: %#v", Normal, err)
+		}
+
+		// for now we just support charge change from PostPaid to PrePaid
+		configPayType := PayType(d.Get("instance_charge_type").(string))
+		if changePayType && configPayType == PrePaid {
+			_, err = client.WithRkvClient(func(rkvClient *r_kvstore.Client) (interface{}, error) {
+				return rkvClient.TransformToPrePaid(prePaidRequest)
+			})
+		}
+		if err != nil {
+			return fmt.Errorf("TransformToPrePaid got an error: %#v", err)
 		}
 		// wait instance status is Normal after modifying
 		if err := kvstoreService.WaitForRKVInstance(d.Id(), Normal, DefaultLongTimeout); err != nil {

--- a/alicloud/resource_alicloud_kvstore_instance_test.go
+++ b/alicloud/resource_alicloud_kvstore_instance_test.go
@@ -218,44 +218,6 @@ func TestAccAlicloudKVStoreInstance_updateSecurityIps(t *testing.T) {
 
 }
 
-func TestAccAlicloudKVStoreInstance_changeChargeType(t *testing.T) {
-	var instance r_kvstore.DBInstanceAttribute
-
-	resource.Test(t, resource.TestCase{
-		PreCheck: func() {
-			testAccPreCheck(t)
-		},
-
-		// module name
-		IDRefreshName: "alicloud_kvstore_instance.foo",
-
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckKVStoreInstanceNopDestroy,
-		Steps: []resource.TestStep{
-			resource.TestStep{
-				Config: testAccKVStoreInstance_vpc,
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckKVStoreInstanceExists(
-						"alicloud_kvstore_instance.foo", &instance),
-					resource.TestCheckResourceAttr("alicloud_kvstore_instance.foo", "instance_class", "redis.master.small.default"),
-				),
-			},
-
-			resource.TestStep{
-				Config: testAccKVStoreInstance_changeChargeType,
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckKVStoreInstanceExists(
-						"alicloud_kvstore_instance.foo", &instance),
-					resource.TestCheckResourceAttr("alicloud_kvstore_instance.foo", "instance_charge_type", "PrePaid"),
-					resource.TestCheckResourceAttr("alicloud_kvstore_instance.foo", "period", "1"),
-					resource.TestCheckResourceAttr("alicloud_kvstore_instance.foo", "instance_name", "tf-testAccKVStoreInstance_changeChargeType"),
-				),
-			},
-		},
-	})
-
-}
-
 func testAccCheckKVStoreInstanceExists(n string, d *r_kvstore.DBInstanceAttribute) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[n]
@@ -299,10 +261,6 @@ func testAccCheckKVStoreInstanceDestroy(s *terraform.State) error {
 		return fmt.Errorf("Error KVStore Instance still exist")
 	}
 
-	return nil
-}
-
-func testAccCheckKVStoreInstanceNopDestroy(s *terraform.State) error {
 	return nil
 }
 
@@ -387,34 +345,5 @@ resource "alicloud_kvstore_instance" "foo" {
 	vswitch_id     = "${alicloud_vswitch.foo.id}"
 	private_ip     = "172.16.0.10"
 	security_ips   = ["10.110.10.10", "10.110.10.20"]
-}
-`
-const testAccKVStoreInstance_changeChargeType = `
-data "alicloud_zones" "default" {
-	available_resource_creation = "KVStore"
-}
-variable "name" {
-	default = "tf-testAccKVStoreInstance_changeChargeType"
-}
-resource "alicloud_vpc" "foo" {
-	name = "${var.name}"
-	cidr_block = "172.16.0.0/16"
-}
-
-resource "alicloud_vswitch" "foo" {
- 	vpc_id = "${alicloud_vpc.foo.id}"
- 	cidr_block = "172.16.0.0/24"
- 	availability_zone = "${data.alicloud_zones.default.zones.0.id}"
- 	name = "${var.name}"
-}
-
-resource "alicloud_kvstore_instance" "foo" {
-	instance_class = "redis.master.small.default"
-	instance_name  = "${var.name}"
-	password       = "Test12345"
-	vswitch_id     = "${alicloud_vswitch.foo.id}"
-	private_ip     = "172.16.0.10"
-    instance_charge_type = "PrePaid"
-    period = 1
 }
 `

--- a/alicloud/resource_alicloud_kvstore_instance_test.go
+++ b/alicloud/resource_alicloud_kvstore_instance_test.go
@@ -218,6 +218,44 @@ func TestAccAlicloudKVStoreInstance_updateSecurityIps(t *testing.T) {
 
 }
 
+func TestAccAlicloudKVStoreInstance_changeChargeType(t *testing.T) {
+	var instance r_kvstore.DBInstanceAttribute
+
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+		},
+
+		// module name
+		IDRefreshName: "alicloud_kvstore_instance.foo",
+
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckKVStoreInstanceNopDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccKVStoreInstance_vpc,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckKVStoreInstanceExists(
+						"alicloud_kvstore_instance.foo", &instance),
+					resource.TestCheckResourceAttr("alicloud_kvstore_instance.foo", "instance_class", "redis.master.small.default"),
+				),
+			},
+
+			resource.TestStep{
+				Config: testAccKVStoreInstance_changeChargeType,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckKVStoreInstanceExists(
+						"alicloud_kvstore_instance.foo", &instance),
+					resource.TestCheckResourceAttr("alicloud_kvstore_instance.foo", "instance_charge_type", "PrePaid"),
+					resource.TestCheckResourceAttr("alicloud_kvstore_instance.foo", "period", "1"),
+					resource.TestCheckResourceAttr("alicloud_kvstore_instance.foo", "instance_name", "tf-testAccKVStoreInstance_changeChargeType"),
+				),
+			},
+		},
+	})
+
+}
+
 func testAccCheckKVStoreInstanceExists(n string, d *r_kvstore.DBInstanceAttribute) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[n]
@@ -261,6 +299,10 @@ func testAccCheckKVStoreInstanceDestroy(s *terraform.State) error {
 		return fmt.Errorf("Error KVStore Instance still exist")
 	}
 
+	return nil
+}
+
+func testAccCheckKVStoreInstanceNopDestroy(s *terraform.State) error {
 	return nil
 }
 
@@ -345,5 +387,34 @@ resource "alicloud_kvstore_instance" "foo" {
 	vswitch_id     = "${alicloud_vswitch.foo.id}"
 	private_ip     = "172.16.0.10"
 	security_ips   = ["10.110.10.10", "10.110.10.20"]
+}
+`
+const testAccKVStoreInstance_changeChargeType = `
+data "alicloud_zones" "default" {
+	available_resource_creation = "KVStore"
+}
+variable "name" {
+	default = "tf-testAccKVStoreInstance_changeChargeType"
+}
+resource "alicloud_vpc" "foo" {
+	name = "${var.name}"
+	cidr_block = "172.16.0.0/16"
+}
+
+resource "alicloud_vswitch" "foo" {
+ 	vpc_id = "${alicloud_vpc.foo.id}"
+ 	cidr_block = "172.16.0.0/24"
+ 	availability_zone = "${data.alicloud_zones.default.zones.0.id}"
+ 	name = "${var.name}"
+}
+
+resource "alicloud_kvstore_instance" "foo" {
+	instance_class = "redis.master.small.default"
+	instance_name  = "${var.name}"
+	password       = "Test12345"
+	vswitch_id     = "${alicloud_vswitch.foo.id}"
+	private_ip     = "172.16.0.10"
+    instance_charge_type = "PrePaid"
+    period = 1
 }
 `


### PR DESCRIPTION
When change `instance_charge_type`, provider would newly create a kvstore instance, which is not expected.

This PR fix this issue by change the charge_type of the kvstore instance.