### PR TITLE
Add new resource alicloud_db_readonly_instance

### DIFF
--- a/alicloud/import_alicloud_db_readonly_instance_test.go
+++ b/alicloud/import_alicloud_db_readonly_instance_test.go
@@ -1,0 +1,28 @@
+package alicloud
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform/helper/resource"
+)
+
+func TestAccAlicloudDBReadonlyInstance_import(t *testing.T) {
+	resourceName := "alicloud_db_readonly_instance.foo"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckDBReadonlyInstanceDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDBReadonlyInstance_vpc(testAccDBRInstance_vpc(RdsCommonTestCase)),
+			},
+
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}

--- a/alicloud/provider.go
+++ b/alicloud/provider.go
@@ -157,6 +157,7 @@ func Provider() terraform.ResourceProvider {
 			"alicloud_db_backup_policy":             resourceAlicloudDBBackupPolicy(),
 			"alicloud_db_connection":                resourceAlicloudDBConnection(),
 			"alicloud_db_instance":                  resourceAlicloudDBInstance(),
+			"alicloud_db_readonly_instance":         resourceAlicloudDBReadonlyInstance(),
 			"alicloud_ess_scaling_group":            resourceAlicloudEssScalingGroup(),
 			"alicloud_ess_scaling_configuration":    resourceAlicloudEssScalingConfiguration(),
 			"alicloud_ess_scaling_rule":             resourceAlicloudEssScalingRule(),

--- a/alicloud/resource_alicloud_db_readonly_instance.go
+++ b/alicloud/resource_alicloud_db_readonly_instance.go
@@ -1,0 +1,281 @@
+package alicloud
+
+import (
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/aliyun/alibaba-cloud-sdk-go/sdk/requests"
+	"github.com/aliyun/alibaba-cloud-sdk-go/services/rds"
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/helper/schema"
+	"github.com/terraform-providers/terraform-provider-alicloud/alicloud/connectivity"
+)
+
+func resourceAlicloudDBReadonlyInstance() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceAlicloudDBReadonlyInstanceCreate,
+		Read:   resourceAlicloudDBReadonlyInstanceRead,
+		Update: resourceAlicloudDBReadonlyInstanceUpdate,
+		Delete: resourceAlicloudDBReadonlyInstanceDelete,
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
+
+		Schema: map[string]*schema.Schema{
+			"engine_version": &schema.Schema{
+				Type:     schema.TypeString,
+				ForceNew: true,
+				Required: true,
+			},
+
+			"master_db_instance_id": &schema.Schema{
+				Type:     schema.TypeString,
+				Required: true,
+			},
+
+			"instance_name": &schema.Schema{
+				Type:         schema.TypeString,
+				Optional:     true,
+				ValidateFunc: validateDBInstanceName,
+			},
+
+			"instance_type": &schema.Schema{
+				Type:     schema.TypeString,
+				Required: true,
+			},
+
+			"instance_storage": &schema.Schema{
+				Type:     schema.TypeInt,
+				Required: true,
+			},
+
+			"zone_id": &schema.Schema{
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+
+			"vswitch_id": &schema.Schema{
+				Type:     schema.TypeString,
+				ForceNew: true,
+				Optional: true,
+			},
+
+			"connection_string": &schema.Schema{
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+
+			"port": &schema.Schema{
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func resourceAlicloudDBReadonlyInstanceCreate(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*connectivity.AliyunClient)
+	rdsService := RdsService{client}
+
+	request, err := buildDBReadonlyCreateRequest(d, meta)
+	if err != nil {
+		return err
+	}
+
+	raw, err := client.WithRdsClient(func(rdsClient *rds.Client) (interface{}, error) {
+		return rdsClient.CreateReadOnlyDBInstance(request)
+	})
+
+	if err != nil {
+		return fmt.Errorf("Error creating Alicloud db instance: %#v", err)
+	}
+	resp, _ := raw.(*rds.CreateReadOnlyDBInstanceResponse)
+	d.SetId(resp.DBInstanceId)
+
+	// wait instance status change from Creating to running
+	if err := rdsService.WaitForDBInstance(d.Id(), Running, DefaultLongTimeout); err != nil {
+		return fmt.Errorf("WaitForInstance %s got error: %#v", d.Id(), err)
+	}
+
+	return resourceAlicloudDBReadonlyInstanceRead(d, meta)
+}
+
+func resourceAlicloudDBReadonlyInstanceUpdate(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*connectivity.AliyunClient)
+	rdsService := RdsService{client}
+	d.Partial(true)
+
+	if d.HasChange("instance_name") {
+		request := rds.CreateModifyDBInstanceDescriptionRequest()
+		request.DBInstanceId = d.Id()
+		request.DBInstanceDescription = d.Get("instance_name").(string)
+
+		_, err := client.WithRdsClient(func(rdsClient *rds.Client) (interface{}, error) {
+			return rdsClient.ModifyDBInstanceDescription(request)
+		})
+		if err != nil {
+			return fmt.Errorf("ModifyDBInstanceDescription got an error: %#v", err)
+		}
+		d.SetPartial("instance_name")
+	}
+
+	update := false
+	request := rds.CreateModifyDBInstanceSpecRequest()
+	request.DBInstanceId = d.Id()
+	request.PayType = string(Postpaid)
+
+	if d.HasChange("instance_type") {
+		request.DBInstanceClass = d.Get("instance_type").(string)
+		update = true
+	}
+
+	if d.HasChange("instance_storage") {
+		request.DBInstanceStorage = requests.NewInteger(d.Get("instance_storage").(int))
+		update = true
+	}
+
+	if update {
+		// wait instance status is running before modifying
+		if err := rdsService.WaitForDBInstance(d.Id(), Running, 500); err != nil {
+			return fmt.Errorf("WaitForInstance %s got error: %#v", Running, err)
+		}
+		_, err := client.WithRdsClient(func(rdsClient *rds.Client) (interface{}, error) {
+			return rdsClient.ModifyDBInstanceSpec(request)
+		})
+		if err != nil {
+			return err
+		}
+		d.SetPartial("instance_type")
+		d.SetPartial("instance_storage")
+		// wait instance status is running after modifying
+		if err := rdsService.WaitForDBInstance(d.Id(), Running, 1800); err != nil {
+			return fmt.Errorf("WaitForInstance %s got error: %#v", Running, err)
+		}
+	}
+
+	d.Partial(false)
+	return resourceAlicloudDBReadonlyInstanceRead(d, meta)
+}
+
+func resourceAlicloudDBReadonlyInstanceRead(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*connectivity.AliyunClient)
+	rdsService := RdsService{client}
+
+	instance, err := rdsService.DescribeDBInstanceById(d.Id())
+	if err != nil {
+		if rdsService.NotFoundDBInstance(err) {
+			d.SetId("")
+			return nil
+		}
+		return fmt.Errorf("Error Describe DB InstanceAttribute: %#v", err)
+	}
+
+	d.Set("engine", instance.Engine)
+	d.Set("engine_version", instance.EngineVersion)
+	d.Set("instance_type", instance.DBInstanceClass)
+	d.Set("port", instance.Port)
+	d.Set("instance_storage", instance.DBInstanceStorage)
+	d.Set("zone_id", instance.ZoneId)
+	d.Set("vswitch_id", instance.VSwitchId)
+	d.Set("connection_string", instance.ConnectionString)
+	d.Set("instance_name", instance.DBInstanceDescription)
+
+	return nil
+}
+
+func resourceAlicloudDBReadonlyInstanceDelete(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*connectivity.AliyunClient)
+	rdsService := RdsService{client}
+
+	instance, err := rdsService.DescribeDBInstanceById(d.Id())
+	if err != nil {
+		if rdsService.NotFoundDBInstance(err) {
+			return nil
+		}
+		return fmt.Errorf("Error Describe DB InstanceAttribute: %#v", err)
+	}
+	if PayType(instance.PayType) == Prepaid {
+		return fmt.Errorf("At present, 'Prepaid' instance cannot be deleted and must wait it to be expired and release it automatically.")
+	}
+
+	request := rds.CreateDeleteDBInstanceRequest()
+	request.DBInstanceId = d.Id()
+
+	return resource.Retry(5*time.Minute, func() *resource.RetryError {
+		_, err := client.WithRdsClient(func(rdsClient *rds.Client) (interface{}, error) {
+			return rdsClient.DeleteDBInstance(request)
+		})
+
+		if err != nil {
+			if rdsService.NotFoundDBInstance(err) {
+				return nil
+			}
+			return resource.RetryableError(fmt.Errorf("Delete DB instance timeout and got an error: %#v.", err))
+		}
+
+		instance, err := rdsService.DescribeDBInstanceById(d.Id())
+		if err != nil {
+			if NotFoundError(err) {
+				return nil
+			}
+			return resource.NonRetryableError(fmt.Errorf("Error Describe DB InstanceAttribute: %#v", err))
+		}
+		if instance == nil {
+			return nil
+		}
+
+		return resource.RetryableError(fmt.Errorf("Delete DB instance timeout and got an error: %#v.", err))
+	})
+}
+
+func buildDBReadonlyCreateRequest(d *schema.ResourceData, meta interface{}) (*rds.CreateReadOnlyDBInstanceRequest, error) {
+	client := meta.(*connectivity.AliyunClient)
+	vpcService := VpcService{client}
+	request := rds.CreateCreateReadOnlyDBInstanceRequest()
+	request.RegionId = string(client.Region)
+	request.DBInstanceId = Trim(d.Get("master_db_instance_id").(string))
+	request.EngineVersion = Trim(d.Get("engine_version").(string))
+	request.DBInstanceStorage = requests.NewInteger(d.Get("instance_storage").(int))
+	request.DBInstanceClass = Trim(d.Get("instance_type").(string))
+	request.DBInstanceDescription = d.Get("instance_name").(string)
+	request.ZoneId = Trim(d.Get("zone_id").(string))
+
+	vswitchId := Trim(d.Get("vswitch_id").(string))
+
+	request.InstanceNetworkType = string(Classic)
+
+	if vswitchId != "" {
+		request.VSwitchId = vswitchId
+		request.InstanceNetworkType = strings.ToUpper(string(Vpc))
+
+		// check vswitchId in zone
+		vsw, err := vpcService.DescribeVswitch(vswitchId)
+		if err != nil {
+			return nil, fmt.Errorf("DescribeVSwitche got an error: %#v.", err)
+		}
+
+		if strings.Contains(request.ZoneId, MULTI_IZ_SYMBOL) {
+			zonestr := strings.Split(strings.SplitAfter(request.ZoneId, "(")[1], ")")[0]
+			if !strings.Contains(zonestr, string([]byte(vsw.ZoneId)[len(vsw.ZoneId)-1])) {
+				return nil, fmt.Errorf("The specified vswitch %s isn't in the multi zone %s.", vsw.VSwitchId, request.ZoneId)
+			}
+		} else if request.ZoneId != vsw.ZoneId {
+			return nil, fmt.Errorf("The specified vswitch %s isn't in the zone %s.", vsw.VSwitchId, request.ZoneId)
+		}
+
+		request.VPCId = vsw.VpcId
+	}
+
+	request.PayType = string(Postpaid)
+
+	randomUuid, err := uuid.GenerateUUID()
+	if err != nil {
+		randomUuid = resource.UniqueId()
+	}
+	request.ClientToken = fmt.Sprintf("Terraform-Alicloud-%d-%s", time.Now().Unix(), randomUuid)
+
+	return request, nil
+}

--- a/alicloud/resource_alicloud_db_readonly_instance_test.go
+++ b/alicloud/resource_alicloud_db_readonly_instance_test.go
@@ -1,0 +1,200 @@
+package alicloud
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/aliyun/alibaba-cloud-sdk-go/services/rds"
+	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/terraform"
+	"github.com/terraform-providers/terraform-provider-alicloud/alicloud/connectivity"
+)
+
+func init() {
+	resource.AddTestSweepers("alicloud_db_readonly_instance", &resource.Sweeper{
+		Name: "alicloud_db_readonly_instance",
+		F:    testSweepDBInstances,
+	})
+}
+
+func TestAccAlicloudDBReadonlyInstance_vpc(t *testing.T) {
+	var instance rds.DBInstanceAttribute
+
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+		},
+
+		// module name
+		IDRefreshName: "alicloud_db_readonly_instance.foo",
+
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckDBReadonlyInstanceDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccDBReadonlyInstance_vpc(RdsCommonTestCase),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckDBInstanceExists(
+						"alicloud_db_readonly_instance.foo", &instance),
+					resource.TestCheckResourceAttr(
+						"alicloud_db_readonly_instance.foo",
+						"instance_storage",
+						"30"),
+					resource.TestCheckResourceAttr(
+						"alicloud_db_readonly_instance.foo",
+						"engine_version",
+						"5.6"),
+				),
+			},
+		},
+	})
+
+}
+
+func TestAccAlicloudDBReadonlyInstance_upgrade(t *testing.T) {
+	var instance rds.DBInstanceAttribute
+
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+		},
+
+		// module name
+		IDRefreshName: "alicloud_db_readonly_instance.foo",
+
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckDBReadonlyInstanceDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccDBReadonlyInstance_vpc(RdsCommonTestCase),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckDBInstanceExists(
+						"alicloud_db_readonly_instance.foo", &instance),
+					resource.TestCheckResourceAttr(
+						"alicloud_db_readonly_instance.foo",
+						"instance_storage",
+						"30"),
+					resource.TestCheckResourceAttr(
+						"alicloud_db_readonly_instance.foo",
+						"engine_version",
+						"5.6"),
+				),
+			},
+			resource.TestStep{
+				Config: testAccDBReadonlyInstance_upgrade(RdsCommonTestCase),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckDBInstanceExists(
+						"alicloud_db_readonly_instance.foo", &instance),
+					resource.TestCheckResourceAttr(
+						"alicloud_db_readonly_instance.foo",
+						"instance_storage",
+						"40"),
+					resource.TestCheckResourceAttr(
+						"alicloud_db_readonly_instance.foo",
+						"engine_version",
+						"5.6"),
+				),
+			},
+		},
+	})
+
+}
+
+func testAccDBReadonlyInstance_vpc(common string) string {
+	return fmt.Sprintf(`
+	%s
+	variable "creation" {
+		default = "Rds"
+	}
+	variable "multi_az" {
+		default = "false"
+	}
+	variable "name" {
+		default = "tf-testAccDBInstance_vpc"
+	}
+
+	resource "alicloud_db_instance" "foo" {
+		engine = "MySQL"
+		engine_version = "5.6"
+		instance_type = "rds.mysql.s2.large"
+		instance_storage = "20"
+		instance_charge_type = "Postpaid"
+		instance_name = "${var.name}"
+		vswitch_id = "${alicloud_vswitch.default.id}"
+		security_ips = ["10.168.1.12", "100.69.7.112"]
+	}
+
+	resource "alicloud_db_readonly_instance" "foo" {
+		master_db_instance_id = "${alicloud_db_instance.foo.id}"
+		zone_id = "${alicloud_db_instance.foo.zone_id}"
+		engine_version = "${alicloud_db_instance.foo.engine_version}"
+		instance_type = "${alicloud_db_instance.foo.instance_type}"
+		instance_storage = "30"
+		instance_name = "${var.name}ro"
+		vswitch_id = "${alicloud_vswitch.default.id}"
+	}
+	`, common)
+}
+
+func testAccDBReadonlyInstance_upgrade(common string) string {
+	return fmt.Sprintf(`
+	%s
+	variable "creation" {
+		default = "Rds"
+	}
+	variable "multi_az" {
+		default = "false"
+	}
+	variable "name" {
+		default = "tf-testAccDBInstance_vpc"
+	}
+
+	resource "alicloud_db_instance" "foo" {
+		engine = "MySQL"
+		engine_version = "5.6"
+		instance_type = "rds.mysql.s2.large"
+		instance_storage = "20"
+		instance_charge_type = "Postpaid"
+		instance_name = "${var.name}"
+		vswitch_id = "${alicloud_vswitch.default.id}"
+		security_ips = ["10.168.1.12", "100.69.7.112"]
+	}
+
+	resource "alicloud_db_readonly_instance" "foo" {
+		master_db_instance_id = "${alicloud_db_instance.foo.id}"
+		zone_id = "${alicloud_db_instance.foo.zone_id}"
+		engine_version = "${alicloud_db_instance.foo.engine_version}"
+		instance_type = "${alicloud_db_instance.foo.instance_type}"
+		instance_storage = "40"
+		instance_name = "${var.name}ro"
+		vswitch_id = "${alicloud_vswitch.default.id}"
+	}
+	`, common)
+}
+
+func testAccCheckDBReadonlyInstanceDestroy(s *terraform.State) error {
+	client := testAccProvider.Meta().(*connectivity.AliyunClient)
+	rdsService := RdsService{client}
+
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "alicloud_db_readonly_instance" {
+			continue
+		}
+
+		ins, err := rdsService.DescribeDBInstanceById(rs.Primary.ID)
+
+		if ins != nil {
+			return fmt.Errorf("Error DB Instance still exist")
+		}
+
+		// Verify the error is what we want
+		if err != nil {
+			if NotFoundError(err) {
+				continue
+			}
+			return err
+		}
+	}
+
+	return nil
+}

