### PR TITLE
Adding https_config options to the alicloud_cdn_domain resource

### DIFF
--- a/alicloud/resource_alicloud_cdn_domain.go
+++ b/alicloud/resource_alicloud_cdn_domain.go
@@ -164,6 +164,32 @@ func resourceAlicloudCdnDomain() *schema.Resource {
 				MaxItems: 1,
 			},
 
+			"certificate_config": {
+				Type:     schema.TypeList,
+				Optional: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"server_certificate": {
+							Type:      schema.TypeString,
+							Optional:  true,
+							Sensitive: true,
+						},
+						"server_certificate_status": {
+							Type:         schema.TypeString,
+							Default:      "on",
+							Optional:     true,
+							ValidateFunc: validateCdnEnable,
+						},
+						"private_key": {
+							Type:      schema.TypeString,
+							Optional:  true,
+							Sensitive: true,
+						},
+					},
+				},
+				MaxItems: 1,
+			},
+
 			"auth_config": {
 				Type:     schema.TypeSet,
 				Optional: true,
@@ -293,7 +319,7 @@ func resourceAlicloudCdnDomainCreate(d *schema.ResourceData, meta interface{}) e
 
 	err = WaitForDomainStatus(d.Id(), Configuring, 60, meta)
 	if err != nil {
-		return fmt.Errorf("Timeout when Cdn Domain Available")
+		return fmt.Errorf("Timeout when Cdn Domain Available. Error: %#v", err)
 	}
 
 	return resourceAlicloudCdnDomainUpdate(d, meta)
@@ -389,6 +415,18 @@ func resourceAlicloudCdnDomainUpdate(d *schema.ResourceData, meta interface{}) e
 		}
 	}
 
+	if d.HasChange("certificate_config") {
+		if d.IsNewResource() {
+			err := WaitForDomainStatus(d.Id(), Online, 360, meta)
+			if err != nil {
+				return fmt.Errorf("Timeout when Cdn Domain Online. Error: %#v", err)
+			}
+		}
+		if err := certificateConfigUpdate(client, d); err != nil {
+			return err
+		}
+	}
+
 	d.Partial(false)
 	return resourceAlicloudCdnDomainRead(d, meta)
 }
@@ -427,6 +465,26 @@ func resourceAlicloudCdnDomainRead(d *schema.ResourceData, meta interface{}) err
 			"hash_key_args": strings.Split(queryStringConfig.HashKeyArgs, ","),
 		}
 		d.Set("parameter_filter_config", config)
+	}
+
+	if _, ok := d.GetOk("certificate_config"); ok {
+		ov := d.Get("certificate_config")
+		oldConfig := ov.([]interface{})
+		config := make([]map[string]interface{}, 1)
+		serverCertificateStatus := domain.ServerCertificateStatus
+		if serverCertificateStatus == "" {
+			serverCertificateStatus = "off"
+		}
+		config[0] = map[string]interface{}{
+			"server_certificate":        domain.ServerCertificate,
+			"server_certificate_status": serverCertificateStatus,
+		}
+		if oldConfig != nil && len(oldConfig) > 0 {
+			val := oldConfig[0].(map[string]interface{})
+			config[0]["private_key"] = val["private_key"]
+		}
+
+		d.Set("certificate_config", config)
 	}
 
 	errorPageConfig := configs.ErrorPageConfig
@@ -716,6 +774,65 @@ func authConfigUpdate(client *connectivity.AliyunClient, d *schema.ResourceData)
 	return nil
 }
 
