### PR TITLE
Improve vpc resource and data source testcases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 IMPROVEMENTS:
 
+- Improve vpc resource and data source testcases [GH-684]
 - Modify the slb sever group testcase name [GH-681]
 - Improve sweeper testcases [GH-680]
 - Improve db instance's testcases [GH-679]

--- a/alicloud/data_source_alicloud_vpcs_test.go
+++ b/alicloud/data_source_alicloud_vpcs_test.go
@@ -35,6 +35,90 @@ func TestAccAlicloudVpcsDataSource_cidr_block(t *testing.T) {
 	})
 }
 
+func TestAccCheckAlicloudVpcsDataSource_Status(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+		},
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCheckAlicloudVpcsDataSourceStatus,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAlicloudDataSourceID("data.alicloud_vpcs.vpc"),
+					resource.TestCheckResourceAttr("data.alicloud_vpcs.vpc", "vpcs.#", "1"),
+					resource.TestCheckResourceAttrSet("data.alicloud_vpcs.vpc", "vpcs.0.id"),
+					resource.TestCheckResourceAttrSet("data.alicloud_vpcs.vpc", "vpcs.0.region_id"),
+					resource.TestCheckResourceAttr("data.alicloud_vpcs.vpc", "vpcs.0.status", "Available"),
+					resource.TestCheckResourceAttr("data.alicloud_vpcs.vpc", "vpcs.0.vpc_name", "tf-testAccVpcsdatasourceStatus"),
+					resource.TestCheckResourceAttr("data.alicloud_vpcs.vpc", "vpcs.0.vswitch_ids.#", "0"),
+					resource.TestCheckResourceAttr("data.alicloud_vpcs.vpc", "vpcs.0.cidr_block", "172.16.0.0/12"),
+					resource.TestCheckResourceAttrSet("data.alicloud_vpcs.vpc", "vpcs.0.vrouter_id"),
+					resource.TestCheckResourceAttrSet("data.alicloud_vpcs.vpc", "vpcs.0.route_table_id"),
+					resource.TestCheckResourceAttr("data.alicloud_vpcs.vpc", "vpcs.0.description", ""),
+					resource.TestCheckResourceAttr("data.alicloud_vpcs.vpc", "vpcs.0.is_default", "false"),
+					resource.TestCheckResourceAttrSet("data.alicloud_vpcs.vpc", "vpcs.0.creation_time"),
+				),
+			},
+		},
+	})
+}
+func TestAccCheckAlicloudVpcsDataSource_Is_Default(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+		},
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCheckAlicloudVpcsDataSourceIsDefault,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAlicloudDataSourceID("data.alicloud_vpcs.vpc"),
+					resource.TestCheckResourceAttr("data.alicloud_vpcs.vpc", "vpcs.#", "1"),
+					resource.TestCheckResourceAttrSet("data.alicloud_vpcs.vpc", "vpcs.0.id"),
+					resource.TestCheckResourceAttrSet("data.alicloud_vpcs.vpc", "vpcs.0.region_id"),
+					resource.TestCheckResourceAttr("data.alicloud_vpcs.vpc", "vpcs.0.status", "Available"),
+					resource.TestCheckResourceAttr("data.alicloud_vpcs.vpc", "vpcs.0.vpc_name", "tf-testAccVpcsdatasourceIsDefault"),
+					resource.TestCheckResourceAttr("data.alicloud_vpcs.vpc", "vpcs.0.vswitch_ids.#", "0"),
+					resource.TestCheckResourceAttr("data.alicloud_vpcs.vpc", "vpcs.0.cidr_block", "172.16.0.0/12"),
+					resource.TestCheckResourceAttrSet("data.alicloud_vpcs.vpc", "vpcs.0.vrouter_id"),
+					resource.TestCheckResourceAttrSet("data.alicloud_vpcs.vpc", "vpcs.0.route_table_id"),
+					resource.TestCheckResourceAttr("data.alicloud_vpcs.vpc", "vpcs.0.description", ""),
+					resource.TestCheckResourceAttr("data.alicloud_vpcs.vpc", "vpcs.0.is_default", "false"),
+					resource.TestCheckResourceAttrSet("data.alicloud_vpcs.vpc", "vpcs.0.creation_time"),
+				),
+			},
+		},
+	})
+}
+func TestAccCheckAlicloudVpcsDataSource_VSwitch_ID(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+		},
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCheckAlicloudVpcsDataSourceVSwitchID,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAlicloudDataSourceID("data.alicloud_vpcs.vpc"),
+					resource.TestCheckResourceAttr("data.alicloud_vpcs.vpc", "vpcs.#", "1"),
+					resource.TestCheckResourceAttrSet("data.alicloud_vpcs.vpc", "vpcs.0.id"),
+					resource.TestCheckResourceAttrSet("data.alicloud_vpcs.vpc", "vpcs.0.region_id"),
+					resource.TestCheckResourceAttr("data.alicloud_vpcs.vpc", "vpcs.0.status", "Available"),
+					resource.TestCheckResourceAttr("data.alicloud_vpcs.vpc", "vpcs.0.vpc_name", "tf-testAccVpcsdatasourceVSwitchID"),
+					resource.TestCheckResourceAttr("data.alicloud_vpcs.vpc", "vpcs.0.vswitch_ids.#", "1"),
+					resource.TestCheckResourceAttr("data.alicloud_vpcs.vpc", "vpcs.0.cidr_block", "172.16.0.0/12"),
+					resource.TestCheckResourceAttrSet("data.alicloud_vpcs.vpc", "vpcs.0.vrouter_id"),
+					resource.TestCheckResourceAttrSet("data.alicloud_vpcs.vpc", "vpcs.0.route_table_id"),
+					resource.TestCheckResourceAttr("data.alicloud_vpcs.vpc", "vpcs.0.description", ""),
+					resource.TestCheckResourceAttr("data.alicloud_vpcs.vpc", "vpcs.0.is_default", "false"),
+					resource.TestCheckResourceAttrSet("data.alicloud_vpcs.vpc", "vpcs.0.creation_time"),
+				),
+			},
+		},
+	})
+}
 func TestAccAlicloudVpcsDataSource_empty(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
@@ -77,7 +161,51 @@ data "alicloud_vpcs" "vpc" {
   cidr_block = "${alicloud_vpc.foo.cidr_block}"
 }
 `
-
+const testAccCheckAlicloudVpcsDataSourceStatus = `
+variable "name" {
+  default = "tf-testAccVpcsdatasourceStatus"
+}
+resource "alicloud_vpc" "foo" {
+  name = "${var.name}"
+  cidr_block = "172.16.0.0/12"
+}
+data "alicloud_vpcs" "vpc" {
+  name_regex = "${alicloud_vpc.foo.name}"
+  status = "Available"
+}
+`
+const testAccCheckAlicloudVpcsDataSourceIsDefault = `
+variable "name" {
+  default = "tf-testAccVpcsdatasourceIsDefault"
+}
+resource "alicloud_vpc" "foo" {
+  name = "${var.name}"
+  cidr_block = "172.16.0.0/12"
+}
+data "alicloud_vpcs" "vpc" {
+  name_regex = "${alicloud_vpc.foo.name}"
+  is_default="false"
+}
+`
+const testAccCheckAlicloudVpcsDataSourceVSwitchID = `
+variable "name" {
+  default = "tf-testAccVpcsdatasourceVSwitchID"
+}
+resource "alicloud_vpc" "foo" {
+  name = "${var.name}"
+  cidr_block = "172.16.0.0/12"
+}
+data "alicloud_zones" "default" {}
+resource "alicloud_vswitch" "vswitch" {
+	name = "${var.name}"
+	cidr_block = "172.16.0.0/16"
+	vpc_id = "${alicloud_vpc.foo.id}"
+	availability_zone = "${data.alicloud_zones.default.zones.0.id}"
+}
+data "alicloud_vpcs" "vpc" {
+  vswitch_id="${alicloud_vswitch.vswitch.id}"
+}
+`
 const testAccCheckAlicloudVpcsDataSourceEmpty = `
 data "alicloud_vpcs" "vpc" {
   name_regex = "^tf-fake-name"

--- a/alicloud/resource_alicloud_vpc.go
+++ b/alicloud/resource_alicloud_vpc.go
@@ -101,7 +101,7 @@ func resourceAliyunVpcCreate(d *schema.ResourceData, meta interface{}) error {
 		return fmt.Errorf("Timeout when WaitForVpcAvailable")
 	}
 
-	return resourceAliyunVpcUpdate(d, meta)
+	return resourceAliyunVpcRead(d, meta)
 }
 
 func resourceAliyunVpcRead(d *schema.ResourceData, meta interface{}) error {

--- a/alicloud/resource_alicloud_vpc_test.go
+++ b/alicloud/resource_alicloud_vpc_test.go
@@ -118,12 +118,11 @@ func TestAccAlicloudVpc_basic(t *testing.T) {
 				Config: testAccVpcConfig,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckVpcExists("alicloud_vpc.foo", &vpc),
-					resource.TestCheckResourceAttr(
-						"alicloud_vpc.foo", "cidr_block", "172.16.0.0/12"),
-					resource.TestCheckResourceAttrSet(
-						"alicloud_vpc.foo", "router_id"),
-					resource.TestCheckResourceAttrSet(
-						"alicloud_vpc.foo", "route_table_id"),
+					resource.TestCheckResourceAttr("alicloud_vpc.foo", "cidr_block", "172.16.0.0/12"),
+					resource.TestCheckResourceAttrSet("alicloud_vpc.foo", "router_id"),
+					resource.TestCheckResourceAttrSet("alicloud_vpc.foo", "route_table_id"),
+					resource.TestCheckResourceAttr("alicloud_vpc.foo", "name", "tf-testAccVpcConfig"),
+					resource.TestCheckResourceAttr("alicloud_vpc.foo", "description", ""),
 				),
 			},
 		},
