### PR TITLE
Add attribute parameters to resource alicloud_db_instance

### DIFF
--- a/alicloud/resource_alicloud_db_instance_test.go
+++ b/alicloud/resource_alicloud_db_instance_test.go
@@ -2,6 +2,7 @@ package alicloud
 
 import (
 	"fmt"
+	"github.com/hashicorp/terraform/helper/hashcode"
 	"log"
 	"strings"
 	"testing"
@@ -213,6 +214,7 @@ func TestAccAlicloudDBInstance_parameter(t *testing.T) {
 						"MySQL"),
 				),
 			},
+			// update parameter
 			resource.TestStep{
 				Config: testAccDBInstance_parameter(RdsCommonTestCase),
 				Check: resource.ComposeTestCheckFunc(
@@ -220,8 +222,85 @@ func TestAccAlicloudDBInstance_parameter(t *testing.T) {
 						"alicloud_db_instance.foo",
 						"engine_version",
 						"5.6"),
+					resource.TestCheckResourceAttr("alicloud_db_instance.foo",
+						fmt.Sprintf("parameters.%d.value",
+							hashcode.String("innodb_large_prefix")), "ON"),
+				),
+			},
+			// update multi parameter
+			resource.TestStep{
+				Config: testAccDBInstance_parameterMulti(RdsCommonTestCase),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(
+						"alicloud_db_instance.foo",
+						"engine_version",
+						"5.6"),
+					resource.TestCheckResourceAttr("alicloud_db_instance.foo",
+						fmt.Sprintf("parameters.%d.value",
+							hashcode.String("innodb_large_prefix")), "ON"),
+					resource.TestCheckResourceAttr("alicloud_db_instance.foo",
+						fmt.Sprintf("parameters.%d.value",
+							hashcode.String("connect_timeout")), "50"),
+				),
+			},
+			// remove parameter definition, parameter value not change
+			resource.TestStep{
+				Config: testAccDBInstance_parameter(RdsCommonTestCase),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(
+						"alicloud_db_instance.foo",
+						"engine_version",
+						"5.6"),
+					resource.TestCheckResourceAttr("alicloud_db_instance.foo",
+						fmt.Sprintf("parameters.%d.value",
+							hashcode.String("innodb_large_prefix")), "ON"),
 					testAccCheckDBParameterExpects(
-						"alicloud_db_instance.foo", "innodb_large_prefix", "ON"),
+						"alicloud_db_instance.foo", "connect_timeout", "50"),
+				),
+			},
+		},
+	})
+
+}
+
+func TestAccAlicloudDBInstance_CreateWithParameter(t *testing.T) {
+	var instance rds.DBInstanceAttribute
+
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+		},
+
+		// module name
+		IDRefreshName: "alicloud_db_instance.foo",
+
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckDBInstanceDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccDBInstance_parameter(RdsCommonTestCase),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckDBInstanceExists(
+						"alicloud_db_instance.foo", &instance),
+					resource.TestCheckResourceAttr(
+						"alicloud_db_instance.foo",
+						"instance_storage",
+						"20"),
+					resource.TestCheckResourceAttr(
+						"alicloud_db_instance.foo",
+						"engine_version",
+						"5.6"),
+					resource.TestCheckResourceAttr(
+						"alicloud_db_instance.foo",
+						"engine",
+						"MySQL"),
+					resource.TestCheckResourceAttr(
+						"alicloud_db_instance.foo",
+						"engine_version",
+						"5.6"),
+					resource.TestCheckResourceAttr("alicloud_db_instance.foo",
+						fmt.Sprintf("parameters.%d.value",
+							hashcode.String("innodb_large_prefix")), "ON"),
 				),
 			},
 		},
@@ -420,6 +499,8 @@ func testAccCheckDBInstanceExists(n string, d *rds.DBInstanceAttribute) resource
 	}
 }
 
