### PR TITLE
Fix deleting ram role error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,10 @@
 ## 1.29.0 (Unreleased)
+
+BUG FIXES:
+
+- Fix deleting ram role error [GH-674]
+- Fix k8s cluster worker_period_unit type error [GH-672]
+
 ## 1.28.0 (January 16, 2019)
 
 IMPROVEMENTS:

--- a/alicloud/data_source_alicloud_pvtz_zone_records.go
+++ b/alicloud/data_source_alicloud_pvtz_zone_records.go
@@ -93,7 +93,7 @@ func dataSourceAlicloudPvtzZoneRecordsRead(d *schema.ResourceData, meta interfac
 				return pvtzClient.DescribeZoneRecords(args)
 			})
 			raw = resp
-			return BuildWrapError(args.GetActionName(), args.ZoneId, AlibabaCloudSdkGoERROR, err)
+			return BuildWrapError(args.GetActionName(), args.ZoneId, AlibabaCloudSdkGoERROR, err, "")
 		})
 
 		if err != nil {

--- a/alicloud/data_source_alicloud_pvtz_zones.go
+++ b/alicloud/data_source_alicloud_pvtz_zones.go
@@ -90,7 +90,7 @@ func dataSourceAlicloudPvtzZonesRead(d *schema.ResourceData, meta interface{}) e
 				return pvtzClient.DescribeZones(args)
 			})
 			raw = resp
