### PR TITLE
k8s support user_ca

### DIFF
--- a/alicloud/data_source_alicloud_vpn_connections.go
+++ b/alicloud/data_source_alicloud_vpn_connections.go
@@ -252,9 +252,9 @@ func vpnConnectionsDecriptionAttributes(d *schema.ResourceData, vpnSetTypes []vp
 	var s []map[string]interface{}
 	for _, conn := range vpnSetTypes {
 		mapping := map[string]interface{}{
-			"id":                  conn.VpnConnectionId,
 			"customer_gateway_id": conn.CustomerGatewayId,
 			"vpn_gateway_id":      conn.VpnGatewayId,
+			"id":                  conn.VpnConnectionId,
 			"name":                conn.Name,
 			"local_subnet":        conn.LocalSubnet,
 			"remote_subnet":       conn.RemoteSubnet,

--- a/alicloud/resource_alicloud_cs_kubernetes.go
+++ b/alicloud/resource_alicloud_cs_kubernetes.go
@@ -142,6 +142,11 @@ func resourceAlicloudCSKubernetes() *schema.Resource {
 				Optional:      true,
 				ConflictsWith: []string{"password"},
 			},
+			"user_ca": {
+				Type:     schema.TypeString,
+				ForceNew: true,
+				Optional: true,
+			},
 			"pod_cidr": {
 				Type:     schema.TypeString,
 				ForceNew: true,
@@ -1067,6 +1072,14 @@ func buildKubernetesArgs(d *schema.ResourceData, meta interface{}) (*cs.Kubernet
 		}
 	}
 
+	if userCa, ok := d.GetOk("user_ca"); ok {
+		userCaContent, err := loadFileContent(userCa.(string))
+		if err != nil {
+			return nil, fmt.Errorf("reading user_ca file failed %s", err)
+		}
+		creationArgs.UserCA = string(userCaContent)
+	}
+
 	return creationArgs, nil
 }
 
@@ -1173,6 +1186,14 @@ func buildKubernetesMultiAZArgs(d *schema.ResourceData, meta interface{}) (*cs.K
 			creationArgs.WorkerPeriod = d.Get("worker_period").(int)
 			creationArgs.WorkerPeriodUnit = d.Get("worker_period_unit").(string)
 		}
+	}
+
+	if userCa, ok := d.GetOk("user_ca"); ok {
+		userCaContent, err := loadFileContent(userCa.(string))
+		if err != nil {
+			return nil, fmt.Errorf("reading user_ca file failed %s", err)
+		}
+		creationArgs.UserCA = string(userCaContent)
 	}
 
 	return creationArgs, nil

--- a/alicloud/resource_alicloud_cs_kubernetes_test.go
+++ b/alicloud/resource_alicloud_cs_kubernetes_test.go
@@ -1,6 +1,10 @@
 package alicloud
 
 import (
+	"crypto/tls"
+	"io/ioutil"
+	"net/http"
+	"os"
 	"regexp"
 	"testing"
 
@@ -12,6 +16,84 @@ import (
 	"github.com/hashicorp/terraform/terraform"
 	"github.com/terraform-providers/terraform-provider-alicloud/alicloud/connectivity"
 )
+
+// # Generate a CA cert pair.
+//echo '{"CN":"CA","key":{"algo":"rsa","size":2048}}' | cfssl gencert -initca - | cfssljson -bare ca -
+//echo '{"signing":{"default":{"expiry":"438000h","usages":["signing","key encipherment","server auth","client auth"]}}}' > ca-config.json
+
+//# Use CA cert to sign a client cert pair.
+//export ADDRESS=
+//export NAME=kubernetes-admin
+//echo '{"CN":"'$NAME'","O": "system:masters","hosts":[""],"key":{"algo":"rsa","size":2048}}' | cfssl gencert -config=ca-config.json -ca=ca.pem -ca-key=ca-key.pem -hostname="$ADDRESS" - | cfssljson -bare $NAME
+
+const caCert = `-----BEGIN CERTIFICATE-----
+MIIC6jCCAdKgAwIBAgIUfSCqJB17C26e20n1wp3QZ0ypbsQwDQYJKoZIhvcNAQEL
+BQAwDTELMAkGA1UEAxMCQ0EwHhcNMTkwMTA5MDcwNTAwWhcNMjQwMTA4MDcwNTAw
+WjANMQswCQYDVQQDEwJDQTCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEB
+AMwEC6JM3KxwWcg8l+bpehMBGAE/gUzglYaSwZt0SxlTYyLjx16HIUZcv2JQX5kP
+D0jSLqTrd6C2lc3EaLGyU9SLAdjB6uV5jDKeCJhbAXJEtdHiaI5SuJPd1f/RwUym
+7aUcG9puLN18203zvfp+Ot4uaoKlUd/sq+VREiojEz5oGbRrrHIVMD4VyqZidmfL
+bOG2Zfz3XSKwcJEs2EuI7nlXYLEtWm2YDZQlC2goLfDbj/QkChjgpooyrlo9+Pp3
+JTpydgrE3aTecrpVRRzioUKuUJ4RsXHqLfdDFVpN0GB0JdDfGdjGaptfUVD5Dn7I
+Zfe69kTXmH9qwEALEmF1pl8CAwEAAaNCMEAwDgYDVR0PAQH/BAQDAgEGMA8GA1Ud
+EwEB/wQFMAMBAf8wHQYDVR0OBBYEFM/M1RKZToaXmUK434EthsoNsNunMA0GCSqG
+SIb3DQEBCwUAA4IBAQA2cuOyLAb3mkYrfJsv8PHDuZ/c6TUNRDdHUpq6ItQRKuu3
+a5fhmAcJD5MZp67n1gVzVZsQ95qrsduwnSCnwDBSZJP21vcqdeIaG+mjlg/zXXnw
+b3qCqbtk27Yuypw91+3Jza834vzEAUvHQiWgVOiiHzFO5jImQhAosTMV838ae/kd
+ws6mhM65UuWFg5HLbdM2J/zrjWrhuAJZgR1Kx2eReleUyDg97Bc0SPTBth28tGvH
+UjY7X0eHM5vuv6NUOyElHVteY8oQ1f0f06K5K4lB7lJ1SB/9PdxYv/AawQwqJIQr
+iPn9wR9zlLX6d0Zge293YJ/HGOsm7UzI65DxfDfp
+-----END CERTIFICATE-----`
+
+const clientCert = `-----BEGIN CERTIFICATE-----
+MIIDXzCCAkegAwIBAgIUCaHVJZr6XAsKp+DCO2J7M4d2J6kwDQYJKoZIhvcNAQEL
+BQAwDTELMAkGA1UEAxMCQ0EwIBcNMTkwMTA5MDczNzAwWhgPMjA2ODEyMjcwNzM3
+MDBaMDQxFzAVBgNVBAoTDnN5c3RlbTptYXN0ZXJzMRkwFwYDVQQDExBrdWJlcm5l
+dGVzLWFkbWluMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEArvxZY4hy
+rbAGwjYPx1naFDQi/JDdZkypZ11MGGevSf5516tRjJSgGPm0hCR4kKvoY29QLmk9
+c67X0Gsih7xnr2ockl4lL9Mf+RrBDO3w55mnxfZ4PBTsuptBvj+MGu+y7jUySmDW
+EH+PAJGG+UUj+CGN2yZrAGHlBSyhtVZ3CzX9WOeNj89cXv0cqdNtTyW+Nx3ny2rj
+RI5zUeXfCELiwfNGPUbKMOHro302vqaYeFNzFxaf4aYqcPnG1Nk/LSHLSWXnKlsi
+qACgSDZZmYEHtjNAMOC/sH0J3HneiIrmyQ2H1il5ai2ZXQvgRM9T5YPAu92O9ipl
+aOdGEfO0q+DVzwIDAQABo4GNMIGKMA4GA1UdDwEB/wQEAwIFoDAdBgNVHSUEFjAU
+BggrBgEFBQcDAQYIKwYBBQUHAwIwDAYDVR0TAQH/BAIwADAdBgNVHQ4EFgQUeC6+
+JAmWJLIz3bF3wFgW0y9nUB4wHwYDVR0jBBgwFoAUz8zVEplOhpeZQrjfgS2Gyg2w
+26cwCwYDVR0RBAQwAoIAMA0GCSqGSIb3DQEBCwUAA4IBAQAMiu/BpYXwtlmA+cp8
+rZlRaBALAhFjEHSh4eJALcYXEEI1b1moWwqPJ8Cs3TGneK9MYhVOAPzsZcqNAzJq
+UyrF9LKJPPymWvJztubYvqNBLHorAXGouruyc7Tf3HcHEf7j1bwtiNJN0SqHVYDT
+qsUXxParkcOhV52CHGShwtLEmT7Tp1IuOJe+PGUrEkeePCDF+I3e5u3c8zUQ10eV
+NOB1xGm2n5rdl8Qyl2aTr4Psmgzhx/OKQpDO4z4vK9ABbqJXxcPiVUrlbflsFniG
+wzs74ptWLax2EQHY/lv6mdMFDRt24zyBJUQJ3rlgwRF64w6LgtX7cl9Qo4L0a5mt
+SNex
+-----END CERTIFICATE-----`
+
+const clientCertKey = `-----BEGIN RSA PRIVATE KEY-----
+MIIEowIBAAKCAQEArvxZY4hyrbAGwjYPx1naFDQi/JDdZkypZ11MGGevSf5516tR
+jJSgGPm0hCR4kKvoY29QLmk9c67X0Gsih7xnr2ockl4lL9Mf+RrBDO3w55mnxfZ4
+PBTsuptBvj+MGu+y7jUySmDWEH+PAJGG+UUj+CGN2yZrAGHlBSyhtVZ3CzX9WOeN
+j89cXv0cqdNtTyW+Nx3ny2rjRI5zUeXfCELiwfNGPUbKMOHro302vqaYeFNzFxaf
+4aYqcPnG1Nk/LSHLSWXnKlsiqACgSDZZmYEHtjNAMOC/sH0J3HneiIrmyQ2H1il5
+ai2ZXQvgRM9T5YPAu92O9iplaOdGEfO0q+DVzwIDAQABAoIBAEcAXcTlOKMBKbzj
+8sMQ0kwgW5HftfYsZRBr6tR8PcPoXcgE27IPHGcF6xkzMziAiGrQX9h1G1o1N5x5
+3Cj3aZrjk3RQfwZIxFBvaqW0ZmuTDWBmAaNfWi7dkG+BmXfUiuXc7+r+H93R5FR2
+uC2swEuOUeD6VbByCFtxIKxTyTniooNhHaTRSZ0KLycCHgEQci1EabqnGcYCRnHg
+wd8GeU0i70JxFDAdL4qnjOq6nwqpinU9DIp+4jhVdJ/ymvg+o2gwqVHt9qiwHm4x
+ns/7P/Qrq+9lgAESVGf5q0r6uDkVTxrZ+KH6S76EpQog929w9GjrA97jd+Eq+xC3
+cChEPQECgYEA0N9vNynoIN+T07GMU+c/ivB8foVkJlAYrWah9YJnwAP/hrvW4vCe
+G0xzIq1ZRaTNQdq0AxzJ97PICRIV8RjbogzLS+cM8/g7iaqin7Gx0V0QOrUiSkrb
+YIgm3yRi+jgNfukyCnPUz4oZmr+w5wAbRDXjEODAzSAEmBVvNzfSlzsCgYEA1neW
+Na+xzHUN+ywsjr8/+CZf4W1L2wTTTeN+j+D2Ua/RR54VbFKU1mz/YJlkpGl30XCu
+/qkGR8WXldCOXf52kZqtia2rwC6gXEEA9pQS1Sj3lWVlR72PlkjKVyTx+3iIbYGs
+YvyiSIHEpOCOPK4vJlMnWLZ1Y96Tizd8x7MDGn0CgYAbDIRTiXrFHw7+wCRjDTRe
+YsxMeivBBmhbtEnPCGc1J49kvFiUpQJkmJ7kY7yG11O5boAXUxgYmtCR1CTBRy3S
+K4P8PVyhD4luR4mt0o4rhbi/UYuyQUVtl9Qo24ZxzuZ4g+x2DBAIHGM6dg6Lq6jc
+SXoxSlnNdpMBuuzfIryD1wKBgExBPPFdxPQTcqMp87XVnmMXEeRPPjdjodYB21BB
+BpPI1bqHJMrdGfqbyrmIENa8gVPAoxf89TSzttAX1WbqQTJIMwfO7lBow6/JlRQX
+VhLgfBdsc/RsHA+tVfRiOH/XPXriLm8LsI/jRA3zod9Fd5JC4qySQ279BqzrT7yZ
+k7LpAoGBAMBVPRGuDhLnVggOUdZ+nzJ61AggsJZd1pEI6/yt0Q/KcQiaNM4yZmMX
+KdCIHS7bM3yDVqLYB1XoQ1fXiHpbojf+kkdu8f7WhTiMXLgPYfWpn74U0WqD6rcH
+KKXMFi8uMDIellyOaUOsiPhAWnm4GqERwQuc4U4i3Z5k/eiKReWT
+-----END RSA PRIVATE KEY-----`
 
 func TestAccAlicloudCSKubernetes_basic(t *testing.T) {
 	var k8s cs.ClusterType
@@ -79,6 +161,80 @@ func TestAccAlicloudCSKubernetes_autoVpc(t *testing.T) {
 			},
 		},
 	})
