### PR TITLE
Fix deleting log project requestTimeout error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ IMPROVEMENTS:
 
 BUG FIXES:
 
+- Fix deleting log project requestTimeout error [GH-666]
 - Fix cs_kubernetes setting int value error [GH-665]
 - Fix pvtz zone attaching vpc system busy error [GH-660]
 - Fix ecs and ess tags read bug with ignore system tag [GH-659]

--- a/alicloud/data_source_alicloud_pvtz_zone_records.go
+++ b/alicloud/data_source_alicloud_pvtz_zone_records.go
@@ -93,7 +93,7 @@ func dataSourceAlicloudPvtzZoneRecordsRead(d *schema.ResourceData, meta interfac
 				return pvtzClient.DescribeZoneRecords(args)
 			})
 			raw = resp
-			return BuildWrapError(args.GetActionName(), args.ZoneId, SDKERROR, err)
+			return BuildWrapError(args.GetActionName(), args.ZoneId, AlibabaCloudSdkGoERROR, err)
 		})
 
 		if err != nil {

--- a/alicloud/data_source_alicloud_pvtz_zones.go
+++ b/alicloud/data_source_alicloud_pvtz_zones.go
@@ -90,7 +90,7 @@ func dataSourceAlicloudPvtzZonesRead(d *schema.ResourceData, meta interface{}) e
 				return pvtzClient.DescribeZones(args)
 			})
 			raw = resp
-			return BuildWrapError(args.GetActionName(), args.Keyword, SDKERROR, err)
+			return BuildWrapError(args.GetActionName(), args.Keyword, AlibabaCloudSdkGoERROR, err)
 		})
 		if err != nil {
 			return fmt.Errorf("Error DescribeZones: %#v", err)

--- a/alicloud/errors.go
+++ b/alicloud/errors.go
@@ -215,6 +215,7 @@ const (
 	GroupNotExist        = "GroupNotExist"
 	MachineGroupNotExist = "MachineGroupNotExist"
 	LogClientTimeout     = "Client.Timeout exceeded while awaiting headers"
+	LogRequestTimeout    = "RequestTimeout"
 
 	// OTS
 	OTSObjectNotExist = "OTSObjectNotExist"
@@ -405,8 +406,13 @@ func GetTimeoutMessage(product, status string) string {
 type ErrorSource string
 
 const (
-	SDKERROR      = ErrorSource("[SDK ERROR]")
-	ProviderERROR = ErrorSource("[Provider ERROR]")
+	AlibabaCloudSdkGoERROR = ErrorSource("[SDK alibaba-cloud-sdk-go ERROR]")
+	AliyunLogGoSdkERROR    = ErrorSource("[SDK aliyun-log-go-sdk ERROR]")
+	AliyunDatahubSdkGo     = ErrorSource("[SDK aliyun-datahub-sdk-go ERROR]")
+	AliyunOssGoSdk         = ErrorSource("[SDK aliyun-oss-go-sdk ERROR]")
+	FcGoSdk                = ErrorSource("[SDK fc-go-sdk ERROR]")
+	DenverdinoAliyungo     = ErrorSource("[SDK denverdino/aliyungo ERROR]")
+	ProviderERROR          = ErrorSource("[Provider ERROR]")
 )
 
 // An Error to wrap the different erros

--- a/alicloud/resource_alicloud_log_project.go
+++ b/alicloud/resource_alicloud_log_project.go
@@ -103,11 +103,11 @@ func resourceAlicloudLogProjectDelete(d *schema.ResourceData, meta interface{}) 
 			return nil, slsClient.DeleteProject(d.Id())
 		})
 		if err != nil {
-			if IsExceptedErrors(err, []string{LogClientTimeout}) {
-				return resource.RetryableError(fmt.Errorf("Timeout. DeleteProject with an error: %s", err))
+			if IsExceptedErrors(err, []string{LogClientTimeout, LogRequestTimeout}) {
+				return resource.RetryableError(BuildWrapError("DeleteProject", d.Id(), AliyunLogGoSdkERROR, err))
 			}
 			if !IsExceptedErrors(err, []string{ProjectNotExist}) {
-				return resource.NonRetryableError(fmt.Errorf("DeleteProject got an error: %s", err))
+				return resource.NonRetryableError(BuildWrapError("DeleteProject", d.Id(), AliyunLogGoSdkERROR, err))
 			}
 		}
 
@@ -116,15 +116,15 @@ func resourceAlicloudLogProjectDelete(d *schema.ResourceData, meta interface{}) 
 		})
 		if err != nil {
 			if IsExceptedErrors(err, []string{LogClientTimeout}) {
-				return resource.RetryableError(fmt.Errorf("CheckProjectExist with an error: %s", err))
+				return resource.RetryableError(BuildWrapError("CheckProjectExist", d.Id(), AliyunLogGoSdkERROR, err))
 			}
-			return resource.NonRetryableError(fmt.Errorf("While deleting log project, checking project existing got an error: %s.", err))
+			return resource.NonRetryableError(BuildWrapError("CheckProjectExist", d.Id(), AliyunLogGoSdkERROR, err))
 		}
 		exist, _ := raw.(bool)
 		if !exist {
 			return nil
 		}
 