--- a/alicloud/resource_alicloud_db_readonly_instance_test.go
+++ b/alicloud/resource_alicloud_db_readonly_instance_test.go
@@ -2,6 +2,7 @@ package alicloud
 
 import (
 	"fmt"
+	"github.com/hashicorp/terraform/helper/hashcode"
 	"testing"
 
 	"github.com/aliyun/alibaba-cloud-sdk-go/services/rds"
@@ -9,13 +10,6 @@ import (
 	"github.com/hashicorp/terraform/terraform"
 	"github.com/terraform-providers/terraform-provider-alicloud/alicloud/connectivity"
 )
-
-func init() {
-	resource.AddTestSweepers("alicloud_db_readonly_instance", &resource.Sweeper{
-		Name: "alicloud_db_readonly_instance",
-		F:    testSweepDBInstances,
-	})
-}
 
 func TestAccAlicloudDBReadonlyInstance_vpc(t *testing.T) {
 	var instance rds.DBInstanceAttribute
@@ -32,18 +26,128 @@ func TestAccAlicloudDBReadonlyInstance_vpc(t *testing.T) {
 		CheckDestroy: testAccCheckDBReadonlyInstanceDestroy,
 		Steps: []resource.TestStep{
 			resource.TestStep{
-				Config: testAccDBReadonlyInstance_vpc(RdsCommonTestCase),
+				Config: testAccDBReadonlyInstance_vpc(testAccDBRInstance_vpc(RdsCommonTestCase)),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckDBInstanceExists(
 						"alicloud_db_readonly_instance.foo", &instance),
 					resource.TestCheckResourceAttr(
-						"alicloud_db_readonly_instance.foo",
-						"instance_storage",
-						"30"),
+						"alicloud_db_readonly_instance.foo", "instance_storage", "30"),
 					resource.TestCheckResourceAttr(
-						"alicloud_db_readonly_instance.foo",
-						"engine_version",
-						"5.6"),
+						"alicloud_db_readonly_instance.foo", "engine_version", "5.6"),
+					resource.TestCheckResourceAttr(
+						"alicloud_db_readonly_instance.foo", "engine", "MySQL"),
+					resource.TestCheckResourceAttr(
+						"alicloud_db_readonly_instance.foo", "port", "3306"),
+					resource.TestCheckResourceAttr(
+						"alicloud_db_readonly_instance.foo", "instance_name", "tf-testAccDBInstance_vpc_ro"),
+					resource.TestCheckResourceAttr(
+						"alicloud_db_readonly_instance.foo", "instance_type", "rds.mysql.t1.small"),
+					resource.TestCheckNoResourceAttr(
+						"alicloud_db_readonly_instance.foo", "parameters"),
+					resource.TestCheckResourceAttrSet(
+						"alicloud_db_readonly_instance.foo", "master_db_instance_id"),
+					resource.TestCheckResourceAttrSet(
+						"alicloud_db_readonly_instance.foo", "zone_id"),
+					resource.TestCheckResourceAttrSet(
+						"alicloud_db_readonly_instance.foo", "vswitch_id"),
+					resource.TestCheckResourceAttrSet(
+						"alicloud_db_readonly_instance.foo", "connection_string"),
+				),
+			},
+		},
+	})
+
+}
+
+func TestAccAlicloudDBReadonlyInstance_multiAZ_classic(t *testing.T) {
+	var instance rds.DBInstanceAttribute
+
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+		},
+
+		// module name
+		IDRefreshName: "alicloud_db_readonly_instance.foo",
+
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckDBReadonlyInstanceDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccDBReadonlyInstance_multiAZ(testAccDBInstance_multiAZ),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckDBInstanceExists(
+						"alicloud_db_readonly_instance.foo", &instance),
+					resource.TestCheckResourceAttr(
+						"alicloud_db_readonly_instance.foo", "instance_storage", "30"),
+					resource.TestCheckResourceAttr(
+						"alicloud_db_readonly_instance.foo", "engine_version", "5.6"),
+					resource.TestCheckResourceAttr(
+						"alicloud_db_readonly_instance.foo", "engine", "MySQL"),
+					resource.TestCheckResourceAttr(
+						"alicloud_db_readonly_instance.foo", "port", "3306"),
+					resource.TestCheckResourceAttr(
+						"alicloud_db_readonly_instance.foo", "instance_name", "tf-testAccDBInstance_multiAZ_ro"),
+					resource.TestCheckResourceAttr(
+						"alicloud_db_readonly_instance.foo", "instance_type", "rds.mysql.t1.small"),
+					resource.TestCheckNoResourceAttr(
+						"alicloud_db_readonly_instance.foo", "parameters"),
+					resource.TestCheckResourceAttrSet(
+						"alicloud_db_readonly_instance.foo", "master_db_instance_id"),
+					resource.TestCheckResourceAttrSet(
+						"alicloud_db_readonly_instance.foo", "zone_id"),
+					resource.TestCheckResourceAttr(
+						"alicloud_db_readonly_instance.foo", "vswitch_id", ""),
+					resource.TestCheckResourceAttrSet(
+						"alicloud_db_readonly_instance.foo", "connection_string"),
+				),
+			},
+		},
+	})
+
+}
+
+func TestAccAlicloudDBReadonlyInstance_multiAZ_vpc(t *testing.T) {
+	var instance rds.DBInstanceAttribute
+
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheckWithRegions(t, false, connectivity.RdsMultiAzNoSupportedRegions)
+		},
+
+		// module name
+		IDRefreshName: "alicloud_db_readonly_instance.foo",
+
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckDBReadonlyInstanceDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccDBReadonlyInstance_multiAZ_vpc(testAccDBInstance_vpc_multiAZ(DBMultiAZCommonTestCase)),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckDBInstanceExists(
+						"alicloud_db_readonly_instance.foo", &instance),
+					resource.TestCheckResourceAttr(
+						"alicloud_db_readonly_instance.foo", "instance_storage", "30"),
+					resource.TestCheckResourceAttr(
+						"alicloud_db_readonly_instance.foo", "engine_version", "5.6"),
+					resource.TestCheckResourceAttr(
+						"alicloud_db_readonly_instance.foo", "engine", "MySQL"),
+					resource.TestCheckResourceAttr(
+						"alicloud_db_readonly_instance.foo", "port", "3306"),
+					resource.TestCheckResourceAttr(
+						"alicloud_db_readonly_instance.foo", "instance_name", "tf-testAccDBInstance_multiAZ_ro"),
+					resource.TestCheckResourceAttr(
+						"alicloud_db_readonly_instance.foo", "instance_type", "rds.mysql.t1.small"),
+					resource.TestCheckNoResourceAttr(
+						"alicloud_db_readonly_instance.foo", "parameters"),
+					resource.TestCheckResourceAttrSet(
+						"alicloud_db_readonly_instance.foo", "master_db_instance_id"),
+					resource.TestCheckResourceAttrSet(
+						"alicloud_db_readonly_instance.foo", "zone_id"),
+					resource.TestCheckResourceAttrSet(
+						"alicloud_db_readonly_instance.foo", "vswitch_id"),
+					resource.TestCheckResourceAttrSet(
+						"alicloud_db_readonly_instance.foo", "connection_string"),
 				),
 			},
 		},
