### PR TITLE
Datasource instance_types supports filter results and used to create kuberneters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,10 +2,12 @@
 
 FEATURES:
 
+- **New Resource:** `alicloud_elasticsearch_instance` [GH-722]
 - **New Resource:** `alicloud_logtail_attachment` [GH-705]
 
 IMPROVEMENTS:
 
+- Datasource instance_types supports filter results and used to create kuberneters [GH-723]
 - Add ids parameter extraction in data source regions,zones,dns_domain,images and instance_types[GH-718]
 - Improve dns group testcase [GH-717]
 - Improve security group rule testcase for classic [GH-716]

--- a/alicloud/common.go
+++ b/alicloud/common.go
@@ -284,6 +284,13 @@ const (
 	TagResourceEni           = TagResourceType("eni")
 )
 
+type KubernetesNodeType string
+
+const (
+	KubernetesNodeMaster = ResourceType("Master")
+	KubernetesNodeWorker = ResourceType("Worker")
+)
+
 func getPagination(pageNumber, pageSize int) (pagination common.Pagination) {
 	pagination.PageSize = pageSize
 	pagination.PageNumber = pageNumber

--- a/alicloud/data_source_alicloud_instance_types_test.go
+++ b/alicloud/data_source_alicloud_instance_types_test.go
@@ -70,6 +70,45 @@ func TestAccAlicloudInstanceTypesDataSource_gpu(t *testing.T) {
 					resource.TestCheckResourceAttrSet("data.alicloud_instance_types.gpu", "ids.#"),
 				),
 			},
+			{
+				Config: testAccCheckAlicloudInstanceTypesDataSourceGpuK8SMaster,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAlicloudDataSourceID("data.alicloud_instance_types.gpu"),
+					resource.TestCheckResourceAttr("data.alicloud_instance_types.gpu", "instance_types.#", "0"),
+					resource.TestCheckNoResourceAttr("data.alicloud_instance_types.gpu", "instance_types.0.cpu_core_count"),
+					resource.TestCheckNoResourceAttr("data.alicloud_instance_types.gpu", "instance_types.0.memory_size"),
+					resource.TestCheckNoResourceAttr("data.alicloud_instance_types.gpu", "instance_types.0.family"),
+					resource.TestCheckNoResourceAttr("data.alicloud_instance_types.gpu", "instance_types.0.eni_amount"),
+					resource.TestCheckNoResourceAttr("data.alicloud_instance_types.gpu", "instance_types.0.availability_zones.#"),
+					resource.TestCheckNoResourceAttr("data.alicloud_instance_types.gpu", "instance_types.0.gpu.%"),
+					resource.TestCheckNoResourceAttr("data.alicloud_instance_types.gpu", "instance_types.0.burstable_instance.%"),
+					resource.TestCheckNoResourceAttr("data.alicloud_instance_types.gpu", "instance_types.0.local_storage.%"),
+					resource.TestCheckResourceAttrSet("data.alicloud_instance_types.gpu", "ids.#"),
+				),
+			},
+			{
+				Config: testAccCheckAlicloudInstanceTypesDataSourceGpuK8SWorker,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAlicloudDataSourceID("data.alicloud_instance_types.gpu"),
+					resource.TestCheckResourceAttrSet("data.alicloud_instance_types.gpu", "instance_types.0.id"),
+					resource.TestCheckResourceAttrSet("data.alicloud_instance_types.gpu", "instance_types.0.cpu_core_count"),
+					resource.TestCheckResourceAttrSet("data.alicloud_instance_types.gpu", "instance_types.0.memory_size"),
+					resource.TestCheckResourceAttr("data.alicloud_instance_types.gpu", "instance_types.0.family", "ecs.gn5"),
+					resource.TestCheckResourceAttrSet("data.alicloud_instance_types.gpu", "instance_types.0.eni_amount"),
+					resource.TestCheckResourceAttrSet("data.alicloud_instance_types.gpu", "instance_types.0.availability_zones.#"),
+					resource.TestCheckResourceAttr("data.alicloud_instance_types.gpu", "instance_types.0.gpu.%", "2"),
+					resource.TestCheckResourceAttrSet("data.alicloud_instance_types.gpu", "instance_types.0.gpu.amount"),
+					resource.TestCheckResourceAttrSet("data.alicloud_instance_types.gpu", "instance_types.0.gpu.category"),
+					resource.TestCheckResourceAttr("data.alicloud_instance_types.gpu", "instance_types.0.burstable_instance.%", "2"),
+					resource.TestCheckResourceAttrSet("data.alicloud_instance_types.gpu", "instance_types.0.burstable_instance.initial_credit"),
+					resource.TestCheckResourceAttrSet("data.alicloud_instance_types.gpu", "instance_types.0.burstable_instance.baseline_credit"),
+					resource.TestCheckResourceAttr("data.alicloud_instance_types.gpu", "instance_types.0.local_storage.%", "3"),
+					resource.TestCheckResourceAttrSet("data.alicloud_instance_types.gpu", "instance_types.0.local_storage.capacity"),
+					resource.TestCheckResourceAttrSet("data.alicloud_instance_types.gpu", "instance_types.0.local_storage.amount"),
+					resource.TestCheckResourceAttrSet("data.alicloud_instance_types.gpu", "instance_types.0.local_storage.category"),
+					resource.TestCheckResourceAttrSet("data.alicloud_instance_types.gpu", "ids.#"),
+				),
+			},
 		},
 	})
 }