+// check instance parameter value using SDK API, make sure that
+// real parameter value is expected
 func testAccCheckDBParameterExpects(n string, key string, value string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[n]
@@ -565,6 +646,39 @@ func testAccDBInstance_parameter(common string) string {
 		parameters = [{
 			name = "innodb_large_prefix"
 			value = "ON"
+		}]
+	}
+	`, common)
+}
+
+func testAccDBInstance_parameterMulti(common string) string {
+	return fmt.Sprintf(`
+	%s
+	variable "creation" {
+		default = "Rds"
+	}
+	variable "multi_az" {
+		default = "false"
+	}
+	variable "name" {
+		default = "tf-testAccDBInstance_vpc"
+	}
+
+	resource "alicloud_db_instance" "foo" {
+		engine = "MySQL"
+		engine_version = "5.6"
+		instance_type = "rds.mysql.s2.large"
+		instance_storage = "20"
+		instance_charge_type = "Postpaid"
+		instance_name = "${var.name}"
+		vswitch_id = "${alicloud_vswitch.default.id}"
+		security_ips = ["10.168.1.12", "100.69.7.112"]
+		parameters = [{
+			name = "innodb_large_prefix"
+			value = "ON"
+		},{
+			name = "connect_timeout"
+			value = "50"
 		}]
 	}
 	`, common)

--- a/alicloud/service_alicloud_rds.go
+++ b/alicloud/service_alicloud_rds.go
@@ -110,6 +110,26 @@ func (s *RdsService) DescribeDatabaseByName(instanceId, dbName string) (ds *rds.
 	return ds, err
 }
 
+func (s *RdsService) DescribeParameters(instanceId string) (ds *rds.DescribeParametersResponse, err error) {
+	request := rds.CreateDescribeParametersRequest()
+	request.DBInstanceId = instanceId
+
+	raw, err := s.client.WithRdsClient(func(rdsClient *rds.Client) (interface{}, error) {
+		return rdsClient.DescribeParameters(request)
+	})
+	if err != nil {
+		if IsExceptedErrors(err, []string{InvalidDBInstanceIdNotFound, InvalidDBInstanceNameNotFound}) {
+			return nil, GetNotFoundErrorFromString(GetNotFoundMessage("DB Instance", instanceId))
+		}
+		return nil, err
+	}
+	resp, _ := raw.(*rds.DescribeParametersResponse)
+	if resp == nil {
+		err = GetNotFoundErrorFromString(GetNotFoundMessage("Rds Instance Parameter", instanceId))
+	}
+	return resp, err
+}
+
 func (s *RdsService) AllocateDBPublicConnection(instanceId, prefix, port string) error {
 	request := rds.CreateAllocateInstancePublicConnectionRequest()
 	request.DBInstanceId = instanceId

--- a/website/docs/r/db_instance.html.markdown
+++ b/website/docs/r/db_instance.html.markdown
@@ -57,7 +57,7 @@ The multiple zone ID can be retrieved by setting `multi` to "true" in the data s
 * `backup_retention_period` - (Deprecated) It has been deprecated from version 1.5.0. New resource `alicloud_db_backup_policy` field 'retention_period' replaces it.
 * `security_ips` - (Optional) List of IP addresses allowed to access all databases of an instance. The list contains up to 1,000 IP addresses, separated by commas. Supported formats include 0.0.0.0/0, 10.23.12.24 (IP), and 10.23.12.24/24 (Classless Inter-Domain Routing (CIDR) mode. /24 represents the length of the prefix in an IP address. The range of the prefix length is [1,32]).
 * `db_mappings` - (Deprecated) It has been deprecated from version 1.5.0. New resource `alicloud_db_database` replaces it.
-* `parameters` - (Optional) The parameters needs to be set after DB instance was launched.
+* `parameters` - (Optional) Set of parameters needs to be set after DB instance was launched. Available parameters can refer to the latest docs [View database parameter templates](https://www.alibabacloud.com/help/doc-detail/26284.htm) .
 
 ~> **NOTE:** Because of data backup and migration, change DB instance type and storage would cost 15~20 minutes. Please make full preparation before changing them.
 
@@ -91,7 +91,6 @@ The following attributes are exported:
 * `preferred_backup_period` - (Deprecated from version 1.5.0).
 * `preferred_backup_time` - (Deprecated from version 1.5.0).
 * `backup_retention_period` - (Deprecated from version 1.5.0).
-* `parameters` - Database parameters modified.
 
 ## Import
 

--- a/website/docs/r/db_instance.html.markdown
+++ b/website/docs/r/db_instance.html.markdown
@@ -57,6 +57,7 @@ The multiple zone ID can be retrieved by setting `multi` to "true" in the data s
 * `backup_retention_period` - (Deprecated) It has been deprecated from version 1.5.0. New resource `alicloud_db_backup_policy` field 'retention_period' replaces it.
 * `security_ips` - (Optional) List of IP addresses allowed to access all databases of an instance. The list contains up to 1,000 IP addresses, separated by commas. Supported formats include 0.0.0.0/0, 10.23.12.24 (IP), and 10.23.12.24/24 (Classless Inter-Domain Routing (CIDR) mode. /24 represents the length of the prefix in an IP address. The range of the prefix length is [1,32]).
 * `db_mappings` - (Deprecated) It has been deprecated from version 1.5.0. New resource `alicloud_db_database` replaces it.
+* `parameters` - (Optional) The parameters needs to be set after DB instance was launched.
 
 ~> **NOTE:** Because of data backup and migration, change DB instance type and storage would cost 15~20 minutes. Please make full preparation before changing them.
 
@@ -90,6 +91,7 @@ The following attributes are exported:
 * `preferred_backup_period` - (Deprecated from version 1.5.0).
 * `preferred_backup_time` - (Deprecated from version 1.5.0).
 * `backup_retention_period` - (Deprecated from version 1.5.0).
+* `parameters` - Database parameters modified.
 
 ## Import
 


### PR DESCRIPTION
```
GOROOT=/usr/local/Cellar/go/1.11.1/libexec #gosetup
GOPATH=/Users/panjiabang/Projects/GOPATH #gosetup
/usr/local/Cellar/go/1.11.1/libexec/bin/go test -c -o /private/var/folders/tt/t72n_q9s77l82s54_c_73rsc0000gn/T/___TestAccAlicloudDBInstance_parameter_in_github_com_terraform_providers_terraform_provider_alicloud_alicloud github.com/terraform-providers/terraform-provider-alicloud/alicloud #gosetup
/usr/local/Cellar/go/1.11.1/libexec/bin/go tool test2json -t /private/var/folders/tt/t72n_q9s77l82s54_c_73rsc0000gn/T/___TestAccAlicloudDBInstance_parameter_in_github_com_terraform_providers_terraform_provider_alicloud_alicloud -test.v -test.run ^TestAccAlicloudDBInstance_parameter$ #gosetup
=== RUN   TestAccAlicloudDBInstance_parameter
--- PASS: TestAccAlicloudDBInstance_parameter (205.55s)
PASS
```


```
GOROOT=/usr/local/Cellar/go/1.11.1/libexec #gosetup
GOPATH=/Users/panjiabang/Projects/GOPATH #gosetup
/usr/local/Cellar/go/1.11.1/libexec/bin/go test -c -o /private/var/folders/tt/t72n_q9s77l82s54_c_73rsc0000gn/T/___TestAccAlicloudDBInstance_classic_in_github_com_terraform_providers_terraform_provider_alicloud_alicloud github.com/terraform-providers/terraform-provider-alicloud/alicloud #gosetup
/usr/local/Cellar/go/1.11.1/libexec/bin/go tool test2json -t /private/var/folders/tt/t72n_q9s77l82s54_c_73rsc0000gn/T/___TestAccAlicloudDBInstance_classic_in_github_com_terraform_providers_terraform_provider_alicloud_alicloud -test.v -test.run ^TestAccAlicloudDBInstance_classic$ #gosetup
=== RUN   TestAccAlicloudDBInstance_classic
--- PASS: TestAccAlicloudDBInstance_classic (423.79s)
PASS
```

```
GOROOT=/usr/local/Cellar/go/1.11.1/libexec #gosetup
GOPATH=/Users/panjiabang/Projects/GOPATH #gosetup
/usr/local/Cellar/go/1.11.1/libexec/bin/go test -c -o /private/var/folders/tt/t72n_q9s77l82s54_c_73rsc0000gn/T/___TestAccAlicloudDBInstance_upgradeClass_in_github_com_terraform_providers_terraform_provider_alicloud_alicloud github.com/terraform-providers/terraform-provider-alicloud/alicloud #gosetup
/usr/local/Cellar/go/1.11.1/libexec/bin/go tool test2json -t /private/var/folders/tt/t72n_q9s77l82s54_c_73rsc0000gn/T/___TestAccAlicloudDBInstance_upgradeClass_in_github_com_terraform_providers_terraform_provider_alicloud_alicloud -test.v -test.run ^TestAccAlicloudDBInstance_upgradeClass$ #gosetup
=== RUN   TestAccAlicloudDBInstance_upgradeClass
--- PASS: TestAccAlicloudDBInstance_upgradeClass (486.25s)
```

```
GOROOT=/usr/local/Cellar/go/1.11.1/libexec #gosetup
GOPATH=/Users/panjiabang/Projects/GOPATH #gosetup
/usr/local/Cellar/go/1.11.1/libexec/bin/go test -c -o /private/var/folders/tt/t72n_q9s77l82s54_c_73rsc0000gn/T/___TestAccAlicloudDBInstance_securityIps_in_github_com_terraform_providers_terraform_provider_alicloud_alicloud github.com/terraform-providers/terraform-provider-alicloud/alicloud #gosetup
/usr/local/Cellar/go/1.11.1/libexec/bin/go tool test2json -t /private/var/folders/tt/t72n_q9s77l82s54_c_73rsc0000gn/T/___TestAccAlicloudDBInstance_securityIps_in_github_com_terraform_providers_terraform_provider_alicloud_alicloud -test.v -test.run ^TestAccAlicloudDBInstance_securityIps$ #gosetup
=== RUN   TestAccAlicloudDBInstance_securityIps
--- PASS: TestAccAlicloudDBInstance_securityIps (426.85s)
PASS
```

```
GOROOT=/usr/local/Cellar/go/1.11.1/libexec #gosetup
GOPATH=/Users/panjiabang/Projects/GOPATH #gosetup
/usr/local/Cellar/go/1.11.1/libexec/bin/go test -c -o /private/var/folders/tt/t72n_q9s77l82s54_c_73rsc0000gn/T/___TestAccAlicloudDBInstance_CreateWithParameter_in_github_com_terraform_providers_terraform_provider_alicloud_alicloud github.com/terraform-providers/terraform-provider-alicloud/alicloud #gosetup
/usr/local/Cellar/go/1.11.1/libexec/bin/go tool test2json -t /private/var/folders/tt/t72n_q9s77l82s54_c_73rsc0000gn/T/___TestAccAlicloudDBInstance_CreateWithParameter_in_github_com_terraform_providers_terraform_provider_alicloud_alicloud -test.v -test.run ^TestAccAlicloudDBInstance_CreateWithParameter$ #gosetup
=== RUN   TestAccAlicloudDBInstance_CreateWithParameter
--- PASS: TestAccAlicloudDBInstance_CreateWithParameter (102.37s)
PASS
```