-		return resource.RetryableError(fmt.Errorf("Deleting log project %s timeout.", d.Id()))
+		return resource.RetryableError(BuildWrapError("DeleteProject", d.Id(), ProviderERROR, fmt.Errorf("Timeout")))
 	})
 }

--- a/alicloud/resource_alicloud_pvtz_zone.go
+++ b/alicloud/resource_alicloud_pvtz_zone.go
@@ -68,11 +68,11 @@ func resourceAlicloudPvtzZoneCreate(d *schema.ResourceData, meta interface{}) er
 		raw = rsp
 		return err
 	}); err != nil {
-		return BuildWrapError(args.GetActionName(), args.ZoneName, SDKERROR, err)
+		return BuildWrapError(args.GetActionName(), args.ZoneName, AlibabaCloudSdkGoERROR, err)
 	}
 	response, _ := raw.(*pvtz.AddZoneResponse)
 	if response == nil {
-		return BuildWrapError(args.GetActionName(), args.ZoneName, SDKERROR, fmt.Errorf("AddZone got a nil response: %#v", response))
+		return BuildWrapError(args.GetActionName(), args.ZoneName, AlibabaCloudSdkGoERROR, fmt.Errorf("AddZone got a nil response: %#v", response))
 	}
 
 	d.SetId(response.ZoneId)
@@ -118,7 +118,7 @@ func resourceAlicloudPvtzZoneUpdate(d *schema.ResourceData, meta interface{}) er
 			_, err := client.WithPvtzClient(func(pvtzClient *pvtz.Client) (interface{}, error) {
 				return pvtzClient.UpdateZoneRemark(request)
 			})
