### PR TITLE
Add Alicloud Elasticsearch data source instances.

### DIFF
--- a/alicloud/data_source_alicloud_elasticsearch_instances.go
+++ b/alicloud/data_source_alicloud_elasticsearch_instances.go
@@ -1,0 +1,186 @@
+package alicloud
+
+import (
+	"regexp"
+
+	"github.com/aliyun/alibaba-cloud-sdk-go/sdk/requests"
+	"github.com/aliyun/alibaba-cloud-sdk-go/services/elasticsearch"
+	"github.com/hashicorp/terraform/helper/schema"
+	"github.com/terraform-providers/terraform-provider-alicloud/alicloud/connectivity"
+)
+
+func dataSourceAlicloudElasticsearch() *schema.Resource {
+	return &schema.Resource{
+		Read: dataSourceAlicloudElasticsearchRead,
+
+		Schema: map[string]*schema.Schema{
+			"description_regex": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ValidateFunc: validateNameRegex,
+			},
+			"version": {
+				Type:     schema.TypeString,
+				Optional: true,
+				ValidateFunc: validateAllowedStringValue([]string{
+					"5.5.3_with_X-Pack",
+					"6.3.2_with_X-Pack",
+				}),
+			},
+
+			// Computed values
+			"instances": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"description": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"instance_charge_type": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"status": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"data_node_amount": {
+							Type:     schema.TypeInt,
+							Computed: true,
+						},
+						"data_node_spec": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"data_node_disk_size": {
+							Type:     schema.TypeInt,
+							Computed: true,
+						},
+						"data_node_disk_type": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"version": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"vswitch_id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"created_at": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"updated_at": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func dataSourceAlicloudElasticsearchRead(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*connectivity.AliyunClient)
+
+	request := elasticsearch.CreateListInstanceRequest()
+	request.RegionId = client.RegionId
+	request.EsVersion = d.Get("version").(string)
+	request.Size = requests.NewInteger(PageSizeLarge)
+	request.Page = requests.NewInteger(1)
+
+	var instances []elasticsearch.Instance
+
+	for {
+		raw, err := client.WithElasticsearchClient(func(elasticsearchClient *elasticsearch.Client) (interface{}, error) {
+			return elasticsearchClient.ListInstance(request)
+		})
+		if err != nil {
+			return WrapError(err)
+		}
+		resp, _ := raw.(*elasticsearch.ListInstanceResponse)
+		if resp == nil || len(resp.Result) < 1 {
+			break
+		}
+
+		for _, item := range resp.Result {
+			instances = append(instances, item)
+		}
+
+		if len(resp.Result) < PageSizeLarge {
+			break
+		}
+
+		if page, err := getNextpageNumber(request.Page); err != nil {
+			return WrapError(err)
+		} else {
+			request.Page = page
+		}
+	}
+
+	var filteredInstance []elasticsearch.Instance
+	descriptionRegex, ok := d.GetOk("description_regex")
+	if (ok && descriptionRegex.(string) != "") || (len(instances) > 0) {
+		var r *regexp.Regexp
+		if descriptionRegex != "" {
+			r = regexp.MustCompile(descriptionRegex.(string))
+		}
+
+		for _, instance := range instances {
+			if r != nil && !r.MatchString(instance.Description) {
+				continue
+			}
+
+			filteredInstance = append(filteredInstance, instance)
+		}
+	} else {
+		filteredInstance = instances
+	}
+
+	return extractInstance(d, filteredInstance)
+}
+
+func extractInstance(d *schema.ResourceData, instances []elasticsearch.Instance) error {
+	var ids []string
+	var s []map[string]interface{}
+
+	for _, item := range instances {
+		mapping := map[string]interface{}{
+			"id":                   item.InstanceId,
+			"description":          item.Description,
+			"instance_charge_type": getChargeType(item.PaymentType),
+			"data_node_amount":     item.NodeAmount,
+			"data_node_spec":       item.NodeSpec.Spec,
+			"data_node_disk_size":  item.NodeSpec.Disk,
+			"data_node_disk_type":  item.NodeSpec.DiskType,
+			"status":               item.Status,
+			"version":              item.EsVersion,
+			"created_at":           item.CreatedAt,
+			"updated_at":           item.UpdatedAt,
+			"vswitch_id":           item.NetworkConfig.VswitchId,
+		}
+
+		ids = append(ids, item.InstanceId)
+		s = append(s, mapping)
+	}
+
+	d.SetId(dataResourceIdHash(ids))
+	if err := d.Set("instances", s); err != nil {
+		return err
+	}
+
+	// create a json file in current directory and write data source to it
+	if output, ok := d.GetOk("output_file"); ok && output.(string) != "" {
+		writeToFile(output.(string), s)
+	}
+	return nil
+}

--- a/alicloud/data_source_alicloud_elasticsearch_instances_test.go
+++ b/alicloud/data_source_alicloud_elasticsearch_instances_test.go
@@ -1,0 +1,221 @@
+package alicloud
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform/helper/resource"
+)
+
+func TestAccAlicloudElasticsearchDataSource(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+		},
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccElasticsearchDatasourceProfile(BasicElasticsearchDatasourceDescription),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAlicloudDataSourceID("data.alicloud_elasticsearch_instances.default"),
+					resource.TestCheckResourceAttr("data.alicloud_elasticsearch_instances.default", "instances.#", "1"),
+					resource.TestCheckResourceAttrSet("data.alicloud_elasticsearch_instances.default", "instances.0.id"),
+					resource.TestCheckResourceAttr("data.alicloud_elasticsearch_instances.default", "instances.0.instance_charge_type", string(PostPaid)),
+					resource.TestCheckResourceAttr("data.alicloud_elasticsearch_instances.default", "instances.0.description", "tf-testAccESDataSource"),
+					resource.TestCheckResourceAttr("data.alicloud_elasticsearch_instances.default", "instances.0.data_node_amount", "2"),
+					resource.TestCheckResourceAttr("data.alicloud_elasticsearch_instances.default", "instances.0.data_node_spec", "elasticsearch.sn2ne.large"),
+					resource.TestCheckResourceAttr("data.alicloud_elasticsearch_instances.default", "instances.0.status", string(ElasticsearchStatusActive)),
+					resource.TestCheckResourceAttrSet("data.alicloud_elasticsearch_instances.default", "instances.0.version"),
+					resource.TestCheckResourceAttrSet("data.alicloud_elasticsearch_instances.default", "instances.0.created_at"),
+					resource.TestCheckResourceAttrSet("data.alicloud_elasticsearch_instances.default", "instances.0.updated_at"),
+					resource.TestCheckResourceAttrSet("data.alicloud_elasticsearch_instances.default", "instances.0.vswitch_id"),
+				),
+			},
+			{
+				Config: testAccElasticsearchDatasourceProfile(BasicElasticsearchDatasourceDescriptionEmpty),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAlicloudDataSourceID("data.alicloud_elasticsearch_instances.default"),
+					resource.TestCheckResourceAttr("data.alicloud_elasticsearch_instances.default", "instances.#", "0"),
+					resource.TestCheckNoResourceAttr("data.alicloud_elasticsearch_instances.default", "instances.0.id"),
+					resource.TestCheckNoResourceAttr("data.alicloud_elasticsearch_instances.default", "instances.0.instance_charge_type"),
+					resource.TestCheckNoResourceAttr("data.alicloud_elasticsearch_instances.default", "instances.0.description"),
+					resource.TestCheckNoResourceAttr("data.alicloud_elasticsearch_instances.default", "instances.0.data_node_amount"),
+					resource.TestCheckNoResourceAttr("data.alicloud_elasticsearch_instances.default", "instances.0.data_node_spec"),
+					resource.TestCheckNoResourceAttr("data.alicloud_elasticsearch_instances.default", "instances.0.status"),
+					resource.TestCheckNoResourceAttr("data.alicloud_elasticsearch_instances.default", "instances.0.version"),
+					resource.TestCheckNoResourceAttr("data.alicloud_elasticsearch_instances.default", "instances.0.created_at"),
+					resource.TestCheckNoResourceAttr("data.alicloud_elasticsearch_instances.default", "instances.0.updated_at"),
+					resource.TestCheckNoResourceAttr("data.alicloud_elasticsearch_instances.default", "instances.0.vswitch_id"),
+				),
+			},
+			{
+				Config: testAccElasticsearchDatasourceProfile(BasicElasticsearchDatasourceDescriptionExists),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAlicloudDataSourceID("data.alicloud_elasticsearch_instances.default"),
+					resource.TestCheckResourceAttr("data.alicloud_elasticsearch_instances.default", "instances.#", "1"),
+					resource.TestCheckResourceAttrSet("data.alicloud_elasticsearch_instances.default", "instances.0.id"),
+					resource.TestCheckResourceAttr("data.alicloud_elasticsearch_instances.default", "instances.0.instance_charge_type", string(PostPaid)),
+					resource.TestCheckResourceAttr("data.alicloud_elasticsearch_instances.default", "instances.0.description", "tf-testAccESDataSource"),
+					resource.TestCheckResourceAttr("data.alicloud_elasticsearch_instances.default", "instances.0.data_node_amount", "2"),
+					resource.TestCheckResourceAttr("data.alicloud_elasticsearch_instances.default", "instances.0.data_node_spec", "elasticsearch.sn2ne.large"),
+					resource.TestCheckResourceAttr("data.alicloud_elasticsearch_instances.default", "instances.0.status", string(ElasticsearchStatusActive)),
+					resource.TestCheckResourceAttrSet("data.alicloud_elasticsearch_instances.default", "instances.0.version"),
+					resource.TestCheckResourceAttrSet("data.alicloud_elasticsearch_instances.default", "instances.0.created_at"),
+					resource.TestCheckResourceAttrSet("data.alicloud_elasticsearch_instances.default", "instances.0.updated_at"),
+					resource.TestCheckResourceAttrSet("data.alicloud_elasticsearch_instances.default", "instances.0.vswitch_id"),
+				),
+			},
+			{
+				Config: testAccElasticsearchDatasourceProfileWithVersion(BasicElasticsearchDatasourceDescription, string(ESVersion553WithXPack)),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAlicloudDataSourceID("data.alicloud_elasticsearch_instances.default"),
+					resource.TestCheckResourceAttr("data.alicloud_elasticsearch_instances.default", "instances.#", "1"),
+					resource.TestCheckResourceAttrSet("data.alicloud_elasticsearch_instances.default", "instances.0.id"),
+					resource.TestCheckResourceAttr("data.alicloud_elasticsearch_instances.default", "instances.0.instance_charge_type", string(PostPaid)),
+					resource.TestCheckResourceAttr("data.alicloud_elasticsearch_instances.default", "instances.0.description", "tf-testAccESDataSource"),
+					resource.TestCheckResourceAttr("data.alicloud_elasticsearch_instances.default", "instances.0.data_node_amount", "2"),
+					resource.TestCheckResourceAttr("data.alicloud_elasticsearch_instances.default", "instances.0.data_node_spec", "elasticsearch.sn2ne.large"),
+					resource.TestCheckResourceAttr("data.alicloud_elasticsearch_instances.default", "instances.0.status", string(ElasticsearchStatusActive)),
+					resource.TestCheckResourceAttrSet("data.alicloud_elasticsearch_instances.default", "instances.0.version"),
+					resource.TestCheckResourceAttrSet("data.alicloud_elasticsearch_instances.default", "instances.0.created_at"),
+					resource.TestCheckResourceAttrSet("data.alicloud_elasticsearch_instances.default", "instances.0.updated_at"),
+					resource.TestCheckResourceAttrSet("data.alicloud_elasticsearch_instances.default", "instances.0.vswitch_id"),
+				),
+			},
+			{
+				Config: testAccElasticsearchDatasourceProfileWithVersion(BasicElasticsearchDatasourceDescription, string(ESVersion632WithXPck)),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAlicloudDataSourceID("data.alicloud_elasticsearch_instances.default"),
+					resource.TestCheckResourceAttr("data.alicloud_elasticsearch_instances.default", "instances.#", "0"),
+					resource.TestCheckNoResourceAttr("data.alicloud_elasticsearch_instances.default", "instances.0.id"),
+					resource.TestCheckNoResourceAttr("data.alicloud_elasticsearch_instances.default", "instances.0.instance_charge_type"),
+					resource.TestCheckNoResourceAttr("data.alicloud_elasticsearch_instances.default", "instances.0.description"),
+					resource.TestCheckNoResourceAttr("data.alicloud_elasticsearch_instances.default", "instances.0.data_node_amount"),
+					resource.TestCheckNoResourceAttr("data.alicloud_elasticsearch_instances.default", "instances.0.data_node_spec"),
+					resource.TestCheckNoResourceAttr("data.alicloud_elasticsearch_instances.default", "instances.0.status"),
+					resource.TestCheckNoResourceAttr("data.alicloud_elasticsearch_instances.default", "instances.0.version"),
+					resource.TestCheckNoResourceAttr("data.alicloud_elasticsearch_instances.default", "instances.0.created_at"),
+					resource.TestCheckNoResourceAttr("data.alicloud_elasticsearch_instances.default", "instances.0.updated_at"),
+					resource.TestCheckNoResourceAttr("data.alicloud_elasticsearch_instances.default", "instances.0.vswitch_id"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAlicloudElasticsearchDataSource_empty(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCheckAlicloudElasticsearchDataSourceEmpty,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAlicloudDataSourceID("data.alicloud_elasticsearch_instances.default"),
+					resource.TestCheckResourceAttr("data.alicloud_elasticsearch_instances.default", "instances.#", "0"),
+					resource.TestCheckNoResourceAttr("data.alicloud_elasticsearch_instances.default", "instances.0.id"),
+					resource.TestCheckNoResourceAttr("data.alicloud_elasticsearch_instances.default", "instances.0.instance_charge_type"),
+					resource.TestCheckNoResourceAttr("data.alicloud_elasticsearch_instances.default", "instances.0.description"),
+					resource.TestCheckNoResourceAttr("data.alicloud_elasticsearch_instances.default", "instances.0.data_node_amount"),
+					resource.TestCheckNoResourceAttr("data.alicloud_elasticsearch_instances.default", "instances.0.data_node_spec"),
+					resource.TestCheckNoResourceAttr("data.alicloud_elasticsearch_instances.default", "instances.0.status"),
+					resource.TestCheckNoResourceAttr("data.alicloud_elasticsearch_instances.default", "instances.0.version"),
+					resource.TestCheckNoResourceAttr("data.alicloud_elasticsearch_instances.default", "instances.0.created_at"),
+					resource.TestCheckNoResourceAttr("data.alicloud_elasticsearch_instances.default", "instances.0.updated_at"),
+					resource.TestCheckNoResourceAttr("data.alicloud_elasticsearch_instances.default", "instances.0.vswitch_id"),
+				),
+			},
+		},
+	})
+}
+
+func testAccElasticsearchDatasourceProfile(descriptionRegex string) string {
+	return fmt.Sprintf(`
+data "alicloud_elasticsearch_instances" "default" {
+  description_regex = "%s"
+}
+
+data "alicloud_zones" "default" {
+  available_resource_creation = "Elasticsearch"
+}
+
+variable "name" {
+  default = "tf-testAccESDataSource"
+}
+
+resource "alicloud_vpc" "default" {
+  name       = "${var.name}"
+  cidr_block = "172.16.0.0/16"
+}
+
+resource "alicloud_vswitch" "default" {
+  vpc_id            = "${alicloud_vpc.default.id}"
+  cidr_block        = "172.16.0.0/24"
+  availability_zone = "${data.alicloud_zones.default.zones.0.id}"
+  name              = "${var.name}"
+}
+
+resource "alicloud_elasticsearch_instance" "default" {
+  description          = "${var.name}"
+  password             = "Test@12345"
+  vswitch_id           = "${alicloud_vswitch.default.id}"
+  data_node_amount     = "2"
+  data_node_spec       = "elasticsearch.sn2ne.large"
+  data_node_disk_size  = "20"
+  data_node_disk_type  = "cloud_ssd"
+  instance_charge_type = "PostPaid"
+  version              = "5.5.3_with_X-Pack"
+}
+`, descriptionRegex)
+}
+
+func testAccElasticsearchDatasourceProfileWithVersion(description_regex string, version string) string {
+	return fmt.Sprintf(`
+data "alicloud_elasticsearch_instances" "default" {
+  version           = "%s"
+  description_regex = "%s"
+}
+
+data "alicloud_zones" "default" {
+  available_resource_creation = "Elasticsearch"
+}
+
+variable "name" {
+  default = "tf-testAccESDataSource"
+}
+
+resource "alicloud_vpc" "default" {
+  name       = "${var.name}"
+  cidr_block = "172.16.0.0/16"
+}
+
+resource "alicloud_vswitch" "default" {
+  vpc_id            = "${alicloud_vpc.default.id}"
+  cidr_block        = "172.16.0.0/24"
+  availability_zone = "${data.alicloud_zones.default.zones.0.id}"
+  name              = "${var.name}"
+}
+
+resource "alicloud_elasticsearch_instance" "default" {
+  description          = "${var.name}"
+  password             = "Test@12345"
+  vswitch_id           = "${alicloud_vswitch.default.id}"
+  data_node_amount     = "2"
+  data_node_spec       = "elasticsearch.sn2ne.large"
+  data_node_disk_size  = "20"
+  data_node_disk_type  = "cloud_ssd"
+  instance_charge_type = "PostPaid"
+  version              = "5.5.3_with_X-Pack"
+}
+`, description_regex, version)
+}
+
+const BasicElasticsearchDatasourceDescription = "${alicloud_elasticsearch_instance.default.description}"
+const BasicElasticsearchDatasourceDescriptionEmpty = "^tf-testAccESDataSourcea.*"
+const BasicElasticsearchDatasourceDescriptionExists = "^tf-testAccESDataSour.*"
+
+const testAccCheckAlicloudElasticsearchDataSourceEmpty = `
+data "alicloud_elasticsearch_instances" "default" {
+  description_regex = "^tf-testAcc-fake-name"
+}
+`

