### PR TITLE
Fix pvtz throttling user bug and add WrafError

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,14 @@
 
 IMPROVEMENTS:
 
-- Improve db_account testcase and its docs [GH-633]
-- Improve pvtz_zone testcase by using rand [GH-633]
+- Improve pvtz_zone testcase by using rand [GH-639]
+- Slb listener can not be updated when load balancer instance is shared-performance [GH-637]
+- Improve db_account testcase and its docs [GH-635]
+
+BUG FIXES:
+
+- Fix pvtz throttling user bug and add WrafError [GH-642]
+- Fix kvstore instance docs [GH-636]
 
 ## 1.27.0 (January 08, 2019)
 

--- a/alicloud/common.go
+++ b/alicloud/common.go
@@ -17,6 +17,8 @@ import (
 
 	"time"
 
+	"runtime"
+
 	"github.com/aliyun/alibaba-cloud-sdk-go/sdk/requests"
 	"github.com/denverdino/aliyungo/common"
 	"github.com/google/uuid"
@@ -496,4 +498,21 @@ func loadFileContent(v string) ([]byte, error) {
 		return nil, err
 	}
 	return fileContent, nil
+}
+
+type ErrorSource string
+
+const (
+	APIERROR      = ErrorSource("[API ERROR]")
+	SDKERROR      = ErrorSource("[SDK ERROR]")
+	ProviderERROR = ErrorSource("[Provider ERROR]")
+)
+
+func WrapError(action, id string, source ErrorSource, err error) error {
+	pc, file, line, ok := runtime.Caller(1)
+	if !ok {
+		log.Printf("[ERROR] runtime.Caller error")
+		return fmt.Errorf("[ERROR] %s %s Failed. %s: %#v.", action, id, source, err)
+	}
+	return fmt.Errorf("[ERROR] - %s - %s:%d: %s %s Failed. %s: %#v.", runtime.FuncForPC(pc).Name(), file, line, action, id, source, err)
 }

--- a/alicloud/errors.go
+++ b/alicloud/errors.go
@@ -208,6 +208,7 @@ const (
 	GroupNotExist        = "GroupNotExist"
 	MachineGroupNotExist = "MachineGroupNotExist"
 	LogClientTimeout     = "Client.Timeout exceeded while awaiting headers"
+	PvtzThrottlingUser   = "Throttling.User"
 
 	// OTS
 	OTSObjectNotExist = "OTSObjectNotExist"

--- a/alicloud/extension_pvtz.go
+++ b/alicloud/extension_pvtz.go
@@ -9,3 +9,11 @@ const (
 	RecordMX    = RecordType("MX")
 	RecordPTR   = RecordType("PTR")
 )
+
+var PvtzThrottlingUserCatcher = Catcher{PvtzThrottlingUser, 30, 2}
+
+func NewPvtzInvoker() Invoker {
+	i := Invoker{}
+	i.AddCatcher(PvtzThrottlingUserCatcher)
+	return i
+}

--- a/alicloud/service_alicloud_pvtz.go
+++ b/alicloud/service_alicloud_pvtz.go
@@ -16,7 +16,8 @@ func (s *PvtzService) DescribePvtzZoneInfo(zoneId string) (zone pvtz.DescribeZon
 	request := pvtz.CreateDescribeZoneInfoRequest()
 	request.ZoneId = zoneId
 
-	invoker := NewInvoker()
+	invoker := NewPvtzInvoker()
+	invoker.AddCatcher(ServiceBusyCatcher)
 	err = invoker.Run(func() error {
 		raw, err := s.client.WithPvtzClient(func(pvtzClient *pvtz.Client) (interface{}, error) {
 			return pvtzClient.DescribeZoneInfo(request)


### PR DESCRIPTION
```
TF_ACC=1 go test ./alicloud -v -run=TestAccAlicloudPvtz -timeout=120m
=== RUN   TestAccAlicloudPvtzZoneRecordsDataSource_basic
--- PASS: TestAccAlicloudPvtzZoneRecordsDataSource_basic (4.39s)
=== RUN   TestAccAlicloudPvtzZoneRecordsDataSource_empty
--- PASS: TestAccAlicloudPvtzZoneRecordsDataSource_empty (1.88s)
=== RUN   TestAccAlicloudPvtzZonesDataSource_basic
--- PASS: TestAccAlicloudPvtzZonesDataSource_basic (3.33s)
=== RUN   TestAccAlicloudPvtzZonesDataSource_empty
--- PASS: TestAccAlicloudPvtzZonesDataSource_empty (0.78s)
=== RUN   TestAccAlicloudPvtzZoneAttachment_importBasic
--- PASS: TestAccAlicloudPvtzZoneAttachment_importBasic (18.03s)
=== RUN   TestAccAlicloudPvtzZoneRecord_importBasic
--- PASS: TestAccAlicloudPvtzZoneRecord_importBasic (2.95s)
=== RUN   TestAccAlicloudPvtzZone_importBasic
--- PASS: TestAccAlicloudPvtzZone_importBasic (1.63s)
=== RUN   TestAccAlicloudPvtzZoneAttachment_Basic
--- PASS: TestAccAlicloudPvtzZoneAttachment_Basic (17.54s)
=== RUN   TestAccAlicloudPvtzZoneAttachment_update
--- PASS: TestAccAlicloudPvtzZoneAttachment_update (39.01s)
=== RUN   TestAccAlicloudPvtzZoneAttachment_multi
--- PASS: TestAccAlicloudPvtzZoneAttachment_multi (28.84s)
=== RUN   TestAccAlicloudPvtzZoneRecord_Basic
--- PASS: TestAccAlicloudPvtzZoneRecord_Basic (3.00s)
=== RUN   TestAccAlicloudPvtzZoneRecord_updateRr
--- PASS: TestAccAlicloudPvtzZoneRecord_updateRr (4.65s)
=== RUN   TestAccAlicloudPvtzZoneRecord_updateType
--- PASS: TestAccAlicloudPvtzZoneRecord_updateType (4.50s)
=== RUN   TestAccAlicloudPvtzZoneRecord_updateValue
--- PASS: TestAccAlicloudPvtzZoneRecord_updateValue (4.53s)
=== RUN   TestAccAlicloudPvtzZoneRecord_updatePriority
--- PASS: TestAccAlicloudPvtzZoneRecord_updatePriority (4.52s)
=== RUN   TestAccAlicloudPvtzZoneRecord_updateTTL
--- PASS: TestAccAlicloudPvtzZoneRecord_updateTTL (4.42s)
=== RUN   TestAccAlicloudPvtzZoneRecord_updateAll
--- PASS: TestAccAlicloudPvtzZoneRecord_updateAll (4.43s)
=== RUN   TestAccAlicloudPvtzZoneRecord_multi
--- PASS: TestAccAlicloudPvtzZoneRecord_multi (6.32s)
=== RUN   TestAccAlicloudPvtzZone_Basic
--- PASS: TestAccAlicloudPvtzZone_Basic (1.64s)
=== RUN   TestAccAlicloudPvtzZone_update
--- PASS: TestAccAlicloudPvtzZone_update (2.68s)
=== RUN   TestAccAlicloudPvtzZone_multi
--- PASS: TestAccAlicloudPvtzZone_multi (4.81s)
PASS
ok  	github.com/terraform-providers/terraform-provider-alicloud/alicloud	163.934s
```