### PR TITLE
 Support oss client https

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 IMPROVEMENTS:
 
+- Support oss client https [GH-617]
 - Support change kvstore instance charge type [GH-602]
 - add region checks to kubernetes, multiaz kubernetes, swarm clusters [GH-607]
 - Add forcenew for ess lifecycle hook name and improve ess testcase by random name [GH-603]
@@ -13,7 +14,7 @@ IMPROVEMENTS:
 
 BUG FIXES:
 
-- Fix ots instance description force new bug [GH-615]
+- Fix ots instance description force new bug [GH-616]
 - Fix oss bucket object testcase destroy bug [GH-605]
 - Fix deleting ess group timeout bug [GH-604]
 - Fix deleting mns subscription bug [GH-601]


### PR DESCRIPTION
```
TF_ACC=1 go test ./alicloud -v -run=TestAccAlicloudOss -timeout=240m
=== RUN   TestAccAlicloudOssBucketObjectsDataSource_basic
--- PASS: TestAccAlicloudOssBucketObjectsDataSource_basic (8.56s)
=== RUN   TestAccAlicloudOssBucketObjectsDataSource_filterByPrefix
--- PASS: TestAccAlicloudOssBucketObjectsDataSource_filterByPrefix (8.68s)
=== RUN   TestAccAlicloudOssBucketObjectsDataSource_empty
--- PASS: TestAccAlicloudOssBucketObjectsDataSource_empty (7.31s)
=== RUN   TestAccAlicloudOssBucketsDataSource_basic
--- PASS: TestAccAlicloudOssBucketsDataSource_basic (11.45s)
=== RUN   TestAccAlicloudOssBucketsDataSource_full
--- PASS: TestAccAlicloudOssBucketsDataSource_full (18.08s)
=== RUN   TestAccAlicloudOssBucketsDataSource_empty
--- PASS: TestAccAlicloudOssBucketsDataSource_empty (3.69s)
=== RUN   TestAccAlicloudOssBucket_importBasic
--- PASS: TestAccAlicloudOssBucket_importBasic (8.50s)
=== RUN   TestAccAlicloudOssBucket_importCors
--- PASS: TestAccAlicloudOssBucket_importCors (7.61s)
=== RUN   TestAccAlicloudOssBucket_importWebsite
--- PASS: TestAccAlicloudOssBucket_importWebsite (7.82s)
=== RUN   TestAccAlicloudOssBucket_importLogging
--- PASS: TestAccAlicloudOssBucket_importLogging (14.13s)
=== RUN   TestAccAlicloudOssBucket_importReferer
--- PASS: TestAccAlicloudOssBucket_importReferer (7.65s)
=== RUN   TestAccAlicloudOssBucket_importLifecycle
--- PASS: TestAccAlicloudOssBucket_importLifecycle (7.60s)
=== RUN   TestAccAlicloudOssBucketObject_source
--- PASS: TestAccAlicloudOssBucketObject_source (7.70s)
=== RUN   TestAccAlicloudOssBucketObject_content
--- PASS: TestAccAlicloudOssBucketObject_content (7.72s)
=== RUN   TestAccAlicloudOssBucketObject_acl
--- PASS: TestAccAlicloudOssBucketObject_acl (7.74s)
=== RUN   TestAccAlicloudOssBucketBasic
--- PASS: TestAccAlicloudOssBucketBasic (7.96s)
=== RUN   TestAccAlicloudOssBucketCors
--- PASS: TestAccAlicloudOssBucketCors (7.10s)
=== RUN   TestAccAlicloudOssBucketWebsite
--- PASS: TestAccAlicloudOssBucketWebsite (7.32s)
=== RUN   TestAccAlicloudOssBucketLogging
--- PASS: TestAccAlicloudOssBucketLogging (13.48s)
=== RUN   TestAccAlicloudOssBucketReferer
--- PASS: TestAccAlicloudOssBucketReferer (7.07s)
=== RUN   TestAccAlicloudOssBucketLifecycle
--- PASS: TestAccAlicloudOssBucketLifecycle (7.03s)
PASS
ok  	github.com/terraform-providers/terraform-provider-alicloud/alicloud	184.256s
```