### PR TITLE
Improve dns_domains testcase

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 IMPROVEMENTS:
 
+- Improve dns_domains testcase [GH-561]
 - Improve ram_role_attachment testcase [GH-560]
 - Add retry and timemout for fc client [GH-557]
 - Datasource alicloud_zones supports filter FunctionCompute [GH-555]

--- a/alicloud/data_source_alicloud_dns_domains_test.go
+++ b/alicloud/data_source_alicloud_dns_domains_test.go
@@ -17,7 +17,7 @@ func TestAccAlicloudDnsDomainsDataSource_ali_domain(t *testing.T) {
 		Providers: testAccProviders,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccCheckAlicloudDomainsDataSourceAliDomainConfig(acctest.RandInt()),
+				Config: testAccCheckAlicloudDomainsDataSourceAliDomainConfig(acctest.RandIntRange(1000, 9999)),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAlicloudDataSourceID("data.alicloud_dns_domains.domain"),
 					resource.TestCheckResourceAttr("data.alicloud_dns_domains.domain", "domains.#", "1"),
@@ -36,7 +36,7 @@ func TestAccAlicloudDnsDomainsDataSource_name_regex(t *testing.T) {
 		Providers: testAccProviders,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccCheckAlicloudDomainsDataSourceNameRegexConfig(acctest.RandInt()),
+				Config: testAccCheckAlicloudDomainsDataSourceNameRegexConfig(acctest.RandIntRange(1000, 9999)),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAlicloudDataSourceID("data.alicloud_dns_domains.domain"),
 					resource.TestCheckResourceAttr("data.alicloud_dns_domains.domain", "domains.#", "1"),
@@ -75,28 +75,28 @@ func TestAccAlicloudDnsDomainsDataSource_empty(t *testing.T) {
 func testAccCheckAlicloudDomainsDataSourceAliDomainConfig(randInt int) string {
 	return fmt.Sprintf(`
 resource "alicloud_dns_group" "group" {
-  name = "testaccdnsalidomain%v"
+  name = "testaccdnsdomain%d"
 }
 
 resource "alicloud_dns" "dns" {
-  name = "testaccdnsalidomain%v.abc"
+  name = "testaccdnsalidomain%d.abc"
   group_id = "${alicloud_dns_group.group.id}"
 }
 
 data "alicloud_dns_domains" "domain" {
   ali_domain = "${alicloud_dns.dns.name == "" ? false : false}"
   group_name_regex = "${alicloud_dns_group.group.name}"
-}`, randInt%1000, randInt%1000)
+}`, randInt, randInt)
 }
 
 func testAccCheckAlicloudDomainsDataSourceNameRegexConfig(randInt int) string {
 	return fmt.Sprintf(`
 resource "alicloud_dns" "dns" {
-  name = "testaccdnsnameregex%v.abc"
+  name = "testaccdnsnameregex%d.abc"
 }
 data "alicloud_dns_domains" "domain" {
   domain_name_regex = "${alicloud_dns.dns.name}"
-}`, randInt%1000)
+}`, randInt)
 }
 
 const testAccCheckAlicloudDomainsDataSourceEmpty = `

--- a/alicloud/resource_alicloud_ram_role_attachment_test.go
+++ b/alicloud/resource_alicloud_ram_role_attachment_test.go
@@ -125,7 +125,7 @@ func testAccCheckRamRoleAttachmentDestroy(s *terraform.State) error {
 	return nil
 }
 
-func testAccRamRoleAttachmentConfig(common string) string{
+func testAccRamRoleAttachmentConfig(common string) string {
 	return fmt.Sprintf(`
 	%s
 	variable "name" {


### PR DESCRIPTION
```
TF_ACC=1 go test ./alicloud -v -run=TestAccAlicloudDns -timeout=240m
=== RUN   TestAccAlicloudDnsDomainsDataSource_ali_domain
--- PASS: TestAccAlicloudDnsDomainsDataSource_ali_domain (8.12s)
=== RUN   TestAccAlicloudDnsDomainsDataSource_name_regex
--- PASS: TestAccAlicloudDnsDomainsDataSource_name_regex (4.32s)
=== RUN   TestAccAlicloudDnsDomainsDataSource_empty
--- PASS: TestAccAlicloudDnsDomainsDataSource_empty (2.23s)
=== RUN   TestAccAlicloudDnsGroupsDataSource_name_regex
--- PASS: TestAccAlicloudDnsGroupsDataSource_name_regex (1.50s)
=== RUN   TestAccAlicloudDnsGroupsDataSource_empty
--- PASS: TestAccAlicloudDnsGroupsDataSource_empty (1.49s)
=== RUN   TestAccAlicloudDnsRecordsDataSource_host_record_regex
--- PASS: TestAccAlicloudDnsRecordsDataSource_host_record_regex (6.90s)
=== RUN   TestAccAlicloudDnsRecordsDataSource_type
--- PASS: TestAccAlicloudDnsRecordsDataSource_type (6.49s)
=== RUN   TestAccAlicloudDnsRecordsDataSource_value_regex
--- PASS: TestAccAlicloudDnsRecordsDataSource_value_regex (6.71s)
=== RUN   TestAccAlicloudDnsRecordsDataSource_line
--- PASS: TestAccAlicloudDnsRecordsDataSource_line (6.71s)
=== RUN   TestAccAlicloudDnsRecordsDataSource_status
--- PASS: TestAccAlicloudDnsRecordsDataSource_status (7.05s)
=== RUN   TestAccAlicloudDnsRecordsDataSource_is_locked
--- PASS: TestAccAlicloudDnsRecordsDataSource_is_locked (6.00s)
=== RUN   TestAccAlicloudDnsRecordsDataSource_empty
--- PASS: TestAccAlicloudDnsRecordsDataSource_empty (4.03s)
=== RUN   TestAccAlicloudDnsDomainRecord_importBasic
--- PASS: TestAccAlicloudDnsDomainRecord_importBasic (7.02s)
=== RUN   TestAccAlicloudDnsDomain_importBasic
--- PASS: TestAccAlicloudDnsDomain_importBasic (3.28s)
=== RUN   TestAccAlicloudDnsGroup_basic
--- PASS: TestAccAlicloudDnsGroup_basic (2.58s)
=== RUN   TestAccAlicloudDnsRecord_basic
--- PASS: TestAccAlicloudDnsRecord_basic (6.64s)
=== RUN   TestAccAlicloudDnsRecord_priority
--- PASS: TestAccAlicloudDnsRecord_priority (6.20s)
=== RUN   TestAccAlicloudDnsRecord_multi
--- PASS: TestAccAlicloudDnsRecord_multi (37.03s)
=== RUN   TestAccAlicloudDnsRecord_routing
--- PASS: TestAccAlicloudDnsRecord_routing (5.86s)
=== RUN   TestAccAlicloudDns_basic
--- PASS: TestAccAlicloudDns_basic (4.34s)
PASS
ok  	github.com/terraform-providers/terraform-provider-alicloud/alicloud	134.569s
```