### PR TITLE
Improve vswitch resource and data source testcases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,8 @@
 ## 1.29.0 (Unreleased)
 
 IMPROVEMENTS:
-
+- Improve vswitch resource and data source testcases [GH-687]
+- Improve security_group resource and data source testcases [GH-686]
 - Improve vpc resource and data source testcases [GH-684]
 - Modify the slb sever group testcase name [GH-681]
 - Improve sweeper testcases [GH-680]

--- a/alicloud/data_source_alicloud_vswitches_test.go
+++ b/alicloud/data_source_alicloud_vswitches_test.go
@@ -1,10 +1,12 @@
 package alicloud
 
 import (
+	"fmt"
 	"testing"
 
 	"regexp"
 
+	"github.com/hashicorp/terraform/helper/acctest"
 	"github.com/hashicorp/terraform/helper/resource"
 )
 
@@ -26,6 +28,87 @@ func TestAccAlicloudVSwitchesDataSource(t *testing.T) {
 					resource.TestMatchResourceAttr("data.alicloud_vswitches.foo", "vswitches.0.name", regexp.MustCompile("^tf-testAcc-for-vswitch-datasourc")),
 					resource.TestCheckResourceAttr("data.alicloud_vswitches.foo", "vswitches.0.instance_ids.#", "0"),
 					resource.TestCheckResourceAttr("data.alicloud_vswitches.foo", "vswitches.0.cidr_block", "172.16.0.0/16"),
+					resource.TestCheckResourceAttr("data.alicloud_vswitches.foo", "vswitches.0.description", ""),
+					resource.TestCheckResourceAttr("data.alicloud_vswitches.foo", "vswitches.0.is_default", "false"),
+					resource.TestCheckResourceAttrSet("data.alicloud_vswitches.foo", "vswitches.0.creation_time"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAlicloudVSwitchesDataSource_Name_Regex(t *testing.T) {
+	rand := acctest.RandIntRange(10000, 99999)
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+		},
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCheckAlicloudVSwitchesDataSourceConfigNameRegex(rand),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAlicloudDataSourceID("data.alicloud_vswitches.foo"),
+					resource.TestCheckResourceAttr("data.alicloud_vswitches.foo", "vswitches.#", "1"),
+					resource.TestCheckResourceAttrSet("data.alicloud_vswitches.foo", "vswitches.0.id"),
+					resource.TestCheckResourceAttrSet("data.alicloud_vswitches.foo", "vswitches.0.vpc_id"),
+					resource.TestCheckResourceAttrSet("data.alicloud_vswitches.foo", "vswitches.0.zone_id"),
+					resource.TestMatchResourceAttr("data.alicloud_vswitches.foo", "vswitches.0.name", regexp.MustCompile(fmt.Sprintf("tf-testAcc-for-vswitch-datasource-name-regex-%d", rand))),
+					resource.TestCheckResourceAttr("data.alicloud_vswitches.foo", "vswitches.0.cidr_block", "172.16.1.0/24"),
+					resource.TestCheckResourceAttr("data.alicloud_vswitches.foo", "vswitches.0.instance_ids.#", "0"),
+					resource.TestCheckResourceAttr("data.alicloud_vswitches.foo", "vswitches.0.description", ""),
+					resource.TestCheckResourceAttr("data.alicloud_vswitches.foo", "vswitches.0.is_default", "false"),
+					resource.TestCheckResourceAttrSet("data.alicloud_vswitches.foo", "vswitches.0.creation_time"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAlicloudVSwitchesDataSource_vpcid(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+		},
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCheckAlicloudVSwitchesDataSourceConfigVPCID,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAlicloudDataSourceID("data.alicloud_vswitches.foo"),
+					resource.TestCheckResourceAttr("data.alicloud_vswitches.foo", "vswitches.#", "1"),
+					resource.TestCheckResourceAttrSet("data.alicloud_vswitches.foo", "vswitches.0.id"),
+					resource.TestCheckResourceAttrSet("data.alicloud_vswitches.foo", "vswitches.0.vpc_id"),
+					resource.TestCheckResourceAttrSet("data.alicloud_vswitches.foo", "vswitches.0.zone_id"),
+					resource.TestMatchResourceAttr("data.alicloud_vswitches.foo", "vswitches.0.name", regexp.MustCompile("^tf-testAcc-for-vswitch-datasource-VPC-ID")),
+					resource.TestCheckResourceAttr("data.alicloud_vswitches.foo", "vswitches.0.cidr_block", "172.16.0.0/24"),
+					resource.TestCheckResourceAttr("data.alicloud_vswitches.foo", "vswitches.0.instance_ids.#", "0"),
+					resource.TestCheckResourceAttr("data.alicloud_vswitches.foo", "vswitches.0.description", ""),
+					resource.TestCheckResourceAttr("data.alicloud_vswitches.foo", "vswitches.0.is_default", "false"),
+					resource.TestCheckResourceAttrSet("data.alicloud_vswitches.foo", "vswitches.0.creation_time"),
+				),
+			},
+		},
+	})
+}
+func TestAccAlicloudVSwitchesDataSource_Zone_ID(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+		},
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCheckAlicloudVSwitchesDataSourceConfigAvailabilityZoneID,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAlicloudDataSourceID("data.alicloud_vswitches.foo"),
+					resource.TestCheckResourceAttr("data.alicloud_vswitches.foo", "vswitches.#", "1"),
+					resource.TestCheckResourceAttrSet("data.alicloud_vswitches.foo", "vswitches.0.id"),
+					resource.TestCheckResourceAttrSet("data.alicloud_vswitches.foo", "vswitches.0.vpc_id"),
+					resource.TestCheckResourceAttrSet("data.alicloud_vswitches.foo", "vswitches.0.zone_id"),
+					resource.TestMatchResourceAttr("data.alicloud_vswitches.foo", "vswitches.0.name", regexp.MustCompile("^tf-testAcc-for-vswitch-datasource-availability_zone_ID")),
+					resource.TestCheckResourceAttr("data.alicloud_vswitches.foo", "vswitches.0.instance_ids.#", "0"),
+					resource.TestCheckResourceAttr("data.alicloud_vswitches.foo", "vswitches.0.cidr_block", "172.16.0.0/24"),
 					resource.TestCheckResourceAttr("data.alicloud_vswitches.foo", "vswitches.0.description", ""),
 					resource.TestCheckResourceAttr("data.alicloud_vswitches.foo", "vswitches.0.is_default", "false"),
 					resource.TestCheckResourceAttrSet("data.alicloud_vswitches.foo", "vswitches.0.creation_time"),
