### PR TITLE
Fix pvtz zone attaching vpc system busy error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,8 +18,9 @@ IMPROVEMENTS:
 
 BUG FIXES:
 
-- Fix ecs and ess tags read bug with ignore system tag [GH-658]
-- Fix cs cluster not found error and improve its testcase [GH-657]
+- Fix pvtz zone attaching vpc system busy error [GH-660]
+- Fix ecs and ess tags read bug with ignore system tag [GH-659]
+- Fix cs cluster not found error and improve its testcase [GH-658]
 - Fix deleting pvtz zone not exist and internal error [GH-657]
 - Fix pvtz throttling user bug and improve WrapError [GH-650]
 - Fix ess group describing error [GH-644]

--- a/alicloud/errors.go
+++ b/alicloud/errors.go
@@ -204,6 +204,7 @@ const (
 	RecordInvalidConflict = "Record.Invalid.Conflict"
 	PvtzInternalError     = "InternalError"
 	PvtzThrottlingUser    = "Throttling.User"
+	PvtzSystemBusy        = "System.Busy"
 
 	// log
 	ProjectNotExist      = "ProjectNotExist"

--- a/alicloud/extension_pvtz.go
+++ b/alicloud/extension_pvtz.go
@@ -11,10 +11,12 @@ const (
 )
 
 var PvtzThrottlingUserCatcher = Catcher{PvtzThrottlingUser, 30, 2}
+var PvtzSystemBusyCatcher = Catcher{PvtzSystemBusy, 30, 5}
 
 func PvtzInvoker() Invoker {
 	i := Invoker{}
 	i.AddCatcher(PvtzThrottlingUserCatcher)
 	i.AddCatcher(ServiceBusyCatcher)
+	i.AddCatcher(PvtzSystemBusyCatcher)
 	return i
 }

--- a/alicloud/resource_alicloud_cs_swarm_test.go
+++ b/alicloud/resource_alicloud_cs_swarm_test.go
@@ -107,7 +107,7 @@ func TestAccAlicloudCSSwarm_vpc_zero_node(t *testing.T) {
 	rand := acctest.RandIntRange(10000, 999999)
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
-			testAccPreCheck(t)
+			testAccPreCheckWithRegions(t, true, connectivity.SwarmSupportedRegions)
 		},
 
 		IDRefreshName: "alicloud_cs_swarm.cs_vpc",

--- a/alicloud/resource_alicloud_pvtz_zone.go
+++ b/alicloud/resource_alicloud_pvtz_zone.go
@@ -141,7 +141,8 @@ func resourceAlicloudPvtzZoneDelete(d *schema.ResourceData, meta interface{}) er
 		})
 
 		if err != nil {
-			if IsExceptedErrors(err, []string{PvtzThrottlingUser}) {
+			if IsExceptedErrors(err, []string{PvtzThrottlingUser, PvtzSystemBusy}) {
+				time.Sleep(time.Duration(2) * time.Second)
 				return resource.RetryableError(BuildWrapError(request.GetActionName(), d.Id(), SDKERROR, err))
 			}
 			if IsExceptedErrors(err, []string{ZoneNotExists, ZoneVpcNotExists}) {

--- a/alicloud/resource_alicloud_pvtz_zone_attachment.go
+++ b/alicloud/resource_alicloud_pvtz_zone_attachment.go
@@ -134,7 +134,8 @@ func resourceAlicloudPvtzZoneAttachmentDelete(d *schema.ResourceData, meta inter
 		})
 
 		if err != nil {
-			if IsExceptedErrors(err, []string{PvtzThrottlingUser}) {
+			if IsExceptedErrors(err, []string{PvtzThrottlingUser, PvtzSystemBusy}) {
+				time.Sleep(time.Duration(2) * time.Second)
 				return resource.RetryableError(BuildWrapError(request.GetActionName(), d.Id(), SDKERROR, err))
 			}
 			if !IsExceptedErrors(err, []string{PvtzInternalError}) {

--- a/alicloud/resource_alicloud_pvtz_zone_record.go
+++ b/alicloud/resource_alicloud_pvtz_zone_record.go
@@ -251,7 +251,8 @@ func resourceAlicloudPvtzZoneRecordDelete(d *schema.ResourceData, meta interface
 		})
 
 		if err != nil {
-			if IsExceptedErrors(err, []string{PvtzThrottlingUser}) {
+			if IsExceptedErrors(err, []string{PvtzThrottlingUser, PvtzSystemBusy}) {
+				time.Sleep(time.Duration(2) * time.Second)
 				return resource.RetryableError(BuildWrapError(request.GetActionName(), d.Id(), SDKERROR, err))
 			}
 			return resource.NonRetryableError(BuildWrapError(request.GetActionName(), d.Id(), SDKERROR, err))


### PR DESCRIPTION
```
TF_ACC=1 go test ./alicloud -v -run=TestAccAlicloudPvtz -timeout=120m
=== RUN   TestAccAlicloudPvtzZoneRecordsDataSource_basic
--- PASS: TestAccAlicloudPvtzZoneRecordsDataSource_basic (2.79s)
=== RUN   TestAccAlicloudPvtzZoneRecordsDataSource_empty
--- PASS: TestAccAlicloudPvtzZoneRecordsDataSource_empty (1.23s)
=== RUN   TestAccAlicloudPvtzZonesDataSource_basic
--- PASS: TestAccAlicloudPvtzZonesDataSource_basic (1.87s)
=== RUN   TestAccAlicloudPvtzZonesDataSource_empty
--- PASS: TestAccAlicloudPvtzZonesDataSource_empty (0.43s)
=== RUN   TestAccAlicloudPvtzZoneAttachment_importBasic
--- PASS: TestAccAlicloudPvtzZoneAttachment_importBasic (32.10s)
=== RUN   TestAccAlicloudPvtzZoneRecord_importBasic
--- PASS: TestAccAlicloudPvtzZoneRecord_importBasic (1.75s)
=== RUN   TestAccAlicloudPvtzZone_importBasic
--- PASS: TestAccAlicloudPvtzZone_importBasic (0.93s)
=== RUN   TestAccAlicloudPvtzZoneAttachment_Basic
--- PASS: TestAccAlicloudPvtzZoneAttachment_Basic (31.23s)
=== RUN   TestAccAlicloudPvtzZoneAttachment_update
--- PASS: TestAccAlicloudPvtzZoneAttachment_update (84.65s)
=== RUN   TestAccAlicloudPvtzZoneAttachment_multi
--- PASS: TestAccAlicloudPvtzZoneAttachment_multi (62.28s)
=== RUN   TestAccAlicloudPvtzZoneRecord_Basic
--- PASS: TestAccAlicloudPvtzZoneRecord_Basic (1.94s)
=== RUN   TestAccAlicloudPvtzZoneRecord_updateRr
--- PASS: TestAccAlicloudPvtzZoneRecord_updateRr (2.90s)
=== RUN   TestAccAlicloudPvtzZoneRecord_updateType
--- PASS: TestAccAlicloudPvtzZoneRecord_updateType (2.94s)
=== RUN   TestAccAlicloudPvtzZoneRecord_updateValue
--- PASS: TestAccAlicloudPvtzZoneRecord_updateValue (2.85s)
=== RUN   TestAccAlicloudPvtzZoneRecord_updatePriority
--- PASS: TestAccAlicloudPvtzZoneRecord_updatePriority (2.89s)
=== RUN   TestAccAlicloudPvtzZoneRecord_updateTTL
--- PASS: TestAccAlicloudPvtzZoneRecord_updateTTL (2.73s)
=== RUN   TestAccAlicloudPvtzZoneRecord_updateAll
--- PASS: TestAccAlicloudPvtzZoneRecord_updateAll (2.68s)
=== RUN   TestAccAlicloudPvtzZoneRecord_multi
--- PASS: TestAccAlicloudPvtzZoneRecord_multi (3.89s)
=== RUN   TestAccAlicloudPvtzZone_Basic
--- PASS: TestAccAlicloudPvtzZone_Basic (0.98s)
=== RUN   TestAccAlicloudPvtzZone_update
--- PASS: TestAccAlicloudPvtzZone_update (1.73s)
=== RUN   TestAccAlicloudPvtzZone_multi
--- PASS: TestAccAlicloudPvtzZone_multi (2.72s)
PASS
ok  	github.com/terraform-providers/terraform-provider-alicloud/alicloud	247.582s
```