### PR TITLE
Improve api_gateway_vpc_access testcases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ FEATURES:
 
 IMPROVEMENTS:
 
+- Improve api_gateway_vpc_access testcases [GH-738]
 - provider supports getting credential via ecs role name [GH-731]
 - Update testcases for cen region domain route entries [GH-729]
 - cs_kubernetes supports user_ca [GH-726]

--- a/alicloud/import_alicloud_api_gateway_vpc_test.go
+++ b/alicloud/import_alicloud_api_gateway_vpc_test.go
@@ -3,6 +3,7 @@ package alicloud
 import (
 	"testing"
 
+	"github.com/hashicorp/terraform/helper/acctest"
 	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/terraform-providers/terraform-provider-alicloud/alicloud/connectivity"
 )
@@ -16,7 +17,7 @@ func TestAccAlicloudApigatewayVpc_importBasic(t *testing.T) {
 		CheckDestroy: testAccCheckAlicloudApigatewayVpcDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAlicloudApigatwaVpcBasic,
+				Config: testAccAlicloudApigatwaVpcBasic(acctest.RandIntRange(10000, 999999)),
 			},
 
 			{

--- a/alicloud/resource_alicloud_api_gateway_vpc_test.go
+++ b/alicloud/resource_alicloud_api_gateway_vpc_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/aliyun/alibaba-cloud-sdk-go/sdk/requests"
 
 	"github.com/aliyun/alibaba-cloud-sdk-go/services/cloudapi"
+	"github.com/hashicorp/terraform/helper/acctest"
 	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/terraform"
 	"github.com/terraform-providers/terraform-provider-alicloud/alicloud/connectivity"
@@ -84,17 +85,17 @@ func testSweepApiGatewayVpc(region string) error {
 
 func TestAccAlicloudApigatewayVpc_basic(t *testing.T) {
 	var vpc cloudapi.VpcAccessAttribute
-
+	rand := acctest.RandIntRange(10000, 999999)
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheckWithRegions(t, false, connectivity.ApiGatewayNoSupportedRegions) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAlicloudApigatewayVpcDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAlicloudApigatwaVpcBasic,
+				Config: testAccAlicloudApigatwaVpcBasic(rand),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAlicloudApigatewayVpcExists("alicloud_api_gateway_vpc_access.foo", &vpc),
-					resource.TestCheckResourceAttr("alicloud_api_gateway_vpc_access.foo", "name", "tf-testAccApiGatewayVpc"),
+					resource.TestCheckResourceAttr("alicloud_api_gateway_vpc_access.foo", "name", fmt.Sprintf("tf-testAccApiGatewayVpc-%d", rand)),
 					resource.TestCheckResourceAttr("alicloud_api_gateway_vpc_access.foo", "port", "8080"),
 					resource.TestCheckResourceAttrSet("alicloud_api_gateway_vpc_access.foo", "vpc_id"),
 					resource.TestCheckResourceAttrSet("alicloud_api_gateway_vpc_access.foo", "instance_id"),
@@ -149,66 +150,68 @@ func testAccCheckAlicloudApigatewayVpcDestroy(s *terraform.State) error {
 	return nil
 }
 
-const testAccAlicloudApigatwaVpcBasic = `
+func testAccAlicloudApigatwaVpcBasic(rand int) string {
+	return fmt.Sprintf(`
 
-data "alicloud_zones" "default" {
-  "available_disk_category"= "cloud_efficiency"
-  "available_resource_creation"= "VSwitch"
+	data "alicloud_zones" "default" {
+	  "available_disk_category"= "cloud_efficiency"
+	  "available_resource_creation"= "VSwitch"
+	}
+
+	data "alicloud_instance_types" "default" {
+	  availability_zone = "${data.alicloud_zones.default.zones.0.id}"
+	  cpu_core_count = 1
+	  memory_size = 2
+	}
+
+	data "alicloud_images" "default" {
+	  name_regex = "^ubuntu_14.*_64"
+	  most_recent = true
+	  owners = "system"
+	}
+
+	variable "name" {
+	  default = "tf-testAccApiGatewayVpc-%d"
+	}
+
+	resource "alicloud_vpc" "foo" {
+	  name = "${var.name}"
+	  cidr_block = "172.16.0.0/12"
+	}
+
+	resource "alicloud_vswitch" "foo" {
+	  vpc_id = "${alicloud_vpc.foo.id}"
+	  cidr_block = "172.16.0.0/21"
+	  availability_zone = "${data.alicloud_zones.default.zones.0.id}"
+	  name = "${var.name}"
+	}
+
+	resource "alicloud_security_group" "tf_test_foo" {
+	  name = "${var.name}"
+	  description = "foo"
+	  vpc_id = "${alicloud_vpc.foo.id}"
+	}
+
+	resource "alicloud_instance" "foo" {
+	  vswitch_id = "${alicloud_vswitch.foo.id}"
+	  image_id = "${data.alicloud_images.default.images.0.id}"
+
+	  # series III
+	  instance_type = "${data.alicloud_instance_types.default.instance_types.0.id}"
+	  system_disk_category = "cloud_efficiency"
+
+	  internet_charge_type = "PayByTraffic"
+	  internet_max_bandwidth_out = 5
+	  security_groups = ["${alicloud_security_group.tf_test_foo.id}"]
+	  instance_name = "${var.name}"
+	}
+
+	resource "alicloud_api_gateway_vpc_access" "foo" {
+	  name        = "${var.name}"
+	  vpc_id      = "${alicloud_vpc.foo.id}"
+	  instance_id = "${alicloud_instance.foo.id}"
+	  port        = 8080
+	}
+
+	`, rand)
 }
-
-data "alicloud_instance_types" "default" {
-  availability_zone = "${data.alicloud_zones.default.zones.0.id}"
-  cpu_core_count = 1
-  memory_size = 2
-}
-
-data "alicloud_images" "default" {
-  name_regex = "^ubuntu_14.*_64"
-  most_recent = true
-  owners = "system"
-}
-
-variable "name" {
-  default = "tf-testAccInstanceConfigVPC"
-}
-
-resource "alicloud_vpc" "foo" {
-  name = "${var.name}"
-  cidr_block = "172.16.0.0/12"
-}
-
-resource "alicloud_vswitch" "foo" {
-  vpc_id = "${alicloud_vpc.foo.id}"
-  cidr_block = "172.16.0.0/21"
-  availability_zone = "${data.alicloud_zones.default.zones.0.id}"
-  name = "${var.name}"
-}
-
-resource "alicloud_security_group" "tf_test_foo" {
-  name = "${var.name}"
-  description = "foo"
-  vpc_id = "${alicloud_vpc.foo.id}"
-}
-
-resource "alicloud_instance" "foo" {
-  vswitch_id = "${alicloud_vswitch.foo.id}"
-  image_id = "${data.alicloud_images.default.images.0.id}"
-
-  # series III
-  instance_type = "${data.alicloud_instance_types.default.instance_types.0.id}"
-  system_disk_category = "cloud_efficiency"
-
-  internet_charge_type = "PayByTraffic"
-  internet_max_bandwidth_out = 5
-  security_groups = ["${alicloud_security_group.tf_test_foo.id}"]
-  instance_name = "${var.name}"
-}
-
-resource "alicloud_api_gateway_vpc_access" "foo" {
-  name        = "tf-testAccApiGatewayVpc"
-  vpc_id      = "${alicloud_vpc.foo.id}"
-  instance_id = "${alicloud_instance.foo.id}"
-  port        = 8080
-}
-
-`


### PR DESCRIPTION
```
 TF_ACC=1 go test ./alicloud -v -run=TestAccAlicloudApigatewayVpc -timeout=240m
=== RUN   TestAccAlicloudApigatewayVpc_importBasic
--- PASS: TestAccAlicloudApigatewayVpc_importBasic (143.89s)
=== RUN   TestAccAlicloudApigatewayVpc_basic
--- PASS: TestAccAlicloudApigatewayVpc_basic (156.17s)
PASS
ok  	github.com/terraform-providers/terraform-provider-alicloud/alicloud	300.123s
```