@@ -72,19 +155,107 @@ resource "alicloud_vpc" "vpc" {
   cidr_block = "172.16.0.0/16"
   name = "${var.name}"
 }
-
 resource "alicloud_vswitch" "vswitch" {
   name = "${var.name}"
   cidr_block = "172.16.0.0/16"
   vpc_id = "${alicloud_vpc.vpc.id}"
   availability_zone = "${data.alicloud_zones.default.zones.0.id}"
 }
-
 data "alicloud_vswitches" "foo" {
   name_regex = "^tf-testAcc-.*-datasource"
   vpc_id = "${alicloud_vpc.vpc.id}"
   cidr_block = "${alicloud_vswitch.vswitch.cidr_block}"
   zone_id = "${data.alicloud_zones.default.zones.0.id}"
+}
+`
+
+func testAccCheckAlicloudVSwitchesDataSourceConfigNameRegex(rand int) string {
+	return fmt.Sprintf(
+		`
+variable "name" {
+  default = "tf-testAcc-for-vswitch-datasource-name-regex-%d"
+}
+data "alicloud_zones" "default" {}
+
+resource "alicloud_vpc" "vpc" {
+  cidr_block = "172.16.0.0/16"
+  name = "${var.name}"
+}
+resource "alicloud_vswitch" "vswitch" {
+  name = "${var.name}"
+  cidr_block = "172.16.0.0/24"
+  vpc_id = "${alicloud_vpc.vpc.id}"
+  availability_zone = "${data.alicloud_zones.default.zones.0.id}"
+}
+resource "alicloud_vswitch" "vswitch1" {
+  name = "${var.name}-A"
+  cidr_block = "172.16.1.0/24"
+  vpc_id = "${alicloud_vpc.vpc.id}"
+  availability_zone = "${data.alicloud_zones.default.zones.1.id}"
+}
+data "alicloud_vswitches" "foo" {
+  name_regex = "${alicloud_vswitch.vswitch1.name}"
+}
+`, rand)
+}
+
+const testAccCheckAlicloudVSwitchesDataSourceConfigAvailabilityZoneID = `
+variable "name" {
+  default = "tf-testAcc-for-vswitch-datasource-availability_zone_ID"
+}
+data "alicloud_zones" "default" {}
+
+resource "alicloud_vpc" "vpc" {
+  cidr_block = "172.16.0.0/16"
+  name = "${var.name}"
+}
+
+resource "alicloud_vswitch" "vswitch" {
+  name = "${var.name}"
+  cidr_block = "172.16.0.0/24"
+  vpc_id = "${alicloud_vpc.vpc.id}"
+  availability_zone = "${data.alicloud_zones.default.zones.0.id}"
+}
+resource "alicloud_vswitch" "vswitch1" {
+  name = "${var.name}-A"
+  cidr_block = "172.16.1.0/24"
+  vpc_id = "${alicloud_vpc.vpc.id}"
+  availability_zone = "${data.alicloud_zones.default.zones.1.id}"
+}
+data "alicloud_vswitches" "foo" {
+	vpc_id = "${alicloud_vpc.vpc.id}"
+  zone_id = "${alicloud_vswitch.vswitch.availability_zone}"
+}
+`
+const testAccCheckAlicloudVSwitchesDataSourceConfigVPCID = `
+variable "name" {
+  default = "tf-testAcc-for-vswitch-datasource-VPC-ID"
+}
+data "alicloud_zones" "default" {}
+
+resource "alicloud_vpc" "vpc" {
+  cidr_block = "172.16.0.0/16"
+  name = "${var.name}"
+}
+resource "alicloud_vpc" "vpc1" {
+  cidr_block = "192.168.0.0/16"
+  name = "${var.name}-A"
+}
+resource "alicloud_vswitch" "vswitch" {
+  name = "${var.name}"
+  cidr_block = "172.16.0.0/24"
+  vpc_id = "${alicloud_vpc.vpc.id}"
+  availability_zone = "${data.alicloud_zones.default.zones.0.id}"
+}
+
+resource "alicloud_vswitch" "vswitch1" {
+  name = "${var.name}"
+  cidr_block = "192.168.0.0/16"
+  vpc_id = "${alicloud_vpc.vpc1.id}"
+  availability_zone = "${data.alicloud_zones.default.zones.1.id}"
+}
+data "alicloud_vswitches" "foo" {
+	vpc_id = "${alicloud_vswitch.vswitch.vpc_id}"
 }
 `
 const testAccCheckAlicloudVSwitchesDataSourceEmpty = `