-			return BuildWrapError(request.GetActionName(), d.Id(), SDKERROR, err)
+			return BuildWrapError(request.GetActionName(), d.Id(), AlibabaCloudSdkGoERROR, err)
 		})
 		if err != nil {
 			return err
@@ -143,13 +143,13 @@ func resourceAlicloudPvtzZoneDelete(d *schema.ResourceData, meta interface{}) er
 		if err != nil {
 			if IsExceptedErrors(err, []string{PvtzThrottlingUser, PvtzSystemBusy}) {
 				time.Sleep(time.Duration(2) * time.Second)
-				return resource.RetryableError(BuildWrapError(request.GetActionName(), d.Id(), SDKERROR, err))
+				return resource.RetryableError(BuildWrapError(request.GetActionName(), d.Id(), AlibabaCloudSdkGoERROR, err))
 			}
 			if IsExceptedErrors(err, []string{ZoneNotExists, ZoneVpcNotExists}) {
 				return nil
 			}
 			if !IsExceptedErrors(err, []string{PvtzInternalError}) {
-				return resource.NonRetryableError(BuildWrapError(request.GetActionName(), d.Id(), SDKERROR, err))
+				return resource.NonRetryableError(BuildWrapError(request.GetActionName(), d.Id(), AlibabaCloudSdkGoERROR, err))
 			}
 		}
 

--- a/alicloud/resource_alicloud_pvtz_zone_attachment.go
+++ b/alicloud/resource_alicloud_pvtz_zone_attachment.go
@@ -83,7 +83,7 @@ func resourceAlicloudPvtzZoneAttachmentUpdate(d *schema.ResourceData, meta inter
 			_, err := client.WithPvtzClient(func(pvtzClient *pvtz.Client) (interface{}, error) {
 				return pvtzClient.BindZoneVpc(args)
 			})
-			return BuildWrapError(args.GetActionName(), args.ZoneId, SDKERROR, err)
+			return BuildWrapError(args.GetActionName(), args.ZoneId, AlibabaCloudSdkGoERROR, err)
 		}); err != nil {
 			return err
 		}
@@ -136,10 +136,10 @@ func resourceAlicloudPvtzZoneAttachmentDelete(d *schema.ResourceData, meta inter
 		if err != nil {
 			if IsExceptedErrors(err, []string{PvtzThrottlingUser, PvtzSystemBusy}) {
 				time.Sleep(time.Duration(2) * time.Second)
-				return resource.RetryableError(BuildWrapError(request.GetActionName(), d.Id(), SDKERROR, err))
+				return resource.RetryableError(BuildWrapError(request.GetActionName(), d.Id(), AlibabaCloudSdkGoERROR, err))
 			}
 			if !IsExceptedErrors(err, []string{PvtzInternalError}) {
-				return resource.NonRetryableError(BuildWrapError(request.GetActionName(), d.Id(), SDKERROR, err))
+				return resource.NonRetryableError(BuildWrapError(request.GetActionName(), d.Id(), AlibabaCloudSdkGoERROR, err))
 			}
 		}
 

--- a/alicloud/resource_alicloud_pvtz_zone_record.go
+++ b/alicloud/resource_alicloud_pvtz_zone_record.go
@@ -96,7 +96,7 @@ func resourceAlicloudPvtzZoneRecordCreate(d *schema.ResourceData, meta interface
 			return pvtzClient.AddZoneRecord(args)
 		})
 		raw = rsp
-		return BuildWrapError(args.GetActionName(), args.ZoneId, SDKERROR, err)
+		return BuildWrapError(args.GetActionName(), args.ZoneId, AlibabaCloudSdkGoERROR, err)
 	})
 
 	if err != nil {
@@ -113,7 +113,7 @@ func resourceAlicloudPvtzZoneRecordCreate(d *schema.ResourceData, meta interface
 						return pvtzClient.DescribeZoneRecords(req)
 					})
 					raw = rep
-					return BuildWrapError(req.GetActionName(), req.ZoneId, SDKERROR, err)
+					return BuildWrapError(req.GetActionName(), req.ZoneId, AlibabaCloudSdkGoERROR, err)
 				}); err != nil {
 					return err
 				}
@@ -137,11 +137,11 @@ func resourceAlicloudPvtzZoneRecordCreate(d *schema.ResourceData, meta interface
 				}
 			}
 		}
-		return BuildWrapError(args.GetActionName(), args.ZoneId, SDKERROR, err)
+		return BuildWrapError(args.GetActionName(), args.ZoneId, AlibabaCloudSdkGoERROR, err)
 	}
 	resp, _ := raw.(*pvtz.AddZoneRecordResponse)
 	if resp == nil {
-		return BuildWrapError(args.GetActionName(), args.ZoneId, SDKERROR, fmt.Errorf("Parsing AddZoneRecordResponse got nil."))
+		return BuildWrapError(args.GetActionName(), args.ZoneId, AlibabaCloudSdkGoERROR, fmt.Errorf("Parsing AddZoneRecordResponse got nil."))
 	}
 
 	d.SetId(fmt.Sprintf("%d%s%s", resp.RecordId, COLON_SEPARATED, args.ZoneId))
