### PR TITLE
Fix modify kvstore policy not working bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 IMPROVEMENTS:
 
-- Improve cdn testcase [GH-705]
+- Improve cdn testcase [GH-708]
 - Add notes for datahub and improve its testcase [GH-704]
 - Improve security_group_rule resource and data source testcases [GH-703]
 - Improve kvstore backup policy [GH-701]
@@ -12,6 +12,7 @@ IMPROVEMENTS:
 
 BUG FIXES:
 
+- Fix modify kvstore policy not working bug [GH-709]
 - reattach the key pair after update OS image [GH-699]
 - Fix ServiceUnavailable error on VPC and VSW [GH-695]
 

--- a/alicloud/errors.go
+++ b/alicloud/errors.go
@@ -602,5 +602,6 @@ func WrapComplexError(cause, err error, filepath string, fileline int) error {
 // A default message of ComplexError's Err. It is format to Resource <resource-id> <operation> Failed!!! <error source>
 const DefaultErrorMsg = "Resource %s %s Failed!!! %s"
 const NotFoundMsg = ResourceNotFound + "!!! %s"
+const DefaultTimeoutMsg = "Resource %s %s Timeout!!! %s"
 const DeleteTimeoutMsg = "Resource %s Still Exists. %s Timeout!!! %s"
 const DataDefaultErrorMsg = "Datasource %s %s Failed!!! %s"

--- a/alicloud/resource_alicloud_kvstore_backup_policy.go
+++ b/alicloud/resource_alicloud_kvstore_backup_policy.go
@@ -5,8 +5,11 @@ import (
 	"strings"
 
 	"github.com/aliyun/alibaba-cloud-sdk-go/services/r-kvstore"
+	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/helper/schema"
 	"github.com/terraform-providers/terraform-provider-alicloud/alicloud/connectivity"
+	"sort"
+	"time"
 )
 
 func resourceAlicloudKVStoreBackupPolicy() *schema.Resource {
@@ -72,18 +75,37 @@ func resourceAlicloudKVStoreBackupPolicyRead(d *schema.ResourceData, meta interf
 func resourceAlicloudKVStoreBackupPolicyUpdate(d *schema.ResourceData, meta interface{}) error {
 	if d.HasChange("backup_time") || d.HasChange("backup_period") {
 		client := meta.(*connectivity.AliyunClient)
+		kvstoreService := KvstoreService{client}
 		request := r_kvstore.CreateModifyBackupPolicyRequest()
 		request.InstanceId = d.Id()
 		request.PreferredBackupTime = d.Get("backup_time").(string)
 		periodList := expandStringList(d.Get("backup_period").(*schema.Set).List())
-		backupPeriod := fmt.Sprintf("%s", strings.Join(periodList[:], COMMA_SEPARATED))
-		request.PreferredBackupPeriod = backupPeriod
-		_, err := client.WithRkvClient(func(rkvClient *r_kvstore.Client) (interface{}, error) {
-			return rkvClient.ModifyBackupPolicy(request)
-		})
-		if err != nil {
-			return err
+		request.PreferredBackupPeriod = fmt.Sprintf("%s", strings.Join(periodList, COMMA_SEPARATED))
+		if err := resource.Retry(2*time.Minute, func() *resource.RetryError {
+			_, err := client.WithRkvClient(func(rkvClient *r_kvstore.Client) (interface{}, error) {
+				return rkvClient.ModifyBackupPolicy(request)
+			})
+			if err != nil {
+				return resource.NonRetryableError(WrapError(err))
+			}
+
+			// There is a random error and need waiting some seconds to ensure the update is success
+			policy, err := kvstoreService.DescribeRKVInstancebackupPolicy(d.Id())
+			if err != nil {
+				return resource.NonRetryableError(WrapError(err))
+			}
+			// periodList default in the alphabetic order
+			// policy.PreferredBackupPeriod default in week order
+			outputPeriods := strings.Split(policy.PreferredBackupPeriod, COMMA_SEPARATED)
+			sort.Strings(outputPeriods)
+			if policy.PreferredBackupTime != request.PreferredBackupTime || strings.Join(outputPeriods, COMMA_SEPARATED) != request.PreferredBackupPeriod {
+				return resource.RetryableError(WrapErrorf(err, DefaultTimeoutMsg, d.Id(), request.GetActionName(), ProviderERROR))
+			}
+			return nil
+		}); err != nil {
+			return WrapError(err)
 		}
+
 	}
 
 	return resourceAlicloudKVStoreBackupPolicyRead(d, meta)


### PR DESCRIPTION
```
TF_ACC=1 go test ./alicloud -v -run=TestAccAlicloudKVStoreRedisBackup -timeout=600m
=== RUN   TestAccAlicloudKVStoreRedisBackupPolicy_import
--- PASS: TestAccAlicloudKVStoreRedisBackupPolicy_import (256.32s)
=== RUN   TestAccAlicloudKVStoreRedisBackupPolicy_classic
--- PASS: TestAccAlicloudKVStoreRedisBackupPolicy_classic (266.80s)
=== RUN   TestAccAlicloudKVStoreRedisBackupPolicy_vpc
--- PASS: TestAccAlicloudKVStoreRedisBackupPolicy_vpc (355.55s)
PASS
ok  	github.com/terraform-providers/terraform-provider-alicloud/alicloud	878.709s
```