### PR TITLE
Support https for ram, cdn, kms and fc client

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 IMPROVEMENTS:
 
+- Support https for ram, cdn, kms and fc client [GH-621]
 - Support https for dns client [GH-620]
 - Support https for services client using official sdk [GH-619]
 - Support mns client https and improve mns testcase [GH-618]


### PR DESCRIPTION
```
TF_ACC=1 go test ./alicloud -v -run=TestAccAlicloudRam -timeout=240m
=== RUN   TestAccAlicloudRamAccountAliasDataSource_basic
--- PASS: TestAccAlicloudRamAccountAliasDataSource_basic (3.58s)
=== RUN   TestAccAlicloudRamGroupsDataSource_for_user
--- PASS: TestAccAlicloudRamGroupsDataSource_for_user (12.19s)
=== RUN   TestAccAlicloudRamGroupsDataSource_for_policy
--- PASS: TestAccAlicloudRamGroupsDataSource_for_policy (16.57s)
=== RUN   TestAccAlicloudRamGroupsDataSource_for_all
--- PASS: TestAccAlicloudRamGroupsDataSource_for_all (3.04s)
=== RUN   TestAccAlicloudRamGroupsDataSource_group_name_regex
--- PASS: TestAccAlicloudRamGroupsDataSource_group_name_regex (5.81s)
=== RUN   TestAccAlicloudRamGroupsDataSource_Empty
--- PASS: TestAccAlicloudRamGroupsDataSource_Empty (2.96s)
=== RUN   TestAccAlicloudRamPoliciesDataSource_for_group
--- PASS: TestAccAlicloudRamPoliciesDataSource_for_group (16.81s)
=== RUN   TestAccAlicloudRamPoliciesDataSource_for_role
--- PASS: TestAccAlicloudRamPoliciesDataSource_for_role (16.45s)
=== RUN   TestAccAlicloudRamPoliciesDataSource_for_user
--- PASS: TestAccAlicloudRamPoliciesDataSource_for_user (17.37s)
=== RUN   TestAccAlicloudRamPoliciesDataSource_policy_name_regex
--- PASS: TestAccAlicloudRamPoliciesDataSource_policy_name_regex (13.35s)
=== RUN   TestAccAlicloudRamPoliciesDataSource_policy_type
--- PASS: TestAccAlicloudRamPoliciesDataSource_policy_type (10.23s)
=== RUN   TestAccAlicloudRamPoliciesDataSource_empty
--- PASS: TestAccAlicloudRamPoliciesDataSource_empty (6.54s)
=== RUN   TestAccAlicloudRamRolesDataSource_for_policy
--- PASS: TestAccAlicloudRamRolesDataSource_for_policy (13.91s)
=== RUN   TestAccAlicloudRamRolesDataSource_for_all
--- PASS: TestAccAlicloudRamRolesDataSource_for_all (20.20s)
=== RUN   TestAccAlicloudRamRolesDataSource_role_name_regex
--- PASS: TestAccAlicloudRamRolesDataSource_role_name_regex (6.30s)
=== RUN   TestAccAlicloudRamRolesDataSource_empty
--- PASS: TestAccAlicloudRamRolesDataSource_empty (3.12s)
=== RUN   TestAccAlicloudRamUsersDataSource_for_group
--- PASS: TestAccAlicloudRamUsersDataSource_for_group (11.97s)
=== RUN   TestAccAlicloudRamUsersDataSource_for_policy
--- PASS: TestAccAlicloudRamUsersDataSource_for_policy (13.08s)
=== RUN   TestAccAlicloudRamUsersDataSource_for_all
--- PASS: TestAccAlicloudRamUsersDataSource_for_all (3.22s)
=== RUN   TestAccAlicloudRamUsersDataSource_user_name_regex
--- PASS: TestAccAlicloudRamUsersDataSource_user_name_regex (5.59s)
=== RUN   TestAccAlicloudRamUsersDataSource_empty
--- PASS: TestAccAlicloudRamUsersDataSource_empty (3.23s)
=== RUN   TestAccAlicloudRamLoginProfile_importBasic
--- PASS: TestAccAlicloudRamLoginProfile_importBasic (8.23s)
=== RUN   TestAccAlicloudRamPolicy_importBasic
--- PASS: TestAccAlicloudRamPolicy_importBasic (6.82s)
=== RUN   TestAccAlicloudRamRole_importBasic
--- PASS: TestAccAlicloudRamRole_importBasic (4.89s)
=== RUN   TestAccAlicloudRamUser_importBasic
--- PASS: TestAccAlicloudRamUser_importBasic (5.22s)
=== RUN   TestAccAlicloudRamAccessKey_basic
--- PASS: TestAccAlicloudRamAccessKey_basic (8.81s)
=== RUN   TestAccAlicloudRamAccountAlias_basic
--- PASS: TestAccAlicloudRamAccountAlias_basic (4.23s)
=== RUN   TestAccAlicloudRamGroupMembership_basic
--- PASS: TestAccAlicloudRamGroupMembership_basic (15.37s)
=== RUN   TestAccAlicloudRamGroupPolicyAttachment_basic
--- PASS: TestAccAlicloudRamGroupPolicyAttachment_basic (12.44s)
=== RUN   TestAccAlicloudRamGroup_basic
--- PASS: TestAccAlicloudRamGroup_basic (5.45s)
=== RUN   TestAccAlicloudRamLoginProfile_basic
--- PASS: TestAccAlicloudRamLoginProfile_basic (8.14s)
=== RUN   TestAccAlicloudRamPolicy_basic
--- PASS: TestAccAlicloudRamPolicy_basic (6.13s)
=== RUN   TestAccAlicloudRamRoleAttachment_basic
--- PASS: TestAccAlicloudRamRoleAttachment_basic (235.88s)
=== RUN   TestAccAlicloudRamRolePolicyAttachment_basic
--- PASS: TestAccAlicloudRamRolePolicyAttachment_basic (11.69s)
=== RUN   TestAccAlicloudRamRole_basic
--- PASS: TestAccAlicloudRamRole_basic (4.57s)
=== RUN   TestAccAlicloudRamUserPolicyAttachment_basic
--- PASS: TestAccAlicloudRamUserPolicyAttachment_basic (12.18s)
=== RUN   TestAccAlicloudRamUser_basic
--- PASS: TestAccAlicloudRamUser_basic (4.84s)
PASS
ok  	github.com/terraform-providers/terraform-provider-alicloud/alicloud	560.456s
```
```
TF_ACC=1 go test ./alicloud -v -run=TestAccAlicloudCdn -timeout=240m
=== RUN   TestAccAlicloudCdnDomain_basic
--- PASS: TestAccAlicloudCdnDomain_basic (99.61s)
PASS
ok  	github.com/terraform-providers/terraform-provider-alicloud/alicloud	99.745s
```
```
TF_ACC=1 go test ./alicloud -v -run=TestAccAlicloudKms -timeout=240m
=== RUN   TestAccAlicloudKmsKeyDataSource_basic
--- PASS: TestAccAlicloudKmsKeyDataSource_basic (15.72s)
=== RUN   TestAccAlicloudKmsKeyDataSource_enpty
--- PASS: TestAccAlicloudKmsKeyDataSource_enpty (16.44s)
=== RUN   TestAccAlicloudKmsKey_import
--- PASS: TestAccAlicloudKmsKey_import (4.31s)
=== RUN   TestAccAlicloudKmsKey_basic
--- PASS: TestAccAlicloudKmsKey_basic (6.50s)
PASS
ok  	github.com/terraform-providers/terraform-provider-alicloud/alicloud	43.022s
```