### PR TITLE
Modify db account returning update to read after creating

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 IMPROVEMENTS:
 
+- Modify db account returning update to read after creating [GH-708]
 - Improve cdn testcase [GH-708]
 - Add notes for datahub and improve its testcase [GH-704]
 - Improve security_group_rule resource and data source testcases [GH-703]

--- a/alicloud/resource_alicloud_db_account.go
+++ b/alicloud/resource_alicloud_db_account.go
@@ -99,7 +99,7 @@ func resourceAlicloudDBAccountCreate(d *schema.ResourceData, meta interface{}) e
 		return fmt.Errorf("Wait db account %s got an error: %#v.", Available, err)
 	}
 
-	return resourceAlicloudDBAccountUpdate(d, meta)
+	return resourceAlicloudDBAccountRead(d, meta)
 }
 
 func resourceAlicloudDBAccountRead(d *schema.ResourceData, meta interface{}) error {
@@ -130,7 +130,7 @@ func resourceAlicloudDBAccountUpdate(d *schema.ResourceData, meta interface{}) e
 	instanceId := parts[0]
 	accountName := parts[1]
 
-	if d.HasChange("description") && !d.IsNewResource() {
+	if d.HasChange("description") {
 
 		request := rds.CreateModifyAccountDescriptionRequest()
 		request.DBInstanceId = instanceId
@@ -146,7 +146,7 @@ func resourceAlicloudDBAccountUpdate(d *schema.ResourceData, meta interface{}) e
 		d.SetPartial("description")
 	}
 
-	if d.HasChange("password") && !d.IsNewResource() {
+	if d.HasChange("password") {
 
 		request := rds.CreateResetAccountPasswordRequest()
 		request.DBInstanceId = instanceId


### PR DESCRIPTION
```
TF_ACC=1 go test ./alicloud -v -run=TestAccAlicloudDBAccount -timeout=600m
=== RUN   TestAccAlicloudDBAccountPrivilege_import
--- PASS: TestAccAlicloudDBAccountPrivilege_import (268.59s)
=== RUN   TestAccAlicloudDBAccount_import
--- PASS: TestAccAlicloudDBAccount_import (592.81s)
=== RUN   TestAccAlicloudDBAccountPrivilege_basic
--- PASS: TestAccAlicloudDBAccountPrivilege_basic (304.38s)
=== RUN   TestAccAlicloudDBAccount_mysql
--- PASS: TestAccAlicloudDBAccount_mysql (606.12s)
PASS
ok  	github.com/terraform-providers/terraform-provider-alicloud/alicloud	1771.975s
```