### PR TITLE
Fix slb OperationFailed.TokenIsProcessing error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ IMPROVEMENTS:
 
 BUG FIXES:
 
+- Fix slb OperationFailed.TokenIsProcessing error [GH-667]
 - Fix deleting log project requestTimeout error [GH-666]
 - Fix cs_kubernetes setting int value error [GH-665]
 - Fix pvtz zone attaching vpc system busy error [GH-660]

--- a/alicloud/common.go
+++ b/alicloud/common.go
@@ -390,19 +390,12 @@ func (a *Invoker) AddCatcher(catcher Catcher) {
 func (a *Invoker) Run(f func() error) error {
 	err := f()
 
-	var retryError error
-	if e, ok := err.(*WrapError); ok {
-		retryError = e.originError
-	} else {
-		retryError = err
-	}
-
-	if retryError == nil {
+	if err == nil {
 		return nil
 	}
 
 	for _, catcher := range a.catchers {
-		if IsExceptedErrors(retryError, []string{catcher.Reason}) {
+		if IsExceptedErrors(err, []string{catcher.Reason}) {
 			catcher.RetryCount--
 
 			if catcher.RetryCount <= 0 {
@@ -417,7 +410,7 @@ func (a *Invoker) Run(f func() error) error {
 }
 
 func buildClientToken(prefix string) string {
-	token := strings.Replace(fmt.Sprintf("%s-%d-%s", prefix, time.Now().Unix(), uuid.New().String()), " ", "", -1)
+	token := strings.TrimSpace(fmt.Sprintf("%s-%d-%s", prefix, time.Now().Unix(), strings.Trim(uuid.New().String(), "-")))
 	if len(token) > 64 {
 		token = token[0:64]
 	}


### PR DESCRIPTION
```
TF_ACC=1 go test ./alicloud -v -run=TestAccAlicloudSlb -timeout=240m
=== RUN   TestAccAlicloudSlbAclsDataSource_basic
--- PASS: TestAccAlicloudSlbAclsDataSource_basic (6.47s)
=== RUN   TestAccAlicloudSlbAclsDataSource_empty
--- PASS: TestAccAlicloudSlbAclsDataSource_empty (2.08s)
=== RUN   TestAccAlicloudSlbAttachmentsDataSource_basic
--- PASS: TestAccAlicloudSlbAttachmentsDataSource_basic (207.86s)
=== RUN   TestAccAlicloudSlbAttachmentsDataSource_empty
--- PASS: TestAccAlicloudSlbAttachmentsDataSource_empty (56.29s)
=== RUN   TestAccAlicloudSlbCACertificatesDataSource_basic
--- PASS: TestAccAlicloudSlbCACertificatesDataSource_basic (11.36s)
=== RUN   TestAccAlicloudSlbCACertificatesDataSource_empty
--- PASS: TestAccAlicloudSlbCACertificatesDataSource_empty (4.12s)
=== RUN   TestAccAlicloudSlbListenersDataSource_http
--- PASS: TestAccAlicloudSlbListenersDataSource_http (65.22s)
=== RUN   TestAccAlicloudSlbListenersDataSource_https
--- PASS: TestAccAlicloudSlbListenersDataSource_https (37.39s)
=== RUN   TestAccAlicloudSlbListenersDataSource_tcp
--- PASS: TestAccAlicloudSlbListenersDataSource_tcp (68.47s)
=== RUN   TestAccAlicloudSlbListenersDataSource_udp
--- PASS: TestAccAlicloudSlbListenersDataSource_udp (64.16s)
=== RUN   TestAccAlicloudSlbListenersDataSource_empty
--- PASS: TestAccAlicloudSlbListenersDataSource_empty (50.71s)
=== RUN   TestAccAlicloudSlbRulesDataSource_basic
--- PASS: TestAccAlicloudSlbRulesDataSource_basic (212.57s)
=== RUN   TestAccAlicloudSlbRulesDataSource_empty
--- PASS: TestAccAlicloudSlbRulesDataSource_empty (43.46s)
=== RUN   TestAccAlicloudSlbServerCertificatesDataSource_basic
--- PASS: TestAccAlicloudSlbServerCertificatesDataSource_basic (6.42s)
=== RUN   TestAccAlicloudSlbServerCertificatesDataSource_empty
--- PASS: TestAccAlicloudSlbServerCertificatesDataSource_empty (4.21s)
=== RUN   TestAccAlicloudSlbServerGroupsDataSource_basic
--- PASS: TestAccAlicloudSlbServerGroupsDataSource_basic (215.76s)
=== RUN   TestAccAlicloudSlbServerGroupsDataSource_empty
--- PASS: TestAccAlicloudSlbServerGroupsDataSource_empty (76.12s)
=== RUN   TestAccAlicloudSlbsDataSource_basic
--- PASS: TestAccAlicloudSlbsDataSource_basic (62.93s)
=== RUN   TestAccAlicloudSlbsDataSource_filterByIds
--- PASS: TestAccAlicloudSlbsDataSource_filterByIds (61.23s)
=== RUN   TestAccAlicloudSlbsDataSource_filterByAllFields
--- PASS: TestAccAlicloudSlbsDataSource_filterByAllFields (59.20s)
=== RUN   TestAccAlicloudSlbsDataSource_filterByTags
--- PASS: TestAccAlicloudSlbsDataSource_filterByTags (156.86s)
=== RUN   TestAccAlicloudSlbsDataSource_empty
--- PASS: TestAccAlicloudSlbsDataSource_empty (5.78s)
=== RUN   TestAccAlicloudSlbAcl_import
--- PASS: TestAccAlicloudSlbAcl_import (6.55s)
=== RUN   TestAccAlicloudSlbAttachment_import
--- PASS: TestAccAlicloudSlbAttachment_import (197.21s)
=== RUN   TestAccAlicloudSlbCACertificate_import
--- PASS: TestAccAlicloudSlbCACertificate_import (7.13s)
=== RUN   TestAccAlicloudSlbListener_importHttp
--- PASS: TestAccAlicloudSlbListener_importHttp (33.86s)
=== RUN   TestAccAlicloudSlbListener_importHttps
--- PASS: TestAccAlicloudSlbListener_importHttps (36.53s)
=== RUN   TestAccAlicloudSlbListener_importTcp
--- PASS: TestAccAlicloudSlbListener_importTcp (37.44s)
=== RUN   TestAccAlicloudSlbListener_importUdp
--- PASS: TestAccAlicloudSlbListener_importUdp (35.20s)
=== RUN   TestAccAlicloudSlbRule_import
--- PASS: TestAccAlicloudSlbRule_import (195.41s)
=== RUN   TestAccAlicloudSlbServerCertificate_import
--- PASS: TestAccAlicloudSlbServerCertificate_import (4.83s)
=== RUN   TestAccAlicloudSlbServerGroup_import
--- PASS: TestAccAlicloudSlbServerGroup_import (198.48s)
=== RUN   TestAccAlicloudSlb_import
--- PASS: TestAccAlicloudSlb_import (45.06s)
=== RUN   TestAccAlicloudSlbAcl_basic
--- PASS: TestAccAlicloudSlbAcl_basic (10.79s)
=== RUN   TestAccAlicloudSlbAttachment_basic
--- PASS: TestAccAlicloudSlbAttachment_basic (194.91s)
=== RUN   TestAccAlicloudSlbCACertificate_basic
--- PASS: TestAccAlicloudSlbCACertificate_basic (7.88s)
=== RUN   TestAccAlicloudSlbListener_http
--- PASS: TestAccAlicloudSlbListener_http (25.31s)
=== RUN   TestAccAlicloudSlbListener_https
--- PASS: TestAccAlicloudSlbListener_https (39.09s)
=== RUN   TestAccAlicloudSlbListener_https_shared_performance
--- PASS: TestAccAlicloudSlbListener_https_shared_performance (30.16s)
=== RUN   TestAccAlicloudSlbListener_tcp
--- PASS: TestAccAlicloudSlbListener_tcp (23.15s)
=== RUN   TestAccAlicloudSlbListener_tcp_server_group
--- PASS: TestAccAlicloudSlbListener_tcp_server_group (243.79s)
=== RUN   TestAccAlicloudSlbListener_udp
--- PASS: TestAccAlicloudSlbListener_udp (22.47s)
=== RUN   TestAccAlicloudSlbRule_basic
--- PASS: TestAccAlicloudSlbRule_basic (200.15s)
=== RUN   TestAccAlicloudSlbRule_url
--- PASS: TestAccAlicloudSlbRule_url (199.30s)
=== RUN   TestAccAlicloudSlbServerCertificate_basic
--- PASS: TestAccAlicloudSlbServerCertificate_basic (8.70s)
=== RUN   TestAccAlicloudSlbServerGroup_vpc
--- PASS: TestAccAlicloudSlbServerGroup_vpc (198.81s)
=== RUN   TestAccAlicloudSlbServerGroup_empty
--- PASS: TestAccAlicloudSlbServerGroup_empty (42.66s)
=== RUN   TestAccAlicloudSlb_paybybandwidth
--- PASS: TestAccAlicloudSlb_paybybandwidth (13.31s)
=== RUN   TestAccAlicloudSlb_vpc
--- PASS: TestAccAlicloudSlb_vpc (87.46s)
=== RUN   TestAccAlicloudSlb_spec
--- PASS: TestAccAlicloudSlb_spec (80.31s)
PASS
ok  	github.com/terraform-providers/terraform-provider-alicloud/alicloud	3704.644s
```