--- a/alicloud/resource_alicloud_vswitch_test.go
+++ b/alicloud/resource_alicloud_vswitch_test.go
@@ -106,7 +106,7 @@ func testSweepVSwitches(region string) error {
 	return nil
 }
 
-func TestAccAlicloudVSwitch_basic(t *testing.T) {
+func TestAccAlicloudVSwitch_Update(t *testing.T) {
 	var vsw vpc.DescribeVSwitchAttributesResponse
 
 	resource.Test(t, resource.TestCase{
@@ -123,13 +123,40 @@ func TestAccAlicloudVSwitch_basic(t *testing.T) {
 				Config: testAccVswitchConfig,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckVswitchExists("alicloud_vswitch.foo", &vsw),
-					resource.TestCheckResourceAttr(
-						"alicloud_vswitch.foo", "cidr_block", "172.16.0.0/21"),
+					resource.TestCheckResourceAttr("alicloud_vswitch.foo", "cidr_block", "172.16.0.0/21"),
+					resource.TestCheckResourceAttr("alicloud_vswitch.foo", "name", "tf-testAccVswitchConfig"),
+					resource.TestCheckResourceAttr("alicloud_vswitch.foo", "description", ""),
+				),
+			},
+			{
+				Config: testAccVswitchConfigRename,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckVswitchExists("alicloud_vswitch.foo", &vsw),
+					resource.TestCheckResourceAttr("alicloud_vswitch.foo", "cidr_block", "172.16.0.0/21"),
+					resource.TestCheckResourceAttr("alicloud_vswitch.foo", "name", "tf-testAccVswitchConfigRename"),
+					resource.TestCheckResourceAttr("alicloud_vswitch.foo", "description", ""),
+				),
+			},
+			{
+				Config: testAccVswitchConfigRedesc,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckVswitchExists("alicloud_vswitch.foo", &vsw),
+					resource.TestCheckResourceAttr("alicloud_vswitch.foo", "cidr_block", "172.16.0.0/21"),
+					resource.TestCheckResourceAttr("alicloud_vswitch.foo", "name", "tf-testAccVswitchConfigRename"),
+					resource.TestCheckResourceAttr("alicloud_vswitch.foo", "description", "I am MrX"),
+				),
+			},
+			{
+				Config: testAccVswitchConfigUpdate,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckVswitchExists("alicloud_vswitch.foo", &vsw),
+					resource.TestCheckResourceAttr("alicloud_vswitch.foo", "cidr_block", "172.16.0.0/21"),
+					resource.TestCheckResourceAttr("alicloud_vswitch.foo", "name", "tf-testAccVswitchConfigUpdate"),
+					resource.TestCheckResourceAttr("alicloud_vswitch.foo", "description", "How Are You"),
 				),
 			},
 		},
 	})