-			return BuildWrapError(args.GetActionName(), args.Keyword, AlibabaCloudSdkGoERROR, err)
+			return BuildWrapError(args.GetActionName(), args.Keyword, AlibabaCloudSdkGoERROR, err, "")
 		})
 		if err != nil {
 			return fmt.Errorf("Error DescribeZones: %#v", err)

--- a/alicloud/resource_alicloud_cs_kubernetes.go
+++ b/alicloud/resource_alicloud_cs_kubernetes.go
@@ -607,13 +607,13 @@ func resourceAlicloudCSKubernetesRead(d *schema.ResourceData, meta interface{}) 
 	d.Set("security_group_id", cluster.SecurityGroupID)
 	d.Set("key_name", cluster.Parameters.KeyPair)
 	if size, err := strconv.Atoi(cluster.Parameters.MasterSystemDiskSize); err != nil {
-		return BuildWrapError("strconv.Atoi", d.Id(), ProviderERROR, err)
+		return BuildWrapError("strconv.Atoi", d.Id(), ProviderERROR, err, "")
 	} else {
 		d.Set("master_disk_size", size)
 	}
 	d.Set("master_disk_category", cluster.Parameters.MasterSystemDiskCategory)
 	if size, err := strconv.Atoi(cluster.Parameters.WorkerSystemDiskSize); err != nil {
-		return BuildWrapError("strconv.Atoi", d.Id(), ProviderERROR, err)
+		return BuildWrapError("strconv.Atoi", d.Id(), ProviderERROR, err, "")
 	} else {
 		d.Set("worker_disk_size", size)
 	}
@@ -624,14 +624,14 @@ func resourceAlicloudCSKubernetesRead(d *schema.ResourceData, meta interface{}) 
 	if cluster.Parameters.MasterInstanceChargeType == string(PrePaid) {
 		d.Set("master_instance_charge_type", string(PrePaid))
 		if period, err := strconv.Atoi(cluster.Parameters.MasterPeriod); err != nil {
-			return BuildWrapError("strconv.Atoi", d.Id(), ProviderERROR, err)
+			return BuildWrapError("strconv.Atoi", d.Id(), ProviderERROR, err, "")
 		} else {
 			d.Set("master_period", period)
 		}
 		d.Set("master_period_unit", cluster.Parameters.MasterPeriodUnit)
 		d.Set("master_auto_renew", cluster.Parameters.MasterAutoRenew)
 		if period, err := strconv.Atoi(cluster.Parameters.MasterAutoRenewPeriod); err != nil {
-			return BuildWrapError("strconv.Atoi", d.Id(), ProviderERROR, err)
+			return BuildWrapError("strconv.Atoi", d.Id(), ProviderERROR, err, "")
 		} else {
 			d.Set("master_auto_renew_period", period)
 		}
@@ -642,14 +642,14 @@ func resourceAlicloudCSKubernetesRead(d *schema.ResourceData, meta interface{}) 
 	if cluster.Parameters.WorkerInstanceChargeType == string(PrePaid) {
 		d.Set("worker_instance_charge_type", string(PrePaid))
 		if period, err := strconv.Atoi(cluster.Parameters.WorkerPeriod); err != nil {
-			return BuildWrapError("strconv.Atoi", d.Id(), ProviderERROR, err)
+			return BuildWrapError("strconv.Atoi", d.Id(), ProviderERROR, err, "")
 		} else {
 			d.Set("worker_period", period)
 		}
 		d.Set("worker_period_unit", cluster.Parameters.WorkerPeriodUnit)
 		d.Set("worker_auto_renew", cluster.Parameters.WorkerAutoRenew)
 		if period, err := strconv.Atoi(cluster.Parameters.WorkerAutoRenewPeriod); err != nil {
-			return BuildWrapError("strconv.Atoi", d.Id(), ProviderERROR, err)
+			return BuildWrapError("strconv.Atoi", d.Id(), ProviderERROR, err, "")
 		} else {
 			d.Set("worker_auto_renew_period", period)
 		}
@@ -660,12 +660,12 @@ func resourceAlicloudCSKubernetesRead(d *schema.ResourceData, meta interface{}) 
 	if cidrMask, err := strconv.Atoi(cluster.Parameters.NodeCIDRMask); err == nil {
 		d.Set("node_cidr_mask", cidrMask)
 	} else {
-		return BuildWrapError("strconv.Atoi", d.Id(), ProviderERROR, err)
+		return BuildWrapError("strconv.Atoi", d.Id(), ProviderERROR, err, "")
 	}
 
 	if cluster.Parameters.WorkerDataDisk {
 		if size, err := strconv.Atoi(cluster.Parameters.WorkerDataDiskSize); err != nil {
-			return BuildWrapError("strconv.Atoi", d.Id(), ProviderERROR, err)
+			return BuildWrapError("strconv.Atoi", d.Id(), ProviderERROR, err, "")
 		} else {
 			d.Set("worker_data_disk_size", size)
 		}
@@ -705,7 +705,7 @@ func resourceAlicloudCSKubernetesRead(d *schema.ResourceData, meta interface{}) 
 		d.Set("worker_instance_types", []string{cluster.Parameters.WorkerInstanceTypeA, cluster.Parameters.WorkerInstanceTypeB, cluster.Parameters.WorkerInstanceTypeC})
 	} else {
 		if numOfNode, err := strconv.Atoi(cluster.Parameters.NumOfNodes); err != nil {
-			return BuildWrapError("strconv.Atoi", d.Id(), ProviderERROR, err)
+			return BuildWrapError("strconv.Atoi", d.Id(), ProviderERROR, err, "")
 		} else {
 			d.Set("worker_numbers", []int{numOfNode})
 		}

--- a/alicloud/resource_alicloud_cs_managed_kubernetes.go
+++ b/alicloud/resource_alicloud_cs_managed_kubernetes.go
@@ -377,7 +377,7 @@ func resourceAlicloudCSManagedKubernetesRead(d *schema.ResourceData, meta interf
 	if size, err := strconv.Atoi(cluster.Parameters.WorkerSystemDiskSize); err == nil {
 		d.Set("worker_disk_size", size)
 	} else {
-		return BuildWrapError("strconv.Atoi", d.Id(), ProviderERROR, err)
+		return BuildWrapError("strconv.Atoi", d.Id(), ProviderERROR, err, "")
 	}
 	d.Set("worker_disk_category", cluster.Parameters.WorkerSystemDiskCategory)
 	d.Set("availability_zone", cluster.ZoneId)
@@ -385,14 +385,14 @@ func resourceAlicloudCSManagedKubernetesRead(d *schema.ResourceData, meta interf
 	if cluster.Parameters.WorkerInstanceChargeType == string(PrePaid) {
 		d.Set("worker_instance_charge_type", string(PrePaid))
 		if period, err := strconv.Atoi(cluster.Parameters.WorkerPeriod); err != nil {
-			return BuildWrapError("strconv.Atoi", d.Id(), ProviderERROR, err)
+			return BuildWrapError("strconv.Atoi", d.Id(), ProviderERROR, err, "")
 		} else {
 			d.Set("worker_period", period)
 		}
 		d.Set("worker_period_unit", cluster.Parameters.WorkerPeriodUnit)
 		d.Set("worker_auto_renew", cluster.Parameters.WorkerAutoRenew)
 		if period, err := strconv.Atoi(cluster.Parameters.WorkerAutoRenewPeriod); err != nil {
-			return BuildWrapError("strconv.Atoi", d.Id(), ProviderERROR, err)
+			return BuildWrapError("strconv.Atoi", d.Id(), ProviderERROR, err, "")
 		} else {
 			d.Set("worker_auto_renew_period", period)
 		}
@@ -402,7 +402,7 @@ func resourceAlicloudCSManagedKubernetesRead(d *schema.ResourceData, meta interf
 
 	if cluster.Parameters.WorkerDataDisk {
 		if size, err := strconv.Atoi(cluster.Parameters.WorkerDataDiskSize); err != nil {
-			return BuildWrapError("strconv.Atoi", d.Id(), ProviderERROR, err)
+			return BuildWrapError("strconv.Atoi", d.Id(), ProviderERROR, err, "")
 		} else {
 			d.Set("worker_data_disk_size", size)
 		}
@@ -410,7 +410,7 @@ func resourceAlicloudCSManagedKubernetesRead(d *schema.ResourceData, meta interf
 	}
 
 	if numOfNode, err := strconv.Atoi(cluster.Parameters.NumOfNodes); err != nil {
-		return BuildWrapError("strconv.Atoi", d.Id(), ProviderERROR, err)
+		return BuildWrapError("strconv.Atoi", d.Id(), ProviderERROR, err, "")
 	} else {
 		d.Set("worker_numbers", []int{numOfNode})
 	}

--- a/alicloud/resource_alicloud_instance_test.go
+++ b/alicloud/resource_alicloud_instance_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/aliyun/alibaba-cloud-sdk-go/sdk/requests"
 	"github.com/aliyun/alibaba-cloud-sdk-go/services/ecs"
+	"github.com/hashicorp/terraform/helper/acctest"
 	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/helper/schema"
 	"github.com/hashicorp/terraform/terraform"
@@ -851,7 +852,7 @@ func TestAccAlicloudInstanceNetworkSpec_update(t *testing.T) {
 
 func TestAccAlicloudInstance_ramrole(t *testing.T) {
 	var instance ecs.Instance
-
+	rand := acctest.RandIntRange(100000, 999999)
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			testAccPreCheck(t)
@@ -861,13 +862,12 @@ func TestAccAlicloudInstance_ramrole(t *testing.T) {
 		CheckDestroy:  testAccCheckInstanceDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccCheckInstanceRamRole(EcsInstanceCommonTestCase),
+				Config: testAccCheckInstanceRamRole(EcsInstanceCommonTestCase, rand),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckInstanceExists("alicloud_instance.role", &instance),
 					resource.TestCheckResourceAttr(
-						"alicloud_instance.role",
-						"role_name",
-						"tf-testAccCheckInstanceRamRole"),
+						"alicloud_instance.role", "role_name",
+						fmt.Sprintf("tf-testAccCheckInstanceRamRole-%d", rand)),
 				),
 			},
 		},
@@ -1871,11 +1871,11 @@ func testAccCheckInstanceNetworkSpecUpdate(common string) string {
 	}
 	`, common)
 }
-func testAccCheckInstanceRamRole(common string) string {
+func testAccCheckInstanceRamRole(common string, rand int) string {
 	return fmt.Sprintf(`
 	%s
 	variable "name" {
-		default = "tf-testAccCheckInstanceRamRole"
+		default = "tf-testAccCheckInstanceRamRole-%d"
 	}
 
 	resource "alicloud_instance" "role" {
@@ -1914,7 +1914,7 @@ func testAccCheckInstanceRamRole(common string) string {
 	  role_name = "${alicloud_ram_role.role.name}"
 	  policy_type = "${alicloud_ram_policy.policy.type}"
 	}
-	`, common)
+	`, common, rand)
 }
 
 func testAccInstanceConfigDataDisk(common string) string {

--- a/alicloud/resource_alicloud_log_project.go
+++ b/alicloud/resource_alicloud_log_project.go
@@ -104,10 +104,10 @@ func resourceAlicloudLogProjectDelete(d *schema.ResourceData, meta interface{}) 
 		})
 		if err != nil {
 			if IsExceptedErrors(err, []string{LogClientTimeout, LogRequestTimeout}) {
-				return resource.RetryableError(BuildWrapError("DeleteProject", d.Id(), AliyunLogGoSdkERROR, err))
+				return resource.RetryableError(BuildWrapError("DeleteProject", d.Id(), AliyunLogGoSdkERROR, err, ""))
 			}
 			if !IsExceptedErrors(err, []string{ProjectNotExist}) {
-				return resource.NonRetryableError(BuildWrapError("DeleteProject", d.Id(), AliyunLogGoSdkERROR, err))
+				return resource.NonRetryableError(BuildWrapError("DeleteProject", d.Id(), AliyunLogGoSdkERROR, err, ""))
 			}
 		}
 
@@ -116,15 +116,15 @@ func resourceAlicloudLogProjectDelete(d *schema.ResourceData, meta interface{}) 
 		})
 		if err != nil {
 			if IsExceptedErrors(err, []string{LogClientTimeout}) {
-				return resource.RetryableError(BuildWrapError("CheckProjectExist", d.Id(), AliyunLogGoSdkERROR, err))
+				return resource.RetryableError(BuildWrapError("CheckProjectExist", d.Id(), AliyunLogGoSdkERROR, err, ""))
 			}
-			return resource.NonRetryableError(BuildWrapError("CheckProjectExist", d.Id(), AliyunLogGoSdkERROR, err))
+			return resource.NonRetryableError(BuildWrapError("CheckProjectExist", d.Id(), AliyunLogGoSdkERROR, err, ""))
 		}
 		exist, _ := raw.(bool)
 		if !exist {
 			return nil
 		}
 
-		return resource.RetryableError(BuildWrapError("DeleteProject", d.Id(), ProviderERROR, fmt.Errorf("Timeout")))
+		return resource.RetryableError(BuildWrapError("DeleteProject", d.Id(), ProviderERROR, fmt.Errorf("Timeout"), ""))
 	})
 }

--- a/alicloud/resource_alicloud_ots_table.go
+++ b/alicloud/resource_alicloud_ots_table.go
@@ -107,9 +107,9 @@ func resourceAliyunOtsTableCreate(d *schema.ResourceData, meta interface{}) erro
 		})
 		if err != nil {
 			if strings.HasSuffix(err.Error(), SuffixNoSuchHost) {
-				return resource.RetryableError(BuildWrapError("CreateTable", instanceName, AliyunTablestoreGoSdk, err))
+				return resource.RetryableError(BuildWrapError("CreateTable", instanceName, AliyunTablestoreGoSdk, err, ""))
 			}
-			return resource.NonRetryableError(BuildWrapError("CreateTable", instanceName, AliyunTablestoreGoSdk, err))
+			return resource.NonRetryableError(BuildWrapError("CreateTable", instanceName, AliyunTablestoreGoSdk, err, ""))
 		}
 		return nil
 	}); err != nil {

--- a/alicloud/resource_alicloud_pvtz_zone.go
+++ b/alicloud/resource_alicloud_pvtz_zone.go
@@ -68,11 +68,11 @@ func resourceAlicloudPvtzZoneCreate(d *schema.ResourceData, meta interface{}) er
 		raw = rsp
 		return err
 	}); err != nil {
-		return BuildWrapError(args.GetActionName(), args.ZoneName, AlibabaCloudSdkGoERROR, err)
+		return BuildWrapError(args.GetActionName(), args.ZoneName, AlibabaCloudSdkGoERROR, err, "")
 	}
 	response, _ := raw.(*pvtz.AddZoneResponse)
 	if response == nil {
-		return BuildWrapError(args.GetActionName(), args.ZoneName, AlibabaCloudSdkGoERROR, fmt.Errorf("AddZone got a nil response: %#v", response))
+		return BuildWrapError(args.GetActionName(), args.ZoneName, AlibabaCloudSdkGoERROR, fmt.Errorf("AddZone got a nil response: %#v", response), "")
 	}
 
 	d.SetId(response.ZoneId)