@@ -145,16 +144,44 @@ func TestAccAlicloudVpc_update(t *testing.T) {
 				Config: testAccVpcConfig,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckVpcExists("alicloud_vpc.foo", &vpc),
-					resource.TestCheckResourceAttr(
-						"alicloud_vpc.foo", "cidr_block", "172.16.0.0/12"),
+					resource.TestCheckResourceAttr("alicloud_vpc.foo", "cidr_block", "172.16.0.0/12"),
+					resource.TestCheckResourceAttrSet("alicloud_vpc.foo", "router_id"),
+					resource.TestCheckResourceAttrSet("alicloud_vpc.foo", "route_table_id"),
+					resource.TestCheckResourceAttr("alicloud_vpc.foo", "name", "tf-testAccVpcConfig"),
+					resource.TestCheckResourceAttr("alicloud_vpc.foo", "description", ""),
 				),
 			},
 			{
-				Config: testAccVpcConfigUpdate,
+				Config: testAccVpcConfigUpdateName,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckVpcExists("alicloud_vpc.foo", &vpc),
-					resource.TestCheckResourceAttr(
-						"alicloud_vpc.foo", "name", "tf_testAccVpcConfigUpdate"),
+					resource.TestCheckResourceAttr("alicloud_vpc.foo", "cidr_block", "172.16.0.0/12"),
+					resource.TestCheckResourceAttrSet("alicloud_vpc.foo", "router_id"),
+					resource.TestCheckResourceAttrSet("alicloud_vpc.foo", "route_table_id"),
+					resource.TestCheckResourceAttr("alicloud_vpc.foo", "name", "tf_testAccVpcConfigUpdateName"),
+					resource.TestCheckResourceAttr("alicloud_vpc.foo", "description", ""),
+				),
+			},
+			{
+				Config: testAccVpcConfigUpdateDesc,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckVpcExists("alicloud_vpc.foo", &vpc),
+					resource.TestCheckResourceAttr("alicloud_vpc.foo", "cidr_block", "172.16.0.0/12"),
+					resource.TestCheckResourceAttrSet("alicloud_vpc.foo", "router_id"),
+					resource.TestCheckResourceAttrSet("alicloud_vpc.foo", "route_table_id"),
+					resource.TestCheckResourceAttr("alicloud_vpc.foo", "name", "tf_testAccVpcConfigUpdateName"),
+					resource.TestCheckResourceAttr("alicloud_vpc.foo", "description", "hello,world"),
+				),
+			},
+			{
+				Config: testAccVpcConfigUpdateNameAndDesc,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckVpcExists("alicloud_vpc.foo", &vpc),
+					resource.TestCheckResourceAttr("alicloud_vpc.foo", "cidr_block", "172.16.0.0/12"),
+					resource.TestCheckResourceAttrSet("alicloud_vpc.foo", "router_id"),
+					resource.TestCheckResourceAttrSet("alicloud_vpc.foo", "route_table_id"),
+					resource.TestCheckResourceAttr("alicloud_vpc.foo", "name", "tf_testAccVpcConfigUpdateNameAndDesc"),
+					resource.TestCheckResourceAttr("alicloud_vpc.foo", "description", "who am i"),
 				),
 			},
 		},