+func certificateConfigUpdate(client *connectivity.AliyunClient, d *schema.ResourceData) error {
+	ov, nv := d.GetChange("certificate_config")
+	oldConfig, newConfig := ov.([]interface{}), nv.([]interface{})
+	args := cdn.CertificateRequest{
+		DomainName: d.Id(),
+	}
+
+	if newConfig == nil || len(newConfig) == 0 {
+		args.ServerCertificateStatus = "off"
+		_, err := client.WithCdnClient(func(cdnClient *cdn.CdnClient) (interface{}, error) {
+			return cdnClient.SetDomainServerCertificate(args)
+		})
+		if err != nil {
+			return err
+		}
+		d.SetPartial("certificate_config")
+		return nil
+	}
+
+	val := newConfig[0].(map[string]interface{})
+	args.ServerCertificateStatus = val["server_certificate_status"].(string)
+
+	serverCertificate, okServerCertificate := val["server_certificate"]
+	privateKey, okPrivateKey := val["private_key"]
+	if okServerCertificate {
+		args.ServerCertificate = serverCertificate.(string)
+	}
+	if okPrivateKey {
+		args.PrivateKey = privateKey.(string)
+	}
+
+	if args.ServerCertificateStatus == "off" {
+		if oldConfig == nil || len(oldConfig) == 0 {
+			if okServerCertificate || okPrivateKey {
+				return fmt.Errorf("If 'server_certificate_status' value is 'off', you can not set the value of 'server_certificate' and 'private_key'.")
+			}
+		}
+	} else {
+		if !okServerCertificate || !okPrivateKey {
+			return fmt.Errorf("If 'server_certificate_status' value is 'on', you must set 'server_certificate', and 'private_key'")
+		}
+	}
+
+	_, err := client.WithCdnClient(func(cdnClient *cdn.CdnClient) (interface{}, error) {
+		return cdnClient.SetDomainServerCertificate(args)
+	})
+	if err != nil {
+		return err
+	}
+	d.SetPartial("certificate_config")
+	if okServerCertificate && args.ServerCertificateStatus != "off" {
+		err := WaitForServerCertificate(client, d.Id(), args.ServerCertificate, 360)
+		if err != nil {
+			return fmt.Errorf("Timeout waiting for Cdn server certificate. Error: %#v", err)
+		}
+	}
+	return nil
+}
+
 func httpHeaderConfigUpdate(client *connectivity.AliyunClient, d *schema.ResourceData) error {
 	ov, nv := d.GetChange("http_header_config")
 	oldConfigs := ov.(*schema.Set).List()
@@ -810,9 +927,7 @@ func setCacheExpiredConfig(req cdn.CacheConfigRequest, cacheType string, client 
 	return
 }
 
-func DescribeDomainDetail(Id string, meta interface{}) (domain cdn.DomainDetail, err error) {
-	client := meta.(*connectivity.AliyunClient)
-
+func describeDomainDetailClient(Id string, client *connectivity.AliyunClient) (domain cdn.DomainDetail, err error) {
 	args := cdn.DescribeDomainRequest{
 		DomainName: Id,
 	}
@@ -826,6 +941,11 @@ func DescribeDomainDetail(Id string, meta interface{}) (domain cdn.DomainDetail,
 	response, _ := raw.(cdn.DomainResponse)
 	domain = response.GetDomainDetailModel
 	return
+}
+
+func DescribeDomainDetail(Id string, meta interface{}) (domain cdn.DomainDetail, err error) {
+	client := meta.(*connectivity.AliyunClient)
+	return describeDomainDetailClient(Id, client)
 }
 
 func WaitForDomainStatus(Id string, status Status, timeout int, meta interface{}) error {
@@ -844,6 +964,28 @@ func WaitForDomainStatus(Id string, status Status, timeout int, meta interface{}
 		timeout = timeout - DefaultIntervalShort
 		if timeout <= 0 {
 			return GetTimeErrorFromString(GetTimeoutMessage("Domain", string(status)))
+		}
+		time.Sleep(DefaultIntervalShort * time.Second)
+	}
+	return nil
+}
+
+func WaitForServerCertificate(client *connectivity.AliyunClient, Id string, serverCertificate string, timeout int) error {
+	if timeout <= 0 {
+		timeout = DefaultTimeout
+	}
+
+	for {
+		domain, err := describeDomainDetailClient(Id, client)
+		if err != nil {
+			return err
+		}
+		if strings.TrimSpace(domain.ServerCertificate) == strings.TrimSpace(serverCertificate) {
+			break
+		}
+		timeout = timeout - DefaultIntervalShort
+		if timeout <= 0 {
+			return GetTimeErrorFromString(GetTimeoutMessage("ServerCertificate", string(serverCertificate)))
 		}
 		time.Sleep(DefaultIntervalShort * time.Second)
 	}

--- a/alicloud/resource_alicloud_cdn_domain_test.go
+++ b/alicloud/resource_alicloud_cdn_domain_test.go
@@ -112,6 +112,36 @@ func TestAccAlicloudCdnDomain_basic(t *testing.T) {
 	})
 }
 
+func TestAccAlicloudCdnDomain_https(t *testing.T) {
+	var v cdn.DomainDetail
+	rand := acctest.RandInt()
+
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+		},
+
+		// module name
+		IDRefreshName: "alicloud_cdn_domain.domain",
+
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckCdnDomainDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccCdnDomainHttpsConfig(rand),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckCdnDomainExists("alicloud_cdn_domain.domain", &v),
+					resource.TestCheckResourceAttr("alicloud_cdn_domain.domain", "domain_name", fmt.Sprintf("tf-testacc%d.xiaozhu.com", rand)),
+					resource.TestCheckResourceAttr("alicloud_cdn_domain.domain", "certificate_config.#", "1"),
+					resource.TestCheckResourceAttr("alicloud_cdn_domain.domain", "certificate_config.0.server_certificate_status", "on"),
+					resource.TestCheckResourceAttr("alicloud_cdn_domain.domain", "certificate_config.0.server_certificate", strings.Replace(testServerCertificate, `\n`, "\n", -1)),
+					resource.TestCheckResourceAttr("alicloud_cdn_domain.domain", "certificate_config.0.private_key", strings.Replace(testPrivateKey, `\n`, "\n", -1)),
+				),
+			},
+		},
+	})
+}
+
 func testAccCheckCdnDomainExists(n string, domain *cdn.DomainDetail) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[n]
