### PR TITLE
Add wraperror and apply it to vpc and eip

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 ## 1.29.0 (Unreleased)
 
 IMPROVEMENTS:
+
+- Add wraperror and apply it to vpc and eip [GH-688]
 - Improve vswitch resource and data source testcases [GH-687]
 - Improve security_group resource and data source testcases [GH-686]
 - Improve vpc resource and data source testcases [GH-684]

--- a/alicloud/data_source_alicloud_eips.go
+++ b/alicloud/data_source_alicloud_eips.go
@@ -111,7 +111,7 @@ func dataSourceAlicloudEipsRead(d *schema.ResourceData, meta interface{}) error 
 			return vpcClient.DescribeEipAddresses(args)
 		})
 		if err != nil {
-			return err
+			return WrapErrorf(err, DataDefaultErrorMsg, "eips", args.GetActionName(), AlibabaCloudSdkGoERROR)
 		}
 		resp, _ := raw.(*vpc.DescribeEipAddressesResponse)
 		if resp == nil || len(resp.EipAddresses.EipAddress) < 1 {
@@ -137,7 +137,7 @@ func dataSourceAlicloudEipsRead(d *schema.ResourceData, meta interface{}) error 
 		}
 
 		if page, err := getNextpageNumber(args.PageNumber); err != nil {
-			return err
+			return WrapError(err)
 		} else {
 			args.PageNumber = page
 		}
@@ -166,7 +166,7 @@ func eipsDecriptionAttributes(d *schema.ResourceData, eipSetTypes []vpc.EipAddre
 
 	d.SetId(dataResourceIdHash(ids))
 	if err := d.Set("eips", s); err != nil {
-		return err
+		return WrapError(err)
 	}
 
 	// create a json file in current directory and write data source to it.

--- a/alicloud/data_source_alicloud_vpcs.go
+++ b/alicloud/data_source_alicloud_vpcs.go
@@ -1,7 +1,6 @@
 package alicloud
 
 import (
-	"fmt"
 	"regexp"
 
 	"github.com/aliyun/alibaba-cloud-sdk-go/sdk/requests"
@@ -118,7 +117,7 @@ func dataSourceAlicloudVpcsRead(d *schema.ResourceData, meta interface{}) error 
 			return vpcClient.DescribeVpcs(args)
 		})
 		if err != nil {
-			return err
+			return WrapErrorf(err, DataDefaultErrorMsg, "vpcs", args.GetActionName(), AlibabaCloudSdkGoERROR)
 		}
 		resp, _ := raw.(*vpc.DescribeVpcsResponse)
 		if resp == nil || len(resp.Vpcs.Vpc) < 1 {
@@ -132,7 +131,7 @@ func dataSourceAlicloudVpcsRead(d *schema.ResourceData, meta interface{}) error 
 		}
 
 		if page, err := getNextpageNumber(args.PageNumber); err != nil {
-			return err
+			return WrapError(err)
 		} else {
 			args.PageNumber = page
 		}
