### PR TITLE
Improve db instance's testcases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 IMPROVEMENTS:
 
+- Improve db instance's testcases [GH-678]
 - Add multi_zone_ids for datasource alicloud_zones [GH-677]
 - Improve redis and memcache instance testcases [GH-676]
 - Improve ecs instance testcases [GH-675]

--- a/alicloud/connectivity/regions.go
+++ b/alicloud/connectivity/regions.go
@@ -51,6 +51,7 @@ var DrdsSupportedRegions = []Region{Beijing, Shenzhen, Hangzhou, Qingdao, Hongko
 var DrdsClassicNoSupportedRegions = []Region{Hongkong}
 var FcNoSupportedRegions = []Region{Zhangjiakou, Huhehaote, APSouthEast3, APSouthEast5, EUWest1, USEast1, MEEast1}
 var DatahubSupportedRegions = []Region{Beijing, Hangzhou, Shanghai, Shenzhen, APSouthEast1}
+var RdsClassicNoSupportedRegions = []Region{APSouth1, APSouthEast2, APSouthEast3, APNorthEast1, EUCentral1, EUWest1, MEEast1}
 var RdsMultiAzNoSupportedRegions = []Region{Qingdao, APNorthEast1, APSouthEast5, MEEast1}
 var RouteTableNoSupportedRegions = []Region{Beijing, Hangzhou, Shenzhen}
 var ApiGatewayNoSupportedRegions = []Region{Zhangjiakou, Huhehaote, USEast1, USWest1, EUWest1, MEEast1}

--- a/alicloud/data_source_alicloud_db_instances_test.go
+++ b/alicloud/data_source_alicloud_db_instances_test.go
@@ -3,6 +3,8 @@ package alicloud
 import (
 	"testing"
 
+	"fmt"
+
 	"github.com/hashicorp/terraform/helper/resource"
 )
 
@@ -14,7 +16,7 @@ func TestAccAlicloudDBInstancesDataSource(t *testing.T) {
 		Providers: testAccProviders,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccCheckAlicloudDBInstancesDataSourceConfig,
+				Config: testAccCheckAlicloudDBInstancesDataSourceConfig(RdsCommonTestCase),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAlicloudDataSourceID("data.alicloud_db_instances.dbs"),
 					resource.TestCheckResourceAttr("data.alicloud_db_instances.dbs", "instances.#", "1"),
@@ -52,20 +54,29 @@ func TestAccAlicloudDBInstancesDataSourceEmpty(t *testing.T) {
 	})
 }
 
