### PR TITLE
fix volume_tags diff bug when running testcases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,13 @@
 ## 1.33.0 (Unreleased)
+
+FEATURES:
+
+- **New Resource:** `alicloud_nas_file_system` [GH-807]
+
+BUG FIXES:
+
+- fix volume_tags diff bug when running testcases [GH-816]
+
 ## 1.32.1 (March 03, 2019)
 
 BUG FIXES:

--- a/alicloud/resource_alicloud_instance.go
+++ b/alicloud/resource_alicloud_instance.go
@@ -521,9 +521,7 @@ func resourceAliyunInstanceRead(d *schema.ResourceData, meta interface{}) error 
 		})
 	}
 
-	if len(volumeTags) > 0 {
-		d.Set("volume_tags", tagsToMap(volumeTags))
-	}
+	d.Set("volume_tags", tagsToMap(volumeTags))
 
 	return nil
 }


### PR DESCRIPTION
```
TF_ACC=1 go test -v ./alicloud -run=TestAccAlicloudDiskAttachment --timeout=600m
=== RUN   TestAccAlicloudDiskAttachment
--- PASS: TestAccAlicloudDiskAttachment (166.18s)
PASS
ok      github.com/terraform-providers/terraform-provider-alicloud/alicloud     166.244s
```
```
TF_ACC=1 go test -v ./alicloud -run=TestAccAlicloudInstance_vpc --timeout=600m
=== RUN   TestAccAlicloudInstance_vpc
--- PASS: TestAccAlicloudInstance_vpc (151.48s)
PASS
ok      github.com/terraform-providers/terraform-provider-alicloud/alicloud     151.526s

```