### PR TITLE
Improve dns group testcase

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ FEATURES:
 
 IMPROVEMENTS:
 
+- Improve dns group testcase [GH-717]
 - Improve security group rule testcase for classic [GH-716]
 - Improve security group creating request [GH-715]
 - Route entry supports Nat Gateway [GH-713]

--- a/alicloud/data_source_alicloud_dns_groups_test.go
+++ b/alicloud/data_source_alicloud_dns_groups_test.go
@@ -3,10 +3,13 @@ package alicloud
 import (
 	"testing"
 
+	"fmt"
+
+	"github.com/hashicorp/terraform/helper/acctest"
 	"github.com/hashicorp/terraform/helper/resource"
 )
 
-func TestAccAlicloudDnsGroupsDataSource_name_regex(t *testing.T) {
+func TestAccAlicloudDnsGroupsDataSource_nameregexAll(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			testAccPreCheck(t)
@@ -14,12 +17,33 @@ func TestAccAlicloudDnsGroupsDataSource_name_regex(t *testing.T) {
 		Providers: testAccProviders,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccCheckAlicloudDnsGroupsDataSourceNameRegexConfig,
+				Config: testAccCheckAlicloudDnsGroupsDataSourceNameRegexAll,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAlicloudDataSourceID("data.alicloud_dns_groups.group"),
 					resource.TestCheckResourceAttr("data.alicloud_dns_groups.group", "groups.#", "1"),
 					resource.TestCheckResourceAttr("data.alicloud_dns_groups.group", "groups.0.group_id", ""),
 					resource.TestCheckResourceAttr("data.alicloud_dns_groups.group", "groups.0.group_name", "ALL"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAlicloudDnsGroupsDataSource_nameregex(t *testing.T) {
+	rand := acctest.RandIntRange(1000, 9999)
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+		},
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCheckAlicloudDnsGroupsDataSourceNameRegex(rand),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAlicloudDataSourceID("data.alicloud_dns_groups.group"),
+					resource.TestCheckResourceAttr("data.alicloud_dns_groups.group", "groups.#", "1"),
+					resource.TestCheckResourceAttrSet("data.alicloud_dns_groups.group", "groups.0.group_id"),
+					resource.TestCheckResourceAttr("data.alicloud_dns_groups.group", "groups.0.group_name", fmt.Sprintf("tf-testacc-%d", rand)),
 				),
 			},
 		},
@@ -46,10 +70,23 @@ func TestAccAlicloudDnsGroupsDataSource_empty(t *testing.T) {
 	})
 }
 
-const testAccCheckAlicloudDnsGroupsDataSourceNameRegexConfig = `
+const testAccCheckAlicloudDnsGroupsDataSourceNameRegexAll = `
 data "alicloud_dns_groups" "group" {
   name_regex = "^ALL"
 }`
+
+func testAccCheckAlicloudDnsGroupsDataSourceNameRegex(rand int) string {
+	return fmt.Sprintf(`
+	resource "alicloud_dns_group" "foo" {
+	  name = "tf-testacc%d-"
+	}
+	resource "alicloud_dns_group" "group" {
+	  name = "tf-testacc-%d"
+	}
+	data "alicloud_dns_groups" "group" {
+	  name_regex = "${alicloud_dns_group.group.name}"
+	}`, rand, rand)
+}
 
 const testAccCheckAlicloudDnsGroupsDataSourceNameRegexEmpty = `
 data "alicloud_dns_groups" "group" {

--- a/alicloud/resource_alicloud_dns_group_test.go
+++ b/alicloud/resource_alicloud_dns_group_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/denverdino/aliyungo/dns"
+	"github.com/hashicorp/terraform/helper/acctest"
 	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/terraform"
 	"github.com/terraform-providers/terraform-provider-alicloud/alicloud/connectivity"
@@ -13,7 +14,7 @@ import (
 
 func TestAccAlicloudDnsGroup_basic(t *testing.T) {
 	var v dns.DomainGroupType
-
+	rand := acctest.RandIntRange(1000, 9999)
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			testAccPreCheck(t)
@@ -26,14 +27,14 @@ func TestAccAlicloudDnsGroup_basic(t *testing.T) {
 		CheckDestroy: testAccCheckDnsGroupDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccDnsGroupConfig,
+				Config: testAccDnsGroupConfig(rand),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckDnsGroupExists(
 						"alicloud_dns_group.group", &v),
 					resource.TestCheckResourceAttr(
 						"alicloud_dns_group.group",
 						"name",
-						"yutest"),
+						fmt.Sprintf("tf-testacc-%d", rand)),
 				),
 			},
 		},
@@ -104,8 +105,10 @@ func testAccCheckDnsGroupDestroy(s *terraform.State) error {
 	return nil
 }
 
-const testAccDnsGroupConfig = `
-resource "alicloud_dns_group" "group" {
-  name = "yutest"
+func testAccDnsGroupConfig(rand int) string {
+	return fmt.Sprintf(`
+	resource "alicloud_dns_group" "group" {
+	  name = "tf-testacc-%d"
+	}
+	`, rand)
 }
-`


### PR DESCRIPTION
```
  TF_ACC=1 go test ./alicloud -v -run=TestAccAlicloudDnsGroup -timeout=240m
=== RUN   TestAccAlicloudDnsGroupsDataSource_nameregexAll
--- PASS: TestAccAlicloudDnsGroupsDataSource_nameregexAll (0.83s)
=== RUN   TestAccAlicloudDnsGroupsDataSource_nameregex
--- PASS: TestAccAlicloudDnsGroupsDataSource_nameregex (2.67s)
=== RUN   TestAccAlicloudDnsGroupsDataSource_empty
--- PASS: TestAccAlicloudDnsGroupsDataSource_empty (0.71s)
=== RUN   TestAccAlicloudDnsGroup_basic
--- PASS: TestAccAlicloudDnsGroup_basic (1.39s)
PASS
ok  	github.com/terraform-providers/terraform-provider-alicloud/alicloud	5.653s
```