### PR TITLE
Fix api gateway groups filter bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ IMPROVEMENTS:
 
 BUG FIXES:
 
+- Fix api gateway groups filter bug [GH-624]
 - Fix ots instance description force new bug [GH-616]
 - Fix oss bucket object testcase destroy bug [GH-605]
 - Fix deleting ess group timeout bug [GH-604]

--- a/alicloud/data_source_alicloud_api_gateway_groups.go
+++ b/alicloud/data_source_alicloud_api_gateway_groups.go
@@ -112,24 +112,18 @@ func dataSourceAlicloudApigatewayGroupsRead(d *schema.ResourceData, meta interfa
 		}
 	}
 
-	var filteredGroupsTemp []cloudapi.ApiGroupAttribute
-	nameRegex, ok := d.GetOk("name_regex")
-	if ok && nameRegex.(string) != "" {
-		var r *regexp.Regexp
-		if nameRegex != "" {
-			r = regexp.MustCompile(nameRegex.(string))
-		}
-		for _, group := range allGroups {
-			if r != nil && !r.MatchString(group.GroupName) {
-				continue
-			}
-
-			filteredGroupsTemp = append(filteredGroupsTemp, group)
-		}
-	} else {
-		filteredGroupsTemp = allGroups
+	var filteredGroups []cloudapi.ApiGroupAttribute
+	var r *regexp.Regexp
+	if nameRegex, ok := d.GetOk("name_regex"); ok && nameRegex.(string) != "" {
+		r = regexp.MustCompile(nameRegex.(string))
 	}
-	return apigatewayGroupsDecriptionAttributes(d, allGroups, meta)
+	for _, group := range allGroups {
+		if r != nil && !r.MatchString(group.GroupName) {
+			continue
+		}
+		filteredGroups = append(filteredGroups, group)
+	}
+	return apigatewayGroupsDecriptionAttributes(d, filteredGroups, meta)
 }
 
 func apigatewayGroupsDecriptionAttributes(d *schema.ResourceData, groupsSetTypes []cloudapi.ApiGroupAttribute, meta interface{}) error {


### PR DESCRIPTION
```
TF_ACC=1 go test ./alicloud -v -run=TestAccAlicloudApigatewayGroupsDataSource  -timeout=240m
=== RUN   TestAccAlicloudApigatewayGroupsDataSource_basic
--- PASS: TestAccAlicloudApigatewayGroupsDataSource_basic (13.43s)
=== RUN   TestAccAlicloudApigatewayGroupsDataSource_empty
--- PASS: TestAccAlicloudApigatewayGroupsDataSource_empty (7.62s)
PASS
ok  	github.com/terraform-providers/terraform-provider-alicloud/alicloud	21.109s
```