### PR TITLE
Fix typo in docs

### DIFF
--- a/website/docs/r/kvstore_instance.html.markdown
+++ b/website/docs/r/kvstore_instance.html.markdown
@@ -44,7 +44,7 @@ For more information, see [Instance type table](https://www.alibabacloud.com/hel
 The following attributes are exported:
 
 * `id` - The KVStore instance ID.
-* `connections_domain` - Instance connection domain (only Intranet access supported).
+* `connection_domain` - Instance connection domain (only Intranet access supported).
 
 ## Import
 


### PR DESCRIPTION
Attribute name is `connection_domain` not `connections_domain` - [code](https://github.com/terraform-providers/terraform-provider-alicloud/blob/38d3f2e2d5761022f607496576f50fcd12108ecc/alicloud/resource_alicloud_kvstore_instance.go#L85)