### PR TITLE
add vswitch id checker when creating k8s clusters

### DIFF
--- a/alicloud/resource_alicloud_cs_kubernetes.go
+++ b/alicloud/resource_alicloud_cs_kubernetes.go
@@ -585,7 +585,7 @@ func resourceAlicloudCSKubernetesRead(d *schema.ResourceData, meta interface{}) 
 			return csClient.DescribeKubernetesCluster(d.Id())
 		})
 		if e != nil {
-			return e
+			return fmt.Errorf("Describing kubernetes cluster %#v failed, error message: %#v. Please check cluster in the console,", d.Id(), e)
 		}
 		cluster, _ = raw.(cs.KubernetesCluster)
 		return nil

--- a/alicloud/resource_alicloud_cs_kubernetes.go
+++ b/alicloud/resource_alicloud_cs_kubernetes.go
@@ -73,7 +73,8 @@ func resourceAlicloudCSKubernetes() *schema.Resource {
 				ForceNew: true,
 				Computed: true,
 				Elem: &schema.Schema{
-					Type: schema.TypeString,
+					Type:         schema.TypeString,
+					ValidateFunc: validateContainerVswitchId,
 				},
 				MaxItems: 3,
 			},

--- a/alicloud/resource_alicloud_cs_managed_kubernetes.go
+++ b/alicloud/resource_alicloud_cs_managed_kubernetes.go
@@ -57,7 +57,8 @@ func resourceAlicloudCSManagedKubernetes() *schema.Resource {
 				ForceNew: true,
 				Computed: true,
 				Elem: &schema.Schema{
-					Type: schema.TypeString,
+					Type:         schema.TypeString,
+					ValidateFunc: validateContainerVswitchId,
 				},
 				MaxItems: 1,
 			},

--- a/alicloud/resource_alicloud_cs_managed_kubernetes.go
+++ b/alicloud/resource_alicloud_cs_managed_kubernetes.go
@@ -353,7 +353,7 @@ func resourceAlicloudCSManagedKubernetesRead(d *schema.ResourceData, meta interf
 			return csClient.DescribeKubernetesCluster(d.Id())
 		})
 		if e != nil {
-			return e
+			return fmt.Errorf("Describing kubernetes cluster %#v failed, error message: %#v. Please check cluster in the console,", d.Id(), e)
 		}
 		cluster, _ = raw.(cs.KubernetesCluster)
 		return nil

--- a/alicloud/validators.go
+++ b/alicloud/validators.go
@@ -970,6 +970,16 @@ func validateContainerName(v interface{}, k string) (ws []string, errors []error
 	return
 }
 
+func validateContainerVswitchId(v interface{}, k string) (ws []string, errors []error) {
+	value := v.(string)
+	reg := regexp.MustCompile("^vsw-[a-z0-9]*$")
+	if !reg.MatchString(value) {
+		errors = append(errors, fmt.Errorf("%s should start with 'vsw-'.", k))
+	}
+
+	return
+}
+
 func validateContainerNamePrefix(v interface{}, k string) (ws []string, errors []error) {
 	value := v.(string)
 	if len(value) > 37 {


### PR DESCRIPTION
There are some cases when user specified `[""]` for vswitch_ids, which is definitely illegal.
This checker should avoid such cases.