@@ -66,33 +170,69 @@ func TestAccAlicloudDBReadonlyInstance_upgrade(t *testing.T) {
 		CheckDestroy: testAccCheckDBReadonlyInstanceDestroy,
 		Steps: []resource.TestStep{
 			resource.TestStep{
-				Config: testAccDBReadonlyInstance_vpc(RdsCommonTestCase),
+				Config: testAccDBReadonlyInstance_vpc(testAccDBRInstance_vpc(RdsCommonTestCase)),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckDBInstanceExists(
 						"alicloud_db_readonly_instance.foo", &instance),
 					resource.TestCheckResourceAttr(
-						"alicloud_db_readonly_instance.foo",
-						"instance_storage",
-						"30"),
+						"alicloud_db_readonly_instance.foo", "instance_storage", "30"),
 					resource.TestCheckResourceAttr(
-						"alicloud_db_readonly_instance.foo",
-						"engine_version",
-						"5.6"),
+						"alicloud_db_readonly_instance.foo", "engine_version", "5.6"),
+					resource.TestCheckResourceAttr(
+						"alicloud_db_readonly_instance.foo", "engine", "MySQL"),
+					resource.TestCheckResourceAttr(
+						"alicloud_db_readonly_instance.foo", "port", "3306"),
+					resource.TestCheckResourceAttr(
+						"alicloud_db_readonly_instance.foo", "instance_name", "tf-testAccDBInstance_vpc_ro"),
+					resource.TestCheckResourceAttr(
+						"alicloud_db_readonly_instance.foo", "instance_type", "rds.mysql.t1.small"),
+					resource.TestCheckNoResourceAttr(
+						"alicloud_db_readonly_instance.foo", "parameters"),
+					resource.TestCheckResourceAttrSet(
+						"alicloud_db_readonly_instance.foo", "master_db_instance_id"),
+					resource.TestCheckResourceAttrSet(
+						"alicloud_db_readonly_instance.foo", "zone_id"),
+					resource.TestCheckResourceAttrSet(
+						"alicloud_db_readonly_instance.foo", "vswitch_id"),
+					resource.TestCheckResourceAttrSet(
+						"alicloud_db_readonly_instance.foo", "connection_string"),
 				),
 			},
