### PR TITLE
Fix dns record ttl setting error and update bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ IMPROVEMENTS:
 
 BUG FIXES:
 
+- Fix dns record ttl setting error and update bug [GH-800]
 - Fix vpc return custom route table bug [GH-799]
 - fix ssl vpn subnet can not pass comma separated string problem [GH-780]
 - fix(whitelist) Modified whitelist returned and filter the default values [GH-779]

--- a/alicloud/import_alicloud_dns_record_test.go
+++ b/alicloud/import_alicloud_dns_record_test.go
@@ -16,7 +16,7 @@ func TestAccAlicloudDnsDomainRecord_importBasic(t *testing.T) {
 		CheckDestroy: testAccCheckDnsRecordDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccDnsRecordConfig(acctest.RandInt()),
+				Config: testAccDnsRecordTtl(acctest.RandInt()),
 			},
 
 			{


### PR DESCRIPTION
```
 TF_ACC=1 go test ./alicloud -v -run=TestAccAlicloudDnsRecord -timeout=240m
=== RUN   TestAccAlicloudDnsRecordsDataSource_host_record_regex
--- PASS: TestAccAlicloudDnsRecordsDataSource_host_record_regex (4.94s)
=== RUN   TestAccAlicloudDnsRecordsDataSource_type
--- PASS: TestAccAlicloudDnsRecordsDataSource_type (5.24s)
=== RUN   TestAccAlicloudDnsRecordsDataSource_value_regex
--- PASS: TestAccAlicloudDnsRecordsDataSource_value_regex (5.22s)
=== RUN   TestAccAlicloudDnsRecordsDataSource_line
--- PASS: TestAccAlicloudDnsRecordsDataSource_line (5.07s)
=== RUN   TestAccAlicloudDnsRecordsDataSource_status
--- PASS: TestAccAlicloudDnsRecordsDataSource_status (5.51s)
=== RUN   TestAccAlicloudDnsRecordsDataSource_is_locked
--- PASS: TestAccAlicloudDnsRecordsDataSource_is_locked (4.88s)
=== RUN   TestAccAlicloudDnsRecordsDataSource_empty
--- PASS: TestAccAlicloudDnsRecordsDataSource_empty (2.55s)
=== RUN   TestAccAlicloudDnsRecord_ttl
--- PASS: TestAccAlicloudDnsRecord_ttl (6.62s)
=== RUN   TestAccAlicloudDnsRecord_priority
--- PASS: TestAccAlicloudDnsRecord_priority (6.82s)
=== RUN   TestAccAlicloudDnsRecord_multi
--- PASS: TestAccAlicloudDnsRecord_multi (26.65s)
=== RUN   TestAccAlicloudDnsRecord_routing
--- PASS: TestAccAlicloudDnsRecord_routing (6.79s)
PASS
ok  	github.com/terraform-providers/terraform-provider-alicloud/alicloud	80.331s
```