@@ -118,7 +118,7 @@ func resourceAlicloudPvtzZoneUpdate(d *schema.ResourceData, meta interface{}) er
 			_, err := client.WithPvtzClient(func(pvtzClient *pvtz.Client) (interface{}, error) {
 				return pvtzClient.UpdateZoneRemark(request)
 			})
-			return BuildWrapError(request.GetActionName(), d.Id(), AlibabaCloudSdkGoERROR, err)
+			return BuildWrapError(request.GetActionName(), d.Id(), AlibabaCloudSdkGoERROR, err, "")
 		})
 		if err != nil {
 			return err
@@ -143,13 +143,13 @@ func resourceAlicloudPvtzZoneDelete(d *schema.ResourceData, meta interface{}) er
 		if err != nil {
 			if IsExceptedErrors(err, []string{PvtzThrottlingUser, PvtzSystemBusy}) {
 				time.Sleep(time.Duration(2) * time.Second)
-				return resource.RetryableError(BuildWrapError(request.GetActionName(), d.Id(), AlibabaCloudSdkGoERROR, err))
+				return resource.RetryableError(BuildWrapError(request.GetActionName(), d.Id(), AlibabaCloudSdkGoERROR, err, ""))
 			}
 			if IsExceptedErrors(err, []string{ZoneNotExists, ZoneVpcNotExists}) {
 				return nil
 			}
 			if !IsExceptedErrors(err, []string{PvtzInternalError}) {
-				return resource.NonRetryableError(BuildWrapError(request.GetActionName(), d.Id(), AlibabaCloudSdkGoERROR, err))
+				return resource.NonRetryableError(BuildWrapError(request.GetActionName(), d.Id(), AlibabaCloudSdkGoERROR, err, ""))
 			}
 		}
 

--- a/alicloud/resource_alicloud_pvtz_zone_attachment.go
+++ b/alicloud/resource_alicloud_pvtz_zone_attachment.go
@@ -83,7 +83,7 @@ func resourceAlicloudPvtzZoneAttachmentUpdate(d *schema.ResourceData, meta inter
 			_, err := client.WithPvtzClient(func(pvtzClient *pvtz.Client) (interface{}, error) {
 				return pvtzClient.BindZoneVpc(args)
 			})
-			return BuildWrapError(args.GetActionName(), args.ZoneId, AlibabaCloudSdkGoERROR, err)
+			return BuildWrapError(args.GetActionName(), args.ZoneId, AlibabaCloudSdkGoERROR, err, "")
 		}); err != nil {
 			return err
 		}