+			// upgrade storage
 			resource.TestStep{
-				Config: testAccDBReadonlyInstance_upgrade(RdsCommonTestCase),
+				Config: testAccDBReadonlyInstance_upgrade(testAccDBRInstance_vpc(RdsCommonTestCase),
+					"${alicloud_db_instance.foo.instance_type}", "40"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckDBInstanceExists(
 						"alicloud_db_readonly_instance.foo", &instance),
 					resource.TestCheckResourceAttr(
-						"alicloud_db_readonly_instance.foo",
-						"instance_storage",
-						"40"),
+						"alicloud_db_readonly_instance.foo", "instance_storage", "40"),
+				),
+			},
+			// upgrade instanceType
+			resource.TestStep{
+				Config: testAccDBReadonlyInstance_upgrade(testAccDBRInstance_vpc(RdsCommonTestCase),
+					"rds.mysql.s1.small", "40"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckDBInstanceExists(
+						"alicloud_db_readonly_instance.foo", &instance),
 					resource.TestCheckResourceAttr(
-						"alicloud_db_readonly_instance.foo",
-						"engine_version",
-						"5.6"),
+						"alicloud_db_readonly_instance.foo", "instance_storage", "40"),
+					resource.TestCheckResourceAttr(
+						"alicloud_db_readonly_instance.foo", "instance_type", "rds.mysql.s1.small"),
+				),
+			},
+			// upgrade storage and instanceType
+			resource.TestStep{
+				Config: testAccDBReadonlyInstance_upgrade(testAccDBRInstance_vpc(RdsCommonTestCase),
+					"rds.mysql.s1.large", "50"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckDBInstanceExists(
+						"alicloud_db_readonly_instance.foo", &instance),
+					resource.TestCheckResourceAttr(
+						"alicloud_db_readonly_instance.foo", "instance_storage", "50"),
+					resource.TestCheckResourceAttr(
+						"alicloud_db_readonly_instance.foo", "instance_type", "rds.mysql.s1.large"),
 				),
 			},
 		},
