### PR TITLE
Slb listener can not be updated when load balancer instance is shared-performance

### DIFF
--- a/alicloud/resource_alicloud_slb_listener.go
+++ b/alicloud/resource_alicloud_slb_listener.go
@@ -604,14 +604,13 @@ func resourceAliyunSlbListenerUpdate(d *schema.ResourceData, meta interface{}) e
 		}
 
 		if d.HasChange("tls_cipher_policy") {
-			// spec changes check. only specification larger than S1Small instance support.
+			// spec changes check, can not be updated when load balancer instance is "Shared-Performance".
 			slbService := SlbService{client}
 			loadBalancer, _ := slbService.DescribeLoadBalancerAttribute(d.Get("load_balancer_id").(string))
 			spec := loadBalancer.LoadBalancerSpec
-			if spec == "" || spec == S1Small {
+			if spec == "" {
 				if !d.IsNewResource() || string(TlsCipherPolicy_1_0) != d.Get("tls_cipher_policy").(string) {
-					return fmt.Errorf("Currently the param \"tls_cipher_policy\" can not be updated when load balancer instance is \"Shared-Performance\" \n" +
-						"or its specification is \"slb.s1.small\".")
+					return fmt.Errorf("Currently the param \"tls_cipher_policy\" can not be updated when load balancer instance is \"Shared-Performance\".")
 				}
 			} else {
 				httpsArgs.QueryParams["TLSCipherPolicy"] = d.Get("tls_cipher_policy").(string)

--- a/alicloud/resource_alicloud_slb_listener_test.go
+++ b/alicloud/resource_alicloud_slb_listener_test.go
@@ -566,7 +566,7 @@ resource "alicloud_slb" "instance" {
   name = "tf-testAccSlbListenerHttps"
   internet_charge_type = "PayByTraffic"
   internet = true
-  specification = "slb.s2.small"
+  specification = "slb.s1.small"
 }
 resource "alicloud_slb_listener" "https" {
   load_balancer_id = "${alicloud_slb.instance.id}"
@@ -631,7 +631,7 @@ resource "alicloud_slb" "instance" {
   name = "tf-testAccSlbListenerHttps"
   internet_charge_type = "PayByTraffic"
   internet = true
-  specification = "slb.s2.small"
+  specification = "slb.s1.small"
 }
 resource "alicloud_slb_listener" "https" {
   load_balancer_id = "${alicloud_slb.instance.id}"

--- a/website/docs/r/slb_listener.html.markdown
+++ b/website/docs/r/slb_listener.html.markdown
@@ -112,10 +112,10 @@ The following arguments are supported:
 * `idle_timeout` - (Optinal) Timeout of http or https listener established connection idle timeout. Valid value range: [1-60] in seconds. Default to 15.
 * `request_timeout` - (Optinal) Timeout of http or https listener request (which does not get response from backend) timeout. Valid value range: [1-180] in seconds. Default to 60.
 * `enable_http2` - (Optinal) Whether to enable https listener support http2 or not. Valid values are `on` and `off`. Default to `on`.
-* `tls_cipher_policy` - (Optinal)  Https listener TLS cipher policy. Valid values are `tls_cipher_policy_1_0`, `tls_cipher_policy_1_1`, `tls_cipher_policy_1_2`, `tls_cipher_policy_1_2_strict`. Default to `tls_cipher_policy_1_0`. Currently the `tls_cipher_policy` can not be updated when load balancer instance is "Shared-Performance" or its specification is `slb.s1.small`.
+* `tls_cipher_policy` - (Optinal)  Https listener TLS cipher policy. Valid values are `tls_cipher_policy_1_0`, `tls_cipher_policy_1_1`, `tls_cipher_policy_1_2`, `tls_cipher_policy_1_2_strict`. Default to `tls_cipher_policy_1_0`. Currently the `tls_cipher_policy` can not be updated when load balancer instance is "Shared-Performance".
 * `server_group_id` - (Optinal) the id of server group to be apply on the listener, is the id of resource `alicloud_slb_server_group`.
 
-~> **NOTE:** Advantanced feature such as `tls_cipher_policy`,  only support load balancer specification more than slb.s1.small. More info, please refer to [Configure a HTTPS Listener](https://www.alibabacloud.com/help/doc-detail/27593.htm).
+~> **NOTE:** Advantanced feature such as `tls_cipher_policy`, can not be updated when load balancer instance is "Shared-Performance". More info, please refer to [Configure a HTTPS Listener](https://www.alibabacloud.com/help/doc-detail/27593.htm).
 
 ### Block x_forwarded_for
 


### PR DESCRIPTION
MacBook-Pro-2:terraform-provider-alicloud jince$ TF_ACC=1 go test ./alicloud -v -run=TestAccAlicloudSlbListener -timeout=300m

=== RUN   TestAccAlicloudSlbListenersDataSource_http

--- PASS: TestAccAlicloudSlbListenersDataSource_http (34.56s)

=== RUN   TestAccAlicloudSlbListenersDataSource_https

--- PASS: TestAccAlicloudSlbListenersDataSource_https (13.89s)

=== RUN   TestAccAlicloudSlbListenersDataSource_tcp

--- PASS: TestAccAlicloudSlbListenersDataSource_tcp (31.67s)

=== RUN   TestAccAlicloudSlbListenersDataSource_udp

--- PASS: TestAccAlicloudSlbListenersDataSource_udp (32.03s)

=== RUN   TestAccAlicloudSlbListenersDataSource_empty

--- PASS: TestAccAlicloudSlbListenersDataSource_empty (27.21s)

=== RUN   TestAccAlicloudSlbListener_importHttp

--- PASS: TestAccAlicloudSlbListener_importHttp (12.30s)

=== RUN   TestAccAlicloudSlbListener_importHttps

--- PASS: TestAccAlicloudSlbListener_importHttps (12.82s)

=== RUN   TestAccAlicloudSlbListener_importTcp

--- PASS: TestAccAlicloudSlbListener_importTcp (13.43s)

=== RUN   TestAccAlicloudSlbListener_importUdp

--- PASS: TestAccAlicloudSlbListener_importUdp (10.07s)

=== RUN   TestAccAlicloudSlbListener_http

--- PASS: TestAccAlicloudSlbListener_http (10.57s)

=== RUN   TestAccAlicloudSlbListener_https

--- PASS: TestAccAlicloudSlbListener_https (15.34s)

=== RUN   TestAccAlicloudSlbListener_https_shared_performance

--- PASS: TestAccAlicloudSlbListener_https_shared_performance (13.64s)

=== RUN   TestAccAlicloudSlbListener_tcp

--- PASS: TestAccAlicloudSlbListener_tcp (12.18s)

=== RUN   TestAccAlicloudSlbListener_tcp_server_group

--- PASS: TestAccAlicloudSlbListener_tcp_server_group (179.52s)

=== RUN   TestAccAlicloudSlbListener_udp

--- PASS: TestAccAlicloudSlbListener_udp (11.64s)

PASS

ok  	github.com/terraform-providers/terraform-provider-alicloud/alicloud	430.947s