@@ -173,7 +172,7 @@ func dataSourceAlicloudVpcsRead(d *schema.ResourceData, meta interface{}) error 
 			return vpcClient.DescribeVRouters(request)
 		})
 		if err != nil {
-			return fmt.Errorf("Error DescribVRouters by vrouter_id %s: %#v", v.VRouterId, err)
+			return WrapErrorf(err, DataDefaultErrorMsg, "vpcs", request.GetActionName(), AlibabaCloudSdkGoERROR)
 		}
 		vrs, _ := raw.(*vpc.DescribeVRoutersResponse)
 		if vrs != nil && len(vrs.VRouters.VRouter) > 0 {
@@ -218,7 +217,7 @@ func vpcsDecriptionAttributes(d *schema.ResourceData, vpcSetTypes []vpc.Vpc, rou
 
 	d.SetId(dataResourceIdHash(ids))
 	if err := d.Set("vpcs", s); err != nil {
-		return err
+		return WrapError(err)
 	}
 
 	// create a json file in current directory and write data source to it.

--- a/alicloud/resource_alicloud_eip_test.go
+++ b/alicloud/resource_alicloud_eip_test.go
@@ -184,11 +184,7 @@ func testAccCheckEIPExists(n string, eip *vpc.EipAddress) resource.TestCheckFunc
 		log.Printf("[WARN] eip id %#v", rs.Primary.ID)
 
 		if err != nil {
-			return err
-		}
-
-		if d.IpAddress == "" {
-			return fmt.Errorf("EIP not found")
+			return WrapError(err)
 		}
 
 		*eip = d
@@ -215,18 +211,14 @@ func testAccCheckEIPDestroy(s *terraform.State) error {
 			continue
 		}
 
-		d, err := vpcService.DescribeEipAddress(rs.Primary.ID)
+		_, err := vpcService.DescribeEipAddress(rs.Primary.ID)
 
 		// Verify the error is what we want
 		if err != nil {
 			if NotFoundError(err) {
 				continue
 			}
-			return err
-		}
-
-		if d.AllocationId != "" {
-			return fmt.Errorf("Error EIP still exist")
+			return WrapError(err)
 		}
 	}
 

--- a/alicloud/resource_alicloud_vpc_test.go
+++ b/alicloud/resource_alicloud_vpc_test.go
@@ -232,7 +232,7 @@ func testAccCheckVpcExists(n string, vpc *vpc.DescribeVpcAttributeResponse) reso
 		instance, err := vpcService.DescribeVpc(rs.Primary.ID)
 
 		if err != nil {
-			return err
+			return WrapError(err)
 		}
 
 		*vpc = instance
@@ -256,12 +256,9 @@ func testAccCheckVpcDestroy(s *terraform.State) error {
 			if NotFoundError(err) {
 				continue
 			}
-			return err
+			return WrapError(err)
 		}
-
-		if instance.VpcId != "" {
-			return fmt.Errorf("VPC %s still exist", instance.VpcId)
-		}
+		return WrapError(fmt.Errorf("VPC %s still exist", instance.VpcId))
 	}
 
 	return nil


### PR DESCRIPTION
```
TF_ACC=1 go test ./alicloud -v -run=TestAccAlicloudEIP -timeout=240m
=== RUN   TestAccAlicloudEIPsDataSource
--- PASS: TestAccAlicloudEIPsDataSource (8.33s)
=== RUN   TestAccAlicloudEIPsDataSourceEmpty
--- PASS: TestAccAlicloudEIPsDataSourceEmpty (1.80s)
=== RUN   TestAccAlicloudEIP_importBasic
--- PASS: TestAccAlicloudEIP_importBasic (4.63s)
=== RUN   TestAccAlicloudEIPAssociation
--- PASS: TestAccAlicloudEIPAssociation (189.82s)
=== RUN   TestAccAlicloudEIPAssociation_slb
--- PASS: TestAccAlicloudEIPAssociation_slb (62.35s)
=== RUN   TestAccAlicloudEIP_basic
--- PASS: TestAccAlicloudEIP_basic (8.33s)
=== RUN   TestAccAlicloudEIP_paybybandwidth
--- PASS: TestAccAlicloudEIP_paybybandwidth (4.10s)
PASS
ok  	github.com/terraform-providers/terraform-provider-alicloud/alicloud	279.530s
```
```
TF_ACC=1 go test ./alicloud -v -run=TestAccAlicloudVpc -timeout=240m
=== RUN   TestAccAlicloudVpcsDataSource_cidr_block
--- PASS: TestAccAlicloudVpcsDataSource_cidr_block (25.13s)
=== RUN   TestAccAlicloudVpcsDataSource_empty
--- PASS: TestAccAlicloudVpcsDataSource_empty (5.81s)
=== RUN   TestAccAlicloudVpc_importBasic
--- PASS: TestAccAlicloudVpc_importBasic (24.73s)
=== RUN   TestAccAlicloudVpc_basic
--- PASS: TestAccAlicloudVpc_basic (26.91s)
=== RUN   TestAccAlicloudVpc_update
--- PASS: TestAccAlicloudVpc_update (61.21s)
=== RUN   TestAccAlicloudVpc_multi
--- PASS: TestAccAlicloudVpc_multi (54.64s)
PASS
ok  	github.com/terraform-providers/terraform-provider-alicloud/alicloud	198.514s
```