@@ -136,10 +136,10 @@ func resourceAlicloudPvtzZoneAttachmentDelete(d *schema.ResourceData, meta inter
 		if err != nil {
 			if IsExceptedErrors(err, []string{PvtzThrottlingUser, PvtzSystemBusy}) {
 				time.Sleep(time.Duration(2) * time.Second)
-				return resource.RetryableError(BuildWrapError(request.GetActionName(), d.Id(), AlibabaCloudSdkGoERROR, err))
+				return resource.RetryableError(BuildWrapError(request.GetActionName(), d.Id(), AlibabaCloudSdkGoERROR, err, ""))
 			}
 			if !IsExceptedErrors(err, []string{PvtzInternalError}) {
-				return resource.NonRetryableError(BuildWrapError(request.GetActionName(), d.Id(), AlibabaCloudSdkGoERROR, err))
+				return resource.NonRetryableError(BuildWrapError(request.GetActionName(), d.Id(), AlibabaCloudSdkGoERROR, err, ""))
 			}
 		}
 

--- a/alicloud/resource_alicloud_pvtz_zone_record.go
+++ b/alicloud/resource_alicloud_pvtz_zone_record.go
@@ -96,7 +96,7 @@ func resourceAlicloudPvtzZoneRecordCreate(d *schema.ResourceData, meta interface
 			return pvtzClient.AddZoneRecord(args)
 		})
 		raw = rsp
