### PR TITLE
Fix api gateway deleteing app bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 IMPROVEMENTS:
 
-- Improve slb instance docs [GH-631]
+- Improve slb instance docs [GH-632]
 - Upgrade to Go 1.11 [GH-629]
 - Remove ots https schema because of in some region only supports http [GH-630]
 - Support https for log client [GH-623]
@@ -22,6 +22,7 @@ IMPROVEMENTS:
 
 BUG FIXES:
 
+- Fix api gateway deleteing app bug [GH-633]
 - Fix cs_kubernetes missing name error [GH-625]
 - Fix api gateway groups filter bug [GH-624]
 - Fix ots instance description force new bug [GH-616]

--- a/alicloud/resource_alicloud_api_gateway_app_test.go
+++ b/alicloud/resource_alicloud_api_gateway_app_test.go
@@ -67,7 +67,7 @@ func testSweepApiGatewayApp(region string) error {
 		log.Printf("[INFO] Deleting App: %s", name)
 
 		req := cloudapi.CreateDeleteAppRequest()
-		req.AppId = requests.Integer(v.AppId)
+		req.AppId = requests.NewInteger(v.AppId)
 		_, err := client.WithCloudApiClient(func(cloudApiClient *cloudapi.Client) (interface{}, error) {
 			return cloudApiClient.DeleteApp(req)
 		})


### PR DESCRIPTION
```
TF_ACC=1 go test ./alicloud -v  -sweep=cn-beijing -sweep-run=alicloud_api
2019/01/08 16:58:29 [DEBUG] Running Sweepers for region (cn-beijing):
2019/01/08 16:58:30 [INFO] Deleting App: 7512712
2019/01/08 16:58:30 [INFO] Deleting App: 7512711
2019/01/08 16:58:30 [INFO] Deleting App: 7512678
2019/01/08 16:58:30 [INFO] Deleting App: 7512673
2019/01/08 16:58:30 [INFO] Deleting App: 7512595
2019/01/08 16:58:31 [INFO] Deleting App: 7512594
2019/01/08 16:58:31 [INFO] Deleting App: 7512593
2019/01/08 16:58:31 [INFO] Deleting App: 7512556
2019/01/08 16:58:31 [INFO] Deleting App: 7512554
2019/01/08 16:58:31 [INFO] Deleting App: 7512494
2019/01/08 16:58:36 [DEBUG] Sweeper (alicloud_api_gateway_group) has dependency (alicloud_api_gateway_api), running..
2019/01/08 16:58:36 [DEBUG] Sweeper (alicloud_api_gateway_api) already ran in region (cn-beijing)
2019/01/08 16:58:37 Sweeper Tests ran:
	- alicloud_api_gateway_app
	- alicloud_api_gateway_api
	- alicloud_api_gateway_group
	- alicloud_api_gateway_vpc_access
ok  	github.com/terraform-providers/terraform-provider-alicloud/alicloud	7.416s

```