### PR TITLE
Update testcases for cen region domain route entries.

### DIFF
--- a/alicloud/data_source_alicloud_cen_region_route_entries_test.go
+++ b/alicloud/data_source_alicloud_cen_region_route_entries_test.go
@@ -17,39 +17,54 @@ func TestAccAlicloudCenRegionRouteEntriesDataSource_basic(t *testing.T) {
 		Providers: testAccProviders,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccCheckCenRegionRouteEntriesDataSourceBasic(EcsInstanceCommonTestCase, defaultRegionToTest),
+				Config: testAccCheckCenRegionRouteEntriesDataSourceBasic(defaultRegionToTest),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAlicloudDataSourceID("data.alicloud_cen_region_route_entries.entry"),
-					resource.TestCheckResourceAttr("data.alicloud_cen_region_route_entries.entry", "entries.0.cidr_block", "11.0.0.0/16"),
-					resource.TestCheckResourceAttr("data.alicloud_cen_region_route_entries.entry", "entries.0.type", "CBN"),
-					resource.TestCheckResourceAttr("data.alicloud_cen_region_route_entries.entry", "entries.0.next_hop_type", "VPC"),
-					resource.TestCheckResourceAttrSet("data.alicloud_cen_region_route_entries.entry", "entries.0.next_hop_id"),
-					resource.TestCheckResourceAttr("data.alicloud_cen_region_route_entries.entry", "entries.0.next_hop_region_id", defaultRegionToTest),
-					resource.TestCheckResourceAttr("data.alicloud_cen_region_route_entries.entry", "entries.#", "2"),
+					resource.TestCheckResourceAttr("data.alicloud_cen_region_route_entries.entry", "entries.#", "1"),
+					resource.TestCheckResourceAttr("data.alicloud_cen_region_route_entries.entry", "entries.0.cidr_block", "100.64.0.0/10"),
+					resource.TestCheckResourceAttr("data.alicloud_cen_region_route_entries.entry", "entries.0.type", "System"),
+					resource.TestCheckResourceAttr("data.alicloud_cen_region_route_entries.entry", "entries.0.next_hop_type", "local_service"),
+					resource.TestCheckResourceAttr("data.alicloud_cen_region_route_entries.entry", "entries.0.next_hop_id", ""),
+					resource.TestCheckResourceAttr("data.alicloud_cen_region_route_entries.entry", "entries.0.next_hop_region_id", ""),
 				),
 			},
 		},
 	})
 }
 