@@ -181,4 +211,22 @@ func testAccCdnDomainConfig(rand int) string {
 	  range_enable = "off"
 	  video_seek_enable = "off"
 	}`, rand)
+}
+
+const testServerCertificate = `-----BEGIN CERTIFICATE-----\nMIICrDCCAZQCCQDApyXUTYDE+DANBgkqhkiG9w0BAQsFADAYMRYwFAYDVQQDDA0q\nLnhpYW96aHUuY29tMB4XDTE4MTIzMTEwMDY1OVoXDTE5MTIzMTEwMDY1OVowGDEW\nMBQGA1UEAwwNKi54aWFvemh1LmNvbTCCASIwDQYJKoZIhvcNAQEBBQADggEPADCC\nAQoCggEBAM51j0hM0dqY/gHed5LhsSbTShXmw2Sqg18avBpHup/C8YzvpVddvRUe\ndE54idcCfdCVhoWEtcNFXIkKpWDpImFtovoupdNdC2XoBHEC42or9ZA+wVsaCih+\nSRuB3r+yNzXHh+rmUa0FLeij/x0gUovmznUsk7UMMzwJLZwmuyi8LCuiTIlQzQ9R\nTdaYo2t4OuGVkdQiJzsYiRRNPOqCKtYvYcEBLalLFOcVn0aG/I9Fn0P3rc8fK9BE\nHaoYRunmusUCdCcKpisHHKYdtmd3Zgz+Z+PBkjARtufO6kOXSov6u7azLQxZgZJm\neagNkqQ4/R+9b4GQ6crj0Pi655QWZVECAwEAATANBgkqhkiG9w0BAQsFAAOCAQEA\nJAWcQb7942jWDWjFqW5C4eyJBuJxK8dsTsYpOa0ccpp/A2cVCTNMzV/sMCGROy2B\nuhrTMG4q3QawFwV+K4nQX8yJUJp57zyUfdit+yOD4hDzPyF5MOlOwzdqeg9Y9ODL\nSc2O6J3tFsx2332Hb7RXFlYodEk1uFezrj4YLVrAgk1QojaBHpuFiA/O3eCmErjW\nc88bcil60qMvlhBhCWaZzivji6oc3y/6qWRZ3apxp9/6sjOvlm5Q+wwoLHXaU+L6\nw7TZptw6upuSrAS+N4Rwqgn5TfPvbGkdRG0X0TDzE1+F+w377kE71nV8lmi8F786\nbqloD1gWJER071WRz1coHQ==\n-----END CERTIFICATE-----\n`
+const testPrivateKey = `-----BEGIN PRIVATE KEY-----\nMIIEvgIBADANBgkqhkiG9w0BAQEFAASCBKgwggSkAgEAAoIBAQDOdY9ITNHamP4B\n3neS4bEm00oV5sNkqoNfGrwaR7qfwvGM76VXXb0VHnROeInXAn3QlYaFhLXDRVyJ\nCqVg6SJhbaL6LqXTXQtl6ARxAuNqK/WQPsFbGgoofkkbgd6/sjc1x4fq5lGtBS3o\no/8dIFKL5s51LJO1DDM8CS2cJrsovCwrokyJUM0PUU3WmKNreDrhlZHUIic7GIkU\nTTzqgirWL2HBAS2pSxTnFZ9GhvyPRZ9D963PHyvQRB2qGEbp5rrFAnQnCqYrBxym\nHbZnd2YM/mfjwZIwEbbnzupDl0qL+ru2sy0MWYGSZnmoDZKkOP0fvW+BkOnK49D4\nuueUFmVRAgMBAAECggEAGFrP2zSMsN/JXwkSS/Zpwm28WJcPR6nBs49gzyzU/BGw\nEvMWKxc4vewIxlT71axKkTeCVe/QzUc6YkQqPCNkVd/sEN093JAmTxAurfIsR5MF\n9c0hXBDXT+2NzDvmvfBVCPgPtYsT6Xgp8T6fUp1Ef5JrmnD2v62/wX5Hrhr3ixdp\nFoEJ92/FJN+Dt/Duri481+RYqUUbNqiZAuEMsny/hM+aijtpQgZK8FqnVfjIOo0l\np4TwfDoxtTwkj0QeJxelX/sNSD+iQ5xVmnxQ9Q1qmKMk0M1Wl8318ovcrXDTN3RZ\nR/Fp+lNw0aC4OLuOJDc7A13l5unHmex4Ka1kbjOZwQKBgQD8w0hJiVVmiojJ3/YX\n06rG3ufGlKXu4qvRL6eXNqnDp8AnKXpjKiDV5lGz+vK0pcAyF5AhpddDN20Un+nR\n4VU7NslNJdBfjQxfEKJRkGBP22C+pdlxOBDgdgouN9q7TTr9StaQC0KF+HUcF8fO\nsYpEp1R+27iHie+F6uS78ur0mQKBgQDRGnbv8acTDTBW8nll1wTRa0+iVR2yxglS\nndC97HzYHOFb+caVmaM18QzHaaRvAhQ0bZXOjFV0QVv1nytlmHxsMlG/N6LDz5jA\nNLGvbrzDzki+RUk0TWJuYpvdevsnwaCxMwyY6CQ5MKhKAvwgE8AhdAq5MGcE+6U/\noAOZNyOxeQKBgQCiCB2i5mLUpSIjJ2r+wzXK3sH9zvTAOpaiNsZcbTJOto67jB9k\nynDaLhdaJRjJLSgT9H700vc3o6RNgGXHoYedufU5e3AkkKrJlkQ3vTHAf4V5MaA+\nsA5BlenYzv1s7IlQLlV1aYJvl2Kba7MukSlt8UZ9PCUC3i2pz3Zp9cMgoQKBgQCK\nGkR7bMq/1nIausJa9IwGFC3gNP8MV6dInVqEVXCO+2QL7wetPm+A7NdXzPoBJwpZ\nJhdO93ho89Hcg2eSDgf/HazH8eLaGH32U9cW2rhpShDZOcGDfaiI5y+yM8s1Erki\nz2h+hLOH4g8D8ry6ItE+RvneHY2syNb3EqPNyZEVYQKBgGeC4KiyTpW+SqmkDRU/\n/FxIAlZE2vWmtJptAUkmLEVoBi0/GvJoYYJR4Jhj4gS9tJcrI860X0j05NZHvIX8\nUJ/vZZeiFRiatXYUtKbD/ngoOXTF92ew2J3eCwNHH5OKwEO3aejaYwD9m0QM4kTl\nVLWIf79+G3NrxIeqPnqv+l3J\n-----END PRIVATE KEY-----`
+
+func testAccCdnDomainHttpsConfig(rand int) string {
+	return fmt.Sprintf(`
+	resource "alicloud_cdn_domain" "domain" {
+	  domain_name = "tf-testacc%d.xiaozhu.com"
+	  cdn_type = "web"
+		source_type = "oss"
+		scope="overseas"
+		sources = ["terraformtest.aliyuncs.com"]
+		certificate_config {
+			server_certificate = "%s"
+			private_key = "%s"
+		}
+	}`, rand, testServerCertificate, testPrivateKey)
 }

--- a/website/docs/r/cdn_domain.html.markdown
+++ b/website/docs/r/cdn_domain.html.markdown
@@ -19,7 +19,7 @@ resource "alicloud_cdn_domain" "domain" {
   cdn_type = "web"
   source_type = "domain"
   sources = ["${your_cdn_domain_source1}", "${your_cdn_domain_source2}"]
-  
+
   // configs
   optimize_enable = "off"
   page_compress_enable = "off"
@@ -95,34 +95,46 @@ The config supports the following:
 * `range_enable` - (Optional) Range Source config of the accelerated domain. Valid values are `on` and `off`. Default value is `off`.
 * `video_seek_enable` - (Optional) Video Seek config of the accelerated domain. Valid values are `on` and `off`. Default value is `off`.
 
-* `parameter_filter_config` - (Optional, Type: set) Parameter filter config of the accelerated domain. It's a set and consists of at most one item.
-    * `enable` - (Optional) This parameter indicates whether or not the `parameter_filter_config` is enable. Valid values are `on` and `off`. Default value is `off`.  
-    * `hash_key_args` - (Optional, Type: list) Reserved parameters of `parameter_filter_config`. It's a list of string and consists of at most 10 items.
-    
-* `page_404_config` - (Optional, Type: set) Error Page config of the accelerated domain. It's a set and consists of at most one item.
-    * `page_type` - (Optional) Page type of the error page. Valid values are `default`, `charity`, `other`. Default value is `default`.
-    * `custom_page_url` - (Optional) Custom page url of the error page. It must be the full path under the accelerated domain name. It's value must be `http://promotion.alicdn.com/help/oss/error.html` when `page_type` value is `charity` and It can not be set when `page_type` value is `default`.
-     
-* `refer_config` - (Optional, Type: set) Refer anti-theft chain config of the accelerated domain. It's a set and consists of at most 1 item. 
-    * `refer_type` - (Optional) Refer type of the refer config. Valid values are `block` and `allow`. Default value is `block`.
-    * `refer_list` - (Required, Type: list) A list of domain names of the refer config.
-    * `allow_empty` - (Optional) This parameter indicates whether or not to allow empty refer access. Valid values are `on` and `off`. Default value is `on`.
-    
-* `auth_config` - (Optional, Type: set)  Auth config of the accelerated domain. It's a set and consist of at most 1 item.
-    * `auth_type` - (Optional) Auth type of the auth config. Valid values are  `no_auth`, `type_a`, `type_b` and `type_c`. Default value is `no_auth`.
-    * `master_key` - (Optional) Master authentication key of the auth config. This parameter can have a string of 6 to 32 characters and must contain only alphanumeric characters.
-    * `slave_key` - (Optional) Slave authentication key of the auth config. This parameter can have a string of 6 to 32 characters and must contain only alphanumeric characters.
-    * `timeout` - (Optional, Type: int)  Authentication cache time of the auth config. Default value is `1800`. It's value is valid only when the `auth_type` is `type_b` or `type_c`.
-    
-* `http_header_config` - (Optional, Type: set) Http header config of the accelerated domain. It's a set and consist of at most 8 items. The `header_key` for each item can not be repeated.
-    * `header_key` - (Required) Header key of the http header. Valid values are `Content-Type`, `Cache-Control`, `Content-Disposition`, `Content-Language`，`Expires`, `Access-Control-Allow-Origin`, `Access-Control-Allow-Methods` and `Access-Control-Max-Age`.
-    * `header_value` - (Required) Header value of the http header.
-    
-* `cache_config` - (Optional, Type: set)  Cache config of the accelerated domain. It's a set and each item's `cache_content` can not be repeated.
-    * `cache_type` - (Required) Cache type of the cache config. Valid values are `suffix` and `path`.
-    * `cache_content` - (Required) Cache content of the cache config. It's value is a path string when the `cache_type` is `path`. When the `cache_type` is `suffix`, it's value is a string which contains multiple file suffixes separated by commas. 
-    * `ttl` - (Required, Type: int) Cache time of the cache config.
-    * `weight` - (Optional, Type: int) Weight of the cache config. This parameter's value is between 1 and 99. Default value is `1`. The higher the value, the higher the priority.
+### Block parameter_filter_config
+`parameter_filter_config` - (Optional, Type: set) Parameter filter config of the accelerated domain. It's a set and consists of at most one item.
+* `enable` - (Optional) This parameter indicates whether or not the `parameter_filter_config` is enable. Valid values are `on` and `off`. Default value is `off`.  
+* `hash_key_args` - (Optional, Type: list) Reserved parameters of `parameter_filter_config`. It's a list of string and consists of at most 10 items.
+
+### Block page_404_config
+`page_404_config` - (Optional, Type: set) Error Page config of the accelerated domain. It's a set and consists of at most one item.
+* `page_type` - (Optional) Page type of the error page. Valid values are `default`, `charity`, `other`. Default value is `default`.
+* `custom_page_url` - (Optional) Custom page url of the error page. It must be the full path under the accelerated domain name. It's value must be `http://promotion.alicdn.com/help/oss/error.html` when `page_type` value is `charity` and It can not be set when `page_type` value is `default`.
+
+### Block refer_config
+`refer_config` - (Optional, Type: set) Refer anti-theft chain config of the accelerated domain. It's a set and consists of at most 1 item.
+* `refer_type` - (Optional) Refer type of the refer config. Valid values are `block` and `allow`. Default value is `block`.
+* `refer_list` - (Required, Type: list) A list of domain names of the refer config.
+* `allow_empty` - (Optional) This parameter indicates whether or not to allow empty refer access. Valid values are `on` and `off`. Default value is `on`.
+
+### Block auth_config
+`auth_config` - (Optional, Type: set)  Auth config of the accelerated domain. It's a set and consist of at most 1 item.
+* `auth_type` - (Optional) Auth type of the auth config. Valid values are  `no_auth`, `type_a`, `type_b` and `type_c`. Default value is `no_auth`.
+* `master_key` - (Optional) Master authentication key of the auth config. This parameter can have a string of 6 to 32 characters and must contain only alphanumeric characters.
+* `slave_key` - (Optional) Slave authentication key of the auth config. This parameter can have a string of 6 to 32 characters and must contain only alphanumeric characters.
+* `timeout` - (Optional, Type: int)  Authentication cache time of the auth config. Default value is `1800`. It's value is valid only when the `auth_type` is `type_b` or `type_c`.
+
+### Block certificate_config
+`certificate_config` - (Optional, Type: set)  Certificate config of the accelerated domain. It's a set and consist of at most 1 item.
+* `server_certificate_status` - (Optional) This parameter indicates whether or not enable https. Valid values are `on` and `off`. Default value is `on`.
+* `server_certificate` - (Optional) The SSL server certificate string. This is required if `server_certificate_status` is `on`
+* `private_key` - (Optional) The SSL private key. This is required if `server_certificate_status` is `on`
+
+### Block http_header_config
+`http_header_config` - (Optional, Type: set) Http header config of the accelerated domain. It's a set and consist of at most 8 items. The `header_key` for each item can not be repeated.
+* `header_key` - (Required) Header key of the http header. Valid values are `Content-Type`, `Cache-Control`, `Content-Disposition`, `Content-Language`，`Expires`, `Access-Control-Allow-Origin`, `Access-Control-Allow-Methods` and `Access-Control-Max-Age`.
+* `header_value` - (Required) Header value of the http header.
+
+### Block cache_config
+`cache_config` - (Optional, Type: set)  Cache config of the accelerated domain. It's a set and each item's `cache_content` can not be repeated.
+* `cache_type` - (Required) Cache type of the cache config. Valid values are `suffix` and `path`.
+* `cache_content` - (Required) Cache content of the cache config. It's value is a path string when the `cache_type` is `path`. When the `cache_type` is `suffix`, it's value is a string which contains multiple file suffixes separated by commas.
+* `ttl` - (Required, Type: int) Cache time of the cache config.
+* `weight` - (Optional, Type: int) Weight of the cache config. This parameter's value is between 1 and 99. Default value is `1`. The higher the value, the higher the priority.
 
 
 ## Attributes Reference

