### PR TITLE
BugFix: rename cen instance to avoid mistake query.

### DIFF
--- a/alicloud/data_source_alicloud_cen_bandwidth_packages_test.go
+++ b/alicloud/data_source_alicloud_cen_bandwidth_packages_test.go
@@ -3,6 +3,9 @@ package alicloud
 import (
 	"testing"
 
+	"fmt"
+	"time"
+
 	"github.com/hashicorp/terraform/helper/resource"
 )
 
@@ -35,6 +38,7 @@ func TestAccAlicloudCenBandwidthPackagesDataSource_instance_id(t *testing.T) {
 }
 
 func TestAccAlicloudCenBandwidthPackagesDataSource_bandwidth_package_nameRegex(t *testing.T) {
+	rand := time.Now().UnixNano()
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			testAccPreCheck(t)
@@ -42,7 +46,7 @@ func TestAccAlicloudCenBandwidthPackagesDataSource_bandwidth_package_nameRegex(t
 		Providers: testAccProviders,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccCheckAlicloudCenBandwidthPackagesDataSourceNameRegexConfig,
+				Config: testAccCheckAlicloudCenBandwidthPackagesDataSourceNameRegexConfig(defaultRegionToTest, rand),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAlicloudDataSourceID("data.alicloud_cen_bandwidth_packages.tf-testAccCenBwp"),
 					resource.TestCheckResourceAttr("data.alicloud_cen_bandwidth_packages.tf-testAccCenBwp", "packages.0.geographic_region_a_id", "China"),
@@ -52,7 +56,8 @@ func TestAccAlicloudCenBandwidthPackagesDataSource_bandwidth_package_nameRegex(t
 					resource.TestCheckResourceAttr("data.alicloud_cen_bandwidth_packages.tf-testAccCenBwp", "packages.0.business_status", "Normal"),
 					resource.TestCheckResourceAttr("data.alicloud_cen_bandwidth_packages.tf-testAccCenBwp", "packages.0.bandwidth_package_charge_type", "POSTPAY"),
 					resource.TestCheckResourceAttr("data.alicloud_cen_bandwidth_packages.tf-testAccCenBwp", "packages.0.description", ""),
-					resource.TestCheckResourceAttr("data.alicloud_cen_bandwidth_packages.tf-testAccCenBwp", "packages.0.name", "tf-testAccCenBwpName1"),
+					resource.TestCheckResourceAttr("data.alicloud_cen_bandwidth_packages.tf-testAccCenBwp", "packages.0.name",
+						fmt.Sprintf("tf-testAccCenBwpName1-%s-%d", defaultRegionToTest, rand)),
 					resource.TestCheckResourceAttrSet("data.alicloud_cen_bandwidth_packages.tf-testAccCenBwp", "packages.0.creation_time"),
 					resource.TestCheckResourceAttrSet("data.alicloud_cen_bandwidth_packages.tf-testAccCenBwp", "packages.0.id"),
 					resource.TestCheckResourceAttr("data.alicloud_cen_bandwidth_packages.tf-testAccCenBwp", "packages.0.instance_id", ""),
@@ -144,19 +149,21 @@ data "alicloud_cen_bandwidth_packages" "tf-testAccCenBwp" {
 }
 `
 
-const testAccCheckAlicloudCenBandwidthPackagesDataSourceNameRegexConfig = `
-resource "alicloud_cen_bandwidth_package" "tf-testAccCenBwp1" {
-	name = "tf-testAccCenBwpName1"
-    bandwidth = 5
-    geographic_region_ids = [
-		"China",
-		"China"]
-}
+func testAccCheckAlicloudCenBandwidthPackagesDataSourceNameRegexConfig(region string, rand int64) string {
+	return fmt.Sprintf(`
+		resource "alicloud_cen_bandwidth_package" "tf-testAccCenBwp1" {
+			name = "tf-testAccCenBwpName1-%s-%d"
+    		bandwidth = 5
+    		geographic_region_ids = [
+				"China",
+				"China"]
+		}
 
-data "alicloud_cen_bandwidth_packages" "tf-testAccCenBwp" {
-	name_regex = "${alicloud_cen_bandwidth_package.tf-testAccCenBwp1.name}"
+		data "alicloud_cen_bandwidth_packages" "tf-testAccCenBwp" {
+			name_regex = "${alicloud_cen_bandwidth_package.tf-testAccCenBwp1.name}"
+		}
+		`, region, rand)
 }
-`
 
 const testAccCheckAlicloudCenBandwidthPackagesDataSourceMultiBwpIdConfig = `
 resource "alicloud_cen_bandwidth_package" "bwp" {

--- a/alicloud/data_source_alicloud_cen_instances_test.go
+++ b/alicloud/data_source_alicloud_cen_instances_test.go
@@ -17,7 +17,7 @@ func TestAccAlicloudCenInstancesDataSource_cen_id(t *testing.T) {
 				Config: testAccCheckAlicloudCenInstancesDataSourceCenIdConfig,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAlicloudDataSourceID("data.alicloud_cen_instances.tf-testAccCen"),
-					resource.TestCheckResourceAttr("data.alicloud_cen_instances.tf-testAccCen", "instances.0.name", "tf-testAccCenConfig"),
+					resource.TestCheckResourceAttr("data.alicloud_cen_instances.tf-testAccCen", "instances.0.name", "tf-testAccCenInstancesDataSourceCenIdConfig"),
 					resource.TestCheckResourceAttr("data.alicloud_cen_instances.tf-testAccCen", "instances.0.description", "tf-testAccCenConfigDescription"),
 					resource.TestCheckResourceAttr("data.alicloud_cen_instances.tf-testAccCen", "instances.0.status", "Active"),
 					resource.TestCheckResourceAttrSet("data.alicloud_cen_instances.tf-testAccCen", "instances.0.id"),
@@ -40,7 +40,7 @@ func TestAccAlicloudCenInstancesDataSource_name_regex(t *testing.T) {
 				Config: testAccCheckAlicloudCenInstancesDataSourceCenNameRegexConfig,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAlicloudDataSourceID("data.alicloud_cen_instances.tf-testAccCen"),
-					resource.TestCheckResourceAttr("data.alicloud_cen_instances.tf-testAccCen", "instances.0.name", "tf-testAccCenConfig"),
+					resource.TestCheckResourceAttr("data.alicloud_cen_instances.tf-testAccCen", "instances.0.name", "tf-testAccCenDataSourceCenNameRegexConfig"),
 					resource.TestCheckResourceAttr("data.alicloud_cen_instances.tf-testAccCen", "instances.0.description", "tf-testAccCenConfigDescription"),
 					resource.TestCheckResourceAttr("data.alicloud_cen_instances.tf-testAccCen", "instances.0.status", "Active"),
 					resource.TestCheckResourceAttrSet("data.alicloud_cen_instances.tf-testAccCen", "instances.0.id"),
@@ -66,7 +66,7 @@ func TestAccAlicloudCenInstancesDataSource_multi_cen_ids(t *testing.T) {
 					resource.TestCheckResourceAttr("data.alicloud_cen_instances.tf-testAccCen", "instances.#", "5"),
 					resource.TestCheckResourceAttr("data.alicloud_cen_instances.tf-testAccCen", "instances.0.description", "tf-testAccCenConfigDescription"),
 					resource.TestCheckResourceAttr("data.alicloud_cen_instances.tf-testAccCen", "instances.1.status", "Active"),
-					resource.TestCheckResourceAttr("data.alicloud_cen_instances.tf-testAccCen", "instances.2.name", "tf-testAccCenConfig"),
+					resource.TestCheckResourceAttr("data.alicloud_cen_instances.tf-testAccCen", "instances.2.name", "tf-testAccCenInstancesDataSourceMultiCenIdsConfig"),
 				),
 			},
 		},
@@ -96,7 +96,7 @@ func TestAccAlicloudCenInstancesDataSource_empty(t *testing.T) {
 
 const testAccCheckAlicloudCenInstancesDataSourceCenIdConfig = `
 resource "alicloud_cen_instance" "tf-testAccCen" {
-	name = "tf-testAccCenConfig"
+	name = "tf-testAccCenInstancesDataSourceCenIdConfig"
 	description = "tf-testAccCenConfigDescription"
 }
 
@@ -107,7 +107,7 @@ data "alicloud_cen_instances" "tf-testAccCen" {
 
 const testAccCheckAlicloudCenInstancesDataSourceCenNameRegexConfig = `
 resource "alicloud_cen_instance" "tf-testAccCen" {
-	name = "tf-testAccCenConfig"
+	name = "tf-testAccCenDataSourceCenNameRegexConfig"
 	description = "tf-testAccCenConfigDescription"
 }
 
@@ -118,7 +118,7 @@ data "alicloud_cen_instances" "tf-testAccCen" {
 
 const testAccCheckAlicloudCenInstancesDataSourceMultiCenIdsConfig = `
 resource "alicloud_cen_instance" "tf-testAccCen" {
-	name = "tf-testAccCenConfig"
+	name = "tf-testAccCenInstancesDataSourceMultiCenIdsConfig"
 	description = "tf-testAccCenConfigDescription"
 	count = 5
 }


### PR DESCRIPTION
TF_ACC=1 go test ./alicloud -v -run=TestAccAlicloudCenInstancesDataSource -timeout=300m
=== RUN   TestAccAlicloudCenInstancesDataSource_cen_id
--- PASS: TestAccAlicloudCenInstancesDataSource_cen_id (5.46s)
=== RUN   TestAccAlicloudCenInstancesDataSource_name_regex
--- PASS: TestAccAlicloudCenInstancesDataSource_name_regex (6.03s)
=== RUN   TestAccAlicloudCenInstancesDataSource_multi_cen_ids
--- PASS: TestAccAlicloudCenInstancesDataSource_multi_cen_ids (18.38s)
=== RUN   TestAccAlicloudCenInstancesDataSource_empty
--- PASS: TestAccAlicloudCenInstancesDataSource_empty (3.47s)
PASS
ok  	github.com/terraform-providers/terraform-provider-alicloud/alicloud	33.403s