@@ -247,13 +274,26 @@ resource "alicloud_vpc" "foo" {
 }
 `
 
-const testAccVpcConfigUpdate = `
+const testAccVpcConfigUpdateName = `
 resource "alicloud_vpc" "foo" {
 	cidr_block = "172.16.0.0/12"
-	name = "tf_testAccVpcConfigUpdate"
+	name = "tf_testAccVpcConfigUpdateName"
 }
 `
-
+const testAccVpcConfigUpdateDesc = `
+resource "alicloud_vpc" "foo" {
+	cidr_block = "172.16.0.0/12"
+	name = "tf_testAccVpcConfigUpdateName"
+	description="hello,world"
+}
+`
+const testAccVpcConfigUpdateNameAndDesc = `
+resource "alicloud_vpc" "foo" {
+	cidr_block = "172.16.0.0/12"
+	name = "tf_testAccVpcConfigUpdateNameAndDesc"
+	description="who am i"
+}
+`
 const testAccVpcConfigMulti = `
 variable "name" {
   	default = "tf-testAccVpcConfigMulti"


### PR DESCRIPTION
```
> go test ./alicloud -v -run=TestAccCheckAlicloudVpcsDataSource_ -timeout=1440m
=== RUN   TestAccCheckAlicloudVpcsDataSource_Status
--- PASS: TestAccCheckAlicloudVpcsDataSource_Status (8.78s)
=== RUN   TestAccCheckAlicloudVpcsDataSource_Is_Default
--- PASS: TestAccCheckAlicloudVpcsDataSource_Is_Default (8.62s)
=== RUN   TestAccCheckAlicloudVpcsDataSource_VSwitch_ID
--- PASS: TestAccCheckAlicloudVpcsDataSource_VSwitch_ID (20.99s)
PASS
ok      github.com/terraform-providers/terraform-provider-alicloud/alicloud     41.124s
```

```
> go test ./alicloud -v -run=TestAccAlicloudVpc_ -timeout=1440m
=== RUN   TestAccAlicloudVpc_importBasic
--- PASS: TestAccAlicloudVpc_importBasic (9.25s)
=== RUN   TestAccAlicloudVpc_basic
--- PASS: TestAccAlicloudVpc_basic (8.80s)
=== RUN   TestAccAlicloudVpc_update
--- PASS: TestAccAlicloudVpc_update (13.41s)
=== RUN   TestAccAlicloudVpc_multi
--- PASS: TestAccAlicloudVpc_multi (14.96s)
PASS
ok      github.com/terraform-providers/terraform-provider-alicloud/alicloud     49.160s
```