--- a/website/docs/r/cdn_domain.html.markdown
+++ b/website/docs/r/cdn_domain.html.markdown
@@ -96,22 +96,26 @@ The config supports the following:
 * `video_seek_enable` - (Optional) Video Seek config of the accelerated domain. Valid values are `on` and `off`. Default value is `off`.
 
 ### Block parameter_filter_config
+
 `parameter_filter_config` - (Optional, Type: set) Parameter filter config of the accelerated domain. It's a set and consists of at most one item.
 * `enable` - (Optional) This parameter indicates whether or not the `parameter_filter_config` is enable. Valid values are `on` and `off`. Default value is `off`.  
 * `hash_key_args` - (Optional, Type: list) Reserved parameters of `parameter_filter_config`. It's a list of string and consists of at most 10 items.
 
 ### Block page_404_config
+
 `page_404_config` - (Optional, Type: set) Error Page config of the accelerated domain. It's a set and consists of at most one item.
 * `page_type` - (Optional) Page type of the error page. Valid values are `default`, `charity`, `other`. Default value is `default`.
 * `custom_page_url` - (Optional) Custom page url of the error page. It must be the full path under the accelerated domain name. It's value must be `http://promotion.alicdn.com/help/oss/error.html` when `page_type` value is `charity` and It can not be set when `page_type` value is `default`.
 
 ### Block refer_config
