### PR TITLE
Support https for dns client

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 IMPROVEMENTS:
 
+- Support https for dns client [GH-620]
 - Support https for services client using official sdk [GH-619]
 - Support mns client https and improve mns testcase [GH-618]
 - Support oss client https [GH-617]

--- a/alicloud/connectivity/client.go
+++ b/alicloud/connectivity/client.go
@@ -323,6 +323,14 @@ func (client *AliyunClient) WithDnsClient(do func(*dns.Client) (interface{}, err
 		dnsconn.SetBusinessInfo(businessInfoKey)
 		dnsconn.SetUserAgent(client.getUserAgent())
 		dnsconn.SetSecurityToken(client.config.SecurityToken)
+		endpoint := loadEndpoint(client.config.RegionId, DNSCode)
+		if endpoint == "" {
+			endpoint = "alidns.aliyuncs.com"
+		}
+		if !strings.HasPrefix(endpoint, "http") {
+			endpoint = fmt.Sprintf("https://%s", strings.Replace(endpoint, "://", "", 1))
+		}
+		dnsconn.SetEndpoint(endpoint)
 
 		client.dnsconn = dnsconn
 	}

--- a/alicloud/connectivity/endpoint.go
+++ b/alicloud/connectivity/endpoint.go
@@ -25,6 +25,7 @@ const (
 	CMSCode      = ServiceCode("CMS")
 	KMSCode      = ServiceCode("KMS")
 	OTSCode      = ServiceCode("OTS")
+	DNSCode      = ServiceCode("DNS")
 	PVTZCode     = ServiceCode("PVTZ")
 	LOGCode      = ServiceCode("LOG")
 	FCCode       = ServiceCode("FC")


### PR DESCRIPTION
```
TF_ACC=1 go test ./alicloud -v -run=TestAccAlicloudDns -timeout=240m
=== RUN   TestAccAlicloudDnsDomainsDataSource_ali_domain
--- PASS: TestAccAlicloudDnsDomainsDataSource_ali_domain (8.12s)
=== RUN   TestAccAlicloudDnsDomainsDataSource_name_regex
--- PASS: TestAccAlicloudDnsDomainsDataSource_name_regex (4.32s)
=== RUN   TestAccAlicloudDnsDomainsDataSource_empty
--- PASS: TestAccAlicloudDnsDomainsDataSource_empty (2.23s)
=== RUN   TestAccAlicloudDnsGroupsDataSource_name_regex
--- PASS: TestAccAlicloudDnsGroupsDataSource_name_regex (1.50s)
=== RUN   TestAccAlicloudDnsGroupsDataSource_empty
--- PASS: TestAccAlicloudDnsGroupsDataSource_empty (1.49s)
=== RUN   TestAccAlicloudDnsRecordsDataSource_host_record_regex
--- PASS: TestAccAlicloudDnsRecordsDataSource_host_record_regex (6.90s)
=== RUN   TestAccAlicloudDnsRecordsDataSource_type
--- PASS: TestAccAlicloudDnsRecordsDataSource_type (6.49s)
=== RUN   TestAccAlicloudDnsRecordsDataSource_value_regex
--- PASS: TestAccAlicloudDnsRecordsDataSource_value_regex (6.71s)
=== RUN   TestAccAlicloudDnsRecordsDataSource_line
--- PASS: TestAccAlicloudDnsRecordsDataSource_line (6.71s)
=== RUN   TestAccAlicloudDnsRecordsDataSource_status
--- PASS: TestAccAlicloudDnsRecordsDataSource_status (7.05s)
=== RUN   TestAccAlicloudDnsRecordsDataSource_is_locked
--- PASS: TestAccAlicloudDnsRecordsDataSource_is_locked (6.00s)
=== RUN   TestAccAlicloudDnsRecordsDataSource_empty
--- PASS: TestAccAlicloudDnsRecordsDataSource_empty (4.03s)
=== RUN   TestAccAlicloudDnsDomainRecord_importBasic
--- PASS: TestAccAlicloudDnsDomainRecord_importBasic (7.02s)
=== RUN   TestAccAlicloudDnsDomain_importBasic
--- PASS: TestAccAlicloudDnsDomain_importBasic (3.28s)
=== RUN   TestAccAlicloudDnsGroup_basic
--- PASS: TestAccAlicloudDnsGroup_basic (2.58s)
=== RUN   TestAccAlicloudDnsRecord_basic
--- PASS: TestAccAlicloudDnsRecord_basic (6.64s)
=== RUN   TestAccAlicloudDnsRecord_priority
--- PASS: TestAccAlicloudDnsRecord_priority (6.20s)
=== RUN   TestAccAlicloudDnsRecord_multi
--- PASS: TestAccAlicloudDnsRecord_multi (37.03s)
=== RUN   TestAccAlicloudDnsRecord_routing
--- PASS: TestAccAlicloudDnsRecord_routing (5.86s)
=== RUN   TestAccAlicloudDns_basic
--- PASS: TestAccAlicloudDns_basic (4.34s)
PASS
ok  	github.com/terraform-providers/terraform-provider-alicloud/alicloud	134.569s
```