-const testAccCheckAlicloudDBInstancesDataSourceConfig = `
-data "alicloud_db_instances" "dbs" {
-  name_regex = "${alicloud_db_instance.db.instance_name}"
+func testAccCheckAlicloudDBInstancesDataSourceConfig(common string) string {
+	return fmt.Sprintf(`
+	%s
+	data "alicloud_db_instances" "dbs" {
+	  name_regex = "${alicloud_db_instance.db.instance_name}"
+	}
+	variable "creation" {
+		default = "Rds"
+	}
+	variable "name" {
+		default = "tf-testAccCheckAlicloudDBInstancesDataSourceConfig"
+	}
+	resource "alicloud_db_instance" "db" {
+	  engine               = "MySQL"
+	  engine_version       = "5.6"
+	  instance_type        = "rds.mysql.t1.small"
+	  instance_storage     = "10"
+	  instance_name        = "${var.name}"
+	  instance_charge_type = "Postpaid"
+	  vswitch_id = "${alicloud_vswitch.default.id}"
+	}
+	`, common)
 }
-
-resource "alicloud_db_instance" "db" {
-  engine               = "MySQL"
-  engine_version       = "5.6"
-  instance_type        = "rds.mysql.t1.small"
-  instance_storage     = "10"
-  instance_name        = "tf-testAccCheckAlicloudDBInstancesDataSourceConfig"
-  instance_charge_type = "Postpaid"
-}
-`
 
 const testAccCheckAlicloudDBInstancesDataSourceEmpty = `
 data "alicloud_db_instances" "dbs" {

--- a/alicloud/data_source_alicloud_kvstore_instances_test.go
+++ b/alicloud/data_source_alicloud_kvstore_instances_test.go
@@ -16,7 +16,7 @@ func TestAccAlicloudKVStoreInstancesDataSource(t *testing.T) {
 		Providers: testAccProviders,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccCheckAlicloudRKVInstancesDataSourceConfig(DatabaseCommonTestCase, string(KVStoreRedis), redisInstanceClassForTest, string(KVStore2Dot8)),
+				Config: testAccCheckAlicloudRKVInstancesDataSourceConfig(KVStoreCommonTestCase, string(KVStoreRedis), redisInstanceClassForTest, string(KVStore2Dot8)),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAlicloudDataSourceID("data.alicloud_kvstore_instances.rkvs"),
 					resource.TestCheckResourceAttr("data.alicloud_kvstore_instances.rkvs", "instances.#", "1"),

--- a/alicloud/import_alicloud_db_account_privilege_test.go
+++ b/alicloud/import_alicloud_db_account_privilege_test.go
@@ -15,7 +15,7 @@ func TestAccAlicloudDBAccountPrivilege_import(t *testing.T) {
 		CheckDestroy: testAccCheckDBAccountPrivilegeDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccDBAccountPrivilege_basic(DatabaseCommonTestCase),
+				Config: testAccDBAccountPrivilege_basic(RdsCommonTestCase),
 			},
 
 			{

--- a/alicloud/import_alicloud_db_account_test.go
+++ b/alicloud/import_alicloud_db_account_test.go
@@ -15,7 +15,7 @@ func TestAccAlicloudDBAccount_import(t *testing.T) {
 		CheckDestroy: testAccCheckDBAccountDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccDBAccount_mysql(DatabaseCommonTestCase),
+				Config: testAccDBAccount_mysql(RdsCommonTestCase),
 			},
 
 			{

--- a/alicloud/import_alicloud_db_backup_policy_test.go
+++ b/alicloud/import_alicloud_db_backup_policy_test.go
@@ -15,7 +15,7 @@ func TestAccAlicloudDBBackupPolicy_import(t *testing.T) {
 		CheckDestroy: testAccCheckDBBackupPolicyDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccDBBackupPolicy_basic(DatabaseCommonTestCase),
+				Config: testAccDBBackupPolicy_basic(RdsCommonTestCase),
 			},
 
 			{

--- a/alicloud/import_alicloud_db_connection_test.go
+++ b/alicloud/import_alicloud_db_connection_test.go
@@ -15,7 +15,7 @@ func TestAccAlicloudDBConnection_import(t *testing.T) {
 		CheckDestroy: testAccCheckDBConnectionDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccDBConnection_basic(DatabaseCommonTestCase),
+				Config: testAccDBConnection_basic(RdsCommonTestCase),
 			},
 
 			{

--- a/alicloud/import_alicloud_db_database_test.go
+++ b/alicloud/import_alicloud_db_database_test.go
@@ -15,7 +15,7 @@ func TestAccAlicloudDBDatabase_import(t *testing.T) {
 		CheckDestroy: testAccCheckDBDatabaseDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccDBDatabase_basic(DatabaseCommonTestCase),
+				Config: testAccDBDatabase_basic(RdsCommonTestCase),
 			},
 
 			{

--- a/alicloud/import_alicloud_db_instance_test.go
+++ b/alicloud/import_alicloud_db_instance_test.go
@@ -15,7 +15,7 @@ func TestAccAlicloudDBInstance_import(t *testing.T) {
 		CheckDestroy: testAccCheckDBInstanceDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccDBInstance_vpc(DatabaseCommonTestCase),
+				Config: testAccDBInstance_vpc(RdsCommonTestCase),
 			},
 
 			{

--- a/alicloud/import_alicloud_kvstore_backup_policy_test.go
+++ b/alicloud/import_alicloud_kvstore_backup_policy_test.go
@@ -36,7 +36,7 @@ func TestAccAlicloudKVStoreMemcacheBackupPolicy_import(t *testing.T) {
 		CheckDestroy: testAccCheckKVStoreBackupPolicyDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccKVStoreBackupPolicy_vpc(DatabaseCommonTestCase, string(KVStoreMemcache), memcacheInstanceClassForTest, string(KVStore2Dot8)),
+				Config: testAccKVStoreBackupPolicy_vpc(KVStoreCommonTestCase, string(KVStoreMemcache), memcacheInstanceClassForTest, string(KVStore2Dot8)),
 			},
 
 			{

--- a/alicloud/import_alicloud_kvstore_instance_test.go
+++ b/alicloud/import_alicloud_kvstore_instance_test.go
@@ -15,7 +15,7 @@ func TestAccAlicloudKVStoreRedisInstance_import(t *testing.T) {
 		CheckDestroy: testAccCheckKVStoreInstanceDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccKVStoreInstance_vpc(DatabaseCommonTestCase, redisInstanceClassForTest, string(KVStoreRedis), string(KVStore4Dot0)),
+				Config: testAccKVStoreInstance_vpc(KVStoreCommonTestCase, redisInstanceClassForTest, string(KVStoreRedis), string(KVStore4Dot0)),
 			},
 
 			{
@@ -37,7 +37,7 @@ func TestAccAlicloudKVStoreMemcacheInstance_import(t *testing.T) {
 		CheckDestroy: testAccCheckKVStoreInstanceDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccKVStoreInstance_vpc(DatabaseCommonTestCase, memcacheInstanceClassForTest, string(KVStoreMemcache), string(KVStore2Dot8)),
+				Config: testAccKVStoreInstance_vpc(KVStoreCommonTestCase, memcacheInstanceClassForTest, string(KVStoreMemcache), string(KVStore2Dot8)),
 			},
 
 			{

--- a/alicloud/resource_alicloud_cs_kubernetes_test.go
+++ b/alicloud/resource_alicloud_cs_kubernetes_test.go
@@ -240,12 +240,12 @@ func testAccMultiAZKubernetes_basic(rand int) string {
 	}
 
 	data "alicloud_instance_types" "instance_types_1" {
-		availability_zone = "${data.alicloud_zones.main.zones.1.id}"
+		availability_zone = "${lookup(data.alicloud_zones.main.zones[(length(data.alicloud_zones.main.zones)-1)%%length(data.alicloud_zones.main.zones)], "id")}"
 		cpu_core_count = 2
 		memory_size = 4
 	}
 	data "alicloud_instance_types" "instance_types_2" {
-		availability_zone = "${data.alicloud_zones.main.zones.2.id}"
+		availability_zone = "${lookup(data.alicloud_zones.main.zones[(length(data.alicloud_zones.main.zones)-2)%%length(data.alicloud_zones.main.zones)], "id")}"
 		cpu_core_count = 2
 		memory_size = 4
 	}
@@ -266,14 +266,14 @@ func testAccMultiAZKubernetes_basic(rand int) string {
 	  name = "${var.name}"
 	  vpc_id = "${alicloud_vpc.foo.id}"
 	  cidr_block = "10.1.2.0/24"
-	  availability_zone = "${data.alicloud_zones.main.zones.1.id}"
+	  availability_zone = "${lookup(data.alicloud_zones.main.zones[(length(data.alicloud_zones.main.zones)-1)%%length(data.alicloud_zones.main.zones)], "id")}"
 	}
 
 	resource "alicloud_vswitch" "vsw3" {
 	  name = "${var.name}"
 	  vpc_id = "${alicloud_vpc.foo.id}"
 	  cidr_block = "10.1.3.0/24"
-	  availability_zone = "${data.alicloud_zones.main.zones.2.id}"
+	  availability_zone = "${lookup(data.alicloud_zones.main.zones[(length(data.alicloud_zones.main.zones)-2)%%length(data.alicloud_zones.main.zones)], "id")}"
 	}
 
 	resource "alicloud_nat_gateway" "nat_gateway" {

--- a/alicloud/resource_alicloud_db_account_privilege_test.go
+++ b/alicloud/resource_alicloud_db_account_privilege_test.go
@@ -27,7 +27,7 @@ func TestAccAlicloudDBAccountPrivilege_basic(t *testing.T) {
 		CheckDestroy: testAccCheckDBAccountPrivilegeDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccDBAccountPrivilege_basic(DatabaseCommonTestCase),
+				Config: testAccDBAccountPrivilege_basic(RdsCommonTestCase),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckDBAccountPrivilegeExists(
 						"alicloud_db_account_privilege.privilege", &account),
@@ -104,9 +104,7 @@ func testAccDBAccountPrivilege_basic(common string) string {
 	variable "creation" {
 		default = "Rds"
 	}
-	variable "multi_az" {
-		default = "false"
-	}
+
 	variable "name" {
 		default = "tf-testaccDBaccountprivilege_basic"
 	}

--- a/alicloud/resource_alicloud_db_account_test.go
+++ b/alicloud/resource_alicloud_db_account_test.go
@@ -26,7 +26,7 @@ func TestAccAlicloudDBAccount_mysql(t *testing.T) {
 		CheckDestroy: testAccCheckDBAccountDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccDBAccount_mysql(DatabaseCommonTestCase),
+				Config: testAccDBAccount_mysql(RdsCommonTestCase),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckDBAccountExists("alicloud_db_account.account", &account),
 					resource.TestCheckResourceAttrSet("alicloud_db_account.account", "instance_id"),
@@ -107,9 +107,6 @@ func testAccDBAccount_mysql(common string) string {
 	%s
 	variable "creation" {
 		default = "Rds"
-	}
-	variable "multi_az" {
-		default = "false"
 	}
 	variable "name" {
 		default = "tf-testAccDBaccount_mysql"

--- a/alicloud/resource_alicloud_db_backup_policy_test.go
+++ b/alicloud/resource_alicloud_db_backup_policy_test.go
@@ -25,7 +25,7 @@ func TestAccAlicloudDBBackupPolicy_basic(t *testing.T) {
 		CheckDestroy: testAccCheckDBBackupPolicyDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccDBBackupPolicy_basic(DatabaseCommonTestCase),
+				Config: testAccDBBackupPolicy_basic(RdsCommonTestCase),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckDBBackupPolicyExists(
 						"alicloud_db_backup_policy.policy", &policy),
@@ -95,9 +95,7 @@ func testAccDBBackupPolicy_basic(common string) string {
 	variable "creation" {
 		default = "Rds"
 	}
-	variable "multi_az" {
-		default = "false"
-	}
+
 	variable "name" {
 		default = "tf-testAccDBbackuppolicy_basic"
 	}

--- a/alicloud/resource_alicloud_db_connection_test.go
+++ b/alicloud/resource_alicloud_db_connection_test.go
@@ -30,7 +30,7 @@ func TestAccAlicloudDBConnection_basic(t *testing.T) {
 		CheckDestroy: testAccCheckDBConnectionDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccDBConnection_basic(DatabaseCommonTestCase),
+				Config: testAccDBConnection_basic(RdsCommonTestCase),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckDBConnectionExists(
 						"alicloud_db_connection.foo", &connection),
@@ -44,7 +44,7 @@ func TestAccAlicloudDBConnection_basic(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccDBConnection_update(DatabaseCommonTestCase),
+				Config: testAccDBConnection_update(RdsCommonTestCase),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckDBConnectionExists(
 						"alicloud_db_connection.foo", &connection),
@@ -125,9 +125,7 @@ func testAccDBConnection_basic(common string) string {
 	variable "creation" {
 		default = "Rds"
 	}
-	variable "multi_az" {
-		default = "false"
-	}
+
 	variable "name" {
 		default = "tf-testAccDBconnection_basic"
 	}
@@ -153,9 +151,7 @@ func testAccDBConnection_update(common string) string {
 	variable "creation" {
 		default = "Rds"
 	}
-	variable "multi_az" {
-		default = "false"
-	}
+
 	variable "name" {
 		default = "tf-testAccDBconnection_basic"
 	}

--- a/alicloud/resource_alicloud_db_database_test.go
+++ b/alicloud/resource_alicloud_db_database_test.go
@@ -26,7 +26,7 @@ func TestAccAlicloudDBDatabase_basic(t *testing.T) {
 		CheckDestroy: testAccCheckDBDatabaseDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccDBDatabase_basic(DatabaseCommonTestCase),
+				Config: testAccDBDatabase_basic(RdsCommonTestCase),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckDBDatabaseExists(
 						"alicloud_db_database.db", &database),
@@ -93,9 +93,7 @@ func testAccDBDatabase_basic(common string) string {
 	variable "creation" {
 		default = "Rds"
 	}
-	variable "multi_az" {
-		default = "false"
-	}
+
 	variable "name" {
 		default = "tf-testAccDBdatabase_basic"
 	}

--- a/alicloud/resource_alicloud_kvstore_backup_policy_test.go
+++ b/alicloud/resource_alicloud_kvstore_backup_policy_test.go
@@ -135,7 +135,7 @@ func TestAccAlicloudKVStoreRedisBackupPolicy_vpc(t *testing.T) {
 		CheckDestroy: testAccCheckKVStoreBackupPolicyDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccKVStoreBackupPolicy_vpc(DatabaseCommonTestCase, string(KVStoreRedis), redisInstanceClassForTest, string(KVStore2Dot8)),
+				Config: testAccKVStoreBackupPolicy_vpc(KVStoreCommonTestCase, string(KVStoreRedis), redisInstanceClassForTest, string(KVStore2Dot8)),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckKVStoreBackupPolicyExists("alicloud_kvstore_backup_policy.policy", &policy),
 					resource.TestCheckResourceAttrSet("alicloud_kvstore_backup_policy.policy", "instance_id"),
@@ -144,7 +144,7 @@ func TestAccAlicloudKVStoreRedisBackupPolicy_vpc(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccKVStoreBackupPolicy_vpcUpdatePeriod(DatabaseCommonTestCase, string(KVStoreRedis), redisInstanceClassForTest, string(KVStore2Dot8)),
+				Config: testAccKVStoreBackupPolicy_vpcUpdatePeriod(KVStoreCommonTestCase, string(KVStoreRedis), redisInstanceClassForTest, string(KVStore2Dot8)),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckKVStoreBackupPolicyExists("alicloud_kvstore_backup_policy.policy", &policy),
 					resource.TestCheckResourceAttrSet("alicloud_kvstore_backup_policy.policy", "instance_id"),
@@ -153,7 +153,7 @@ func TestAccAlicloudKVStoreRedisBackupPolicy_vpc(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccKVStoreBackupPolicy_vpcUpdateTime(DatabaseCommonTestCase, string(KVStoreRedis), redisInstanceClassForTest, string(KVStore2Dot8)),
+				Config: testAccKVStoreBackupPolicy_vpcUpdateTime(KVStoreCommonTestCase, string(KVStoreRedis), redisInstanceClassForTest, string(KVStore2Dot8)),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckKVStoreBackupPolicyExists("alicloud_kvstore_backup_policy.policy", &policy),
 					resource.TestCheckResourceAttrSet("alicloud_kvstore_backup_policy.policy", "instance_id"),
@@ -162,7 +162,7 @@ func TestAccAlicloudKVStoreRedisBackupPolicy_vpc(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccKVStoreBackupPolicy_vpcUpdateAll(DatabaseCommonTestCase, string(KVStoreRedis), redisInstanceClassForTest, string(KVStore2Dot8)),
+				Config: testAccKVStoreBackupPolicy_vpcUpdateAll(KVStoreCommonTestCase, string(KVStoreRedis), redisInstanceClassForTest, string(KVStore2Dot8)),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckKVStoreBackupPolicyExists("alicloud_kvstore_backup_policy.policy", &policy),
 					resource.TestCheckResourceAttrSet("alicloud_kvstore_backup_policy.policy", "instance_id"),
@@ -190,7 +190,7 @@ func TestAccAlicloudKVStoreMemcacheBackupPolicy_vpc(t *testing.T) {
 		CheckDestroy: testAccCheckKVStoreBackupPolicyDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccKVStoreBackupPolicy_vpc(DatabaseCommonTestCase, string(KVStoreMemcache), memcacheInstanceClassForTest, string(KVStore2Dot8)),
+				Config: testAccKVStoreBackupPolicy_vpc(KVStoreCommonTestCase, string(KVStoreMemcache), memcacheInstanceClassForTest, string(KVStore2Dot8)),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckKVStoreBackupPolicyExists("alicloud_kvstore_backup_policy.policy", &policy),
 					resource.TestCheckResourceAttrSet("alicloud_kvstore_backup_policy.policy", "instance_id"),
@@ -199,7 +199,7 @@ func TestAccAlicloudKVStoreMemcacheBackupPolicy_vpc(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccKVStoreBackupPolicy_vpcUpdatePeriod(DatabaseCommonTestCase, string(KVStoreMemcache), memcacheInstanceClassForTest, string(KVStore2Dot8)),
+				Config: testAccKVStoreBackupPolicy_vpcUpdatePeriod(KVStoreCommonTestCase, string(KVStoreMemcache), memcacheInstanceClassForTest, string(KVStore2Dot8)),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckKVStoreBackupPolicyExists("alicloud_kvstore_backup_policy.policy", &policy),
 					resource.TestCheckResourceAttrSet("alicloud_kvstore_backup_policy.policy", "instance_id"),
@@ -208,7 +208,7 @@ func TestAccAlicloudKVStoreMemcacheBackupPolicy_vpc(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccKVStoreBackupPolicy_vpcUpdateTime(DatabaseCommonTestCase, string(KVStoreMemcache), memcacheInstanceClassForTest, string(KVStore2Dot8)),
+				Config: testAccKVStoreBackupPolicy_vpcUpdateTime(KVStoreCommonTestCase, string(KVStoreMemcache), memcacheInstanceClassForTest, string(KVStore2Dot8)),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckKVStoreBackupPolicyExists("alicloud_kvstore_backup_policy.policy", &policy),
 					resource.TestCheckResourceAttrSet("alicloud_kvstore_backup_policy.policy", "instance_id"),
@@ -217,7 +217,7 @@ func TestAccAlicloudKVStoreMemcacheBackupPolicy_vpc(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccKVStoreBackupPolicy_vpcUpdateAll(DatabaseCommonTestCase, string(KVStoreMemcache), memcacheInstanceClassForTest, string(KVStore2Dot8)),
+				Config: testAccKVStoreBackupPolicy_vpcUpdateAll(KVStoreCommonTestCase, string(KVStoreMemcache), memcacheInstanceClassForTest, string(KVStore2Dot8)),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckKVStoreBackupPolicyExists("alicloud_kvstore_backup_policy.policy", &policy),
 					resource.TestCheckResourceAttrSet("alicloud_kvstore_backup_policy.policy", "instance_id"),

--- a/alicloud/resource_alicloud_kvstore_instance_test.go
+++ b/alicloud/resource_alicloud_kvstore_instance_test.go
@@ -388,7 +388,7 @@ func TestAccAlicloudKVStoreRedisInstance_vpc(t *testing.T) {
 		CheckDestroy: testAccCheckKVStoreInstanceDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccKVStoreInstance_vpc(DatabaseCommonTestCase, redisInstanceClassForTest, string(KVStoreRedis), string(KVStore4Dot0)),
+				Config: testAccKVStoreInstance_vpc(KVStoreCommonTestCase, redisInstanceClassForTest, string(KVStoreRedis), string(KVStore4Dot0)),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckKVStoreInstanceExists("alicloud_kvstore_instance.foo", &instance),
 					resource.TestCheckResourceAttr("alicloud_kvstore_instance.foo", "instance_name", "tf-testAccKVStoreInstance_vpc"),
@@ -425,7 +425,7 @@ func TestAccAlicloudKVStoreRedisInstance_vpcUpdateSecurityIps(t *testing.T) {
 		CheckDestroy: testAccCheckKVStoreInstanceDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccKVStoreInstance_vpc(DatabaseCommonTestCase, redisInstanceClassForTest, string(KVStoreRedis), string(KVStore2Dot8)),
+				Config: testAccKVStoreInstance_vpc(KVStoreCommonTestCase, redisInstanceClassForTest, string(KVStoreRedis), string(KVStore2Dot8)),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckKVStoreInstanceExists("alicloud_kvstore_instance.foo", &instance),
 					resource.TestCheckResourceAttr("alicloud_kvstore_instance.foo", "instance_name", "tf-testAccKVStoreInstance_vpc"),
@@ -445,7 +445,7 @@ func TestAccAlicloudKVStoreRedisInstance_vpcUpdateSecurityIps(t *testing.T) {
 			},
 
 			{
-				Config: testAccKVStoreInstance_vpcUpdateSecurityIps(DatabaseCommonTestCase, redisInstanceClassForTest, string(KVStoreRedis), string(KVStore2Dot8)),
+				Config: testAccKVStoreInstance_vpcUpdateSecurityIps(KVStoreCommonTestCase, redisInstanceClassForTest, string(KVStoreRedis), string(KVStore2Dot8)),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckKVStoreInstanceExists("alicloud_kvstore_instance.foo", &instance),
 					resource.TestCheckResourceAttr("alicloud_kvstore_instance.foo", "instance_name", "tf-testAccKVStoreInstance_vpc"),
@@ -482,7 +482,7 @@ func TestAccAlicloudKVStoreRedisInstance_vpcUpdateClass(t *testing.T) {
 		CheckDestroy: testAccCheckKVStoreInstanceDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccKVStoreInstance_vpc(DatabaseCommonTestCase, redisInstanceClassForTest, string(KVStoreRedis), string(KVStore4Dot0)),
+				Config: testAccKVStoreInstance_vpc(KVStoreCommonTestCase, redisInstanceClassForTest, string(KVStoreRedis), string(KVStore4Dot0)),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckKVStoreInstanceExists("alicloud_kvstore_instance.foo", &instance),
 					resource.TestCheckResourceAttr("alicloud_kvstore_instance.foo", "instance_name", "tf-testAccKVStoreInstance_vpc"),
@@ -502,7 +502,7 @@ func TestAccAlicloudKVStoreRedisInstance_vpcUpdateClass(t *testing.T) {
 			},
 
 			{
-				Config: testAccKVStoreInstance_vpcUpdateClass(DatabaseCommonTestCase, redisInstanceClassForTestUpdateClass, string(KVStoreRedis), string(KVStore4Dot0)),
+				Config: testAccKVStoreInstance_vpcUpdateClass(KVStoreCommonTestCase, redisInstanceClassForTestUpdateClass, string(KVStoreRedis), string(KVStore4Dot0)),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckKVStoreInstanceExists("alicloud_kvstore_instance.foo", &instance),
 					resource.TestCheckResourceAttr("alicloud_kvstore_instance.foo", "instance_name", "tf-testAccKVStoreInstance_vpc"),
@@ -539,7 +539,7 @@ func TestAccAlicloudKVStoreRedisInstance_vpcUpdateAttr(t *testing.T) {
 		CheckDestroy: testAccCheckKVStoreInstanceDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccKVStoreInstance_vpc(DatabaseCommonTestCase, redisInstanceClassForTest, string(KVStoreRedis), string(KVStore2Dot8)),
+				Config: testAccKVStoreInstance_vpc(KVStoreCommonTestCase, redisInstanceClassForTest, string(KVStoreRedis), string(KVStore2Dot8)),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckKVStoreInstanceExists("alicloud_kvstore_instance.foo", &instance),
 					resource.TestCheckResourceAttr("alicloud_kvstore_instance.foo", "instance_name", "tf-testAccKVStoreInstance_vpc"),
@@ -559,7 +559,7 @@ func TestAccAlicloudKVStoreRedisInstance_vpcUpdateAttr(t *testing.T) {
 			},
 
 			{
-				Config: testAccKVStoreInstance_vpcUpdateAttr(DatabaseCommonTestCase, redisInstanceClassForTest, string(KVStoreRedis), string(KVStore2Dot8)),
+				Config: testAccKVStoreInstance_vpcUpdateAttr(KVStoreCommonTestCase, redisInstanceClassForTest, string(KVStoreRedis), string(KVStore2Dot8)),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckKVStoreInstanceExists("alicloud_kvstore_instance.foo", &instance),
 					resource.TestCheckResourceAttr("alicloud_kvstore_instance.foo", "instance_name", "tf-testAccKVStoreInstance_vpcUpdateAttr"),
@@ -597,7 +597,7 @@ func TestAccAlicloudKVStoreRedisInstance_vpcUpdateAll(t *testing.T) {
 		CheckDestroy: testAccCheckKVStoreInstanceDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccKVStoreInstance_vpc(DatabaseCommonTestCase, redisInstanceClassForTest, string(KVStoreRedis), string(KVStore4Dot0)),
+				Config: testAccKVStoreInstance_vpc(KVStoreCommonTestCase, redisInstanceClassForTest, string(KVStoreRedis), string(KVStore4Dot0)),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckKVStoreInstanceExists("alicloud_kvstore_instance.foo", &instance),
 					resource.TestCheckResourceAttr("alicloud_kvstore_instance.foo", "instance_name", "tf-testAccKVStoreInstance_vpc"),
@@ -617,7 +617,7 @@ func TestAccAlicloudKVStoreRedisInstance_vpcUpdateAll(t *testing.T) {
 			},
 
 			{
-				Config: testAccKVStoreInstance_vpcUpdateAll(DatabaseCommonTestCase, redisInstanceClassForTestUpdateClass, string(KVStoreRedis), string(KVStore4Dot0)),
+				Config: testAccKVStoreInstance_vpcUpdateAll(KVStoreCommonTestCase, redisInstanceClassForTestUpdateClass, string(KVStoreRedis), string(KVStore4Dot0)),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckKVStoreInstanceExists("alicloud_kvstore_instance.foo", &instance),
 					resource.TestCheckResourceAttr("alicloud_kvstore_instance.foo", "instance_name", "tf-testAccKVStoreInstance_vpcUpdateAll"),
@@ -920,7 +920,7 @@ func TestAccAlicloudKVStoreMemcacheInstance_vpc(t *testing.T) {
 		CheckDestroy: testAccCheckKVStoreInstanceDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccKVStoreInstance_vpc(DatabaseCommonTestCase, memcacheInstanceClassForTest, string(KVStoreMemcache), string(KVStore2Dot8)),
+				Config: testAccKVStoreInstance_vpc(KVStoreCommonTestCase, memcacheInstanceClassForTest, string(KVStoreMemcache), string(KVStore2Dot8)),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckKVStoreInstanceExists("alicloud_kvstore_instance.foo", &instance),
 					resource.TestCheckResourceAttr("alicloud_kvstore_instance.foo", "instance_name", "tf-testAccKVStoreInstance_vpc"),
@@ -957,7 +957,7 @@ func TestAccAlicloudKVStoreMemcacheInstance_vpcUpdateSecurityIps(t *testing.T) {
 		CheckDestroy: testAccCheckKVStoreInstanceDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccKVStoreInstance_vpc(DatabaseCommonTestCase, memcacheInstanceClassForTest, string(KVStoreMemcache), string(KVStore2Dot8)),
+				Config: testAccKVStoreInstance_vpc(KVStoreCommonTestCase, memcacheInstanceClassForTest, string(KVStoreMemcache), string(KVStore2Dot8)),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckKVStoreInstanceExists("alicloud_kvstore_instance.foo", &instance),
 					resource.TestCheckResourceAttr("alicloud_kvstore_instance.foo", "instance_name", "tf-testAccKVStoreInstance_vpc"),
@@ -977,7 +977,7 @@ func TestAccAlicloudKVStoreMemcacheInstance_vpcUpdateSecurityIps(t *testing.T) {
 			},
 
 			{
-				Config: testAccKVStoreInstance_vpcUpdateSecurityIps(DatabaseCommonTestCase, memcacheInstanceClassForTest, string(KVStoreMemcache), string(KVStore2Dot8)),
+				Config: testAccKVStoreInstance_vpcUpdateSecurityIps(KVStoreCommonTestCase, memcacheInstanceClassForTest, string(KVStoreMemcache), string(KVStore2Dot8)),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckKVStoreInstanceExists("alicloud_kvstore_instance.foo", &instance),
 					resource.TestCheckResourceAttr("alicloud_kvstore_instance.foo", "instance_name", "tf-testAccKVStoreInstance_vpc"),
@@ -1014,7 +1014,7 @@ func TestAccAlicloudKVStoreMemcacheInstance_vpcUpdateClass(t *testing.T) {
 		CheckDestroy: testAccCheckKVStoreInstanceDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccKVStoreInstance_vpc(DatabaseCommonTestCase, memcacheInstanceClassForTest, string(KVStoreMemcache), string(KVStore2Dot8)),
+				Config: testAccKVStoreInstance_vpc(KVStoreCommonTestCase, memcacheInstanceClassForTest, string(KVStoreMemcache), string(KVStore2Dot8)),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckKVStoreInstanceExists("alicloud_kvstore_instance.foo", &instance),
 					resource.TestCheckResourceAttr("alicloud_kvstore_instance.foo", "instance_name", "tf-testAccKVStoreInstance_vpc"),
@@ -1034,7 +1034,7 @@ func TestAccAlicloudKVStoreMemcacheInstance_vpcUpdateClass(t *testing.T) {
 			},
 
 			{
-				Config: testAccKVStoreInstance_vpcUpdateClass(DatabaseCommonTestCase, memcacheInstanceClassForTestUpdateClass, string(KVStoreMemcache), string(KVStore2Dot8)),
+				Config: testAccKVStoreInstance_vpcUpdateClass(KVStoreCommonTestCase, memcacheInstanceClassForTestUpdateClass, string(KVStoreMemcache), string(KVStore2Dot8)),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckKVStoreInstanceExists("alicloud_kvstore_instance.foo", &instance),
 					resource.TestCheckResourceAttr("alicloud_kvstore_instance.foo", "instance_name", "tf-testAccKVStoreInstance_vpc"),
@@ -1071,7 +1071,7 @@ func TestAccAlicloudKVStoreMemcacheInstance_vpcUpdateAttr(t *testing.T) {
 		CheckDestroy: testAccCheckKVStoreInstanceDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccKVStoreInstance_vpc(DatabaseCommonTestCase, memcacheInstanceClassForTest, string(KVStoreMemcache), string(KVStore2Dot8)),
+				Config: testAccKVStoreInstance_vpc(KVStoreCommonTestCase, memcacheInstanceClassForTest, string(KVStoreMemcache), string(KVStore2Dot8)),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckKVStoreInstanceExists("alicloud_kvstore_instance.foo", &instance),
 					resource.TestCheckResourceAttr("alicloud_kvstore_instance.foo", "instance_name", "tf-testAccKVStoreInstance_vpc"),
@@ -1091,7 +1091,7 @@ func TestAccAlicloudKVStoreMemcacheInstance_vpcUpdateAttr(t *testing.T) {
 			},
 
 			{
-				Config: testAccKVStoreInstance_vpcUpdateAttr(DatabaseCommonTestCase, memcacheInstanceClassForTest, string(KVStoreMemcache), string(KVStore2Dot8)),
+				Config: testAccKVStoreInstance_vpcUpdateAttr(KVStoreCommonTestCase, memcacheInstanceClassForTest, string(KVStoreMemcache), string(KVStore2Dot8)),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckKVStoreInstanceExists("alicloud_kvstore_instance.foo", &instance),
 					resource.TestCheckResourceAttr("alicloud_kvstore_instance.foo", "instance_name", "tf-testAccKVStoreInstance_vpcUpdateAttr"),
@@ -1129,7 +1129,7 @@ func TestAccAlicloudKVStoreMemcacheInstance_vpcUpdateAll(t *testing.T) {
 		CheckDestroy: testAccCheckKVStoreInstanceDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccKVStoreInstance_vpc(DatabaseCommonTestCase, memcacheInstanceClassForTest, string(KVStoreMemcache), string(KVStore2Dot8)),
+				Config: testAccKVStoreInstance_vpc(KVStoreCommonTestCase, memcacheInstanceClassForTest, string(KVStoreMemcache), string(KVStore2Dot8)),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckKVStoreInstanceExists("alicloud_kvstore_instance.foo", &instance),
 					resource.TestCheckResourceAttr("alicloud_kvstore_instance.foo", "instance_name", "tf-testAccKVStoreInstance_vpc"),
@@ -1149,7 +1149,7 @@ func TestAccAlicloudKVStoreMemcacheInstance_vpcUpdateAll(t *testing.T) {
 			},
 
 			{
-				Config: testAccKVStoreInstance_vpcUpdateAll(DatabaseCommonTestCase, memcacheInstanceClassForTestUpdateClass, string(KVStoreMemcache), string(KVStore2Dot8)),
+				Config: testAccKVStoreInstance_vpcUpdateAll(KVStoreCommonTestCase, memcacheInstanceClassForTestUpdateClass, string(KVStoreMemcache), string(KVStore2Dot8)),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckKVStoreInstanceExists("alicloud_kvstore_instance.foo", &instance),
 					resource.TestCheckResourceAttr("alicloud_kvstore_instance.foo", "instance_name", "tf-testAccKVStoreInstance_vpcUpdateAll"),
@@ -1322,9 +1322,6 @@ func testAccKVStoreInstance_vpc(common, instanceClass, instanceType, engineVersi
 	variable "creation" {
 		default = "KVStore"
 	}
-	variable "multi_az" {
-		default = "false"
-	}
 	variable "name" {
 		default = "tf-testAccKVStoreInstance_vpc"
 	}
@@ -1344,9 +1341,6 @@ func testAccKVStoreInstance_vpcUpdateSecurityIps(common, instanceClass, instance
 	%s
 	variable "creation" {
 		default = "KVStore"
-	}
-	variable "multi_az" {
-		default = "false"
 	}
 	variable "name" {
 		default = "tf-testAccKVStoreInstance_vpc"
@@ -1368,9 +1362,6 @@ func testAccKVStoreInstance_vpcUpdateClass(common, instanceClass, instanceType, 
 	variable "creation" {
 		default = "KVStore"
 	}
-	variable "multi_az" {
-		default = "false"
-	}
 	variable "name" {
 		default = "tf-testAccKVStoreInstance_vpc"
 	}
@@ -1390,9 +1381,6 @@ func testAccKVStoreInstance_vpcUpdateAttr(common, instanceClass, instanceType, e
 	%s
 	variable "creation" {
 		default = "KVStore"
-	}
-	variable "multi_az" {
-		default = "false"
 	}
 	variable "name" {
 		default = "tf-testAccKVStoreInstance_vpcUpdateAttr"
@@ -1415,9 +1403,6 @@ func testAccKVStoreInstance_vpcUpdateAll(common, instanceClass, instanceType, en
 	%s
 	variable "creation" {
 		default = "KVStore"
-	}
-	variable "multi_az" {
-		default = "false"
 	}
 	variable "name" {
 		default = "tf-testAccKVStoreInstance_vpcUpdateAll"

--- a/alicloud/service_alicloud_common_test.go
+++ b/alicloud/service_alicloud_common_test.go
@@ -52,10 +52,26 @@ resource "alicloud_security_group_rule" "default" {
 }
 `
 