@@ -100,7 +240,166 @@ func TestAccAlicloudDBReadonlyInstance_upgrade(t *testing.T) {
 
 }
 
-func testAccDBReadonlyInstance_vpc(common string) string {
+func TestAccAlicloudDBReadonlyInstance_parameter(t *testing.T) {
+	var instance rds.DBInstanceAttribute
+
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+		},
+
+		// module name
+		IDRefreshName: "alicloud_db_readonly_instance.foo",
+
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckDBReadonlyInstanceDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccDBReadonlyInstance_vpc(testAccDBRInstance_vpc(RdsCommonTestCase)),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckDBInstanceExists(
+						"alicloud_db_readonly_instance.foo", &instance),
+					resource.TestCheckResourceAttr(
+						"alicloud_db_readonly_instance.foo", "instance_storage", "30"),
+					resource.TestCheckResourceAttr(
+						"alicloud_db_readonly_instance.foo", "engine_version", "5.6"),
+					resource.TestCheckResourceAttr(
+						"alicloud_db_readonly_instance.foo", "engine", "MySQL"),
+					resource.TestCheckResourceAttr(
+						"alicloud_db_readonly_instance.foo", "port", "3306"),
+					resource.TestCheckResourceAttr(
+						"alicloud_db_readonly_instance.foo", "instance_name", "tf-testAccDBInstance_vpc_ro"),
+					resource.TestCheckResourceAttr(
+						"alicloud_db_readonly_instance.foo", "instance_type", "rds.mysql.t1.small"),
+					resource.TestCheckNoResourceAttr(
+						"alicloud_db_readonly_instance.foo", "parameters"),
+					resource.TestCheckResourceAttrSet(
+						"alicloud_db_readonly_instance.foo", "master_db_instance_id"),
+					resource.TestCheckResourceAttrSet(
+						"alicloud_db_readonly_instance.foo", "zone_id"),
+					resource.TestCheckResourceAttrSet(
+						"alicloud_db_readonly_instance.foo", "vswitch_id"),
+					resource.TestCheckResourceAttrSet(
+						"alicloud_db_readonly_instance.foo", "connection_string"),
+				),
+			},
+			// update parameter
+			resource.TestStep{
+				Config: testAccDBReadonlyInstance_parameter(testAccDBRInstance_vpc(RdsCommonTestCase)),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("alicloud_db_readonly_instance.foo",
+						fmt.Sprintf("parameters.%d.value",
+							hashcode.String("innodb_large_prefix")), "ON"),
+				),
+			},
+			// update multi parameter
+			resource.TestStep{
+				Config: testAccDBReadonlyInstance_parameterMulti(testAccDBRInstance_vpc(RdsCommonTestCase)),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("alicloud_db_readonly_instance.foo",
+						fmt.Sprintf("parameters.%d.value",
+							hashcode.String("innodb_large_prefix")), "ON"),
+					resource.TestCheckResourceAttr("alicloud_db_readonly_instance.foo",
+						fmt.Sprintf("parameters.%d.value",
+							hashcode.String("connect_timeout")), "50"),
+				),
+			},
+			// remove parameter definition, parameter value not change
+			resource.TestStep{
+				Config: testAccDBReadonlyInstance_parameter(testAccDBRInstance_vpc(RdsCommonTestCase)),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("alicloud_db_readonly_instance.foo",
+						fmt.Sprintf("parameters.%d.value",
+							hashcode.String("innodb_large_prefix")), "ON"),
+					testAccCheckDBParameterExpects(
+						"alicloud_db_readonly_instance.foo", "connect_timeout", "50"),
+				),
+			},
+		},
+	})
+
+}
+
+func TestAccAlicloudDBReadonlyInstance_updateInstanceName(t *testing.T) {
+	var instance rds.DBInstanceAttribute
+
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+		},
+
+		// module name
+		IDRefreshName: "alicloud_db_readonly_instance.foo",
+
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckDBReadonlyInstanceDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccDBReadonlyInstance_vpc(testAccDBRInstance_vpc(RdsCommonTestCase)),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckDBInstanceExists(
+						"alicloud_db_readonly_instance.foo", &instance),
+					resource.TestCheckResourceAttr(
+						"alicloud_db_readonly_instance.foo", "instance_storage", "30"),
+					resource.TestCheckResourceAttr(
+						"alicloud_db_readonly_instance.foo", "engine_version", "5.6"),
+					resource.TestCheckResourceAttr(
+						"alicloud_db_readonly_instance.foo", "engine", "MySQL"),
+					resource.TestCheckResourceAttr(
+						"alicloud_db_readonly_instance.foo", "port", "3306"),
+					resource.TestCheckResourceAttr(
+						"alicloud_db_readonly_instance.foo", "instance_name", "tf-testAccDBInstance_vpc_ro"),
+					resource.TestCheckResourceAttr(
+						"alicloud_db_readonly_instance.foo", "instance_type", "rds.mysql.t1.small"),
+					resource.TestCheckNoResourceAttr(
+						"alicloud_db_readonly_instance.foo", "parameters"),
+					resource.TestCheckResourceAttrSet(
+						"alicloud_db_readonly_instance.foo", "master_db_instance_id"),
+					resource.TestCheckResourceAttrSet(
+						"alicloud_db_readonly_instance.foo", "zone_id"),
+					resource.TestCheckResourceAttrSet(
+						"alicloud_db_readonly_instance.foo", "vswitch_id"),
+					resource.TestCheckResourceAttrSet(
+						"alicloud_db_readonly_instance.foo", "connection_string"),
+				),
+			},
+			// update instanceName
+			resource.TestStep{
+				Config: testAccDBReadonlyInstance_vpc_instanceName(
+					testAccDBRInstance_vpc(RdsCommonTestCase), "some_other_name"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckDBInstanceExists(
+						"alicloud_db_readonly_instance.foo", &instance),
+					resource.TestCheckResourceAttr(
+						"alicloud_db_readonly_instance.foo", "instance_storage", "30"),
+					resource.TestCheckResourceAttr(
+						"alicloud_db_readonly_instance.foo", "engine_version", "5.6"),
+					resource.TestCheckResourceAttr(
+						"alicloud_db_readonly_instance.foo", "engine", "MySQL"),
+					resource.TestCheckResourceAttr(
+						"alicloud_db_readonly_instance.foo", "port", "3306"),
+					resource.TestCheckResourceAttr(
+						"alicloud_db_readonly_instance.foo", "instance_name", "some_other_name"),
+					resource.TestCheckResourceAttr(
+						"alicloud_db_readonly_instance.foo", "instance_type", "rds.mysql.t1.small"),
+					resource.TestCheckNoResourceAttr(
+						"alicloud_db_readonly_instance.foo", "parameters"),
+					resource.TestCheckResourceAttrSet(
+						"alicloud_db_readonly_instance.foo", "master_db_instance_id"),
+					resource.TestCheckResourceAttrSet(
+						"alicloud_db_readonly_instance.foo", "zone_id"),
+					resource.TestCheckResourceAttrSet(
+						"alicloud_db_readonly_instance.foo", "vswitch_id"),
+					resource.TestCheckResourceAttrSet(
+						"alicloud_db_readonly_instance.foo", "connection_string"),
+				),
+			},
+		},
+	})
+
+}
+
+func testAccDBRInstance_vpc(common string) string {
 	return fmt.Sprintf(`
 	%s
 	variable "creation" {
@@ -116,58 +415,127 @@ func testAccDBReadonlyInstance_vpc(common string) string {
 	resource "alicloud_db_instance" "foo" {
 		engine = "MySQL"
 		engine_version = "5.6"
-		instance_type = "rds.mysql.s2.large"
+		instance_type = "rds.mysql.t1.small"
 		instance_storage = "20"
 		instance_charge_type = "Postpaid"
 		instance_name = "${var.name}"
 		vswitch_id = "${alicloud_vswitch.default.id}"
 		security_ips = ["10.168.1.12", "100.69.7.112"]
 	}
+	`, common)
+}
 