+
 `refer_config` - (Optional, Type: set) Refer anti-theft chain config of the accelerated domain. It's a set and consists of at most 1 item.
 * `refer_type` - (Optional) Refer type of the refer config. Valid values are `block` and `allow`. Default value is `block`.
 * `refer_list` - (Required, Type: list) A list of domain names of the refer config.
 * `allow_empty` - (Optional) This parameter indicates whether or not to allow empty refer access. Valid values are `on` and `off`. Default value is `on`.
 
 ### Block auth_config
+
 `auth_config` - (Optional, Type: set)  Auth config of the accelerated domain. It's a set and consist of at most 1 item.
 * `auth_type` - (Optional) Auth type of the auth config. Valid values are  `no_auth`, `type_a`, `type_b` and `type_c`. Default value is `no_auth`.
 * `master_key` - (Optional) Master authentication key of the auth config. This parameter can have a string of 6 to 32 characters and must contain only alphanumeric characters.
@@ -119,17 +123,20 @@ The config supports the following:
 * `timeout` - (Optional, Type: int)  Authentication cache time of the auth config. Default value is `1800`. It's value is valid only when the `auth_type` is `type_b` or `type_c`.
 
 ### Block certificate_config
+
 `certificate_config` - (Optional, Type: set)  Certificate config of the accelerated domain. It's a set and consist of at most 1 item.
 * `server_certificate_status` - (Optional) This parameter indicates whether or not enable https. Valid values are `on` and `off`. Default value is `on`.
 * `server_certificate` - (Optional) The SSL server certificate string. This is required if `server_certificate_status` is `on`
 * `private_key` - (Optional) The SSL private key. This is required if `server_certificate_status` is `on`
 
 ### Block http_header_config
