### PR TITLE
Fix ServiceUnavailable error on VPC and VSW

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,9 @@
 ## 1.30.0 (Unreleased)
+
+BUG FIXES:
+
+- Fix ServiceUnavailable error on VPC and VSW [GH-695]
+
 ## 1.29.0 (January 21, 2019)
 
 FEATURES:

--- a/alicloud/data_source_alicloud_vpcs.go
+++ b/alicloud/data_source_alicloud_vpcs.go
@@ -111,12 +111,16 @@ func dataSourceAlicloudVpcsRead(d *schema.ResourceData, meta interface{}) error 
 	args.PageNumber = requests.NewInteger(1)
 
 	var allVpcs []vpc.Vpc
-
+	invoker := NewInvoker()
 	for {
-		raw, err := client.WithVpcClient(func(vpcClient *vpc.Client) (interface{}, error) {
-			return vpcClient.DescribeVpcs(args)
-		})
-		if err != nil {
+		var raw interface{}
+		if err := invoker.Run(func() error {
+			rsp, err := client.WithVpcClient(func(vpcClient *vpc.Client) (interface{}, error) {
+				return vpcClient.DescribeVpcs(args)
+			})
+			raw = rsp
+			return err
+		}); err != nil {
 			return WrapErrorf(err, DataDefaultErrorMsg, "vpcs", args.GetActionName(), AlibabaCloudSdkGoERROR)
 		}
 		resp, _ := raw.(*vpc.DescribeVpcsResponse)

--- a/alicloud/data_source_alicloud_vswitches.go
+++ b/alicloud/data_source_alicloud_vswitches.go
@@ -117,11 +117,16 @@ func dataSourceAlicloudVSwitchesRead(d *schema.ResourceData, meta interface{}) e
 			nameRegex = r
 		}
 	}