-		return BuildWrapError(args.GetActionName(), args.ZoneId, AlibabaCloudSdkGoERROR, err)
+		return BuildWrapError(args.GetActionName(), args.ZoneId, AlibabaCloudSdkGoERROR, err, "")
 	})
 
 	if err != nil {
@@ -113,7 +113,7 @@ func resourceAlicloudPvtzZoneRecordCreate(d *schema.ResourceData, meta interface
 						return pvtzClient.DescribeZoneRecords(req)
 					})
 					raw = rep
-					return BuildWrapError(req.GetActionName(), req.ZoneId, AlibabaCloudSdkGoERROR, err)
+					return BuildWrapError(req.GetActionName(), req.ZoneId, AlibabaCloudSdkGoERROR, err, "")
 				}); err != nil {
 					return err
 				}
@@ -137,11 +137,11 @@ func resourceAlicloudPvtzZoneRecordCreate(d *schema.ResourceData, meta interface
 				}
 			}
 		}
-		return BuildWrapError(args.GetActionName(), args.ZoneId, AlibabaCloudSdkGoERROR, err)
+		return BuildWrapError(args.GetActionName(), args.ZoneId, AlibabaCloudSdkGoERROR, err, "")
 	}
 	resp, _ := raw.(*pvtz.AddZoneRecordResponse)
 	if resp == nil {
-		return BuildWrapError(args.GetActionName(), args.ZoneId, AlibabaCloudSdkGoERROR, fmt.Errorf("Parsing AddZoneRecordResponse got nil."))
+		return BuildWrapError(args.GetActionName(), args.ZoneId, AlibabaCloudSdkGoERROR, fmt.Errorf("Parsing AddZoneRecordResponse got nil."), "")
 	}
 
 	d.SetId(fmt.Sprintf("%d%s%s", resp.RecordId, COLON_SEPARATED, args.ZoneId))