+
 `http_header_config` - (Optional, Type: set) Http header config of the accelerated domain. It's a set and consist of at most 8 items. The `header_key` for each item can not be repeated.
 * `header_key` - (Required) Header key of the http header. Valid values are `Content-Type`, `Cache-Control`, `Content-Disposition`, `Content-Language`，`Expires`, `Access-Control-Allow-Origin`, `Access-Control-Allow-Methods` and `Access-Control-Max-Age`.
 * `header_value` - (Required) Header value of the http header.
 
 ### Block cache_config
+
 `cache_config` - (Optional, Type: set)  Cache config of the accelerated domain. It's a set and each item's `cache_content` can not be repeated.
 * `cache_type` - (Required) Cache type of the cache config. Valid values are `suffix` and `path`.
 * `cache_content` - (Required) Cache content of the cache config. It's value is a path string when the `cache_type` is `path`. When the `cache_type` is `suffix`, it's value is a string which contains multiple file suffixes separated by commas.


### PR DESCRIPTION
This PR adds the ability to set a SSL certificate and enable HTTPs on the `alicloud_cdn_domain` resource. Previously it was not possible to enable SSL through terraform.

This is my first time both writing Go and working on a terraform provider, so apologies if the code is strange!

Fixes https://github.com/terraform-providers/terraform-provider-alicloud/issues/591