-const DatabaseCommonTestCase = `
+const RdsCommonTestCase = `
 data "alicloud_zones" "default" {
   available_resource_creation = "${var.creation}"
-  multi = "${var.multi_az}"
+}
+
+resource "alicloud_vpc" "default" {
+  name       = "${var.name}"
+  cidr_block = "172.16.0.0/16"
+}
+
+resource "alicloud_vswitch" "default" {
+  vpc_id            = "${alicloud_vpc.default.id}"
+  cidr_block        = "172.16.0.0/24"
+  availability_zone = "${data.alicloud_zones.default.zones.0.id}"
+  name              = "${var.name}"
+}
+`
+const KVStoreCommonTestCase = `
+data "alicloud_zones" "default" {
+  available_resource_creation = "${var.creation}"
 }
 
 resource "alicloud_vpc" "default" {
@@ -67,6 +83,25 @@ resource "alicloud_vswitch" "default" {
   vpc_id            = "${alicloud_vpc.default.id}"
   cidr_block        = "172.16.0.0/24"
   availability_zone = "${lookup(data.alicloud_zones.default.zones[(length(data.alicloud_zones.default.zones)-1)%length(data.alicloud_zones.default.zones)], "id")}"
+  name              = "${var.name}"
+}
+`
+
+const DBMultiAZCommonTestCase = `
+data "alicloud_zones" "default" {
+  available_resource_creation = "${var.creation}"
+  multi = true
+}
+
+resource "alicloud_vpc" "default" {
+  name       = "${var.name}"
+  cidr_block = "172.16.0.0/16"
+}
+
+resource "alicloud_vswitch" "default" {
+  vpc_id            = "${alicloud_vpc.default.id}"
+  cidr_block        = "172.16.0.0/24"
+  availability_zone = "${data.alicloud_zones.default.zones.0.multi_zone_ids[0]}"
   name              = "${var.name}"
 }
 `

--- a/alicloud/service_alicloud_ecs.go
+++ b/alicloud/service_alicloud_ecs.go
@@ -61,7 +61,7 @@ func (s *EcsService) DescribeZone(zoneID string) (zone ecs.Zone, err error) {
 		}
 		zoneIds = append(zoneIds, z.ZoneId)
 	}
-	return zone, fmt.Errorf("availability_zone not exists in range %s, all zones are %s", s.client.RegionId, zoneIds)
+	return zone, fmt.Errorf("availability_zone %s not exists in region %s, all zones are %s", zoneID, s.client.RegionId, zoneIds)
 }
 
 func (s *EcsService) DescribeInstanceById(id string) (instance ecs.Instance, err error) {


### PR DESCRIPTION
```
TF_ACC=1 go test ./alicloud -v -run=TestAccAlicloudDB -timeout=240m
=== RUN   TestAccAlicloudDBInstancesDataSource
--- PASS: TestAccAlicloudDBInstancesDataSource (92.26s)
=== RUN   TestAccAlicloudDBInstancesDataSourceEmpty
--- PASS: TestAccAlicloudDBInstancesDataSourceEmpty (2.48s)
=== RUN   TestAccAlicloudDBAccountPrivilege_import
--- PASS: TestAccAlicloudDBAccountPrivilege_import (262.29s)
=== RUN   TestAccAlicloudDBAccount_import
--- PASS: TestAccAlicloudDBAccount_import (664.95s)
=== RUN   TestAccAlicloudDBBackupPolicy_import
--- PASS: TestAccAlicloudDBBackupPolicy_import (110.89s)
=== RUN   TestAccAlicloudDBConnection_import
--- PASS: TestAccAlicloudDBConnection_import (318.12s)
=== RUN   TestAccAlicloudDBDatabase_import
--- PASS: TestAccAlicloudDBDatabase_import (270.87s)
=== RUN   TestAccAlicloudDBInstance_import
--- PASS: TestAccAlicloudDBInstance_import (92.54s)
=== RUN   TestAccAlicloudDBAccountPrivilege_basic
--- PASS: TestAccAlicloudDBAccountPrivilege_basic (257.19s)
=== RUN   TestAccAlicloudDBAccount_mysql
```