+func testAccDBReadonlyInstance_vpc(common string) string {
+	return fmt.Sprintf(`
+	%s
 	resource "alicloud_db_readonly_instance" "foo" {
 		master_db_instance_id = "${alicloud_db_instance.foo.id}"
 		zone_id = "${alicloud_db_instance.foo.zone_id}"
 		engine_version = "${alicloud_db_instance.foo.engine_version}"
 		instance_type = "${alicloud_db_instance.foo.instance_type}"
 		instance_storage = "30"
-		instance_name = "${var.name}ro"
+		instance_name = "${var.name}_ro"
 		vswitch_id = "${alicloud_vswitch.default.id}"
 	}
 	`, common)
 }
 
-func testAccDBReadonlyInstance_upgrade(common string) string {
+func testAccDBReadonlyInstance_vpc_instanceName(common, instanceName string) string {
 	return fmt.Sprintf(`
 	%s
-	variable "creation" {
-		default = "Rds"
-	}
-	variable "multi_az" {
-		default = "false"
-	}
-	variable "name" {
-		default = "tf-testAccDBInstance_vpc"
-	}
-
-	resource "alicloud_db_instance" "foo" {
-		engine = "MySQL"
-		engine_version = "5.6"
-		instance_type = "rds.mysql.s2.large"
-		instance_storage = "20"
-		instance_charge_type = "Postpaid"
-		instance_name = "${var.name}"
-		vswitch_id = "${alicloud_vswitch.default.id}"
-		security_ips = ["10.168.1.12", "100.69.7.112"]
-	}
-
 	resource "alicloud_db_readonly_instance" "foo" {
 		master_db_instance_id = "${alicloud_db_instance.foo.id}"
 		zone_id = "${alicloud_db_instance.foo.zone_id}"
 		engine_version = "${alicloud_db_instance.foo.engine_version}"
 		instance_type = "${alicloud_db_instance.foo.instance_type}"
-		instance_storage = "40"
-		instance_name = "${var.name}ro"
+		instance_storage = "30"
+		instance_name = "%s"
 		vswitch_id = "${alicloud_vswitch.default.id}"
+	}
+	`, common, instanceName)
+}
+
+func testAccDBReadonlyInstance_upgrade(common, instanceType, storage string) string {
+	return fmt.Sprintf(`
+	%s
+	resource "alicloud_db_readonly_instance" "foo" {
+		master_db_instance_id = "${alicloud_db_instance.foo.id}"
+		zone_id = "${alicloud_db_instance.foo.zone_id}"
+		engine_version = "${alicloud_db_instance.foo.engine_version}"
+		instance_type = "%s"
+		instance_storage = "%s"
+		instance_name = "${var.name}_ro"
+		vswitch_id = "${alicloud_vswitch.default.id}"
+	}
+	`, common, instanceType, storage)
+}
+
+func testAccDBReadonlyInstance_multiAZ(common string) string {
+	return fmt.Sprintf(`
+	%s
+	resource "alicloud_db_readonly_instance" "foo" {
+		master_db_instance_id = "${alicloud_db_instance.foo.id}"
+		zone_id = "${alicloud_db_instance.foo.zone_id}"
+		engine_version = "${alicloud_db_instance.foo.engine_version}"
+		instance_type = "${alicloud_db_instance.foo.instance_type}"
+		instance_storage = "30"
+		instance_name = "${var.name}_ro"
+	}
+	`, common)
+}
+
+func testAccDBReadonlyInstance_multiAZ_vpc(common string) string {
+	return fmt.Sprintf(`
+	%s
+	resource "alicloud_db_readonly_instance" "foo" {
+		master_db_instance_id = "${alicloud_db_instance.foo.id}"
+		zone_id = "${alicloud_db_instance.foo.zone_id}"
+		engine_version = "${alicloud_db_instance.foo.engine_version}"
+		instance_type = "${alicloud_db_instance.foo.instance_type}"
+		instance_storage = "30"
+		instance_name = "${var.name}_ro"
+		vswitch_id = "${alicloud_vswitch.default.id}"
+	}
+	`, common)
+}
+
+func testAccDBReadonlyInstance_parameter(common string) string {
+	return fmt.Sprintf(`
+	%s
+	resource "alicloud_db_readonly_instance" "foo" {
+		master_db_instance_id = "${alicloud_db_instance.foo.id}"
+		zone_id = "${alicloud_db_instance.foo.zone_id}"
+		engine_version = "${alicloud_db_instance.foo.engine_version}"
+		instance_type = "${alicloud_db_instance.foo.instance_type}"
+		instance_storage = "30"
+		instance_name = "${var.name}_ro"
+		vswitch_id = "${alicloud_vswitch.default.id}"
+		parameters = [{
+			name = "innodb_large_prefix"
+			value = "ON"
+		}]
+	}
+	`, common)
+}
+
+func testAccDBReadonlyInstance_parameterMulti(common string) string {
+	return fmt.Sprintf(`
+	%s
+	resource "alicloud_db_readonly_instance" "foo" {
+		master_db_instance_id = "${alicloud_db_instance.foo.id}"
+		zone_id = "${alicloud_db_instance.foo.zone_id}"
+		engine_version = "${alicloud_db_instance.foo.engine_version}"
+		instance_type = "${alicloud_db_instance.foo.instance_type}"
+		instance_storage = "30"
+		instance_name = "${var.name}_ro"
+		vswitch_id = "${alicloud_vswitch.default.id}"
+		parameters = [{
+			name = "innodb_large_prefix"
+			value = "ON"
+		},{
+			name = "connect_timeout"
+			value = "50"
+		}]
 	}
 	`, common)
 }

--- a/website/alicloud.erb
+++ b/website/alicloud.erb
@@ -380,6 +380,9 @@
                         <li<%= sidebar_current("docs-alicloud-resource-rds") %>>
                             <a href="/docs/providers/alicloud/r/db_instance.html">alicloud_db_instance</a>
                         </li>
+                        <li<%= sidebar_current("docs-alicloud-resource-rds") %>>
+                            <a href="/docs/providers/alicloud/r/db_readonly_instance.html">alicloud_db_readonly_instance</a>
+                        </li>
                     </ul>
                 </li>
 

--- a/website/docs/r/db_readonly_instance.html.markdown
+++ b/website/docs/r/db_readonly_instance.html.markdown
@@ -1,0 +1,71 @@
+---
+layout: "alicloud"
+page_title: "Alicloud: alicloud_db_readonly_instance"
+sidebar_current: "docs-alicloud-resource-db-readonly-instance"
+description: |-
+  Provides an RDS readonly instance resource.
+---
+
+# alicloud\_db\_readonly\_instance
+
+Provides an RDS readonly instance resource. 
+
+## Example Usage
+
+```
+resource "alicloud_db_instance" "default" {
+	engine = "MySQL"
+	engine_version = "5.6"
+	db_instance_class = "rds.mysql.t1.small"
+	db_instance_storage = "10"
+}
+
+resource "alicloud_db_readonly_instance" "foo" {
+	master_db_instance_id = "${alicloud_db_instance.default.id}"
+	zone_id = "${alicloud_db_instance.default.zone_id}"
+	engine_version = "${alicloud_db_instance.default.engine_version}"
+	instance_type = "${alicloud_db_instance.default.instance_type}"
+	instance_storage = "30"
+	instance_name = "${var.name}ro"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `engine_version` - (Required) Database version. Value options can refer to the latest docs [CreateDBInstance](https://www.alibabacloud.com/help/doc-detail/26228.htm) `EngineVersion`.
+* `zone_id` - (Required) The Zone to launch the DB instance.
+* `master_db_instance_id` - (Required) ID of the master instance.
+* `instance_type` - (Required) DB Instance type. For details, see [Instance type table](https://www.alibabacloud.com/help/doc-detail/26312.htm).
+* `instance_storage` - (Required) User-defined DB instance storage space. Value range:
+    - [5, 2000] for MySQL/PostgreSQL/PPAS HA dual node edition;
+    Increase progressively at a rate of 5 GB. For details, see [Instance type table](https://www.alibabacloud.com/help/doc-detail/26312.htm).
+
+* `instance_name` - (Optional) The name of DB instance. It a string of 2 to 256 characters.
+* `vswitch_id` - (Optional) The virtual switch ID to launch DB instances in one VPC.
+
+~> **NOTE:** Because of data backup and migration, change DB instance type and storage would cost 15~20 minutes. Please make full preparation before changing them.
+
+## Attributes Reference
+
+The following attributes are exported:
+
+* `id` - The RDS instance ID.
+* `engine` - Database type.
+* `engine_version` - The database engine version.
+* `instance_type` - The RDS instance type.
+* `instance_storage` - The RDS instance storage space.
+* `instance_name` - The name of DB instance.
+* `port` - RDS database connection port.
+* `connection_string` - RDS database connection string.
+* `zone_id` - The zone ID of the RDS instance.
+* `vswitch_id` - If the rds instance created in VPC, then this value is virtual switch ID.
+
+## Import
+
+RDS instance can be imported using the id, e.g.
+
+```
+$ terraform import alicloud_db_readonly_instance.example rm-abc12345678
+```

--- a/website/docs/r/db_readonly_instance.html.markdown
+++ b/website/docs/r/db_readonly_instance.html.markdown
@@ -13,20 +13,33 @@ Provides an RDS readonly instance resource.
 ## Example Usage
 
 ```
+resource "alicloud_vpc" "default" {
+  name       = "vpc-123456"
+  cidr_block = "172.16.0.0/16"
+}
+
+resource "alicloud_vswitch" "default" {
+  vpc_id            = "${alicloud_vpc.default.id}"
+  cidr_block        = "172.16.0.0/24"
+  availability_zone = "${data.alicloud_zones.default.zones.0.id}"
+  name              = "vpc-123456"
+}
+
 resource "alicloud_db_instance" "default" {
 	engine = "MySQL"
 	engine_version = "5.6"
 	db_instance_class = "rds.mysql.t1.small"
 	db_instance_storage = "10"
+	vswitch_id = "${alicloud_vswitch.default.id}"
 }
 
 resource "alicloud_db_readonly_instance" "foo" {
 	master_db_instance_id = "${alicloud_db_instance.default.id}"
-	zone_id = "${alicloud_db_instance.default.zone_id}"
 	engine_version = "${alicloud_db_instance.default.engine_version}"
 	instance_type = "${alicloud_db_instance.default.instance_type}"
 	instance_storage = "30"
-	instance_name = "${var.name}ro"
+	instance_name = "rm-123456_ro"
+	vswitch_id = "${alicloud_vswitch.default.id}"
 }
 ```
 
@@ -34,16 +47,14 @@ resource "alicloud_db_readonly_instance" "foo" {
 
 The following arguments are supported:
 
-* `engine_version` - (Required) Database version. Value options can refer to the latest docs [CreateDBInstance](https://www.alibabacloud.com/help/doc-detail/26228.htm) `EngineVersion`.
-* `zone_id` - (Required) The Zone to launch the DB instance.
-* `master_db_instance_id` - (Required) ID of the master instance.
+* `engine_version` - (Required, ForceNew) Database version. Value options can refer to the latest docs [CreateDBInstance](https://www.alibabacloud.com/help/doc-detail/26228.htm) `EngineVersion`.
+* `master_db_instance_id` - (Required, ForceNew) ID of the master instance.
 * `instance_type` - (Required) DB Instance type. For details, see [Instance type table](https://www.alibabacloud.com/help/doc-detail/26312.htm).
-* `instance_storage` - (Required) User-defined DB instance storage space. Value range:
-    - [5, 2000] for MySQL/PostgreSQL/PPAS HA dual node edition;
-    Increase progressively at a rate of 5 GB. For details, see [Instance type table](https://www.alibabacloud.com/help/doc-detail/26312.htm).
-
+* `instance_storage` - (Required) User-defined DB instance storage space. Value range: [5, 2000] for MySQL/SQL Server HA dual node edition. Increase progressively at a rate of 5 GB. For details, see [Instance type table](https://www.alibabacloud.com/help/doc-detail/26312.htm).
 * `instance_name` - (Optional) The name of DB instance. It a string of 2 to 256 characters.
-* `vswitch_id` - (Optional) The virtual switch ID to launch DB instances in one VPC.
+* `parameters` - (Optional) Set of parameters needs to be set after DB instance was launched. Available parameters can refer to the latest docs [View database parameter templates](https://www.alibabacloud.com/help/doc-detail/26284.htm).
+* `zone_id` - (Optional, ForceNew) The Zone to launch the DB instance.
+* `vswitch_id` - (Optional, ForceNew) The virtual switch ID to launch DB instances in one VPC.
 
 ~> **NOTE:** Because of data backup and migration, change DB instance type and storage would cost 15~20 minutes. Please make full preparation before changing them.
 
@@ -53,18 +64,12 @@ The following attributes are exported:
 
 * `id` - The RDS instance ID.
 * `engine` - Database type.
-* `engine_version` - The database engine version.
-* `instance_type` - The RDS instance type.
-* `instance_storage` - The RDS instance storage space.
-* `instance_name` - The name of DB instance.
 * `port` - RDS database connection port.
 * `connection_string` - RDS database connection string.
-* `zone_id` - The zone ID of the RDS instance.
-* `vswitch_id` - If the rds instance created in VPC, then this value is virtual switch ID.
 
 ## Import
 
-RDS instance can be imported using the id, e.g.
+RDS readonly instance can be imported using the id, e.g.
 
 ```
 $ terraform import alicloud_db_readonly_instance.example rm-abc12345678


### PR DESCRIPTION
```
GOROOT=/usr/local/Cellar/go/1.11.1/libexec #gosetup
GOPATH=/Users/panjiabang/Projects/GOPATH #gosetup
/usr/local/Cellar/go/1.11.1/libexec/bin/go test -c -o /private/var/folders/tt/t72n_q9s77l82s54_c_73rsc0000gn/T/___TestAccAlicloudDBReadonlyInstance_vpc_in_github_com_terraform_providers_terraform_provider_alicloud_alicloud github.com/terraform-providers/terraform-provider-alicloud/alicloud #gosetup
/usr/local/Cellar/go/1.11.1/libexec/bin/go tool test2json -t /private/var/folders/tt/t72n_q9s77l82s54_c_73rsc0000gn/T/___TestAccAlicloudDBReadonlyInstance_vpc_in_github_com_terraform_providers_terraform_provider_alicloud_alicloud -test.v -test.run ^TestAccAlicloudDBReadonlyInstance_vpc$ #gosetup
=== RUN   TestAccAlicloudDBReadonlyInstance_vpc
--- PASS: TestAccAlicloudDBReadonlyInstance_vpc (1004.83s)
PASS
```

```
GOROOT=/usr/local/Cellar/go/1.11.1/libexec #gosetup
GOPATH=/Users/panjiabang/Projects/GOPATH #gosetup
/usr/local/Cellar/go/1.11.1/libexec/bin/go test -c -o /private/var/folders/tt/t72n_q9s77l82s54_c_73rsc0000gn/T/___TestAccAlicloudDBReadonlyInstance_upgrade_in_github_com_terraform_providers_terraform_provider_alicloud_alicloud github.com/terraform-providers/terraform-provider-alicloud/alicloud #gosetup
/usr/local/Cellar/go/1.11.1/libexec/bin/go tool test2json -t /private/var/folders/tt/t72n_q9s77l82s54_c_73rsc0000gn/T/___TestAccAlicloudDBReadonlyInstance_upgrade_in_github_com_terraform_providers_terraform_provider_alicloud_alicloud -test.v -test.run ^TestAccAlicloudDBReadonlyInstance_upgrade$ #gosetup
=== RUN   TestAccAlicloudDBReadonlyInstance_upgrade
--- PASS: TestAccAlicloudDBReadonlyInstance_upgrade (976.39s)
PASS
```

```
GOROOT=/usr/local/Cellar/go/1.11.1/libexec #gosetup
GOPATH=/Users/panjiabang/Projects/GOPATH #gosetup
/usr/local/Cellar/go/1.11.1/libexec/bin/go test -c -o /private/var/folders/tt/t72n_q9s77l82s54_c_73rsc0000gn/T/___TestAccAlicloudDBReadonlyInstance_multiAZ_in_github_com_terraform_providers_terraform_provider_alicloud_alicloud github.com/terraform-providers/terraform-provider-alicloud/alicloud #gosetup
/usr/local/Cellar/go/1.11.1/libexec/bin/go tool test2json -t /private/var/folders/tt/t72n_q9s77l82s54_c_73rsc0000gn/T/___TestAccAlicloudDBReadonlyInstance_multiAZ_in_github_com_terraform_providers_terraform_provider_alicloud_alicloud -test.v -test.run ^TestAccAlicloudDBReadonlyInstance_multiAZ$ #gosetup
=== RUN   TestAccAlicloudDBReadonlyInstance_multiAZ
--- PASS: TestAccAlicloudDBReadonlyInstance_multiAZ (673.48s)
PASS
```

```
GOROOT=/usr/local/Cellar/go/1.11.1/libexec #gosetup
GOPATH=/Users/panjiabang/Projects/GOPATH #gosetup
/usr/local/Cellar/go/1.11.1/libexec/bin/go test -c -o /private/var/folders/tt/t72n_q9s77l82s54_c_73rsc0000gn/T/___TestAccAlicloudDBInstance_parameter_in_github_com_terraform_providers_terraform_provider_alicloud_alicloud github.com/terraform-providers/terraform-provider-alicloud/alicloud #gosetup
/usr/local/Cellar/go/1.11.1/libexec/bin/go tool test2json -t /private/var/folders/tt/t72n_q9s77l82s54_c_73rsc0000gn/T/___TestAccAlicloudDBInstance_parameter_in_github_com_terraform_providers_terraform_provider_alicloud_alicloud -test.v -test.run ^TestAccAlicloudDBInstance_parameter$ #gosetup
=== RUN   TestAccAlicloudDBInstance_parameter
--- PASS: TestAccAlicloudDBInstance_parameter (112.88s)
PASS
```

```
GOROOT=/usr/local/Cellar/go/1.11.1/libexec #gosetup
GOPATH=/Users/panjiabang/Projects/GOPATH #gosetup
/usr/local/Cellar/go/1.11.1/libexec/bin/go test -c -o /private/var/folders/tt/t72n_q9s77l82s54_c_73rsc0000gn/T/___TestAccAlicloudDBReadonlyInstance_import_in_github_com_terraform_providers_terraform_provider_alicloud_alicloud github.com/terraform-providers/terraform-provider-alicloud/alicloud #gosetup
/usr/local/Cellar/go/1.11.1/libexec/bin/go tool test2json -t /private/var/folders/tt/t72n_q9s77l82s54_c_73rsc0000gn/T/___TestAccAlicloudDBReadonlyInstance_import_in_github_com_terraform_providers_terraform_provider_alicloud_alicloud -test.v -test.run ^TestAccAlicloudDBReadonlyInstance_import$ #gosetup
=== RUN   TestAccAlicloudDBReadonlyInstance_import
--- PASS: TestAccAlicloudDBReadonlyInstance_import (923.46s)
PASS
```