### PR TITLE
Fix deleting ess group timeout bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 IMPROVEMENTS:
 
-- Add forcenew for ess lifecycle hook name and improve ess testcase by random name [GH-602]
+- Add forcenew for ess lifecycle hook name and improve ess testcase by random name [GH-603]
 - Improve ess configuration testcase [GH-600]
 - Improve kvstore and ess schedule testcase [GH-599]
 - Improve apigateway testcase [GH-593]
@@ -11,6 +11,7 @@ IMPROVEMENTS:
 
 BUG FIXES:
 
+- Fix deleting ess group timeout bug [GH-604]
 - Fix deleting mns subscription bug [GH-601]
 - bug fix for the input of cen bandwidth limit [GH-598]
 - Fix log service timeout error [GH-594]

--- a/alicloud/service_alicloud_ess.go
+++ b/alicloud/service_alicloud_ess.go
@@ -197,7 +197,7 @@ func (s *EssService) DeleteScalingGroupById(sgId string) error {
 			if IsExceptedErrors(err, []string{InvalidScalingGroupIdNotFound}) {
 				return nil
 			}
-			return resource.RetryableError(fmt.Errorf("Delete scaling group timeout and got an error:%#v.", err))
+			return resource.NonRetryableError(fmt.Errorf("Delete scaling group error: %#v.", err))
 		}
 
 		_, err = s.DescribeScalingGroupById(sgId)


### PR DESCRIPTION
```
TF_ACC=1 go test ./alicloud -v -run=TestAccAlicloudEssScalingGroup  -timeout=240m
=== RUN   TestAccAlicloudEssScalingGroup_importBasic
--- PASS: TestAccAlicloudEssScalingGroup_importBasic (193.57s)
=== RUN   TestAccAlicloudEssScalingGroup_basic
--- PASS: TestAccAlicloudEssScalingGroup_basic (204.44s)
=== RUN   TestAccAlicloudEssScalingGroup_vpc
--- PASS: TestAccAlicloudEssScalingGroup_vpc (212.35s)
=== RUN   TestAccAlicloudEssScalingGroup_slb
--- PASS: TestAccAlicloudEssScalingGroup_slb (216.53s)
=== RUN   TestAccAlicloudEssScalingGroup_slbempty
--- PASS: TestAccAlicloudEssScalingGroup_slbempty (187.45s)
PASS
ok  	github.com/terraform-providers/terraform-provider-alicloud/alicloud	1014.402s
```