+}
+
+func TestAccAlicloudCSKubernetes_userCa(t *testing.T) {
+	tmpFile, err := ioutil.TempFile("", "tf-acc-alicloud-cs-kubernetes-userca")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.Remove(tmpFile.Name())
+	err = ioutil.WriteFile(tmpFile.Name(), []byte(caCert), 0644)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var k8s cs.ClusterType
+
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() { testAccPreCheckWithRegions(t, true, connectivity.KubernetesSupportedRegions) },
+
+		IDRefreshName: "alicloud_cs_kubernetes.k8s",
+
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckKubernetesClusterDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccKubernetes_userCa(tmpFile.Name()),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckContainerClusterExists("alicloud_cs_kubernetes.k8s", &k8s),
+					resource.TestMatchResourceAttr("alicloud_cs_kubernetes.k8s", "name", regexp.MustCompile("^tf-testAccKubernetes-userCa*")),
+					resource.TestCheckResourceAttr("alicloud_cs_kubernetes.k8s", "worker_numbers.#", "1"),
+					resource.TestCheckResourceAttr("alicloud_cs_kubernetes.k8s", "worker_numbers.0", "1"),
+					resource.TestCheckResourceAttr("alicloud_cs_kubernetes.k8s", "master_nodes.#", "3"),
+					resource.TestCheckResourceAttr("alicloud_cs_kubernetes.k8s", "worker_disk_category", "cloud_ssd"),
+					resource.TestCheckResourceAttr("alicloud_cs_kubernetes.k8s", "master_disk_size", "50"),
+					resource.TestCheckResourceAttr("alicloud_cs_kubernetes.k8s", "master_disk_category", "cloud_efficiency"),
+					resource.TestCheckResourceAttr("alicloud_cs_kubernetes.k8s", "worker_disk_size", "40"),
+					resource.TestCheckResourceAttr("alicloud_cs_kubernetes.k8s", "connections.%", "4"),
+					resource.TestCheckResourceAttrSet("alicloud_cs_kubernetes.k8s", "connections.master_public_ip"),
+					resource.TestCheckResourceAttrSet("alicloud_cs_kubernetes.k8s", "connections.api_server_internet"),
+					resource.TestCheckResourceAttrSet("alicloud_cs_kubernetes.k8s", "connections.api_server_intranet"),
+					resource.TestCheckResourceAttrSet("alicloud_cs_kubernetes.k8s", "connections.service_domain"),
+					testAccCheckUserCA("alicloud_cs_kubernetes.k8s", &k8s),
+				),
+			},
+		},
+	})
+}
+
+func testAccCheckUserCA(n string, d *cs.ClusterType) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		cluster, ok := s.RootModule().Resources[n]
+		if !ok {
+			return fmt.Errorf("cluster not found:%s", n)
+		}
+		if endpoint, ok := cluster.Primary.Attributes["connections.api_server_internet"]; ok {
+			clientCertPair, err := tls.X509KeyPair([]byte(clientCert), []byte(clientCertKey))
+			if err != nil {
+				return fmt.Errorf("error loading client cert %s", err)
+			}
+			tr := &http.Transport{
+				TLSClientConfig: &tls.Config{
+					InsecureSkipVerify: true,
+					Certificates:       []tls.Certificate{clientCertPair},
+				},
+			}
+			client := &http.Client{Transport: tr}
+			resp, err := client.Get(endpoint)
+			if resp.StatusCode != 200 {
+				return fmt.Errorf("accessing endpoint with client cert failed, http code %d", resp.StatusCode)
+			}
+			return nil
+		} else {
+			return fmt.Errorf("connections.api_server_internet not found in cluster %s", cluster.Primary.Attributes)
+		}
+	}
 }
 
 func TestAccAlicloudCSMultiAZKubernetes_basic(t *testing.T) {
@@ -190,9 +346,6 @@ resource "alicloud_cs_kubernetes" "k8s" {
 `
 
 const testAccKubernetes_autoVpc = `
-provider "alicloud" {
-	region="cn-hangzhou"
-}
 variable "name" {
 	default = "tf-testAccKubernetes-autoVpc"
 }
@@ -222,6 +375,40 @@ resource "alicloud_cs_kubernetes" "k8s" {
   master_disk_size = 50
 }
 `
+
+func testAccKubernetes_userCa(userCa string) string {
+	return fmt.Sprintf(`
+variable "name" {
+	default = "tf-testAccKubernetes-userCa"
+}
+data "alicloud_zones" main {
+  available_resource_creation = "VSwitch"
+}
+
+data "alicloud_instance_types" "default" {
+	availability_zone = "${data.alicloud_zones.main.zones.0.id}"
+	cpu_core_count = 1
+	memory_size = 2
+}
+
+resource "alicloud_cs_kubernetes" "k8s" {
+  name_prefix = "${var.name}"
+  availability_zone = "${data.alicloud_zones.main.zones.0.id}"
+  new_nat_gateway = true
+  master_instance_types = ["${data.alicloud_instance_types.default.instance_types.0.id}"]
+  worker_instance_types = ["${data.alicloud_instance_types.default.instance_types.0.id}"]
+  worker_numbers = [1]
+  password = "Test12345"
+  pod_cidr = "172.20.0.0/16"
+  service_cidr = "172.21.0.0/20"
+  enable_ssh = true
+  install_cloud_monitor = true
+  worker_disk_category  = "cloud_ssd"
+  master_disk_size = 50
+  user_ca = "%s"
+}
+`, userCa)
+}
 
 func testAccMultiAZKubernetes_basic(rand int) string {
 	return fmt.Sprintf(`

--- a/vendor/github.com/denverdino/aliyungo/cs/clusters.go
+++ b/vendor/github.com/denverdino/aliyungo/cs/clusters.go
@@ -171,6 +171,7 @@ type KubernetesCreationArgs struct {
 
 	LoginPassword     string `json:"login_password,omitempty"`
 	KeyPair           string `json:"key_pair,omitempty"`
+	UserCA            string `json:"user_ca,omitempty"`
 	NumOfNodes        int64  `json:"num_of_nodes,omitempty"`
 	SNatEntry         bool   `json:"snat_entry"`
 	SSHFlags          bool   `json:"ssh_flags"`
@@ -233,6 +234,7 @@ type KubernetesMultiAZCreationArgs struct {
 	NumOfNodesC       int64  `json:"num_of_nodes_c"`
 	LoginPassword     string `json:"login_password,omitempty"`
 	KeyPair           string `json:"key_pair,omitempty"`
+	UserCA            string `json:"user_ca,omitempty"`
 	SSHFlags          bool   `json:"ssh_flags"`
 	CloudMonitorFlags bool   `json:"cloud_monitor_flags"`
 	NodeCIDRMask      string `json:"node_cidr_mask,omitempty"`

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -455,10 +455,10 @@
 			"revisionTime": "2018-03-30T09:12:25Z"
 		},
 		{
-			"checksumSHA1": "L98lvv1CiZmAoZRFhXh9Pb9MlAw=",
+			"checksumSHA1": "QwvxHLb9WaPbDEjjk0jzMqyPPac=",
 			"path": "github.com/denverdino/aliyungo/cs",
-			"revision": "ea26d44ece43a62acf3ba447d79059cb5f5eab03",
-			"revisionTime": "2019-01-10T06:59:48Z"
+			"revision": "a747050bb1baf06cdd65de7cddc281a2b1c2fde5",
+			"revisionTime": "2019-01-25T01:07:48Z"
 		},
 		{
 			"checksumSHA1": "at2TCvaAzU3jBW7yngHYVD9e7EI=",

--- a/website/docs/r/cs_kubernetes.html.markdown
+++ b/website/docs/r/cs_kubernetes.html.markdown
@@ -70,6 +70,7 @@ The following arguments are supported:
 * `worker_number` - The worker node number of the kubernetes cluster. Default to 3. It is limited up to 50 and if you want to enlarge it, please apply white list or contact with us.
 * `password` - (Required, Force new resource) The password of ssh login cluster node. You have to specify one of `password` and `key_name` fields.
 * `key_name` - (Required, Force new resource) The keypair of ssh login cluster node, you have to create it first.
+* `user_ca` - (Optional, Force new resource) The path of customized CA cert, you can use this CA to sign client certs to connect your cluster.
 * `cluster_network_type` - (Required, Force new resource) The network that cluster uses, use `flannel` or `terway`.
 * `pod_cidr` - (Required, Force new resource) The CIDR block for the pod network. It will be allocated automatically when `vswitch_ids` is not specified.
 It cannot be duplicated with the VPC CIDR and CIDR used by Kubernetes cluster in VPC, cannot be modified after creation.


### PR DESCRIPTION
User CA has been tested.

### Testing Procedure
* Generate a CA cert pair.
* Use CA cert to sign a client cert pair.
* Use user_ca's path to create a k8s cluster.
* Try connect to the k8s cluster using client cert signed.

```bash
# Generate a CA cert pair.
echo '{"CN":"CA","key":{"algo":"rsa","size":2048}}' \
  | cfssl gencert -initca - \
  | cfssljson -bare ca -

echo '{"signing":{"default":{"expiry":"438000h","usages":["signing","key encipherment","server auth","client auth"]}}}' > ca-config.json

# Use CA cert to sign a client cert pair.
export ADDRESS=
export NAME=kubernetes-admin
echo '{"CN":"'$NAME'","O": "system:masters","hosts":[""],"key":{"algo":"rsa","size":2048}}' | \
  cfssl gencert -config=ca-config.json -ca=ca.pem -ca-key=ca-key.pem -hostname="$ADDRESS" - | \
  cfssljson -bare $NAME

# Use user_ca's path to create a k8s cluster.
resource "alicloud_cs_kubernetes" "k8s" {
  ...
  user_ca = "/tmp/ca.pem"
}
terraform apply


# Try connect to the k8s cluster using client cert signed.
curl --cert ./kubernetes-admin.pem --key ./kubernetes-admin-key.pem -k https://<YOU_K8S_CLUSTER_ENDPOINT>:6443
```