### PR TITLE
Improve pvtz attachment test updating case

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 IMPROVEMENTS:
 
+- Improve pvtz attachment test updating case [GH-663]
 - add vswitch id checker when creating k8s clusters [GH-656]
 - Improve route entry retry strategy to avoid concurrence issue [GH-654]
 - Offline drds resource from website results from drds does not support idempotent [GH-653]

--- a/alicloud/resource_alicloud_pvtz_zone_attachment_test.go
+++ b/alicloud/resource_alicloud_pvtz_zone_attachment_test.go
@@ -60,7 +60,7 @@ func TestAccAlicloudPvtzZoneAttachment_update(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccAlicloudPvtzZoneExists("alicloud_pvtz_zone.zone", &zone),
 					testAccCheckVpcExists("alicloud_vpc.vpc1", &vpc),
-					testAccAlicloudPvtzZoneAttachmentExists("alicloud_pvtz_zone_attachment.zone-attachment1", &zone, &vpc),
+					testAccAlicloudPvtzZoneAttachmentExists("alicloud_pvtz_zone_attachment.zone-attachment", &zone, &vpc),
 				),
 			},
 		},
@@ -179,7 +179,7 @@ func testAccPvtzZoneAttachmentConfigUpdate(rand int) string {
 		cidr_block = "192.168.0.0/16"
 	}
 
-	resource "alicloud_pvtz_zone_attachment" "zone-attachment1" {
+	resource "alicloud_pvtz_zone_attachment" "zone-attachment" {
 		zone_id = "${alicloud_pvtz_zone.zone.id}"
 		vpc_ids = ["${alicloud_vpc.vpc1.id}"]
 	}


### PR DESCRIPTION
```
 TF_ACC=1 go test ./alicloud -v -run=TestAccAlicloudPvtzZoneAttachment_update -timeout=120m
=== RUN   TestAccAlicloudPvtzZoneAttachment_update
--- PASS: TestAccAlicloudPvtzZoneAttachment_update (72.38s)
PASS
ok  	github.com/terraform-providers/terraform-provider-alicloud/alicloud	72.423s
```