+	invoker := NewInvoker()
 	for {
-		raw, err := client.WithVpcClient(func(vpcClient *vpc.Client) (interface{}, error) {
-			return vpcClient.DescribeVSwitches(args)
-		})
-		if err != nil {
+		var raw interface{}
+		if err := invoker.Run(func() error {
+			rsp, err := client.WithVpcClient(func(vpcClient *vpc.Client) (interface{}, error) {
+				return vpcClient.DescribeVSwitches(args)
+			})
+			raw = rsp
+			return err
+		}); err != nil {
 			return err
 		}
 		resp, _ := raw.(*vpc.DescribeVSwitchesResponse)

--- a/alicloud/resource_alicloud_instance_test.go
+++ b/alicloud/resource_alicloud_instance_test.go
@@ -1572,7 +1572,7 @@ func testAccCheckInstanceImageOrigin(common string) string {
 		name_regex = "^centos_6\\w{1,5}[64]{1}.*"
 	}
 	variable "name" {
-		default = "testAccCheckInstanceImageOrigin"
+		default = "tf-testAccCheckInstanceImageOrigin"
 	}
 
 	resource "alicloud_instance" "update_image" {

--- a/alicloud/resource_alicloud_logtail_config.go
+++ b/alicloud/resource_alicloud_logtail_config.go
@@ -3,12 +3,13 @@ package alicloud
 import (
 	"encoding/json"
 	"fmt"
+	"strings"
+	"time"
+
 	"github.com/aliyun/aliyun-log-go-sdk"
 	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/helper/schema"
 	"github.com/terraform-providers/terraform-provider-alicloud/alicloud/connectivity"
-	"strings"
-	"time"
 )
 
 func resourceAlicloudLogtailConfig() *schema.Resource {

--- a/alicloud/resource_alicloud_logtail_config_test.go
+++ b/alicloud/resource_alicloud_logtail_config_test.go
@@ -2,14 +2,15 @@ package alicloud
 
 import (
 	"fmt"
+	"log"
+	"strings"
+	"testing"
+
 	"github.com/aliyun/aliyun-log-go-sdk"
 	"github.com/hashicorp/terraform/helper/acctest"
 	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/terraform"
 	"github.com/terraform-providers/terraform-provider-alicloud/alicloud/connectivity"
-	"log"
-	"strings"
-	"testing"
 )
 
 func init() {

--- a/alicloud/resource_alicloud_vpc_test.go
+++ b/alicloud/resource_alicloud_vpc_test.go
@@ -50,11 +50,16 @@ func testSweepVpcs(region string) error {
 	req.RegionId = client.RegionId
 	req.PageSize = requests.NewInteger(PageSizeLarge)
 	req.PageNumber = requests.NewInteger(1)
+	invoker := NewInvoker()
 	for {
-		raw, err := client.WithVpcClient(func(vpcClient *vpc.Client) (interface{}, error) {
-			return vpcClient.DescribeVpcs(req)
-		})
-		if err != nil {
+		var raw interface{}
+		if err := invoker.Run(func() error {
+			rsp, err := client.WithVpcClient(func(vpcClient *vpc.Client) (interface{}, error) {
+				return vpcClient.DescribeVpcs(req)
+			})
+			raw = rsp
+			return err
+		}); err != nil {
 			return fmt.Errorf("Error retrieving VPCs: %s", err)
 		}
 		resp, _ := raw.(*vpc.DescribeVpcsResponse)

--- a/alicloud/resource_alicloud_vswitch_test.go
+++ b/alicloud/resource_alicloud_vswitch_test.go
@@ -55,11 +55,16 @@ func testSweepVSwitches(region string) error {
 	req.RegionId = client.RegionId
 	req.PageSize = requests.NewInteger(PageSizeLarge)
 	req.PageNumber = requests.NewInteger(1)
+	invoker := NewInvoker()
 	for {
-		raw, err := client.WithVpcClient(func(vpcClient *vpc.Client) (interface{}, error) {
-			return vpcClient.DescribeVSwitches(req)
-		})
-		if err != nil {
+		var raw interface{}
+		if err := invoker.Run(func() error {
+			rsp, err := client.WithVpcClient(func(vpcClient *vpc.Client) (interface{}, error) {
+				return vpcClient.DescribeVSwitches(req)
+			})
+			raw = rsp
+			return err
+		}); err != nil {
 			return fmt.Errorf("Error retrieving VSwitches: %s", err)
 		}
 		resp, _ := raw.(*vpc.DescribeVSwitchesResponse)


### PR DESCRIPTION
```
TF_ACC=1 go test ./alicloud -v -run=TestAccAlicloudVpc -timeout=240m
=== RUN   TestAccAlicloudVpcsDataSource_cidr_block
--- PASS: TestAccAlicloudVpcsDataSource_cidr_block (19.09s)
=== RUN   TestAccAlicloudVpcsDataSource_empty
--- PASS: TestAccAlicloudVpcsDataSource_empty (4.76s)
=== RUN   TestAccAlicloudVpc_importBasic
--- PASS: TestAccAlicloudVpc_importBasic (19.68s)
=== RUN   TestAccAlicloudVpc_basic
--- PASS: TestAccAlicloudVpc_basic (19.09s)
=== RUN   TestAccAlicloudVpc_update
--- PASS: TestAccAlicloudVpc_update (63.16s)
=== RUN   TestAccAlicloudVpc_multi
--- PASS: TestAccAlicloudVpc_multi (42.22s)
PASS
ok  	github.com/terraform-providers/terraform-provider-alicloud/alicloud	168.112s

```
```
 TF_ACC=1 go test ./alicloud -v -run=TestAccAlicloudVSwitch -timeout=240m
=== RUN   TestAccAlicloudVSwitchesDataSource
--- PASS: TestAccAlicloudVSwitchesDataSource (43.47s)
=== RUN   TestAccAlicloudVSwitchesDataSource_Name_Regex
--- PASS: TestAccAlicloudVSwitchesDataSource_Name_Regex (56.08s)
=== RUN   TestAccAlicloudVSwitchesDataSource_vpcid
--- PASS: TestAccAlicloudVSwitchesDataSource_vpcid (60.07s)
=== RUN   TestAccAlicloudVSwitchesDataSource_Zone_ID
--- PASS: TestAccAlicloudVSwitchesDataSource_Zone_ID (51.78s)
=== RUN   TestAccAlicloudVSwitchesDataSourceEmpty
--- PASS: TestAccAlicloudVSwitchesDataSourceEmpty (5.14s)
=== RUN   TestAccAlicloudVSwitch_Update
--- PASS: TestAccAlicloudVSwitch_Update (94.22s)
=== RUN   TestAccAlicloudVSwitch_multi
--- PASS: TestAccAlicloudVSwitch_multi (85.83s)
PASS
ok  	github.com/terraform-providers/terraform-provider-alicloud/alicloud	396.635s

```