### PR TITLE
Improve kvstore backup policy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 IMPROVEMENTS:
 
+- Improve kvstore backup policy [GH-701]
 - Improve pvtz attachment testcase [GH-700]
 - Modify pagesize on API DescribeVSWitches tp avoid ServiceUnavailable [GH-698]
 - Improve eip resource and data source testcases [GH-697]

--- a/alicloud/data_source_alicloud_kvstore_instances_test.go
+++ b/alicloud/data_source_alicloud_kvstore_instances_test.go
@@ -5,10 +5,12 @@ import (
 
 	"fmt"
 
+	"github.com/hashicorp/terraform/helper/acctest"
 	"github.com/hashicorp/terraform/helper/resource"
 )
 
 func TestAccAlicloudKVStoreInstancesDataSource(t *testing.T) {
+	rand := acctest.RandIntRange(10000, 999999)
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			testAccPreCheck(t)
@@ -16,13 +18,13 @@ func TestAccAlicloudKVStoreInstancesDataSource(t *testing.T) {
 		Providers: testAccProviders,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccCheckAlicloudRKVInstancesDataSourceConfig(KVStoreCommonTestCase, string(KVStoreRedis), redisInstanceClassForTest, string(KVStore2Dot8)),
+				Config: testAccCheckAlicloudRKVInstancesDataSourceConfig(KVStoreCommonTestCase, string(KVStoreRedis), redisInstanceClassForTest, string(KVStore2Dot8), rand),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAlicloudDataSourceID("data.alicloud_kvstore_instances.rkvs"),
 					resource.TestCheckResourceAttr("data.alicloud_kvstore_instances.rkvs", "instances.#", "1"),
 					resource.TestCheckResourceAttrSet("data.alicloud_kvstore_instances.rkvs", "instances.0.id"),
 					resource.TestCheckResourceAttr("data.alicloud_kvstore_instances.rkvs", "instances.0.instance_class", redisInstanceClassForTest),
-					resource.TestCheckResourceAttr("data.alicloud_kvstore_instances.rkvs", "instances.0.name", "tf-testAccCheckAlicloudRKVInstancesDataSourceConfig"),
+					resource.TestCheckResourceAttr("data.alicloud_kvstore_instances.rkvs", "instances.0.name", fmt.Sprintf("tf-testAccCheckAlicloudRKVInstancesDataSourceConfig-%d", rand)),
 					resource.TestCheckResourceAttr("data.alicloud_kvstore_instances.rkvs", "instances.0.instance_type", string(KVStoreRedis)),
 					resource.TestCheckResourceAttr("data.alicloud_kvstore_instances.rkvs", "instances.0.charge_type", string(PostPaid)),
 					resource.TestCheckResourceAttrSet("data.alicloud_kvstore_instances.rkvs", "instances.0.region_id"),
@@ -82,7 +84,7 @@ func TestAccAlicloudKVStoreInstancesDataSourceEmpty(t *testing.T) {
 	})
 }
 