@@ -102,6 +141,84 @@ func TestAccAlicloudInstanceTypesDataSource_empty(t *testing.T) {
 	})
 }
 
+func TestAccAlicloudInstanceTypesDataSource_k8sSpec(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+		},
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCheckAlicloudInstanceTypesDataSourceK8S1c2g,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAlicloudDataSourceID("data.alicloud_instance_types.1c2g"),
+					resource.TestCheckResourceAttr("data.alicloud_instance_types.1c2g", "instance_types.#", "0"),
+					resource.TestCheckNoResourceAttr("data.alicloud_instance_types.1c2g", "instance_types.0.id"),
+					resource.TestCheckNoResourceAttr("data.alicloud_instance_types.1c2g", "instance_types.0.cpu_core_count"),
+					resource.TestCheckNoResourceAttr("data.alicloud_instance_types.1c2g", "instance_types.0.memory_size"),
+					resource.TestCheckNoResourceAttr("data.alicloud_instance_types.1c2g", "instance_types.0.family"),
+					resource.TestCheckNoResourceAttr("data.alicloud_instance_types.1c2g", "instance_types.0.eni_amount"),
+					resource.TestCheckNoResourceAttr("data.alicloud_instance_types.1c2g", "instance_types.0.availability_zones.#"),
+					resource.TestCheckNoResourceAttr("data.alicloud_instance_types.1c2g", "instance_types.0.gpu.%"),
+					resource.TestCheckNoResourceAttr("data.alicloud_instance_types.1c2g", "instance_types.0.burstable_instance.%"),
+					resource.TestCheckNoResourceAttr("data.alicloud_instance_types.1c2g", "instance_types.0.local_storage.%"),
+					resource.TestCheckResourceAttrSet("data.alicloud_instance_types.1c2g", "ids.#"),
+				),
+			},
+			{
+				Config: testAccCheckAlicloudInstanceTypesDataSourceK8S2c4g,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAlicloudDataSourceID("data.alicloud_instance_types.2c4g"),
+					resource.TestCheckResourceAttrSet("data.alicloud_instance_types.2c4g", "instance_types.0.id"),
+					resource.TestCheckResourceAttr("data.alicloud_instance_types.2c4g", "instance_types.0.cpu_core_count", "2"),
+					resource.TestCheckResourceAttr("data.alicloud_instance_types.2c4g", "instance_types.0.memory_size", "4"),
+					resource.TestCheckResourceAttrSet("data.alicloud_instance_types.2c4g", "instance_types.0.family"),
+					resource.TestCheckResourceAttrSet("data.alicloud_instance_types.2c4g", "instance_types.0.eni_amount"),
+					resource.TestCheckResourceAttrSet("data.alicloud_instance_types.2c4g", "instance_types.0.availability_zones.#"),
+					resource.TestCheckResourceAttr("data.alicloud_instance_types.2c4g", "instance_types.0.gpu.%", "2"),
+					resource.TestCheckResourceAttrSet("data.alicloud_instance_types.2c4g", "instance_types.0.gpu.amount"),
+					resource.TestCheckResourceAttr("data.alicloud_instance_types.2c4g", "instance_types.0.gpu.category", ""),
+					resource.TestCheckResourceAttr("data.alicloud_instance_types.2c4g", "instance_types.0.burstable_instance.%", "2"),
+					resource.TestCheckResourceAttrSet("data.alicloud_instance_types.2c4g", "instance_types.0.burstable_instance.initial_credit"),
+					resource.TestCheckResourceAttrSet("data.alicloud_instance_types.2c4g", "instance_types.0.burstable_instance.baseline_credit"),
+					resource.TestCheckResourceAttr("data.alicloud_instance_types.2c4g", "instance_types.0.local_storage.%", "3"),
+					resource.TestCheckResourceAttrSet("data.alicloud_instance_types.2c4g", "instance_types.0.local_storage.capacity"),
+					resource.TestCheckResourceAttrSet("data.alicloud_instance_types.2c4g", "instance_types.0.local_storage.amount"),
+					resource.TestCheckResourceAttr("data.alicloud_instance_types.2c4g", "instance_types.0.local_storage.category", ""),
+					resource.TestCheckResourceAttrSet("data.alicloud_instance_types.2c4g", "ids.#"),
+				),
+			},
+		},
+	})
+}
+func TestAccAlicloudInstanceTypesDataSource_k8sFamily(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+		},
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCheckAlicloudInstanceTypesDataSourceK8ST5,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAlicloudDataSourceID("data.alicloud_instance_types.t5"),
+					resource.TestCheckResourceAttr("data.alicloud_instance_types.t5", "instance_types.#", "0"),
+					resource.TestCheckNoResourceAttr("data.alicloud_instance_types.t5", "instance_types.0.id"),
+					resource.TestCheckNoResourceAttr("data.alicloud_instance_types.t5", "instance_types.0.cpu_core_count"),
+					resource.TestCheckNoResourceAttr("data.alicloud_instance_types.t5", "instance_types.0.memory_size"),
+					resource.TestCheckNoResourceAttr("data.alicloud_instance_types.t5", "instance_types.0.family"),
+					resource.TestCheckNoResourceAttr("data.alicloud_instance_types.t5", "instance_types.0.eni_amount"),
+					resource.TestCheckNoResourceAttr("data.alicloud_instance_types.t5", "instance_types.0.availability_zones.#"),
+					resource.TestCheckNoResourceAttr("data.alicloud_instance_types.t5", "instance_types.0.gpu.%"),
+					resource.TestCheckNoResourceAttr("data.alicloud_instance_types.t5", "instance_types.0.burstable_instance.%"),
+					resource.TestCheckNoResourceAttr("data.alicloud_instance_types.t5", "instance_types.0.local_storage.%"),
+					resource.TestCheckResourceAttrSet("data.alicloud_instance_types.t5", "ids.#"),
+				),
+			},
+		},
+	})
+}
+
 const testAccCheckAlicloudInstanceTypesDataSourceBasicConfig = `
 data "alicloud_instance_types" "4c8g" {
 	cpu_core_count = 4
@@ -118,9 +235,50 @@ data "alicloud_instance_types" "gpu" {
 	instance_charge_type = "PrePaid"
 }
 `