@@ -191,7 +191,7 @@ func resourceAlicloudPvtzZoneRecordUpdate(d *schema.ResourceData, meta interface
 			_, err := client.WithPvtzClient(func(pvtzClient *pvtz.Client) (interface{}, error) {
 				return pvtzClient.UpdateZoneRecord(args)
 			})
-			return BuildWrapError(args.GetActionName(), d.Id(), AlibabaCloudSdkGoERROR, err)
+			return BuildWrapError(args.GetActionName(), d.Id(), AlibabaCloudSdkGoERROR, err, "")
 		}); err != nil {
 			return err
 		}
@@ -253,9 +253,9 @@ func resourceAlicloudPvtzZoneRecordDelete(d *schema.ResourceData, meta interface
 		if err != nil {
 			if IsExceptedErrors(err, []string{PvtzThrottlingUser, PvtzSystemBusy}) {
 				time.Sleep(time.Duration(2) * time.Second)
-				return resource.RetryableError(BuildWrapError(request.GetActionName(), d.Id(), AlibabaCloudSdkGoERROR, err))
+				return resource.RetryableError(BuildWrapError(request.GetActionName(), d.Id(), AlibabaCloudSdkGoERROR, err, ""))
 			}
-			return resource.NonRetryableError(BuildWrapError(request.GetActionName(), d.Id(), AlibabaCloudSdkGoERROR, err))
+			return resource.NonRetryableError(BuildWrapError(request.GetActionName(), d.Id(), AlibabaCloudSdkGoERROR, err, ""))
 		}
 
 		if _, e := pvtzService.DescribeZoneRecord(recordId, zoneId); e != nil {

--- a/alicloud/resource_alicloud_slb.go
+++ b/alicloud/resource_alicloud_slb.go
@@ -264,7 +264,7 @@ func resourceAliyunSlbCreate(d *schema.ResourceData, meta interface{}) error {
 			return slbClient.CreateLoadBalancer(args)
 		})
 		raw = resp
-		return BuildWrapError(args.GetActionName(), "", AlibabaCloudSdkGoERROR, err)
+		return BuildWrapError(args.GetActionName(), "", AlibabaCloudSdkGoERROR, err, "")
 	}); err != nil {
 		if IsExceptedError(err, SlbOrderFailed) {
 			return fmt.Errorf("Your account may not support to create '%s' load balancer. Please change it to '%s' and try again.\n%s.", PayByBandwidth, PayByTraffic, err.Error())


### PR DESCRIPTION
```
TF_ACC=1 go test ./alicloud -v -run=TestAccAlicloudInstance_ramrole -timeout=240m
=== RUN   TestAccAlicloudInstance_ramrole
--- PASS: TestAccAlicloudInstance_ramrole (128.89s)
PASS
ok  	github.com/terraform-providers/terraform-provider-alicloud/alicloud	128.935s
```
```
TF_ACC=1 go test ./alicloud -v -run=TestAccAlicloudRam -timeout=300m
=== RUN   TestAccAlicloudRamAccountAliasDataSource_basic
--- PASS: TestAccAlicloudRamAccountAliasDataSource_basic (0.81s)
=== RUN   TestAccAlicloudRamGroupsDataSource_for_user
--- PASS: TestAccAlicloudRamGroupsDataSource_for_user (3.54s)
=== RUN   TestAccAlicloudRamGroupsDataSource_for_policy
--- PASS: TestAccAlicloudRamGroupsDataSource_for_policy (3.45s)
=== RUN   TestAccAlicloudRamGroupsDataSource_for_all
--- PASS: TestAccAlicloudRamGroupsDataSource_for_all (0.70s)
=== RUN   TestAccAlicloudRamGroupsDataSource_group_name_regex
--- PASS: TestAccAlicloudRamGroupsDataSource_group_name_regex (1.52s)
=== RUN   TestAccAlicloudRamGroupsDataSource_Empty
--- PASS: TestAccAlicloudRamGroupsDataSource_Empty (0.66s)
=== RUN   TestAccAlicloudRamPoliciesDataSource_for_group
--- PASS: TestAccAlicloudRamPoliciesDataSource_for_group (4.48s)
=== RUN   TestAccAlicloudRamPoliciesDataSource_for_role
--- PASS: TestAccAlicloudRamPoliciesDataSource_for_role (4.33s)
=== RUN   TestAccAlicloudRamPoliciesDataSource_for_user
--- PASS: TestAccAlicloudRamPoliciesDataSource_for_user (5.03s)
=== RUN   TestAccAlicloudRamPoliciesDataSource_policy_name_regex
--- PASS: TestAccAlicloudRamPoliciesDataSource_policy_name_regex (2.77s)
=== RUN   TestAccAlicloudRamPoliciesDataSource_policy_type
--- PASS: TestAccAlicloudRamPoliciesDataSource_policy_type (2.73s)
=== RUN   TestAccAlicloudRamPoliciesDataSource_empty
--- PASS: TestAccAlicloudRamPoliciesDataSource_empty (1.80s)
=== RUN   TestAccAlicloudRamRolesDataSource_for_policy
--- PASS: TestAccAlicloudRamRolesDataSource_for_policy (3.58s)
=== RUN   TestAccAlicloudRamRolesDataSource_for_all
--- PASS: TestAccAlicloudRamRolesDataSource_for_all (4.09s)
=== RUN   TestAccAlicloudRamRolesDataSource_role_name_regex
--- PASS: TestAccAlicloudRamRolesDataSource_role_name_regex (1.56s)
=== RUN   TestAccAlicloudRamRolesDataSource_empty
--- PASS: TestAccAlicloudRamRolesDataSource_empty (0.64s)
=== RUN   TestAccAlicloudRamUsersDataSource_for_group
--- PASS: TestAccAlicloudRamUsersDataSource_for_group (3.57s)
=== RUN   TestAccAlicloudRamUsersDataSource_for_policy
--- PASS: TestAccAlicloudRamUsersDataSource_for_policy (3.59s)
=== RUN   TestAccAlicloudRamUsersDataSource_for_all
--- PASS: TestAccAlicloudRamUsersDataSource_for_all (0.79s)
=== RUN   TestAccAlicloudRamUsersDataSource_user_name_regex
--- PASS: TestAccAlicloudRamUsersDataSource_user_name_regex (1.86s)
=== RUN   TestAccAlicloudRamUsersDataSource_empty
--- PASS: TestAccAlicloudRamUsersDataSource_empty (0.79s)
=== RUN   TestAccAlicloudRamLoginProfile_importBasic
--- PASS: TestAccAlicloudRamLoginProfile_importBasic (2.23s)
=== RUN   TestAccAlicloudRamPolicy_importBasic
--- PASS: TestAccAlicloudRamPolicy_importBasic (1.59s)
=== RUN   TestAccAlicloudRamRole_importBasic
--- PASS: TestAccAlicloudRamRole_importBasic (1.16s)
=== RUN   TestAccAlicloudRamUser_importBasic
--- PASS: TestAccAlicloudRamUser_importBasic (1.54s)
=== RUN   TestAccAlicloudRamAccessKey_basic
--- PASS: TestAccAlicloudRamAccessKey_basic (2.62s)
=== RUN   TestAccAlicloudRamAccountAlias_basic
--- PASS: TestAccAlicloudRamAccountAlias_basic (0.92s)
=== RUN   TestAccAlicloudRamGroupMembership_basic
--- PASS: TestAccAlicloudRamGroupMembership_basic (4.38s)
=== RUN   TestAccAlicloudRamGroupPolicyAttachment_basic
--- PASS: TestAccAlicloudRamGroupPolicyAttachment_basic (3.20s)
=== RUN   TestAccAlicloudRamGroup_basic
--- PASS: TestAccAlicloudRamGroup_basic (1.43s)
=== RUN   TestAccAlicloudRamLoginProfile_basic
--- PASS: TestAccAlicloudRamLoginProfile_basic (2.50s)
=== RUN   TestAccAlicloudRamPolicy_basic
--- PASS: TestAccAlicloudRamPolicy_basic (1.46s)
=== RUN   TestAccAlicloudRamRoleAttachment_basic
--- PASS: TestAccAlicloudRamRoleAttachment_basic (219.36s)
=== RUN   TestAccAlicloudRamRolePolicyAttachment_basic
--- PASS: TestAccAlicloudRamRolePolicyAttachment_basic (3.06s)
=== RUN   TestAccAlicloudRamRole_basic
--- PASS: TestAccAlicloudRamRole_basic (1.05s)
=== RUN   TestAccAlicloudRamUserPolicyAttachment_basic
--- PASS: TestAccAlicloudRamUserPolicyAttachment_basic (3.45s)
=== RUN   TestAccAlicloudRamUser_basic
--- PASS: TestAccAlicloudRamUser_basic (1.52s)
PASS
ok  	github.com/terraform-providers/terraform-provider-alicloud/alicloud	303.832s
```