### PR TITLE
fix rds parameter update issue

### DIFF
--- a/alicloud/resource_alicloud_db_instance.go
+++ b/alicloud/resource_alicloud_db_instance.go
@@ -238,15 +238,17 @@ func resourceAlicloudDBInstance() *schema.Resource {
 						},
 					},
 				},
-				Set: func(v interface{}) int {
-					return hashcode.String(
-						v.(map[string]interface{})["name"].(string))
-				},
+				Set:      parameterToHash,
 				Optional: true,
 				Computed: true,
 			},
 		},
 	}
+}
+
+func parameterToHash(v interface{}) int {
+	m := v.(map[string]interface{})
+	return hashcode.String(m["name"].(string) + "|" + m["value"].(string))
 }
 
 func resourceAlicloudDBInstanceCreate(d *schema.ResourceData, meta interface{}) error {
@@ -416,7 +418,7 @@ func resourceAlicloudDBInstanceDelete(d *schema.ResourceData, meta interface{}) 
 	request := rds.CreateDeleteDBInstanceRequest()
 	request.DBInstanceId = d.Id()
 
-	return resource.Retry(5*time.Minute, func() *resource.RetryError {
+	return resource.Retry(10*5*time.Minute, func() *resource.RetryError {
 		_, err := client.WithRdsClient(func(rdsClient *rds.Client) (interface{}, error) {
 			return rdsClient.DeleteDBInstance(request)
 		})

--- a/alicloud/resource_alicloud_db_instance_test.go
+++ b/alicloud/resource_alicloud_db_instance_test.go
@@ -217,44 +217,56 @@ func TestAccAlicloudDBInstance_parameter(t *testing.T) {
 			},
 			// update parameter
 			resource.TestStep{
-				Config: testAccDBInstance_parameter(RdsCommonTestCase),
+				Config: testAccDBInstance_parameter(RdsCommonTestCase, "ON"),
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr(
-						"alicloud_db_instance.foo",
-						"engine_version",
-						"5.6"),
 					resource.TestCheckResourceAttr("alicloud_db_instance.foo",
 						fmt.Sprintf("parameters.%d.value",
-							hashcode.String("innodb_large_prefix")), "ON"),
+							parameterToHash(map[string]interface{}{
+								"name":  "innodb_large_prefix",
+								"value": "ON",
+							})), "ON"),
+				),
+			},
+			// update parameter
+			resource.TestStep{
+				Config: testAccDBInstance_parameter(RdsCommonTestCase, "OFF"),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("alicloud_db_instance.foo",
+						fmt.Sprintf("parameters.%d.value",
+							parameterToHash(map[string]interface{}{
+								"name":  "innodb_large_prefix",
+								"value": "OFF",
+							})), "OFF"),
 				),
 			},
 			// update multi parameter
 			resource.TestStep{
 				Config: testAccDBInstance_parameterMulti(RdsCommonTestCase),
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr(
-						"alicloud_db_instance.foo",
-						"engine_version",
-						"5.6"),
 					resource.TestCheckResourceAttr("alicloud_db_instance.foo",
 						fmt.Sprintf("parameters.%d.value",
-							hashcode.String("innodb_large_prefix")), "ON"),
+							parameterToHash(map[string]interface{}{
+								"name":  "innodb_large_prefix",
+								"value": "ON",
+							})), "ON"),
 					resource.TestCheckResourceAttr("alicloud_db_instance.foo",
 						fmt.Sprintf("parameters.%d.value",
-							hashcode.String("connect_timeout")), "50"),
+							parameterToHash(map[string]interface{}{
+								"name":  "connect_timeout",
+								"value": "50",
+							})), "50"),
 				),
 			},
 			// remove parameter definition, parameter value not change
 			resource.TestStep{
-				Config: testAccDBInstance_parameter(RdsCommonTestCase),
+				Config: testAccDBInstance_parameter(RdsCommonTestCase, "OFF"),
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr(
-						"alicloud_db_instance.foo",
-						"engine_version",
-						"5.6"),
 					resource.TestCheckResourceAttr("alicloud_db_instance.foo",
 						fmt.Sprintf("parameters.%d.value",
-							hashcode.String("innodb_large_prefix")), "ON"),
+							parameterToHash(map[string]interface{}{
+								"name":  "innodb_large_prefix",
+								"value": "OFF",
+							})), "OFF"),
 					testAccCheckDBParameterExpects(
 						"alicloud_db_instance.foo", "connect_timeout", "50"),
 				),
