### PR TITLE
fix device name for disk attachment

### DIFF
--- a/alicloud/resource_alicloud_disk_attachment.go
+++ b/alicloud/resource_alicloud_disk_attachment.go
@@ -95,9 +95,14 @@ func resourceAliyunDiskAttachmentRead(d *schema.ResourceData, meta interface{}) 
 		return fmt.Errorf("Error DescribeDiskAttribute: %#v", err)
 	}
 
+	device_name := disk.Device
+	if device_name[5] == 'x' {
+		device_name = "/dev/" + string(device_name[6:])
+	}
+
 	d.Set("instance_id", disk.InstanceId)
 	d.Set("disk_id", disk.DiskId)
-	d.Set("device_name", disk.Device)
+	d.Set("device_name", device_name)
 
 	return nil
 }


### PR DESCRIPTION
Hi,
This PR resolves "alicloud_disk_attachment.device_name does not return correct device_name" issue.
Link to the issue:
https://github.com/terraform-providers/terraform-provider-alicloud/issues/781