@@ -191,7 +191,7 @@ func resourceAlicloudPvtzZoneRecordUpdate(d *schema.ResourceData, meta interface
 			_, err := client.WithPvtzClient(func(pvtzClient *pvtz.Client) (interface{}, error) {
 				return pvtzClient.UpdateZoneRecord(args)
 			})
-			return BuildWrapError(args.GetActionName(), d.Id(), SDKERROR, err)
+			return BuildWrapError(args.GetActionName(), d.Id(), AlibabaCloudSdkGoERROR, err)
 		}); err != nil {
 			return err
 		}
@@ -253,9 +253,9 @@ func resourceAlicloudPvtzZoneRecordDelete(d *schema.ResourceData, meta interface
 		if err != nil {
 			if IsExceptedErrors(err, []string{PvtzThrottlingUser, PvtzSystemBusy}) {
 				time.Sleep(time.Duration(2) * time.Second)
-				return resource.RetryableError(BuildWrapError(request.GetActionName(), d.Id(), SDKERROR, err))
+				return resource.RetryableError(BuildWrapError(request.GetActionName(), d.Id(), AlibabaCloudSdkGoERROR, err))
 			}
-			return resource.NonRetryableError(BuildWrapError(request.GetActionName(), d.Id(), SDKERROR, err))
+			return resource.NonRetryableError(BuildWrapError(request.GetActionName(), d.Id(), AlibabaCloudSdkGoERROR, err))
 		}
 
 		if _, e := pvtzService.DescribeZoneRecord(recordId, zoneId); e != nil {


### PR DESCRIPTION
```
TF_ACC=1 go test ./alicloud -v -run=TestAccAlicloudLog  -timeout=240m
=== RUN   TestAccAlicloudLogMachineGroup_import
--- PASS: TestAccAlicloudLogMachineGroup_import (4.00s)
=== RUN   TestAccAlicloudLogProject_import
--- PASS: TestAccAlicloudLogProject_import (2.89s)
=== RUN   TestAccAlicloudLogStoreIndex_importFull
--- PASS: TestAccAlicloudLogStoreIndex_importFull (6.20s)
=== RUN   TestAccAlicloudLogStoreIndex_importField
--- PASS: TestAccAlicloudLogStoreIndex_importField (6.26s)
=== RUN   TestAccAlicloudLogStore_import
--- PASS: TestAccAlicloudLogStore_import (5.06s)
=== RUN   TestAccAlicloudLogMachineGroup_ip
--- PASS: TestAccAlicloudLogMachineGroup_ip (4.30s)
=== RUN   TestAccAlicloudLogMachineGroup_userdefined
--- PASS: TestAccAlicloudLogMachineGroup_userdefined (4.16s)
=== RUN   TestAccAlicloudLogProject_basic
--- PASS: TestAccAlicloudLogProject_basic (3.02s)
=== RUN   TestAccAlicloudLogStoreIndex_fullText
--- PASS: TestAccAlicloudLogStoreIndex_fullText (7.20s)
=== RUN   TestAccAlicloudLogStoreIndex_field
--- PASS: TestAccAlicloudLogStoreIndex_field (6.88s)
=== RUN   TestAccAlicloudLogStoreIndex_all
--- PASS: TestAccAlicloudLogStoreIndex_all (6.78s)
=== RUN   TestAccAlicloudLogStore_basic
--- PASS: TestAccAlicloudLogStore_basic (5.13s)
PASS
ok  	github.com/terraform-providers/terraform-provider-alicloud/alicloud	61.922s
```