-
 }
 
 func TestAccAlicloudVSwitch_multi(t *testing.T) {
@@ -148,14 +175,11 @@ func TestAccAlicloudVSwitch_multi(t *testing.T) {
 				Config: testAccVswitchMulti,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckVswitchExists("alicloud_vswitch.foo_0", &vsw),
-					resource.TestCheckResourceAttr(
-						"alicloud_vswitch.foo_0", "cidr_block", "172.16.0.0/24"),
+					resource.TestCheckResourceAttr("alicloud_vswitch.foo_0", "cidr_block", "172.16.0.0/24"),
 					testAccCheckVswitchExists("alicloud_vswitch.foo_1", &vsw),
-					resource.TestCheckResourceAttr(
-						"alicloud_vswitch.foo_1", "cidr_block", "172.16.1.0/24"),
+					resource.TestCheckResourceAttr("alicloud_vswitch.foo_1", "cidr_block", "172.16.1.0/24"),
 					testAccCheckVswitchExists("alicloud_vswitch.foo_2", &vsw),
-					resource.TestCheckResourceAttr(
-						"alicloud_vswitch.foo_2", "cidr_block", "172.16.2.0/24"),
+					resource.TestCheckResourceAttr("alicloud_vswitch.foo_2", "cidr_block", "172.16.2.0/24"),
 				),
 			},
 		},
@@ -227,6 +251,65 @@ resource "alicloud_vswitch" "foo" {
   cidr_block = "172.16.0.0/21"
   availability_zone = "${data.alicloud_zones.default.zones.0.id}"
   name = "${var.name}"
+}
+`
+const testAccVswitchConfigRename = `
+data "alicloud_zones" "default" {
+	"available_resource_creation"= "VSwitch"
+}
+variable "name" {
+  default = "tf-testAccVswitchConfigRename"
+}
+resource "alicloud_vpc" "foo" {
+  name = "${var.name}"
+  cidr_block = "172.16.0.0/12"
+}
+
+resource "alicloud_vswitch" "foo" {
+  vpc_id = "${alicloud_vpc.foo.id}"
+  cidr_block = "172.16.0.0/21"
+  availability_zone = "${data.alicloud_zones.default.zones.0.id}"
+  name = "${var.name}"
+}
+`
+const testAccVswitchConfigRedesc = `
+data "alicloud_zones" "default" {
+	"available_resource_creation"= "VSwitch"
+}
+variable "name" {
+  default = "tf-testAccVswitchConfigRename"
+}
+resource "alicloud_vpc" "foo" {
+  name = "${var.name}"
+  cidr_block = "172.16.0.0/12"
+}
+
+resource "alicloud_vswitch" "foo" {
+  vpc_id = "${alicloud_vpc.foo.id}"
+  cidr_block = "172.16.0.0/21"
+  availability_zone = "${data.alicloud_zones.default.zones.0.id}"
+  name = "${var.name}"
+  description="I am MrX"
+}
+`
+const testAccVswitchConfigUpdate = `
+data "alicloud_zones" "default" {
+	"available_resource_creation"= "VSwitch"
+}
+variable "name" {
+  default = "tf-testAccVswitchConfigUpdate"
+}
+resource "alicloud_vpc" "foo" {
+  name = "${var.name}"
+  cidr_block = "172.16.0.0/12"
+}
+
+resource "alicloud_vswitch" "foo" {
+  vpc_id = "${alicloud_vpc.foo.id}"
+  cidr_block = "172.16.0.0/21"
+  availability_zone = "${data.alicloud_zones.default.zones.0.id}"
+  name = "${var.name}"
+  description="How Are You"
 }
 `
 


### PR DESCRIPTION
data_source:
```
go test ./alicloud -v -run=TestAccAlicloudVSwitchesDataSource_ -timeout=1440m
=== RUN   TestAccAlicloudVSwitchesDataSource_Name_Regex
--- PASS: TestAccAlicloudVSwitchesDataSource_Name_Regex (25.13s)
=== RUN   TestAccAlicloudVSwitchesDataSource_vpcid
--- PASS: TestAccAlicloudVSwitchesDataSource_vpcid (24.76s)
=== RUN   TestAccAlicloudVSwitchesDataSource_Zone_ID
--- PASS: TestAccAlicloudVSwitchesDataSource_Zone_ID (22.49s)
PASS
ok      github.com/terraform-providers/terraform-provider-alicloud/alicloud     74.972
```
resource:
```
go test ./alicloud -v -run=TestAccAlicloudVSwitch_ -timeout=1440m
=== RUN   TestAccAlicloudVSwitch_Update
--- PASS: TestAccAlicloudVSwitch_Update (32.20s)
=== RUN   TestAccAlicloudVSwitch_multi
--- PASS: TestAccAlicloudVSwitch_multi (23.73s)
PASS
ok      github.com/terraform-providers/terraform-provider-alicloud/alicloud     58.816s
```