@@ -279,7 +291,7 @@ func TestAccAlicloudDBInstance_CreateWithParameter(t *testing.T) {
 		CheckDestroy: testAccCheckDBInstanceDestroy,
 		Steps: []resource.TestStep{
 			resource.TestStep{
-				Config: testAccDBInstance_parameter(RdsCommonTestCase),
+				Config: testAccDBInstance_parameter(RdsCommonTestCase, "ON"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckDBInstanceExists(
 						"alicloud_db_instance.foo", &instance),
@@ -622,7 +634,7 @@ func testAccDBInstance_vpc(common string) string {
 	`, common)
 }
 
-func testAccDBInstance_parameter(common string) string {
+func testAccDBInstance_parameter(common, value string) string {
 	return fmt.Sprintf(`
 	%s
 	variable "creation" {
@@ -646,10 +658,10 @@ func testAccDBInstance_parameter(common string) string {
 		security_ips = ["10.168.1.12", "100.69.7.112"]
 		parameters = [{
 			name = "innodb_large_prefix"
-			value = "ON"
+			value = "%s"
 		}]
 	}
-	`, common)
+	`, common, value)
 }
 
 func testAccDBInstance_parameterMulti(common string) string {

--- a/alicloud/resource_alicloud_db_readonly_instance.go
+++ b/alicloud/resource_alicloud_db_readonly_instance.go
@@ -5,8 +5,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/hashicorp/terraform/helper/hashcode"
-
 	"github.com/aliyun/alibaba-cloud-sdk-go/sdk/requests"
 	"github.com/aliyun/alibaba-cloud-sdk-go/services/rds"
 	"github.com/hashicorp/terraform/helper/resource"
@@ -79,10 +77,7 @@ func resourceAlicloudDBReadonlyInstance() *schema.Resource {
 						},
 					},
 				},
-				Set: func(v interface{}) int {
-					return hashcode.String(
-						v.(map[string]interface{})["name"].(string))
-				},
+				Set:      parameterToHash,
 				Optional: true,
 				Computed: true,
 			},

--- a/alicloud/service_alicloud_rds.go
+++ b/alicloud/service_alicloud_rds.go
@@ -167,9 +167,13 @@ func (s *RdsService) RefreshParameters(d *schema.ResourceData, attribute string)
 		}
 	}
 
