### PR TITLE
Improve route entry retry strategy to avoid concurrence issue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,9 @@
 
 IMPROVEMENTS:
 
-- Offline drds resource from website results from drds does not support idempotent [GH-652]
+- add vswitch id checker when creating k8s clusters [GH-656]
+- Improve route entry retry strategy to avoid concurrence issue [GH-654]
+- Offline drds resource from website results from drds does not support idempotent [GH-653]
 - Support customer endpoints in the provider [GH-652]
 - Reback image filter to meet many non-ecs testcase [GH-649]
 - Improve ecs instance testcase by update instance type [GH-646]


### PR DESCRIPTION
```
TF_ACC=1 go test ./alicloud -v -run=TestAccAlicloudRouteEntry -timeout=240m
=== RUN   TestAccAlicloudRouteEntry_importBasic
--- PASS: TestAccAlicloudRouteEntry_importBasic (190.37s)
=== RUN   TestAccAlicloudRouteEntry_Basic
--- PASS: TestAccAlicloudRouteEntry_Basic (195.52s)
=== RUN   TestAccAlicloudRouteEntry_RouteInterface
--- PASS: TestAccAlicloudRouteEntry_RouteInterface (52.33s)
=== RUN   TestAccAlicloudRouteEntry_Concurrence
--- PASS: TestAccAlicloudRouteEntry_Concurrence (101.98s)
PASS
ok  	github.com/terraform-providers/terraform-provider-alicloud/alicloud	540.244s
```