### PR TITLE
Fix ots instance description force new bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 IMPROVEMENTS:
 
+- Support change kvstore instance charge type [GH-602]
+- add region checks to kubernetes, multiaz kubernetes, swarm clusters [GH-607]
 - Add forcenew for ess lifecycle hook name and improve ess testcase by random name [GH-603]
 - Improve ess configuration testcase [GH-600]
 - Improve kvstore and ess schedule testcase [GH-599]
@@ -11,6 +13,7 @@ IMPROVEMENTS:
 
 BUG FIXES:
 
+- Fix ots instance description force new bug [GH-615]
 - Fix oss bucket object testcase destroy bug [GH-605]
 - Fix deleting ess group timeout bug [GH-604]
 - Fix deleting mns subscription bug [GH-601]

--- a/alicloud/resource_alicloud_kvstore_instance.go
+++ b/alicloud/resource_alicloud_kvstore_instance.go
@@ -2,9 +2,10 @@ package alicloud
 
 import (
 	"fmt"
-	"github.com/aliyun/alibaba-cloud-sdk-go/sdk/requests"
 	"strings"
 	"time"
+
+	"github.com/aliyun/alibaba-cloud-sdk-go/sdk/requests"
 
 	"strconv"
 

--- a/alicloud/resource_alicloud_ots_instance.go
+++ b/alicloud/resource_alicloud_ots_instance.go
@@ -48,8 +48,11 @@ func resourceAlicloudOtsInstance() *schema.Resource {
 			},
 			"description": &schema.Schema{
 				Type:     schema.TypeString,
-				Required: true,
+				Optional: true,
 				ForceNew: true,
+				DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
+					return d.Id() != ""
+				},
 			},
 			"tags": tagsSchema(),
 		},

--- a/website/docs/r/ots_instance.html.markdown
+++ b/website/docs/r/ots_instance.html.markdown
@@ -38,7 +38,7 @@ The following arguments are supported:
 
     Default to "Any".
 * `instance_type` - (ForceNew) The type of instance. Valid values are "Capacity" and "HighPerformance". Default to "HighPerformance".
-* `description` - (Required, ForceNew) The description of the instance.
+* `description` - (Optional, ForceNew) The description of the instance. Currently, it does not support modifying.
 * `tags` - A mapping of tags to assign to the instance.
 
 ## Attributes Reference


### PR DESCRIPTION
```
TF_ACC=1 go test ./alicloud -v -run=TestAccAlicloudOtsInstance -timeout=240m
=== RUN   TestAccAlicloudOtsInstanceCapacity_import
--- PASS: TestAccAlicloudOtsInstanceCapacity_import (506.26s)
=== RUN   TestAccAlicloudOtsInstanceHighPerformance_import
--- SKIP: TestAccAlicloudOtsInstanceHighPerformance_import (0.00s)
provider_test.go:76: Skipping unsupported region ap-south-1. Unsupported regions: [cn-qingdao cn-zhangjiakou cn-huhehaote cn-hongkong ap-southeast-2 ap-southeast-5 ap-northeast-1 eu-central-1 me-east-1 ap-south-1].
=== RUN   TestAccAlicloudOtsInstanceCapacityAttachment
--- PASS: TestAccAlicloudOtsInstanceCapacityAttachment (547.18s)
=== RUN   TestAccAlicloudOtsInstanceHighPerformanceAttachment
--- SKIP: TestAccAlicloudOtsInstanceHighPerformanceAttachment (0.00s)
provider_test.go:76: Skipping unsupported region ap-south-1. Unsupported regions: [cn-qingdao cn-zhangjiakou cn-huhehaote cn-hongkong ap-southeast-2 ap-southeast-5 ap-northeast-1 eu-central-1 me-east-1 ap-south-1].
=== RUN   TestAccAlicloudOtsInstanceCapacity_basic
--- PASS: TestAccAlicloudOtsInstanceCapacity_basic (515.74s)
=== RUN   TestAccAlicloudOtsInstanceCapacity_updateAccessBy
--- PASS: TestAccAlicloudOtsInstanceCapacity_updateAccessBy (506.44s)
=== RUN   TestAccAlicloudOtsInstanceCapacity_updateTags
--- PASS: TestAccAlicloudOtsInstanceCapacity_updateTags (505.62s)
=== RUN   TestAccAlicloudOtsInstanceCapacity_updateAll
--- PASS: TestAccAlicloudOtsInstanceCapacity_updateAll (515.80s)
=== RUN   TestAccAlicloudOtsInstanceHighPerformance_basic
--- SKIP: TestAccAlicloudOtsInstanceHighPerformance_basic (0.00s)
provider_test.go:76: Skipping unsupported region ap-south-1. Unsupported regions: [cn-qingdao cn-zhangjiakou cn-huhehaote cn-hongkong ap-southeast-2 ap-southeast-5 ap-northeast-1 eu-central-1 me-east-1 ap-south-1].
=== RUN   TestAccAlicloudOtsInstanceHighPerformance_updateAccessBy
--- SKIP: TestAccAlicloudOtsInstanceHighPerformance_updateAccessBy (0.00s)
provider_test.go:76: Skipping unsupported region ap-south-1. Unsupported regions: [cn-qingdao cn-zhangjiakou cn-huhehaote cn-hongkong ap-southeast-2 ap-southeast-5 ap-northeast-1 eu-central-1 me-east-1 ap-south-1].
=== RUN   TestAccAlicloudOtsInstanceHighPerformance_updateTags
--- SKIP: TestAccAlicloudOtsInstanceHighPerformance_updateTags (0.00s)
provider_test.go:76: Skipping unsupported region ap-south-1. Unsupported regions: [cn-qingdao cn-zhangjiakou cn-huhehaote cn-hongkong ap-southeast-2 ap-southeast-5 ap-northeast-1 eu-central-1 me-east-1 ap-south-1].
=== RUN   TestAccAlicloudOtsInstanceHighPerformance_updateAll
--- SKIP: TestAccAlicloudOtsInstanceHighPerformance_updateAll (0.00s)
provider_test.go:76: Skipping unsupported region ap-south-1. Unsupported regions: [cn-qingdao cn-zhangjiakou cn-huhehaote cn-hongkong ap-southeast-2 ap-southeast-5 ap-northeast-1 eu-central-1 me-east-1 ap-south-1].
PASS
ok	github.com/terraform-providers/terraform-provider-alicloud/alicloud	3097.069s
```