+const testAccCheckAlicloudInstanceTypesDataSourceGpuK8SMaster = `
+provider "alicloud" {
+	region = "cn-hangzhou"
+}
+data "alicloud_instance_types" "gpu" {
+	kubernetes_node = "Master"
+	instance_type_family = "ecs.gn5"
+}
+`
+const testAccCheckAlicloudInstanceTypesDataSourceGpuK8SWorker = `
+provider "alicloud" {
+	region = "cn-hangzhou"
+}
+data "alicloud_instance_types" "gpu" {
+	kubernetes_node = "Worker"
+	instance_type_family = "ecs.gn5"
+}
+`
 
 const testAccCheckAlicloudInstanceTypesDataSourceEmpty = `
 data "alicloud_instance_types" "empty" {
 	instance_type_family = "ecs.fake"
+}
+`
+
+const testAccCheckAlicloudInstanceTypesDataSourceK8S1c2g = `
+data "alicloud_instance_types" "1c2g" {
+	cpu_core_count = 1
+	memory_size = 2
+	kubernetes_node = "Master"
+}
+`
+const testAccCheckAlicloudInstanceTypesDataSourceK8S2c4g = `
+data "alicloud_instance_types" "2c4g" {
+	cpu_core_count = 2
+	memory_size = 4
+	kubernetes_node = "Worker"
+}
+`
+const testAccCheckAlicloudInstanceTypesDataSourceK8ST5 = `
+data "alicloud_instance_types" "t5" {
+	cpu_core_count = 2
+	memory_size = 4
+	kubernetes_node = "Master"
+	instance_type_family = "ecs.t5"
 }
 `


### PR DESCRIPTION
```
TF_ACC=1 go test ./alicloud -v -run=TestAccAlicloudInstanceTypes -timeout=240m
=== RUN   TestAccAlicloudInstanceTypesDataSource_basic
--- PASS: TestAccAlicloudInstanceTypesDataSource_basic (18.65s)
=== RUN   TestAccAlicloudInstanceTypesDataSource_gpu
--- PASS: TestAccAlicloudInstanceTypesDataSource_gpu (4.08s)
=== RUN   TestAccAlicloudInstanceTypesDataSource_empty
--- PASS: TestAccAlicloudInstanceTypesDataSource_empty (10.98s)
=== RUN   TestAccAlicloudInstanceTypesDataSource_k8sSpec
--- PASS: TestAccAlicloudInstanceTypesDataSource_k8sSpec (27.22s)
=== RUN   TestAccAlicloudInstanceTypesDataSource_k8sFamily
--- PASS: TestAccAlicloudInstanceTypesDataSource_k8sFamily (9.96s)
PASS
ok  	github.com/terraform-providers/terraform-provider-alicloud/alicloud	70.937s
```