### PR TITLE
Improve security group rule testcase for classic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ FEATURES:
 
 IMPROVEMENTS:
 
+- Improve security group rule testcase for classic [GH-716]
 - Improve security group creating request [GH-715]
 - Route entry supports Nat Gateway [GH-713]
 - Modify db account returning update to read after creating [GH-711]

--- a/alicloud/data_source_alicloud_security_group_rules_test.go
+++ b/alicloud/data_source_alicloud_security_group_rules_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/terraform-providers/terraform-provider-alicloud/alicloud/connectivity"
 )
 
 func TestAccAlicloudSecurityGroupRulesDataSourceWithDirection(t *testing.T) {
@@ -75,7 +76,7 @@ func TestAccAlicloudSecurityGroupRulesDataSourceWithGroupId(t *testing.T) {
 func TestAccAlicloudSecurityGroupRulesDataSourceWithNic_Type(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
-			testAccPreCheck(t)
+			testAccPreCheckWithRegions(t, true, connectivity.EcsClassicSupportedRegions)
 		},
 		Providers: testAccProviders,
 		Steps: []resource.TestStep{


### PR DESCRIPTION
```
 TF_ACC=1 go test ./alicloud -v -run=TestAccAlicloudSecurityGroupRulesDataSourceWithNic_Type -timeout=240m
=== RUN   TestAccAlicloudSecurityGroupRulesDataSourceWithNic_Type
--- PASS: TestAccAlicloudSecurityGroupRulesDataSourceWithNic_Type (8.53s)
PASS
ok  	github.com/terraform-providers/terraform-provider-alicloud/alicloud	8.587s
```