-	for _, value := range parameters {
-		if documented.(*schema.Set).Contains(value) {
-			param = append(param, value.(map[string]interface{}))
+	for _, parameter := range documented.(*schema.Set).List() {
+		name := parameter.(map[string]interface{})["name"]
+		for _, value := range parameters {
+			if value.(map[string]interface{})["name"] == name {
+				param = append(param, value.(map[string]interface{}))
+				break
+			}
 		}
 	}
 	d.Set(attribute, param)
@@ -179,12 +183,12 @@ func (s *RdsService) RefreshParameters(d *schema.ResourceData, attribute string)
 func (s *RdsService) ModifyParameters(d *schema.ResourceData, attribute string) error {
 	request := rds.CreateModifyParameterRequest()
 	request.DBInstanceId = d.Id()
-	config := make(map[string]interface{})
+	config := make(map[string]string)
 	documented := d.Get(attribute).(*schema.Set).List()
 	if len(documented) > 0 {
 		for _, i := range documented {
 			key := i.(map[string]interface{})["name"].(string)
-			value := i.(map[string]interface{})["value"]
+			value := i.(map[string]interface{})["value"].(string)
 			config[key] = value
 		}
 		cfg, _ := json.Marshal(config)
@@ -199,8 +203,12 @@ func (s *RdsService) ModifyParameters(d *schema.ResourceData, attribute string) 
 		if err != nil {
 			return fmt.Errorf("update parameter got an error: %#v", err)
 		}
-		d.SetPartial(attribute)
+		// wait instance parameter expect after modifying
+		if err := s.WaitForDBParameter(d.Id(), DefaultTimeoutMedium, config); err != nil {
+			return fmt.Errorf("WaitForDBParameter %s got error: %#v", d.Id(), err)
+		}
 	}
+	d.SetPartial(attribute)
 	return nil
 }
 
@@ -519,6 +527,54 @@ func (s *RdsService) WaitForDBInstance(instanceId string, status Status, timeout
 			return err
 		}
 		if instance != nil && strings.ToLower(instance.DBInstanceStatus) == strings.ToLower(string(status)) {
+			break
+		}
+
+		if timeout <= 0 {
+			return GetTimeErrorFromString(GetTimeoutMessage("RDS Instance", instanceId))
+		}
+
+		timeout = timeout - DefaultIntervalMedium
+		time.Sleep(DefaultIntervalMedium * time.Second)
+	}
+	return nil
+}
+
+// WaitForDBParameter waits for instance parameter to given value.
+// Status of DB instance is Running after ModifyParameters API was
+// call, so we can not just wait for instance status become
+// Running, we should wait until parameters have expected values.
+func (s *RdsService) WaitForDBParameter(instanceId string, timeout int, expects map[string]string) error {
+	if timeout <= 0 {
+		timeout = DefaultTimeout
+	}
+	for {
+		response, err := s.DescribeParameters(instanceId)
+		if err != nil {
+			return err
+		}
+
+		var actuals = make(map[string]string)
+		for _, i := range response.RunningParameters.DBInstanceParameter {
+			actuals[i.ParameterName] = i.ParameterValue
+		}
+		for _, i := range response.ConfigParameters.DBInstanceParameter {
+			actuals[i.ParameterName] = i.ParameterValue
+		}
+
+		match := true
+		for name, expect := range expects {
+			if actual, ok := actuals[name]; ok {
+				if expect != actual {
+					match = false
+					break
+				}
+			} else {
+				match = false
+			}
+		}
+
+		if match {
 			break
 		}
 

--- a/website/docs/r/db_instance.html.markdown
+++ b/website/docs/r/db_instance.html.markdown
@@ -14,12 +14,65 @@ databases.
 
 ## Example Usage
 
+### Create a RDS MySQL instance
+
 ```
+resource "alicloud_vpc" "default" {
+	name       = "vpc-123456"
+	cidr_block = "172.16.0.0/16"
+}
+
+resource "alicloud_vswitch" "default" {
+	vpc_id            = "${alicloud_vpc.default.id}"
+	cidr_block        = "172.16.0.0/24"
+	availability_zone = "${data.alicloud_zones.default.zones.0.id}"
+	name              = "vpc-123456"
+}
+
 resource "alicloud_db_instance" "default" {
 	engine = "MySQL"
 	engine_version = "5.6"
 	db_instance_class = "rds.mysql.t1.small"
 	db_instance_storage = "10"
+	vswitch_id = "${alicloud_vswitch.default.id}"
+}
+```
+
+### Create a RDS MySQL instance with specific parameters
+
+```
+resource "alicloud_vpc" "default" {
+	name       = "vpc-123456"
+	cidr_block = "172.16.0.0/16"
+}
+
+resource "alicloud_vswitch" "default" {
+	vpc_id            = "${alicloud_vpc.default.id}"
+	cidr_block        = "172.16.0.0/24"
+	availability_zone = "${data.alicloud_zones.default.zones.0.id}"
+	name              = "vpc-123456"
+}
+
+resource "alicloud_db_instance" "default" {
+	engine = "MySQL"
+	engine_version = "5.6"
+	db_instance_class = "rds.mysql.t1.small"
+	db_instance_storage = "10"
+	vswitch_id = "${alicloud_vswitch.default.id}"
+}
+
+resource "alicloud_db_instance" "default" {
+	engine = "MySQL"
+	engine_version = "5.6"
+	db_instance_class = "rds.mysql.t1.small"
+	db_instance_storage = "10"
+	parameters = [{
+		name = "innodb_large_prefix"
+		value = "ON"
+	},{
+		name = "connect_timeout"
+		value = "50"
+	}]
 }
 ```
 

--- a/website/docs/r/db_readonly_instance.html.markdown
+++ b/website/docs/r/db_readonly_instance.html.markdown
@@ -14,15 +14,15 @@ Provides an RDS readonly instance resource.
 
 ```
 resource "alicloud_vpc" "default" {
-  name       = "vpc-123456"
-  cidr_block = "172.16.0.0/16"
+	name       = "vpc-123456"
+	cidr_block = "172.16.0.0/16"
 }
 
 resource "alicloud_vswitch" "default" {
-  vpc_id            = "${alicloud_vpc.default.id}"
-  cidr_block        = "172.16.0.0/24"
-  availability_zone = "${data.alicloud_zones.default.zones.0.id}"
-  name              = "vpc-123456"
+	vpc_id            = "${alicloud_vpc.default.id}"
+	cidr_block        = "172.16.0.0/24"
+	availability_zone = "${data.alicloud_zones.default.zones.0.id}"
+	name              = "vpc-123456"
 }
 
 resource "alicloud_db_instance" "default" {
@@ -40,6 +40,13 @@ resource "alicloud_db_readonly_instance" "foo" {
 	instance_storage = "30"
 	instance_name = "rm-123456_ro"
 	vswitch_id = "${alicloud_vswitch.default.id}"
+	parameters = [{
+		name = "innodb_large_prefix"
+		value = "ON"
+	},{
+		name = "connect_timeout"
+		value = "50"
+	}]
 }
 ```
 


### PR DESCRIPTION
We found that terraform can not find any diff when we just modify the value of parameter, because the diff strategy of schema.SetType only compare the hash of each element.

This PR fix it by add value to hash.

```
GOROOT=/usr/local/Cellar/go/1.11.1/libexec #gosetup
GOPATH=/Users/panjiabang/Projects/GOPATH #gosetup
/usr/local/Cellar/go/1.11.1/libexec/bin/go test -c -o /private/var/folders/tt/t72n_q9s77l82s54_c_73rsc0000gn/T/___TestAccAlicloudDBInstance_parameter_in_github_com_terraform_providers_terraform_provider_alicloud_alicloud github.com/terraform-providers/terraform-provider-alicloud/alicloud #gosetup
/usr/local/Cellar/go/1.11.1/libexec/bin/go tool test2json -t /private/var/folders/tt/t72n_q9s77l82s54_c_73rsc0000gn/T/___TestAccAlicloudDBInstance_parameter_in_github_com_terraform_providers_terraform_provider_alicloud_alicloud -test.v -test.run ^TestAccAlicloudDBInstance_parameter$ #gosetup
=== RUN   TestAccAlicloudDBInstance_parameter
--- PASS: TestAccAlicloudDBInstance_parameter (314.28s)
PASS
```