### PR TITLE
Fix pvtz record Zone.NotExists error when deleting record

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ IMPROVEMENTS:
 
 BUG FIXES:
 
+- Fix pvtz record Zone.NotExists error when deleting record [GH-710]
 - Fix modify kvstore policy not working bug [GH-709]
 - reattach the key pair after update OS image [GH-699]
 - Fix ServiceUnavailable error on VPC and VSW [GH-695]

--- a/alicloud/resource_alicloud_kvstore_backup_policy.go
+++ b/alicloud/resource_alicloud_kvstore_backup_policy.go
@@ -4,12 +4,13 @@ import (
 	"fmt"
 	"strings"
 
+	"sort"
+	"time"
+
 	"github.com/aliyun/alibaba-cloud-sdk-go/services/r-kvstore"
 	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/helper/schema"
 	"github.com/terraform-providers/terraform-provider-alicloud/alicloud/connectivity"
-	"sort"
-	"time"
 )
 
 func resourceAlicloudKVStoreBackupPolicy() *schema.Resource {

--- a/alicloud/resource_alicloud_pvtz_zone_attachment.go
+++ b/alicloud/resource_alicloud_pvtz_zone_attachment.go
@@ -143,6 +143,9 @@ func resourceAlicloudPvtzZoneAttachmentDelete(d *schema.ResourceData, meta inter
 		})
 
 		if err != nil {
+			if IsExceptedErrors(err, []string{ZoneNotExists, ZoneVpcNotExists}) {
+				return nil
+			}
 			if IsExceptedErrors(err, []string{PvtzThrottlingUser, PvtzSystemBusy}) {
 				time.Sleep(time.Duration(2) * time.Second)
 				return resource.RetryableError(WrapErrorf(err, DefaultErrorMsg, d.Id(), request.GetActionName(), AlibabaCloudSdkGoERROR))

--- a/alicloud/resource_alicloud_pvtz_zone_record.go
+++ b/alicloud/resource_alicloud_pvtz_zone_record.go
@@ -251,6 +251,9 @@ func resourceAlicloudPvtzZoneRecordDelete(d *schema.ResourceData, meta interface
 		})
 
 		if err != nil {
+			if IsExceptedErrors(err, []string{ZoneNotExists, ZoneVpcNotExists}) {
+				return nil
+			}
 			if IsExceptedErrors(err, []string{PvtzThrottlingUser, PvtzSystemBusy}) {
 				time.Sleep(time.Duration(2) * time.Second)
 				return resource.RetryableError(BuildWrapError(request.GetActionName(), d.Id(), AlibabaCloudSdkGoERROR, err, ""))

--- a/alicloud/service_alicloud_pvtz.go
+++ b/alicloud/service_alicloud_pvtz.go
@@ -101,7 +101,7 @@ func (s *PvtzService) DescribeZoneRecord(recordId int, zoneId string) (record pv
 			})
 
 			if err != nil {
-				if IsExceptedErrors(err, []string{ZoneNotExists}) {
+				if IsExceptedErrors(err, []string{ZoneNotExists, ZoneVpcNotExists}) {
 					return GetNotFoundErrorFromString(GetNotFoundMessage("PrivateZoneRecord", recordIdStr))
 				}
 				return err


### PR DESCRIPTION
```
TF_ACC=1 go test ./alicloud -v -run=TestAccAlicloudPvtzZoneRecord -timeout=240m
=== RUN   TestAccAlicloudPvtzZoneRecordsDataSource_basic
--- PASS: TestAccAlicloudPvtzZoneRecordsDataSource_basic (20.49s)
=== RUN   TestAccAlicloudPvtzZoneRecordsDataSource_empty
--- PASS: TestAccAlicloudPvtzZoneRecordsDataSource_empty (14.34s)
=== RUN   TestAccAlicloudPvtzZoneRecord_importBasic
--- PASS: TestAccAlicloudPvtzZoneRecord_importBasic (9.38s)
=== RUN   TestAccAlicloudPvtzZoneRecord_Basic
--- PASS: TestAccAlicloudPvtzZoneRecord_Basic (3.44s)
=== RUN   TestAccAlicloudPvtzZoneRecord_updateRr
--- PASS: TestAccAlicloudPvtzZoneRecord_updateRr (5.05s)
=== RUN   TestAccAlicloudPvtzZoneRecord_updateType
--- PASS: TestAccAlicloudPvtzZoneRecord_updateType (5.50s)
=== RUN   TestAccAlicloudPvtzZoneRecord_updateValue
--- PASS: TestAccAlicloudPvtzZoneRecord_updateValue (6.18s)
=== RUN   TestAccAlicloudPvtzZoneRecord_updatePriority
--- PASS: TestAccAlicloudPvtzZoneRecord_updatePriority (10.38s)
=== RUN   TestAccAlicloudPvtzZoneRecord_updateTTL
--- PASS: TestAccAlicloudPvtzZoneRecord_updateTTL (12.65s)
=== RUN   TestAccAlicloudPvtzZoneRecord_updateAll
--- PASS: TestAccAlicloudPvtzZoneRecord_updateAll (19.31s)
=== RUN   TestAccAlicloudPvtzZoneRecord_multi
--- PASS: TestAccAlicloudPvtzZoneRecord_multi (12.87s)
PASS
ok  	github.com/terraform-providers/terraform-provider-alicloud/alicloud	119.646s
```