-func testAccCheckAlicloudRKVInstancesDataSourceConfig(common, instanceType, instanceClass, engineVersion string) string {
+func testAccCheckAlicloudRKVInstancesDataSourceConfig(common, instanceType, instanceClass, engineVersion string, rand int) string {
 	return fmt.Sprintf(`
 	%s
 	data "alicloud_kvstore_instances" "rkvs" {
@@ -95,7 +97,7 @@ func testAccCheckAlicloudRKVInstancesDataSourceConfig(common, instanceType, inst
 		default = "false"
 	}
 	variable "name" {
-		default = "tf-testAccCheckAlicloudRKVInstancesDataSourceConfig"
+		default = "tf-testAccCheckAlicloudRKVInstancesDataSourceConfig-%d"
 	}
 
 	resource "alicloud_kvstore_instance" "rkv" {
@@ -107,7 +109,7 @@ func testAccCheckAlicloudRKVInstancesDataSourceConfig(common, instanceType, inst
 		instance_type = "%s"
 		engine_version = "%s"
 	}
-	`, common, instanceClass, instanceType, engineVersion)
+	`, common, rand, instanceClass, instanceType, engineVersion)
 }
 
 const testAccCheckAlicloudRKVInstancesDataSourceEmpty = `

--- a/alicloud/errors.go
+++ b/alicloud/errors.go
@@ -132,6 +132,7 @@ const (
 	ConnectionConflictMessage              = "The requested resource is sold out in the specified zone; try other types of resources or other regions and zones"
 	DBInternalError                        = "InternalError"
 	OperationDeniedDBInstanceStatus        = "OperationDenied.DBInstanceStatus"
+	DBOperationDeniedOutofUsage            = "OperationDenied.OutofUsage"
 
 	// oss
 	OssBucketNotFound          = "NoSuchBucket"
@@ -280,7 +281,7 @@ var SlbIsBusy = []string{"SystemBusy", "OperationBusy", "ServiceIsStopping", "Ba
 var EcsNotFound = []string{"InvalidInstanceId.NotFound", "Forbidden.InstanceNotFound"}
 var DiskInvalidOperation = []string{"IncorrectDiskStatus", "IncorrectInstanceStatus", "OperationConflict", InternalError, "InvalidOperation.Conflict", "IncorrectDiskStatus.Initializing"}
 var NetworkInterfaceInvalidOperations = []string{"InvalidOperation.InvalidEniState", "InvalidOperation.InvalidEcsState", "OperationConflict", "ServiceUnavailable", "InternalError"}
-var OperationDeniedDBStatus = []string{"OperationDenied.DBStatus", OperationDeniedDBInstanceStatus, DBInternalError}
+var OperationDeniedDBStatus = []string{"OperationDenied.DBStatus", OperationDeniedDBInstanceStatus, DBInternalError, DBOperationDeniedOutofUsage}
 
 // An Error represents a custom error for Terraform failure response
 type ProviderError struct {

--- a/alicloud/resource_alicloud_kvstore_backup_policy.go
+++ b/alicloud/resource_alicloud_kvstore_backup_policy.go
@@ -3,10 +3,8 @@ package alicloud
 import (
 	"fmt"
 	"strings"
-	"time"
 
 	"github.com/aliyun/alibaba-cloud-sdk-go/services/r-kvstore"
-	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/helper/schema"
 	"github.com/terraform-providers/terraform-provider-alicloud/alicloud/connectivity"
 )
@@ -45,32 +43,10 @@ func resourceAlicloudKVStoreBackupPolicy() *schema.Resource {
 }
 
 func resourceAlicloudKVStoreBackupPolicyCreate(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*connectivity.AliyunClient)
 
-	request := r_kvstore.CreateModifyBackupPolicyRequest()
-	request.InstanceId = d.Get("instance_id").(string)
-	request.PreferredBackupTime = d.Get("backup_time").(string)
-	periodList := expandStringList(d.Get("backup_period").(*schema.Set).List())
-	backupPeriod := fmt.Sprintf("%s", strings.Join(periodList[:], COMMA_SEPARATED))
-	request.PreferredBackupPeriod = backupPeriod
+	d.SetId(d.Get("instance_id").(string))
 
-	err := resource.Retry(5*time.Minute, func() *resource.RetryError {
-		_, err := client.WithRkvClient(func(rkvClient *r_kvstore.Client) (interface{}, error) {
-			return rkvClient.ModifyBackupPolicy(request)
-		})
-		if err != nil {
-			return resource.NonRetryableError(fmt.Errorf("Create backup policy got an error: %#v", err))
-		}
-		return nil
-	})
-
-	if err != nil {
-		return err
-	}
-
-	d.SetId(request.InstanceId)
-
-	return resourceAlicloudKVStoreBackupPolicyRead(d, meta)
+	return resourceAlicloudKVStoreBackupPolicyUpdate(d, meta)
 }
 
 func resourceAlicloudKVStoreBackupPolicyRead(d *schema.ResourceData, meta interface{}) error {


### PR DESCRIPTION
```
TF_ACC=1 go test ./alicloud -v -run=TestAccAlicloudKVStoreMemcacheBackupPolicy_vpc -timeout=240m
=== RUN   TestAccAlicloudKVStoreMemcacheBackupPolicy_vpc
--- PASS: TestAccAlicloudKVStoreMemcacheBackupPolicy_vpc (389.03s)
PASS
ok  	github.com/terraform-providers/terraform-provider-alicloud/alicloud	389.081s
```
```
TF_ACC=1 go test ./alicloud -v -run=TestAccAlicloudKVStoreInstancesDataSource -timeout=240m
=== RUN   TestAccAlicloudKVStoreInstancesDataSource
--- PASS: TestAccAlicloudKVStoreInstancesDataSource (312.28s)
=== RUN   TestAccAlicloudKVStoreInstancesDataSourceEmpty
--- PASS: TestAccAlicloudKVStoreInstancesDataSourceEmpty (8.91s)
PASS
ok  	github.com/terraform-providers/terraform-provider-alicloud/alicloud	321.246s
```
```
TF_ACC=1 go test ./alicloud -v -run=TestAccAlicloudKVStoreRedisInstance_vpcUpdateAll -timeout=240m
=== RUN   TestAccAlicloudKVStoreRedisInstance_vpcUpdateAll
--- PASS: TestAccAlicloudKVStoreRedisInstance_vpcUpdateAll (900.95s)
PASS
ok  	github.com/terraform-providers/terraform-provider-alicloud/alicloud	901.010s
```