### PR TITLE
fix import managed kubernetes test

### DIFF
--- a/alicloud/import_alicloud_cs_managed_kubernetes_test.go
+++ b/alicloud/import_alicloud_cs_managed_kubernetes_test.go
@@ -25,7 +25,7 @@ func TestAccAlicloudCSManagedKubernetes_import(t *testing.T) {
 				ImportState:       true,
 				ImportStateVerify: true,
 				ImportStateVerifyIgnore: []string{"name_prefix", "new_nat_gateway", "pod_cidr",
-					"service_cidr", "password", "install_cloud_monitor"},
+					"service_cidr", "password", "install_cloud_monitor", "slb_internet_enabled"},
 			},
 		},
 	})


### PR DESCRIPTION
Solve issue
```
=== RUN   TestAccAlicloudCSManagedKubernetes_import
--- FAIL: TestAccAlicloudCSManagedKubernetes_import (577.24s)
testing.go:434: Step 1 error: ImportStateVerify attributes not equivalent. Difference is shown below. Top is actual, bottom is expected.

(map[string]string) {
}


(map[string]string) (len=1) {
(string) (len=20) "slb_internet_enabled": (string) (len=5) "false"
}
```