-func testAccCheckCenRegionRouteEntriesDataSourceBasic(common, region string) string {
+func TestAccAlicloudCenRegionRouteEntriesDataSource_empty(t *testing.T) {
+
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+		},
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCheckCenRegionRouteEntriesDataSourceEmpty(defaultRegionToTest),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAlicloudDataSourceID("data.alicloud_cen_region_route_entries.entry"),
+					resource.TestCheckResourceAttr("data.alicloud_cen_region_route_entries.entry", "entries.#", "0"),
+					resource.TestCheckNoResourceAttr("data.alicloud_cen_region_route_entries.entry", "entries.0.cidr_block"),
+					resource.TestCheckNoResourceAttr("data.alicloud_cen_region_route_entries.entry", "entries.0.type"),
+					resource.TestCheckNoResourceAttr("data.alicloud_cen_region_route_entries.entry", "entries.0.next_hop_type"),
+					resource.TestCheckNoResourceAttr("data.alicloud_cen_region_route_entries.entry", "entries.0.next_hop_id"),
+					resource.TestCheckNoResourceAttr("data.alicloud_cen_region_route_entries.entry", "entries.0.next_hop_region_id"),
+				),
+			},
+		},
+	})
+}
+
+func testAccCheckCenRegionRouteEntriesDataSourceBasic(region string) string {
 	return fmt.Sprintf(`
-	%s
 	variable "name" {
 		default = "tf-testAccRegionRouteEntriesDataSourceBasic"
 	}
-	
-	resource "alicloud_instance" "default" {
-		vswitch_id = "${alicloud_vswitch.default.id}"
-		image_id = "${data.alicloud_images.default.images.0.id}"
-	
-		instance_type = "${data.alicloud_instance_types.default.instance_types.0.id}"
-		system_disk_category = "cloud_efficiency"
-	
-		internet_charge_type = "PayByTraffic"
-		internet_max_bandwidth_out = 5
-		security_groups = ["${alicloud_security_group.default.id}"]
-		instance_name = "${var.name}-region-route-entry"
+
+	resource "alicloud_vpc" "default" {
+  		name = "${var.name}-vpc"
+  		cidr_block = "172.16.0.0/12"
 	}
 	
 	resource "alicloud_cen_instance" "cen" {
@@ -63,24 +78,19 @@ func testAccCheckCenRegionRouteEntriesDataSourceBasic(common, region string) str
 	    child_instance_region_id = "%s"
 	}
 	
-	resource "alicloud_route_entry" "route" {
-	    route_table_id = "${alicloud_vpc.default.route_table_id}"
-	    destination_cidrblock = "11.0.0.0/16"
-	    nexthop_type = "Instance"
-	    nexthop_id = "${alicloud_instance.default.id}"
-	}
-	
-	resource "alicloud_cen_route_entry" "foo" {
-	    instance_id = "${alicloud_cen_instance.cen.id}"
-	    route_table_id = "${alicloud_vpc.default.route_table_id}"
-	    cidr_block = "${alicloud_route_entry.route.destination_cidrblock}"
-	    depends_on = [
-			"alicloud_cen_instance_attachment.attach"]
-	}
-	
 	data "alicloud_cen_region_route_entries" "entry" {
-		instance_id = "${alicloud_cen_route_entry.foo.instance_id}"
+		instance_id = "${alicloud_cen_instance_attachment.attach.instance_id}"
+		region_id = "%s"
+    	output_file = "data_resource_tmp.txt"
+	}
+	`, region, region)
+}
+
+func testAccCheckCenRegionRouteEntriesDataSourceEmpty(region string) string {
+	return fmt.Sprintf(`
+	data "alicloud_cen_region_route_entries" "entry" {
+		instance_id = "cen-cidwnnenc"
 		region_id = "%s"
 	}
-	`, common, region, region)
+	`, region)
 }

--- a/alicloud/data_source_alicloud_cen_region_route_entries_test.go
+++ b/alicloud/data_source_alicloud_cen_region_route_entries_test.go
@@ -17,15 +17,27 @@ func TestAccAlicloudCenRegionRouteEntriesDataSource_basic(t *testing.T) {
 		Providers: testAccProviders,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccCheckCenRegionRouteEntriesDataSourceBasic(defaultRegionToTest),
+				Config: testAccCheckCenRegionRouteEntriesDataSourceBasic(EcsInstanceCommonTestCase, defaultRegionToTest),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAlicloudDataSourceID("data.alicloud_cen_region_route_entries.entry"),
-					resource.TestCheckResourceAttr("data.alicloud_cen_region_route_entries.entry", "entries.#", "1"),
+					resource.TestCheckResourceAttr("data.alicloud_cen_region_route_entries.entry", "entries.#", "3"),
 					resource.TestCheckResourceAttr("data.alicloud_cen_region_route_entries.entry", "entries.0.cidr_block", "100.64.0.0/10"),
 					resource.TestCheckResourceAttr("data.alicloud_cen_region_route_entries.entry", "entries.0.type", "System"),
 					resource.TestCheckResourceAttr("data.alicloud_cen_region_route_entries.entry", "entries.0.next_hop_type", "local_service"),
 					resource.TestCheckResourceAttr("data.alicloud_cen_region_route_entries.entry", "entries.0.next_hop_id", ""),
 					resource.TestCheckResourceAttr("data.alicloud_cen_region_route_entries.entry", "entries.0.next_hop_region_id", ""),
+
+					resource.TestCheckResourceAttr("data.alicloud_cen_region_route_entries.entry", "entries.1.cidr_block", "11.0.0.0/16"),
+					resource.TestCheckResourceAttr("data.alicloud_cen_region_route_entries.entry", "entries.1.type", "CBN"),
+					resource.TestCheckResourceAttr("data.alicloud_cen_region_route_entries.entry", "entries.1.next_hop_type", "VPC"),
+					resource.TestCheckResourceAttrSet("data.alicloud_cen_region_route_entries.entry", "entries.1.next_hop_id"),
+					resource.TestCheckResourceAttr("data.alicloud_cen_region_route_entries.entry", "entries.1.next_hop_region_id", "cn-beijing"),
+
+					resource.TestCheckResourceAttr("data.alicloud_cen_region_route_entries.entry", "entries.2.cidr_block", "172.16.0.0/24"),
+					resource.TestCheckResourceAttr("data.alicloud_cen_region_route_entries.entry", "entries.2.type", "CBN"),
+					resource.TestCheckResourceAttr("data.alicloud_cen_region_route_entries.entry", "entries.2.next_hop_type", "VPC"),
+					resource.TestCheckResourceAttrSet("data.alicloud_cen_region_route_entries.entry", "entries.2.next_hop_id"),
+					resource.TestCheckResourceAttr("data.alicloud_cen_region_route_entries.entry", "entries.2.next_hop_region_id", "cn-beijing"),
 				),
 			},
 		},
@@ -56,15 +68,24 @@ func TestAccAlicloudCenRegionRouteEntriesDataSource_empty(t *testing.T) {
 	})
 }
 
-func testAccCheckCenRegionRouteEntriesDataSourceBasic(region string) string {
+func testAccCheckCenRegionRouteEntriesDataSourceBasic(common, region string) string {
 	return fmt.Sprintf(`
+	%s
 	variable "name" {
 		default = "tf-testAccRegionRouteEntriesDataSourceBasic"
 	}
-
-	resource "alicloud_vpc" "default" {
-  		name = "${var.name}-vpc"
-  		cidr_block = "172.16.0.0/12"
+	
+	resource "alicloud_instance" "default" {
+		vswitch_id = "${alicloud_vswitch.default.id}"
+		image_id = "${data.alicloud_images.default.images.0.id}"
+	
+		instance_type = "${data.alicloud_instance_types.default.instance_types.0.id}"
+		system_disk_category = "cloud_efficiency"
+	
+		internet_charge_type = "PayByTraffic"
+		internet_max_bandwidth_out = 5
+		security_groups = ["${alicloud_security_group.default.id}"]
+		instance_name = "${var.name}-region-route-entry"
 	}
 	
 	resource "alicloud_cen_instance" "cen" {
@@ -78,12 +99,27 @@ func testAccCheckCenRegionRouteEntriesDataSourceBasic(region string) string {
 	    child_instance_region_id = "%s"
 	}
 	
+	resource "alicloud_route_entry" "route" {
+	    route_table_id = "${alicloud_vpc.default.route_table_id}"
+	    destination_cidrblock = "11.0.0.0/16"
+	    nexthop_type = "Instance"
+	    nexthop_id = "${alicloud_instance.default.id}"
+	}
+	
+	resource "alicloud_cen_route_entry" "foo" {
+	    instance_id = "${alicloud_cen_instance.cen.id}"
+	    route_table_id = "${alicloud_vpc.default.route_table_id}"
+	    cidr_block = "${alicloud_route_entry.route.destination_cidrblock}"
+	    depends_on = [
+			"alicloud_cen_instance_attachment.attach"]
+	}
+	
 	data "alicloud_cen_region_route_entries" "entry" {
-		instance_id = "${alicloud_cen_instance_attachment.attach.instance_id}"
+		instance_id = "${alicloud_cen_route_entry.foo.instance_id}"
 		region_id = "%s"
     	output_file = "data_resource_tmp.txt"
 	}
-	`, region, region)
+	`, common, region, region)
 }
 
 func testAccCheckCenRegionRouteEntriesDataSourceEmpty(region string) string {

--- a/alicloud/data_source_alicloud_cen_region_route_entries_test.go
+++ b/alicloud/data_source_alicloud_cen_region_route_entries_test.go
@@ -117,7 +117,6 @@ func testAccCheckCenRegionRouteEntriesDataSourceBasic(common, region string) str
 	data "alicloud_cen_region_route_entries" "entry" {
 		instance_id = "${alicloud_cen_route_entry.foo.instance_id}"
 		region_id = "%s"
-    	output_file = "data_resource_tmp.txt"
 	}
 	`, common, region, region)
 }


### PR DESCRIPTION
$TF_ACC=1 go test ./alicloud -v -run=TestAccAlicloudCenRegionRouteEntriesDataSource -timeout=300m
=== RUN   TestAccAlicloudCenRegionRouteEntriesDataSource_basic
--- PASS: TestAccAlicloudCenRegionRouteEntriesDataSource_basic (32.17s)
=== RUN   TestAccAlicloudCenRegionRouteEntriesDataSource_empty
--- PASS: TestAccAlicloudCenRegionRouteEntriesDataSource_empty (1.03s)
PASS
ok  	github.com/terraform-providers/terraform-provider-alicloud/alicloud	33.257s