--- a/alicloud/data_source_alicloud_elasticsearch_instances_test.go
+++ b/alicloud/data_source_alicloud_elasticsearch_instances_test.go
@@ -49,7 +49,7 @@ func TestAccAlicloudElasticsearchDataSource(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccElasticsearchDatasourceProfile(BasicElasticsearchDatasourceDescriptionExists),
+				Config: testAccElasticsearchDatasourceProfile(BasicElasticsearchDatasourceDescriptionExistsRegex),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAlicloudDataSourceID("data.alicloud_elasticsearch_instances.default"),
 					resource.TestCheckResourceAttr("data.alicloud_elasticsearch_instances.default", "instances.#", "1"),
@@ -172,8 +172,8 @@ resource "alicloud_elasticsearch_instance" "default" {
 func testAccElasticsearchDatasourceProfileWithVersion(description_regex string, version string) string {
 	return fmt.Sprintf(`
 data "alicloud_elasticsearch_instances" "default" {
-  version           = "%s"
   description_regex = "%s"
+  version           = "%s"
 }
 
 data "alicloud_zones" "default" {
@@ -212,7 +212,7 @@ resource "alicloud_elasticsearch_instance" "default" {
 
 const BasicElasticsearchDatasourceDescription = "${alicloud_elasticsearch_instance.default.description}"
 const BasicElasticsearchDatasourceDescriptionEmpty = "^tf-testAccESDataSourcea.*"
-const BasicElasticsearchDatasourceDescriptionExists = "^tf-testAccESDataSour.*"
+const BasicElasticsearchDatasourceDescriptionExistsRegex = "^tf-testAccESDataSour.*"
 
 const testAccCheckAlicloudElasticsearchDataSourceEmpty = `
 data "alicloud_elasticsearch_instances" "default" {

--- a/alicloud/provider.go
+++ b/alicloud/provider.go
@@ -134,6 +134,7 @@ func Provider() terraform.ResourceProvider {
 			"alicloud_api_gateway_apis":         dataSourceAlicloudApiGatewayApis(),
 			"alicloud_api_gateway_groups":       dataSourceAlicloudApiGatewayGroups(),
 			"alicloud_api_gateway_apps":         dataSourceAlicloudApiGatewayApps(),
+			"alicloud_elasticsearch_instances":  dataSourceAlicloudElasticsearch(),
 		},
 		ResourcesMap: map[string]*schema.Resource{
 			"alicloud_instance":                     resourceAliyunInstance(),

--- a/website/alicloud.erb
+++ b/website/alicloud.erb
@@ -191,11 +191,15 @@
                             <a href="/docs/providers/alicloud/d/mns_queues.html">alicloud_mns_queues</a>
                         </li>
                         <li<%= sidebar_current("docs-alicloud-datasource-mns-topics") %>>
-                              <a href="/docs/providers/alicloud/d/mns_topics.html">alicloud_mns_topics</a>
+                            <a href="/docs/providers/alicloud/d/mns_topics.html">alicloud_mns_topics</a>
                          </li>
                         <li<%= sidebar_current("docs-alicloud-datasource-mns-topic-subscriptions") %>>
-                               <a href="/docs/providers/alicloud/d/mns_topic_subscriptions.html">alicloud_mns_topic_subscriptions</a>
+                            <a href="/docs/providers/alicloud/d/mns_topic_subscriptions.html">alicloud_mns_topic_subscriptions</a>
                         </li>
+                        <li<%= sidebar_current("docs-alicloud-datasource-elasticsearch-instances") %>>
+                            <a href="/docs/providers/alicloud/d/elasticsearch.html">alicloud_elasticsearch_instances</a>
+                        </li>
+
                     </ul>
                 </li>
 

--- a/website/docs/d/elasticsearch.html.markdown
+++ b/website/docs/d/elasticsearch.html.markdown
@@ -3,7 +3,7 @@ layout: "alicloud"
 page_title: "Alicloud: alicloud_elasticsearch_instances"
 sidebar_current: "docs-alicloud-datasource-elasticsearch-instances"
 description: |-
-    Provides a collection of Elasticsearch instances according to the specified filters.
+  Provides a collection of Elasticsearch instances according to the specified filters.
 ---
 
 # alicloud\_elasticsearch\_instances

--- a/website/docs/d/elasticsearch.html.markdown
+++ b/website/docs/d/elasticsearch.html.markdown
@@ -1,0 +1,46 @@
+---
+layout: "alicloud"
+page_title: "Alicloud: alicloud_elasticsearch_instances"
+sidebar_current: "docs-alicloud-datasource-elasticsearch-instances"
+description: |-
+    Provides a collection of Elasticsearch instances according to the specified filters.
+---
+
+# alicloud\_elasticsearch\_instances
+
+The `alicloud_elasticsearch_instances` data source provides a collection of Elasticsearch instances available in Alicloud account.
+Filters support description regex and other filters which are listed below.
+
+## Example Usage
+
+```
+data "alicloud_elasticsearch_instances" "instances" {
+  description_regex = "myes"
+  version           = "5.5.3_with_X-Pack"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `description_regex` - (Optional) A regex string to apply to the instance description.
+* `version` - (Optional) Elasticsearch version. Options are `5.5.3_with_X-Pack`, and `6.3.2_with_X-Pack`. If no value is specified, all versions are returned.
+
+## Attributes Reference
+
+The following attributes are exported in addition to the arguments listed above:
+
+* `instances` - A list of Elasticsearch instances. Its every element contains the following attributes:
+  * `id` - The ID of the Elasticsearch instance.
+  * `description` - The description of the Elasticsearch instance.
+  * `instance_charge_type` - Billing method. Value options: `PostPaid` for  Pay-As-You-Go and `PrePaid` for subscription.
+  * `data_node_amount` - The Elasticsearch cluster's data node quantity, between 2 and 50.
+  * `data_node_spec` - The data node specifications of the elasticsearch instance.
+  * `data_node_disk_size` - The single data node storage space. Unit: GB.
+  * `data_node_disk_type` - The data node disk type. Included values: `cloud_ssd` and `cloud_efficiency`.
+  * `vswitch_id` - VSwitch ID the instance belongs to.
+  * `version` - Elasticsearch version includes `5.5.3_with_X-Pack` and `6.3.2_with_X-Pack`.
+  * `cerated_at` - The creation time of the instance. It's a GTM format, such as: "2019-01-08T15:50:50.623Z".
+  * `updated_at` - The last modified time of the instance. It's a GMT format, such as: "2019-01-08T15:50:50.623Z".
+  * `status` - Status of the instance. It includes `active`, `activating`, `inactive`


### PR DESCRIPTION
Add instances data sources.

Supports description_regex, version filter.

=== RUN   TestAccAlicloudElasticsearchDataSource_empty
--- PASS: TestAccAlicloudElasticsearchDataSource_empty (0.97s)
PASS
ok  	github.com/terraform-providers/terraform-provider-alicloud/alicloud	879.838s