### PR TITLE
add kubernetes cluster data source

### DIFF
--- a/alicloud/data_source_alicloud_cs_kubernetes_clusters.go
+++ b/alicloud/data_source_alicloud_cs_kubernetes_clusters.go
@@ -1,0 +1,612 @@
+package alicloud
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/aliyun/alibaba-cloud-sdk-go/services/vpc"
+	"github.com/denverdino/aliyungo/common"
+	"github.com/denverdino/aliyungo/cs"
+	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/helper/schema"
+	"github.com/terraform-providers/terraform-provider-alicloud/alicloud/connectivity"
+)
+
+func dataSourceAlicloudCSKubernetesClusters() *schema.Resource {
+	return &schema.Resource{
+		Read: dataSourceAlicloudCSKubernetesClustersRead,
+
+		Schema: map[string]*schema.Schema{
+			"id": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"name": {
+				Type:          schema.TypeString,
+				Optional:      true,
+				ConflictsWith: []string{"name_prefix"},
+			},
+			"name_prefix": {
+				Type:          schema.TypeString,
+				Optional:      true,
+				ConflictsWith: []string{"name"},
+			},
+			"region_id": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"output_file": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			// Computed values
+			"clusters": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"name": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"availability_zone": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"slb_internet_enabled": {
+							Type:     schema.TypeBool,
+							Computed: true,
+						},
+						"security_group_id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"nat_gateway_id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"vpc_id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"vswitch_ids": {
+							Type:     schema.TypeList,
+							Computed: true,
+							Elem: &schema.Schema{
+								Type: schema.TypeString,
+							},
+						},
+						"master_instance_types": {
+							Type:     schema.TypeList,
+							Computed: true,
+							Elem: &schema.Schema{
+								Type: schema.TypeString,
+							},
+						},
+						"worker_instance_types": {
+							Type:     schema.TypeList,
+							Computed: true,
+							Elem: &schema.Schema{
+								Type: schema.TypeString,
+							},
+						},
+						"worker_numbers": {
+							Type:     schema.TypeList,
+							Computed: true,
+							Elem: &schema.Schema{
+								Type: schema.TypeInt,
+							},
+						},
+						"key_name": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"pod_cidr": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"service_cidr": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"cluster_network_type": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"node_cidr_mask": {
+							Type:     schema.TypeInt,
+							Computed: true,
+						},
+						"log_config": {
+							Type:     schema.TypeList,
+							Computed: true,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"type": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+									"project": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+								},
+							},
+						},
+						"image_id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"master_disk_size": {
+							Type:     schema.TypeInt,
+							Computed: true,
+						},
+						"master_disk_category": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"worker_disk_size": {
+							Type:     schema.TypeInt,
+							Computed: true,
+						},
+						"worker_disk_category": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"worker_data_disk_size": {
+							Type:     schema.TypeInt,
+							Computed: true,
+						},
+						"worker_data_disk_category": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"master_instance_charge_type": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"master_period_unit": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"master_period": {
+							Type:     schema.TypeInt,
+							Computed: true,
+						},
+						"master_auto_renew": {
+							Type:     schema.TypeBool,
+							Computed: true,
+						},
+						"master_auto_renew_period": {
+							Type:     schema.TypeInt,
+							Computed: true,
+						},
+						"worker_instance_charge_type": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"worker_period_unit": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"worker_period": {
+							Type:     schema.TypeInt,
+							Computed: true,
+						},
+						"worker_auto_renew": {
+							Type:     schema.TypeBool,
+							Computed: true,
+						},
+						"worker_auto_renew_period": {
+							Type:     schema.TypeInt,
+							Computed: true,
+						},
+						"master_nodes": {
+							Type:     schema.TypeList,
+							Computed: true,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"id": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+									"name": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+									"private_ip": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+								},
+							},
+						},
+						"worker_nodes": {
+							Type:     schema.TypeList,
+							Computed: true,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"id": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+									"name": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+									"private_ip": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+								},
+							},
+						},
+						"connections": {
+							Type:     schema.TypeMap,
+							Computed: true,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"api_server_internet": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+									"api_server_intranet": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+									"master_public_ip": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+									"service_domain": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+}
+func dataSourceAlicloudCSKubernetesClustersRead(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*connectivity.AliyunClient)
+
+	nameFilter := ""
+	if v, ok := d.GetOk("name"); ok {
+		nameFilter = v.(string)
+	}
+
+	var allClusterTypes []cs.ClusterType
+
+	invoker := NewInvoker()
+	if err := invoker.Run(func() error {
+		raw, e := client.WithCsClient(func(csClient *cs.Client) (interface{}, error) {
+			return csClient.DescribeClusters(nameFilter)
+		})
+		if e != nil {
+			return fmt.Errorf("Describing cluster failed, error message: %#v.", e)
+		}
+		allClusterTypes, _ = raw.([]cs.ClusterType)
+		return nil
+	}); err != nil {
+		return err
+	}
+
+	var filteredClusterTypes []cs.ClusterType
+	for _, v := range allClusterTypes {
+		if v.ClusterType != cs.ClusterTypeKubernetes {
+			continue
+		}
+		if namePrefix, ok := d.GetOk("name_prefix"); ok {
+			if !strings.HasPrefix(v.Name, namePrefix.(string)) {
+				continue
+			}
+		}
+		if id, ok := d.GetOk("id"); ok {
+			if id != v.ClusterID {
+				continue
+			}
+		}
+		if regionId, ok := d.GetOk("region_id"); ok {
+			if regionId != string(v.RegionID) {
+				continue
+			}
+		}
+		filteredClusterTypes = append(filteredClusterTypes, v)
+	}
+
+	var filteredKubernetesCluster []cs.KubernetesCluster
+
+	for _, v := range filteredClusterTypes {
+		var kubernetesCluster cs.KubernetesCluster
+
+		invoker := NewInvoker()
+		if err := invoker.Run(func() error {
+			raw, e := client.WithCsClient(func(csClient *cs.Client) (interface{}, error) {
+				return csClient.DescribeKubernetesCluster(v.ClusterID)
+			})
+			if e != nil {
+				return fmt.Errorf("Describing kubernetes cluster %#v failed, error message: %#v. Please check cluster in the console,", v.ClusterID, e)
+			}
+			kubernetesCluster = raw.(cs.KubernetesCluster)
+			return nil
+		}); err != nil {
+			return err
+		}
+
+		if az, ok := d.GetOk("availability_zone"); ok && az != kubernetesCluster.ZoneId {
+			continue
+		}
+
+		filteredKubernetesCluster = append(filteredKubernetesCluster, kubernetesCluster)
+	}
+
+	return csKubernetesClusterDescriptionAttributes(d, filteredKubernetesCluster, meta)
+}
+
+func csKubernetesClusterDescriptionAttributes(d *schema.ResourceData, clusterTypes []cs.KubernetesCluster, meta interface{}) error {
+	var ids []string
+	var s []map[string]interface{}
+	for _, ct := range clusterTypes {
+		mapping := map[string]interface{}{
+			"id":                   ct.ClusterID,
+			"name":                 ct.Name,
+			"vpc_id":               ct.VPCID,
+			"security_group_id":    ct.SecurityGroupID,
+			"key_name":             ct.Parameters.KeyPair,
+			"availability_zone":    ct.ZoneId,
+			"master_disk_category": ct.Parameters.MasterSystemDiskCategory,
+			"worker_disk_category": ct.Parameters.WorkerSystemDiskCategory,
+			"slb_internet_enabled": ct.Parameters.PublicSLB,
+		}
+
+		if ct.Parameters.ImageId != "" {
+			mapping["image_id"] = ct.Parameters.ImageId
+		} else {
+			mapping["image_id"] = ct.Parameters.MasterImageId
+		}
+
+		if size, err := strconv.Atoi(ct.Parameters.MasterSystemDiskSize); err != nil {
+			return BuildWrapError("strconv.Atoi", d.Id(), ProviderERROR, err, "")
+		} else {
+			mapping["master_disk_size"] = size
+		}
+
+		if size, err := strconv.Atoi(ct.Parameters.WorkerSystemDiskSize); err != nil {
+			return BuildWrapError("strconv.Atoi", d.Id(), ProviderERROR, err, "")
+		} else {
+			mapping["worker_disk_size"] = size
+		}
+
+		if ct.Parameters.MasterInstanceChargeType == string(PrePaid) {
+			mapping["master_instance_charge_type"] = string(PrePaid)
+			if period, err := strconv.Atoi(ct.Parameters.MasterPeriod); err != nil {
+				return BuildWrapError("strconv.Atoi", d.Id(), ProviderERROR, err, "")
+			} else {
+				mapping["master_period"] = period
+			}
+			mapping["master_period_unit"] = ct.Parameters.MasterPeriodUnit
+			mapping["master_auto_renew"] = ct.Parameters.MasterAutoRenew
+			if period, err := strconv.Atoi(ct.Parameters.MasterAutoRenewPeriod); err != nil {
+				return BuildWrapError("strconv.Atoi", d.Id(), ProviderERROR, err, "")
+			} else {
+				mapping["master_auto_renew_period"] = period
+			}
+		} else {
+			mapping["master_instance_charge_type"] = string(PostPaid)
+		}
+
+		if ct.Parameters.WorkerInstanceChargeType == string(PrePaid) {
+			mapping["worker_instance_charge_type"] = string(PrePaid)
+			if period, err := strconv.Atoi(ct.Parameters.WorkerPeriod); err != nil {
+				return BuildWrapError("strconv.Atoi", d.Id(), ProviderERROR, err, "")
+			} else {
+				mapping["worker_period"] = period
+			}
+			mapping["worker_period_unit"] = ct.Parameters.WorkerPeriodUnit
+			mapping["worker_auto_renew"] = ct.Parameters.WorkerAutoRenew
+			if period, err := strconv.Atoi(ct.Parameters.WorkerAutoRenewPeriod); err != nil {
+				return BuildWrapError("strconv.Atoi", d.Id(), ProviderERROR, err, "")
+			} else {
+				mapping["worker_auto_renew_period"] = period
+			}
+		} else {
+			mapping["worker_instance_charge_type"] = string(PostPaid)
+		}
+
+		if cidrMask, err := strconv.Atoi(ct.Parameters.NodeCIDRMask); err == nil {
+			mapping["node_cidr_mask"] = cidrMask
+		} else {
+			return BuildWrapError("strconv.Atoi", d.Id(), ProviderERROR, err, "")
+		}
+
+		if ct.Parameters.WorkerDataDisk {
+			if size, err := strconv.Atoi(ct.Parameters.WorkerDataDiskSize); err != nil {
+				return BuildWrapError("strconv.Atoi", d.Id(), ProviderERROR, err, "")
+			} else {
+				mapping["worker_data_disk_size"] = size
+			}
+			mapping["worker_data_disk_category"] = ct.Parameters.WorkerDataDiskCategory
+		}
+
+		if ct.Parameters.LoggingType != "None" {
+			logConfig := map[string]interface{}{}
+			logConfig["type"] = ct.Parameters.LoggingType
+			if ct.Parameters.SLSProjectName == "None" {
+				logConfig["project"] = ""
+			} else {
+				logConfig["project"] = ct.Parameters.SLSProjectName
+			}
+			mapping["log_config"] = []map[string]interface{}{logConfig}
+		}
+
+		// Each k8s cluster contains 3 master nodes
+		if ct.MetaData.MultiAZ || ct.MetaData.SubClass == "3az" {
+			numOfNodeA, err := strconv.Atoi(ct.Parameters.NumOfNodesA)
+			if err != nil {
+				return fmt.Errorf("error convert NumOfNodesA %s to int: %s", ct.Parameters.NumOfNodesA, err.Error())
+			}
+			numOfNodeB, err := strconv.Atoi(ct.Parameters.NumOfNodesB)
+			if err != nil {
+				return fmt.Errorf("error convert NumOfNodesB %s to int: %s", ct.Parameters.NumOfNodesB, err.Error())
+			}
+			numOfNodeC, err := strconv.Atoi(ct.Parameters.NumOfNodesC)
+			if err != nil {
+				return fmt.Errorf("error convert NumOfNodesC %s to int: %s", ct.Parameters.NumOfNodesC, err.Error())
+			}
+			mapping["worker_numbers"] = []int{numOfNodeA, numOfNodeB, numOfNodeC}
+			mapping["vswitch_ids"] = []string{ct.Parameters.VSwitchIdA, ct.Parameters.VSwitchIdB, ct.Parameters.VSwitchIdC}
+			mapping["master_instance_types"] = []string{ct.Parameters.MasterInstanceTypeA, ct.Parameters.MasterInstanceTypeB, ct.Parameters.MasterInstanceTypeC}
+			mapping["worker_instance_types"] = []string{ct.Parameters.WorkerInstanceTypeA, ct.Parameters.WorkerInstanceTypeB, ct.Parameters.WorkerInstanceTypeC}
+		} else {
+			if numOfNode, err := strconv.Atoi(ct.Parameters.NumOfNodes); err != nil {
+				return BuildWrapError("strconv.Atoi", d.Id(), ProviderERROR, err, "")
+			} else {
+				mapping["worker_numbers"] = []int{numOfNode}
+			}
+			mapping["vswitch_ids"] = []string{ct.Parameters.VSwitchID}
+			mapping["master_instance_types"] = []string{ct.Parameters.MasterInstanceType}
+			mapping["worker_instance_types"] = []string{ct.Parameters.WorkerInstanceType}
+		}
+
+		var masterNodes []map[string]interface{}
+		var workerNodes []map[string]interface{}
+
+		invoker := NewInvoker()
+		client := meta.(*connectivity.AliyunClient)
+		pageNumber := 1
+		for {
+			var result []cs.KubernetesNodeType
+			var pagination *cs.PaginationResult
+
+			if err := invoker.Run(func() error {
+				raw, e := client.WithCsClient(func(csClient *cs.Client) (interface{}, error) {
+					nodes, paginationResult, err := csClient.GetKubernetesClusterNodes(ct.ClusterID, common.Pagination{PageNumber: pageNumber, PageSize: PageSizeLarge})
+					return []interface{}{nodes, paginationResult}, err
+				})
+				if e != nil {
+					return e
+				}
+				result, _ = raw.([]interface{})[0].([]cs.KubernetesNodeType)
+				pagination, _ = raw.([]interface{})[1].(*cs.PaginationResult)
+				return nil
+			}); err != nil {
+				return fmt.Errorf("[ERROR] GetKubernetesClusterNodes got an error: %#v.", err)
+			}
+
+			if pageNumber == 1 && (len(result) == 0 || result[0].InstanceId == "") {
+				err := resource.Retry(5*time.Minute, func() *resource.RetryError {
+					if err := invoker.Run(func() error {
+						raw, e := client.WithCsClient(func(csClient *cs.Client) (interface{}, error) {
+							nodes, _, err := csClient.GetKubernetesClusterNodes(ct.ClusterID, common.Pagination{PageNumber: pageNumber, PageSize: PageSizeLarge})
+							return nodes, err
+						})
+						if e != nil {
+							return e
+						}
+						tmp, _ := raw.([]cs.KubernetesNodeType)
+						if len(tmp) > 0 && tmp[0].InstanceId != "" {
+							result = tmp
+						}
+						return nil
+					}); err != nil {
+						return resource.NonRetryableError(fmt.Errorf("[ERROR] GetKubernetesClusterNodes got an error: %#v.", err))
+					}
+					for _, stableState := range cs.NodeStableClusterState {
+						// If cluster is in NodeStableClusteState, node list will not change
+						if ct.State == stableState {
+							return nil
+						}
+					}
+					time.Sleep(5 * time.Second)
+					return resource.RetryableError(fmt.Errorf("[ERROR] There is no any nodes in kubernetes cluster %s.", d.Id()))
+				})
+				if err != nil {
+					return err
+				}
+
+			}
+
+			for _, node := range result {
+				subMapping := map[string]interface{}{
+					"id":         node.InstanceId,
+					"name":       node.InstanceName,
+					"private_ip": node.IpAddress[0],
+				}
+				if node.InstanceRole == "Master" {
+					masterNodes = append(masterNodes, subMapping)
+				} else {
+					workerNodes = append(workerNodes, subMapping)
+				}
+			}
+
+			if len(result) < pagination.PageSize {
+				break
+			}
+			pageNumber += 1
+		}
+		mapping["master_nodes"] = masterNodes
+		mapping["worker_nodes"] = workerNodes
+
+		if err := invoker.Run(func() error {
+			rawEndpoints, e := client.WithCsClient(func(csClient *cs.Client) (interface{}, error) {
+				endpoints, err := csClient.GetClusterEndpoints(ct.ClusterID)
+				return endpoints, err
+			})
+			if e != nil {
+				return e
+			}
+			connection := make(map[string]string)
+			if endpoints, ok := rawEndpoints.(cs.ClusterEndpoints); ok && endpoints.ApiServerEndpoint != "" {
+				connection["api_server_internet"] = endpoints.ApiServerEndpoint
+				connection["master_public_ip"] = strings.TrimSuffix(strings.TrimPrefix(endpoints.ApiServerEndpoint, "https://"), ":6443")
+			}
+			if endpoints, ok := rawEndpoints.(cs.ClusterEndpoints); ok && endpoints.IntranetApiServerEndpoint != "" {
+				connection["api_server_intranet"] = endpoints.IntranetApiServerEndpoint
+			}
+			connection["service_domain"] = fmt.Sprintf("*.%s.%s.alicontainer.com", ct.ClusterID, ct.RegionID)
+
+			mapping["connections"] = connection
+			return nil
+		}); err != nil {
+			return fmt.Errorf("[ERROR] GetKubernetesClusterNodes got an error: %#v.", err)
+		}
+
+		req := vpc.CreateDescribeNatGatewaysRequest()
+		req.VpcId = ct.VPCID
+		raw, err := client.WithVpcClient(func(vpcClient *vpc.Client) (interface{}, error) {
+			return vpcClient.DescribeNatGateways(req)
+		})
+		if err != nil {
+			return fmt.Errorf("[ERROR] DescribeNatGateways by VPC Id %s: %#v.", ct.VPCID, err)
+		}
+		nat, _ := raw.(*vpc.DescribeNatGatewaysResponse)
+		if nat != nil && len(nat.NatGateways.NatGateway) > 0 {
+			mapping["nat_gateway_id"] = nat.NatGateways.NatGateway[0].NatGatewayId
+		}
+
+		ids = append(ids, ct.ClusterID)
+		s = append(s, mapping)
+	}
+
+	d.SetId(dataResourceIdHash(ids))
+	if err := d.Set("clusters", s); err != nil {
+		return WrapError(err)
+	}
+
+	// create a json file in current directory and write data source to it.
+	if output, ok := d.GetOk("output_file"); ok && output.(string) != "" {
+		writeToFile(output.(string), s)
+	}
+
+	return nil
+}

--- a/alicloud/data_source_alicloud_cs_kubernetes_clusters.go
+++ b/alicloud/data_source_alicloud_cs_kubernetes_clusters.go
@@ -27,16 +27,10 @@ func dataSourceAlicloudCSKubernetesClusters() *schema.Resource {
 					Type: schema.TypeString,
 				},
 			},
-			"name": {
-				Type:          schema.TypeString,
-				Optional:      true,
-				ConflictsWith: []string{"name_regex"},
-			},
 			"name_regex": {
-				Type:          schema.TypeString,
-				Optional:      true,
-				ValidateFunc:  validateNameRegex,
-				ConflictsWith: []string{"name"},
+				Type:         schema.TypeString,
+				Optional:     true,
+				ValidateFunc: validateNameRegex,
 			},
 			"enable_details": {
 				Type:     schema.TypeBool,
@@ -48,14 +42,7 @@ func dataSourceAlicloudCSKubernetesClusters() *schema.Resource {
 				Optional: true,
 			},
 			// Computed values
-			"cluster_ids": {
-				Type:     schema.TypeList,
-				Computed: true,
-				Elem: &schema.Schema{
-					Type: schema.TypeString,
-				},
-			},
-			"cluster_names": {
+			"names": {
 				Type:     schema.TypeList,
 				Computed: true,
 				Elem: &schema.Schema{
@@ -300,17 +287,12 @@ func dataSourceAlicloudCSKubernetesClusters() *schema.Resource {
 func dataSourceAlicloudCSKubernetesClustersRead(d *schema.ResourceData, meta interface{}) error {
 	client := meta.(*connectivity.AliyunClient)
 
-	nameFilter := ""
-	if v, ok := d.GetOk("name"); ok {
-		nameFilter = v.(string)
-	}
-
 	var allClusterTypes []cs.ClusterType
 
 	invoker := NewInvoker()
 	if err := invoker.Run(func() error {
 		raw, e := client.WithCsClient(func(csClient *cs.Client) (interface{}, error) {
-			return csClient.DescribeClusters(nameFilter)
+			return csClient.DescribeClusters("")
 		})
 		if e != nil {
 			return fmt.Errorf("Describing cluster failed, error message: %#v.", e)
@@ -377,11 +359,7 @@ func dataSourceAlicloudCSKubernetesClustersRead(d *schema.ResourceData, meta int
 		filteredKubernetesCluster = append(filteredKubernetesCluster, kubernetesCluster)
 	}
 
-	if detailedEnabled, ok := d.GetOk("enable_details"); ok && detailedEnabled.(bool) {
-		return csKubernetesClusterDescriptionAttributes(d, filteredKubernetesCluster, meta)
-	}
-
-	return csKubernetesClusterDescriptionSimpleAttributes(d, filteredKubernetesCluster, meta)
+	return csKubernetesClusterDescriptionAttributes(d, filteredKubernetesCluster, meta)
 }
 
 func csKubernetesClusterDescriptionAttributes(d *schema.ResourceData, clusterTypes []cs.KubernetesCluster, meta interface{}) error {
@@ -389,240 +367,243 @@ func csKubernetesClusterDescriptionAttributes(d *schema.ResourceData, clusterTyp
 	var s []map[string]interface{}
 	for _, ct := range clusterTypes {
 		mapping := map[string]interface{}{
-			"id":                   ct.ClusterID,
-			"name":                 ct.Name,
-			"vpc_id":               ct.VPCID,
-			"security_group_id":    ct.SecurityGroupID,
-			"key_name":             ct.Parameters.KeyPair,
-			"availability_zone":    ct.ZoneId,
-			"master_disk_category": ct.Parameters.MasterSystemDiskCategory,
-			"worker_disk_category": ct.Parameters.WorkerSystemDiskCategory,
-			"slb_internet_enabled": ct.Parameters.PublicSLB,
+			"id":   ct.ClusterID,
+			"name": ct.Name,
 		}
 
-		if ct.Parameters.ImageId != "" {
-			mapping["image_id"] = ct.Parameters.ImageId
-		} else {
-			mapping["image_id"] = ct.Parameters.MasterImageId
-		}
+		if detailedEnabled, ok := d.GetOk("enable_details"); ok && detailedEnabled.(bool) {
+			mapping["vpc_id"] = ct.VPCID
+			mapping["security_group_id"] = ct.SecurityGroupID
+			mapping["availability_zone"] = ct.ZoneId
+			mapping["key_name"] = ct.Parameters.KeyPair
+			mapping["master_disk_category"] = ct.Parameters.MasterSystemDiskCategory
+			mapping["worker_disk_category"] = ct.Parameters.WorkerSystemDiskCategory
+			mapping["slb_internet_enabled"] = ct.Parameters.PublicSLB
 
-		if size, err := strconv.Atoi(ct.Parameters.MasterSystemDiskSize); err != nil {
-			return BuildWrapError("strconv.Atoi", d.Id(), ProviderERROR, err, "")
-		} else {
-			mapping["master_disk_size"] = size
-		}
+			if ct.Parameters.ImageId != "" {
+				mapping["image_id"] = ct.Parameters.ImageId
+			} else {
+				mapping["image_id"] = ct.Parameters.MasterImageId
+			}
 
-		if size, err := strconv.Atoi(ct.Parameters.WorkerSystemDiskSize); err != nil {
-			return BuildWrapError("strconv.Atoi", d.Id(), ProviderERROR, err, "")
-		} else {
-			mapping["worker_disk_size"] = size
-		}
-
-		if ct.Parameters.MasterInstanceChargeType == string(PrePaid) {
-			mapping["master_instance_charge_type"] = string(PrePaid)
-			if period, err := strconv.Atoi(ct.Parameters.MasterPeriod); err != nil {
+			if size, err := strconv.Atoi(ct.Parameters.MasterSystemDiskSize); err != nil {
 				return BuildWrapError("strconv.Atoi", d.Id(), ProviderERROR, err, "")
 			} else {
-				mapping["master_period"] = period
+				mapping["master_disk_size"] = size
 			}
-			mapping["master_period_unit"] = ct.Parameters.MasterPeriodUnit
-			mapping["master_auto_renew"] = ct.Parameters.MasterAutoRenew
-			if period, err := strconv.Atoi(ct.Parameters.MasterAutoRenewPeriod); err != nil {
+
+			if size, err := strconv.Atoi(ct.Parameters.WorkerSystemDiskSize); err != nil {
 				return BuildWrapError("strconv.Atoi", d.Id(), ProviderERROR, err, "")
 			} else {
-				mapping["master_auto_renew_period"] = period
+				mapping["worker_disk_size"] = size
 			}
-		} else {
-			mapping["master_instance_charge_type"] = string(PostPaid)
-		}
 
-		if ct.Parameters.WorkerInstanceChargeType == string(PrePaid) {
-			mapping["worker_instance_charge_type"] = string(PrePaid)
-			if period, err := strconv.Atoi(ct.Parameters.WorkerPeriod); err != nil {
+			if ct.Parameters.MasterInstanceChargeType == string(PrePaid) {
+				mapping["master_instance_charge_type"] = string(PrePaid)
+				if period, err := strconv.Atoi(ct.Parameters.MasterPeriod); err != nil {
+					return BuildWrapError("strconv.Atoi", d.Id(), ProviderERROR, err, "")
+				} else {
+					mapping["master_period"] = period
+				}
+				mapping["master_period_unit"] = ct.Parameters.MasterPeriodUnit
+				mapping["master_auto_renew"] = ct.Parameters.MasterAutoRenew
+				if period, err := strconv.Atoi(ct.Parameters.MasterAutoRenewPeriod); err != nil {
+					return BuildWrapError("strconv.Atoi", d.Id(), ProviderERROR, err, "")
+				} else {
+					mapping["master_auto_renew_period"] = period
+				}
+			} else {
+				mapping["master_instance_charge_type"] = string(PostPaid)
+			}
+
+			if ct.Parameters.WorkerInstanceChargeType == string(PrePaid) {
+				mapping["worker_instance_charge_type"] = string(PrePaid)
+				if period, err := strconv.Atoi(ct.Parameters.WorkerPeriod); err != nil {
+					return BuildWrapError("strconv.Atoi", d.Id(), ProviderERROR, err, "")
+				} else {
+					mapping["worker_period"] = period
+				}
+				mapping["worker_period_unit"] = ct.Parameters.WorkerPeriodUnit
+				mapping["worker_auto_renew"] = ct.Parameters.WorkerAutoRenew
+				if period, err := strconv.Atoi(ct.Parameters.WorkerAutoRenewPeriod); err != nil {
+					return BuildWrapError("strconv.Atoi", d.Id(), ProviderERROR, err, "")
+				} else {
+					mapping["worker_auto_renew_period"] = period
+				}
+			} else {
+				mapping["worker_instance_charge_type"] = string(PostPaid)
+			}
+
+			if cidrMask, err := strconv.Atoi(ct.Parameters.NodeCIDRMask); err == nil {
+				mapping["node_cidr_mask"] = cidrMask
+			} else {
 				return BuildWrapError("strconv.Atoi", d.Id(), ProviderERROR, err, "")
+			}
+
+			if ct.Parameters.WorkerDataDisk {
+				if size, err := strconv.Atoi(ct.Parameters.WorkerDataDiskSize); err != nil {
+					return BuildWrapError("strconv.Atoi", d.Id(), ProviderERROR, err, "")
+				} else {
+					mapping["worker_data_disk_size"] = size
+				}
+				mapping["worker_data_disk_category"] = ct.Parameters.WorkerDataDiskCategory
+			}
+
+			if ct.Parameters.LoggingType != "None" {
+				logConfig := map[string]interface{}{}
+				logConfig["type"] = ct.Parameters.LoggingType
+				if ct.Parameters.SLSProjectName == "None" {
+					logConfig["project"] = ""
+				} else {
+					logConfig["project"] = ct.Parameters.SLSProjectName
+				}
+				mapping["log_config"] = []map[string]interface{}{logConfig}
+			}
+
+			// Each k8s cluster contains 3 master nodes
+			if ct.MetaData.MultiAZ || ct.MetaData.SubClass == "3az" {
+				numOfNodeA, err := strconv.Atoi(ct.Parameters.NumOfNodesA)
+				if err != nil {
+					return fmt.Errorf("error convert NumOfNodesA %s to int: %s", ct.Parameters.NumOfNodesA, err.Error())
+				}
+				numOfNodeB, err := strconv.Atoi(ct.Parameters.NumOfNodesB)
+				if err != nil {
+					return fmt.Errorf("error convert NumOfNodesB %s to int: %s", ct.Parameters.NumOfNodesB, err.Error())
+				}
+				numOfNodeC, err := strconv.Atoi(ct.Parameters.NumOfNodesC)
+				if err != nil {
+					return fmt.Errorf("error convert NumOfNodesC %s to int: %s", ct.Parameters.NumOfNodesC, err.Error())
+				}
+				mapping["worker_numbers"] = []int{numOfNodeA, numOfNodeB, numOfNodeC}
+				mapping["vswitch_ids"] = []string{ct.Parameters.VSwitchIdA, ct.Parameters.VSwitchIdB, ct.Parameters.VSwitchIdC}
+				mapping["master_instance_types"] = []string{ct.Parameters.MasterInstanceTypeA, ct.Parameters.MasterInstanceTypeB, ct.Parameters.MasterInstanceTypeC}
+				mapping["worker_instance_types"] = []string{ct.Parameters.WorkerInstanceTypeA, ct.Parameters.WorkerInstanceTypeB, ct.Parameters.WorkerInstanceTypeC}
 			} else {
-				mapping["worker_period"] = period
+				if numOfNode, err := strconv.Atoi(ct.Parameters.NumOfNodes); err != nil {
+					return BuildWrapError("strconv.Atoi", d.Id(), ProviderERROR, err, "")
+				} else {
+					mapping["worker_numbers"] = []int{numOfNode}
+				}
+				mapping["vswitch_ids"] = []string{ct.Parameters.VSwitchID}
+				mapping["master_instance_types"] = []string{ct.Parameters.MasterInstanceType}
+				mapping["worker_instance_types"] = []string{ct.Parameters.WorkerInstanceType}
 			}
-			mapping["worker_period_unit"] = ct.Parameters.WorkerPeriodUnit
-			mapping["worker_auto_renew"] = ct.Parameters.WorkerAutoRenew
-			if period, err := strconv.Atoi(ct.Parameters.WorkerAutoRenewPeriod); err != nil {
-				return BuildWrapError("strconv.Atoi", d.Id(), ProviderERROR, err, "")
-			} else {
-				mapping["worker_auto_renew_period"] = period
-			}
-		} else {
-			mapping["worker_instance_charge_type"] = string(PostPaid)
-		}
 
-		if cidrMask, err := strconv.Atoi(ct.Parameters.NodeCIDRMask); err == nil {
-			mapping["node_cidr_mask"] = cidrMask
-		} else {
-			return BuildWrapError("strconv.Atoi", d.Id(), ProviderERROR, err, "")
-		}
+			var masterNodes []map[string]interface{}
+			var workerNodes []map[string]interface{}
 
-		if ct.Parameters.WorkerDataDisk {
-			if size, err := strconv.Atoi(ct.Parameters.WorkerDataDiskSize); err != nil {
-				return BuildWrapError("strconv.Atoi", d.Id(), ProviderERROR, err, "")
-			} else {
-				mapping["worker_data_disk_size"] = size
-			}
-			mapping["worker_data_disk_category"] = ct.Parameters.WorkerDataDiskCategory
-		}
+			invoker := NewInvoker()
+			client := meta.(*connectivity.AliyunClient)
+			pageNumber := 1
+			for {
+				var result []cs.KubernetesNodeType
+				var pagination *cs.PaginationResult
 
-		if ct.Parameters.LoggingType != "None" {
-			logConfig := map[string]interface{}{}
-			logConfig["type"] = ct.Parameters.LoggingType
-			if ct.Parameters.SLSProjectName == "None" {
-				logConfig["project"] = ""
-			} else {
-				logConfig["project"] = ct.Parameters.SLSProjectName
-			}
-			mapping["log_config"] = []map[string]interface{}{logConfig}
-		}
+				if err := invoker.Run(func() error {
+					raw, e := client.WithCsClient(func(csClient *cs.Client) (interface{}, error) {
+						nodes, paginationResult, err := csClient.GetKubernetesClusterNodes(ct.ClusterID, common.Pagination{PageNumber: pageNumber, PageSize: PageSizeLarge})
+						return []interface{}{nodes, paginationResult}, err
+					})
+					if e != nil {
+						return e
+					}
+					result, _ = raw.([]interface{})[0].([]cs.KubernetesNodeType)
+					pagination, _ = raw.([]interface{})[1].(*cs.PaginationResult)
+					return nil
+				}); err != nil {
+					return fmt.Errorf("[ERROR] GetKubernetesClusterNodes got an error: %#v.", err)
+				}
 
-		// Each k8s cluster contains 3 master nodes
-		if ct.MetaData.MultiAZ || ct.MetaData.SubClass == "3az" {
-			numOfNodeA, err := strconv.Atoi(ct.Parameters.NumOfNodesA)
-			if err != nil {
-				return fmt.Errorf("error convert NumOfNodesA %s to int: %s", ct.Parameters.NumOfNodesA, err.Error())
-			}
-			numOfNodeB, err := strconv.Atoi(ct.Parameters.NumOfNodesB)
-			if err != nil {
-				return fmt.Errorf("error convert NumOfNodesB %s to int: %s", ct.Parameters.NumOfNodesB, err.Error())
-			}
-			numOfNodeC, err := strconv.Atoi(ct.Parameters.NumOfNodesC)
-			if err != nil {
-				return fmt.Errorf("error convert NumOfNodesC %s to int: %s", ct.Parameters.NumOfNodesC, err.Error())
-			}
-			mapping["worker_numbers"] = []int{numOfNodeA, numOfNodeB, numOfNodeC}
-			mapping["vswitch_ids"] = []string{ct.Parameters.VSwitchIdA, ct.Parameters.VSwitchIdB, ct.Parameters.VSwitchIdC}
-			mapping["master_instance_types"] = []string{ct.Parameters.MasterInstanceTypeA, ct.Parameters.MasterInstanceTypeB, ct.Parameters.MasterInstanceTypeC}
-			mapping["worker_instance_types"] = []string{ct.Parameters.WorkerInstanceTypeA, ct.Parameters.WorkerInstanceTypeB, ct.Parameters.WorkerInstanceTypeC}
-		} else {
-			if numOfNode, err := strconv.Atoi(ct.Parameters.NumOfNodes); err != nil {
-				return BuildWrapError("strconv.Atoi", d.Id(), ProviderERROR, err, "")
-			} else {
-				mapping["worker_numbers"] = []int{numOfNode}
-			}
-			mapping["vswitch_ids"] = []string{ct.Parameters.VSwitchID}
-			mapping["master_instance_types"] = []string{ct.Parameters.MasterInstanceType}
-			mapping["worker_instance_types"] = []string{ct.Parameters.WorkerInstanceType}
-		}
+				if pageNumber == 1 && (len(result) == 0 || result[0].InstanceId == "") {
+					err := resource.Retry(5*time.Minute, func() *resource.RetryError {
+						if err := invoker.Run(func() error {
+							raw, e := client.WithCsClient(func(csClient *cs.Client) (interface{}, error) {
+								nodes, _, err := csClient.GetKubernetesClusterNodes(ct.ClusterID, common.Pagination{PageNumber: pageNumber, PageSize: PageSizeLarge})
+								return nodes, err
+							})
+							if e != nil {
+								return e
+							}
+							tmp, _ := raw.([]cs.KubernetesNodeType)
+							if len(tmp) > 0 && tmp[0].InstanceId != "" {
+								result = tmp
+							}
+							return nil
+						}); err != nil {
+							return resource.NonRetryableError(fmt.Errorf("[ERROR] GetKubernetesClusterNodes got an error: %#v.", err))
+						}
+						for _, stableState := range cs.NodeStableClusterState {
+							// If cluster is in NodeStableClusteState, node list will not change
+							if ct.State == stableState {
+								return nil
+							}
+						}
+						time.Sleep(5 * time.Second)
+						return resource.RetryableError(fmt.Errorf("[ERROR] There is no any nodes in kubernetes cluster %s.", d.Id()))
+					})
+					if err != nil {
+						return err
+					}
 
-		var masterNodes []map[string]interface{}
-		var workerNodes []map[string]interface{}
+				}
 
-		invoker := NewInvoker()
-		client := meta.(*connectivity.AliyunClient)
-		pageNumber := 1
-		for {
-			var result []cs.KubernetesNodeType
-			var pagination *cs.PaginationResult
+				for _, node := range result {
+					subMapping := map[string]interface{}{
+						"id":         node.InstanceId,
+						"name":       node.InstanceName,
+						"private_ip": node.IpAddress[0],
+					}
+					if node.InstanceRole == "Master" {
+						masterNodes = append(masterNodes, subMapping)
+					} else {
+						workerNodes = append(workerNodes, subMapping)
+					}
+				}
+
+				if len(result) < pagination.PageSize {
+					break
+				}
+				pageNumber += 1
+			}
+			mapping["master_nodes"] = masterNodes
+			mapping["worker_nodes"] = workerNodes
 
 			if err := invoker.Run(func() error {
-				raw, e := client.WithCsClient(func(csClient *cs.Client) (interface{}, error) {
-					nodes, paginationResult, err := csClient.GetKubernetesClusterNodes(ct.ClusterID, common.Pagination{PageNumber: pageNumber, PageSize: PageSizeLarge})
-					return []interface{}{nodes, paginationResult}, err
+				rawEndpoints, e := client.WithCsClient(func(csClient *cs.Client) (interface{}, error) {
+					endpoints, err := csClient.GetClusterEndpoints(ct.ClusterID)
+					return endpoints, err
 				})
 				if e != nil {
 					return e
 				}
-				result, _ = raw.([]interface{})[0].([]cs.KubernetesNodeType)
-				pagination, _ = raw.([]interface{})[1].(*cs.PaginationResult)
+				connection := make(map[string]string)
+				if endpoints, ok := rawEndpoints.(cs.ClusterEndpoints); ok && endpoints.ApiServerEndpoint != "" {
+					connection["api_server_internet"] = endpoints.ApiServerEndpoint
+					connection["master_public_ip"] = strings.TrimSuffix(strings.TrimPrefix(endpoints.ApiServerEndpoint, "https://"), ":6443")
+				}
+				if endpoints, ok := rawEndpoints.(cs.ClusterEndpoints); ok && endpoints.IntranetApiServerEndpoint != "" {
+					connection["api_server_intranet"] = endpoints.IntranetApiServerEndpoint
+				}
+				connection["service_domain"] = fmt.Sprintf("*.%s.%s.alicontainer.com", ct.ClusterID, ct.RegionID)
+
+				mapping["connections"] = connection
 				return nil
 			}); err != nil {
 				return fmt.Errorf("[ERROR] GetKubernetesClusterNodes got an error: %#v.", err)
 			}
 
-			if pageNumber == 1 && (len(result) == 0 || result[0].InstanceId == "") {
-				err := resource.Retry(5*time.Minute, func() *resource.RetryError {
-					if err := invoker.Run(func() error {
-						raw, e := client.WithCsClient(func(csClient *cs.Client) (interface{}, error) {
-							nodes, _, err := csClient.GetKubernetesClusterNodes(ct.ClusterID, common.Pagination{PageNumber: pageNumber, PageSize: PageSizeLarge})
-							return nodes, err
-						})
-						if e != nil {
-							return e
-						}
-						tmp, _ := raw.([]cs.KubernetesNodeType)
-						if len(tmp) > 0 && tmp[0].InstanceId != "" {
-							result = tmp
-						}
-						return nil
-					}); err != nil {
-						return resource.NonRetryableError(fmt.Errorf("[ERROR] GetKubernetesClusterNodes got an error: %#v.", err))
-					}
-					for _, stableState := range cs.NodeStableClusterState {
-						// If cluster is in NodeStableClusteState, node list will not change
-						if ct.State == stableState {
-							return nil
-						}
-					}
-					time.Sleep(5 * time.Second)
-					return resource.RetryableError(fmt.Errorf("[ERROR] There is no any nodes in kubernetes cluster %s.", d.Id()))
-				})
-				if err != nil {
-					return err
-				}
-
-			}
-
-			for _, node := range result {
-				subMapping := map[string]interface{}{
-					"id":         node.InstanceId,
-					"name":       node.InstanceName,
-					"private_ip": node.IpAddress[0],
-				}
-				if node.InstanceRole == "Master" {
-					masterNodes = append(masterNodes, subMapping)
-				} else {
-					workerNodes = append(workerNodes, subMapping)
-				}
-			}
-
-			if len(result) < pagination.PageSize {
-				break
-			}
-			pageNumber += 1
-		}
-		mapping["master_nodes"] = masterNodes
-		mapping["worker_nodes"] = workerNodes
-
-		if err := invoker.Run(func() error {
-			rawEndpoints, e := client.WithCsClient(func(csClient *cs.Client) (interface{}, error) {
-				endpoints, err := csClient.GetClusterEndpoints(ct.ClusterID)
-				return endpoints, err
+			req := vpc.CreateDescribeNatGatewaysRequest()
+			req.VpcId = ct.VPCID
+			raw, err := client.WithVpcClient(func(vpcClient *vpc.Client) (interface{}, error) {
+				return vpcClient.DescribeNatGateways(req)
 			})
-			if e != nil {
-				return e
+			if err != nil {
+				return fmt.Errorf("[ERROR] DescribeNatGateways by VPC Id %s: %#v.", ct.VPCID, err)
 			}
-			connection := make(map[string]string)
-			if endpoints, ok := rawEndpoints.(cs.ClusterEndpoints); ok && endpoints.ApiServerEndpoint != "" {
-				connection["api_server_internet"] = endpoints.ApiServerEndpoint
-				connection["master_public_ip"] = strings.TrimSuffix(strings.TrimPrefix(endpoints.ApiServerEndpoint, "https://"), ":6443")
+			nat, _ := raw.(*vpc.DescribeNatGatewaysResponse)
+			if nat != nil && len(nat.NatGateways.NatGateway) > 0 {
+				mapping["nat_gateway_id"] = nat.NatGateways.NatGateway[0].NatGatewayId
 			}
-			if endpoints, ok := rawEndpoints.(cs.ClusterEndpoints); ok && endpoints.IntranetApiServerEndpoint != "" {
-				connection["api_server_intranet"] = endpoints.IntranetApiServerEndpoint
-			}
-			connection["service_domain"] = fmt.Sprintf("*.%s.%s.alicontainer.com", ct.ClusterID, ct.RegionID)
-
-			mapping["connections"] = connection
-			return nil
-		}); err != nil {
-			return fmt.Errorf("[ERROR] GetKubernetesClusterNodes got an error: %#v.", err)
-		}
-
-		req := vpc.CreateDescribeNatGatewaysRequest()
-		req.VpcId = ct.VPCID
-		raw, err := client.WithVpcClient(func(vpcClient *vpc.Client) (interface{}, error) {
-			return vpcClient.DescribeNatGateways(req)
-		})
-		if err != nil {
-			return fmt.Errorf("[ERROR] DescribeNatGateways by VPC Id %s: %#v.", ct.VPCID, err)
-		}
-		nat, _ := raw.(*vpc.DescribeNatGatewaysResponse)
-		if nat != nil && len(nat.NatGateways.NatGateway) > 0 {
-			mapping["nat_gateway_id"] = nat.NatGateways.NatGateway[0].NatGatewayId
 		}
 
 		ids = append(ids, ct.ClusterID)
@@ -630,40 +611,8 @@ func csKubernetesClusterDescriptionAttributes(d *schema.ResourceData, clusterTyp
 		s = append(s, mapping)
 	}
 
-	d.Set("cluster_ids", ids)
-	d.Set("cluster_names", names)
-	d.SetId(dataResourceIdHash(ids))
-	if err := d.Set("clusters", s); err != nil {
-		return WrapError(err)
-	}
-
-	// create a json file in current directory and write data source to it.
-	if output, ok := d.GetOk("output_file"); ok && output.(string) != "" {
-		writeToFile(output.(string), s)
-	}
-
-	return nil
-}
-
-func csKubernetesClusterDescriptionSimpleAttributes(d *schema.ResourceData, clusterTypes []cs.KubernetesCluster, meta interface{}) error {
-	var ids, names []string
-	var s []map[string]interface{}
-	for _, ct := range clusterTypes {
-		mapping := map[string]interface{}{
-			"id":                ct.ClusterID,
-			"name":              ct.Name,
-			"vpc_id":            ct.VPCID,
-			"security_group_id": ct.SecurityGroupID,
-			"availability_zone": ct.ZoneId,
-		}
-
-		ids = append(ids, ct.ClusterID)
-		names = append(names, ct.Name)
-		s = append(s, mapping)
-	}
-
-	d.Set("cluster_ids", ids)
-	d.Set("cluster_names", names)
+	d.Set("ids", ids)
+	d.Set("names", names)
 	d.SetId(dataResourceIdHash(ids))
 	if err := d.Set("clusters", s); err != nil {
 		return WrapError(err)

--- a/alicloud/data_source_alicloud_cs_kubernetes_clusters_test.go
+++ b/alicloud/data_source_alicloud_cs_kubernetes_clusters_test.go
@@ -1,0 +1,103 @@
+package alicloud
+
+import (
+	"regexp"
+	"testing"
+
+	"github.com/terraform-providers/terraform-provider-alicloud/alicloud/connectivity"
+
+	"github.com/hashicorp/terraform/helper/resource"
+)
+
+func TestAccAlicloudCSKubernetesClustersDataSource_Empty(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheckWithRegions(t, true, connectivity.KubernetesSupportedRegions) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAlicloudCSKubernetesClustersDataSourceEmpty,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAlicloudDataSourceID("data.alicloud_cs_kubernetes_clusters.k8s_clusters"),
+					resource.TestCheckResourceAttrSet("data.alicloud_cs_kubernetes_clusters.k8s_clusters", "clusters.#"),
+				),
+			},
+		},
+	})
+}
+
+const testAccAlicloudCSKubernetesClustersDataSourceEmpty = `
+data "alicloud_cs_kubernetes_clusters" "k8s_clusters" {
+}
+`
+
+func TestAccAlicloudCSKubernetesClustersDataSource_AutoVpc(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheckWithRegions(t, true, connectivity.KubernetesSupportedRegions) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAlicloudCSKubernetesClustersDataSourceAutoVpc,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAlicloudDataSourceID("data.alicloud_cs_kubernetes_clusters.k8s_clusters"),
+					resource.TestCheckResourceAttrSet("data.alicloud_cs_kubernetes_clusters.k8s_clusters", "clusters.#"),
+					resource.TestMatchResourceAttr("data.alicloud_cs_kubernetes_clusters.k8s_clusters", "clusters.0.name", regexp.MustCompile("^tf-testAccKubernetes-autoVpc*")),
+					resource.TestCheckResourceAttr("data.alicloud_cs_kubernetes_clusters.k8s_clusters", "clusters.0.worker_numbers.#", "1"),
+					resource.TestCheckResourceAttr("data.alicloud_cs_kubernetes_clusters.k8s_clusters", "clusters.0.worker_numbers.0", "1"),
+					resource.TestCheckResourceAttr("data.alicloud_cs_kubernetes_clusters.k8s_clusters", "clusters.0.master_nodes.#", "3"),
+					resource.TestCheckResourceAttr("data.alicloud_cs_kubernetes_clusters.k8s_clusters", "clusters.0.worker_disk_category", "cloud_ssd"),
+					resource.TestCheckResourceAttr("data.alicloud_cs_kubernetes_clusters.k8s_clusters", "clusters.0.master_disk_size", "50"),
+					resource.TestCheckResourceAttr("data.alicloud_cs_kubernetes_clusters.k8s_clusters", "clusters.0.master_disk_category", "cloud_efficiency"),
+					resource.TestCheckResourceAttr("data.alicloud_cs_kubernetes_clusters.k8s_clusters", "clusters.0.worker_disk_size", "40"),
+					resource.TestCheckResourceAttr("data.alicloud_cs_kubernetes_clusters.k8s_clusters", "clusters.0.connections.%", "4"),
+					resource.TestCheckResourceAttrSet("data.alicloud_cs_kubernetes_clusters.k8s_clusters", "clusters.0.connections.master_public_ip"),
+					resource.TestCheckResourceAttrSet("data.alicloud_cs_kubernetes_clusters.k8s_clusters", "clusters.0.connections.api_server_internet"),
+					resource.TestCheckResourceAttrSet("data.alicloud_cs_kubernetes_clusters.k8s_clusters", "clusters.0.connections.api_server_intranet"),
+					resource.TestCheckResourceAttrSet("data.alicloud_cs_kubernetes_clusters.k8s_clusters", "clusters.0.connections.service_domain"),
+				),
+			},
+		},
+	})
+}
+
+const testAccAlicloudCSKubernetesClustersDataSourceAutoVpc = `
+variable "name" {
+	default = "tf-testAccKubernetes-autoVpc"
+}
+data "alicloud_zones" main {
+  available_resource_creation = "VSwitch"
+}
+
+data "alicloud_instance_types" "master" {
+	availability_zone = "${data.alicloud_zones.main.zones.0.id}"
+	cpu_core_count = 2
+	memory_size = 4
+	kubernetes_node_role = "Master"
+}
+
+data "alicloud_instance_types" "worker" {
+	availability_zone = "${data.alicloud_zones.main.zones.0.id}"
+	cpu_core_count = 2
+	memory_size = 4
+	kubernetes_node_role = "Worker"
+}
+
+resource "alicloud_cs_kubernetes" "k8s" {
+  name_prefix = "${var.name}"
+  availability_zone = "${data.alicloud_zones.main.zones.0.id}"
+  new_nat_gateway = true
+  master_instance_types = ["${data.alicloud_instance_types.master.instance_types.0.id}"]
+  worker_instance_types = ["${data.alicloud_instance_types.worker.instance_types.0.id}"]
+  worker_numbers = [1]
+  password = "Test12345"
+  pod_cidr = "172.20.0.0/16"
+  service_cidr = "172.21.0.0/20"
+  enable_ssh = true
+  install_cloud_monitor = true
+  worker_disk_category  = "cloud_ssd"
+  master_disk_size = 50
+}
+
+data "alicloud_cs_kubernetes_clusters" "k8s_clusters" {
+  name = "${alicloud_cs_kubernetes.k8s.name}"
+}
+`

--- a/alicloud/data_source_alicloud_cs_kubernetes_clusters_test.go
+++ b/alicloud/data_source_alicloud_cs_kubernetes_clusters_test.go
@@ -99,5 +99,6 @@ resource "alicloud_cs_kubernetes" "k8s" {
 
 data "alicloud_cs_kubernetes_clusters" "k8s_clusters" {
   name = "${alicloud_cs_kubernetes.k8s.name}"
+  enable_details = true
 }
 `

--- a/alicloud/data_source_alicloud_cs_kubernetes_clusters_test.go
+++ b/alicloud/data_source_alicloud_cs_kubernetes_clusters_test.go
@@ -98,7 +98,7 @@ resource "alicloud_cs_kubernetes" "k8s" {
 }
 
 data "alicloud_cs_kubernetes_clusters" "k8s_clusters" {
-  name = "${alicloud_cs_kubernetes.k8s.name}"
+  name_regex = "${alicloud_cs_kubernetes.k8s.name}"
   enable_details = true
 }
 `

--- a/alicloud/provider.go
+++ b/alicloud/provider.go
@@ -134,6 +134,7 @@ func Provider() terraform.ResourceProvider {
 			"alicloud_cen_bandwidth_limits":     dataSourceAlicloudCenBandwidthLimits(),
 			"alicloud_cen_route_entries":        dataSourceAlicloudCenRouteEntries(),
 			"alicloud_cen_region_route_entries": dataSourceAlicloudCenRegionRouteEntries(),
+			"alicloud_cs_kubernetes_clusters":   dataSourceAlicloudCSKubernetesClusters(),
 			"alicloud_mns_queues":               dataSourceAlicloudMNSQueues(),
 			"alicloud_mns_topics":               dataSourceAlicloudMNSTopics(),
 			"alicloud_mns_topic_subscriptions":  dataSourceAlicloudMNSTopicSubscriptions(),

--- a/vendor/github.com/denverdino/aliyungo/cs/clusters.go
+++ b/vendor/github.com/denverdino/aliyungo/cs/clusters.go
@@ -450,6 +450,19 @@ func (client *Client) GetClusterCerts(id string) (certs ClusterCerts, err error)
 	return
 }
 
+type ClusterEndpoints struct {
+	ApiServerEndpoint         string `json:"api_server_endpoint"`
+	DashboardEndpoint         string `json:"dashboard_endpoint"`
+	MiranaEndpoint            string `json:"mirana_endpoint"`
+	ReverseTunnelEndpoint     string `json:"reverse_tunnel_endpoint"`
+	IntranetApiServerEndpoint string `json:"intranet_api_server_endpoint"`
+}
+
+func (client *Client) GetClusterEndpoints(id string) (clusterEndpoints ClusterEndpoints, err error) {
+	err = client.Invoke("", http.MethodGet, "/clusters/"+id+"/endpoints", nil, nil, &clusterEndpoints)
+	return
+}
+
 type ClusterConfig struct {
 	Config string `json:"config"`
 }

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -467,10 +467,10 @@
 			"revisionTime": "2018-03-30T09:12:25Z"
 		},
 		{
-			"checksumSHA1": "QwvxHLb9WaPbDEjjk0jzMqyPPac=",
+			"checksumSHA1": "ldU9GR25GmX0+0CP+3LWAfslqHo=",
 			"path": "github.com/denverdino/aliyungo/cs",
-			"revision": "a747050bb1baf06cdd65de7cddc281a2b1c2fde5",
-			"revisionTime": "2019-01-25T01:07:48Z"
+			"revision": "d68d11b0dce7c515f2dab0298506496a19661050",
+			"revisionTime": "2019-03-04T07:04:24Z"
 		},
 		{
 			"checksumSHA1": "at2TCvaAzU3jBW7yngHYVD9e7EI=",

--- a/website/alicloud.erb
+++ b/website/alicloud.erb
@@ -116,6 +116,9 @@
                         <li<%= sidebar_current("docs-alicloud-datasource-oss-buckets") %>>
                           <a href="/docs/providers/alicloud/d/oss_buckets.html">alicloud_oss_buckets</a>
                         </li>
+                        <li<%= sidebar_current("docs-alicloud-datasource-cs-kubernetes-clusters") %>>
+                          <a href="/docs/providers/alicloud/d/cs_kubernetes_clusters.html">alicloud_cs_kubernetes_clusters</a>
+                        </li>
                         <li<%= sidebar_current("docs-alicloud-datasource-fc-functions") %>>
                           <a href="/docs/providers/alicloud/d/fc_functions.html">alicloud_fc_functions</a>
                         <li<%= sidebar_current("docs-alicloud-datasource-fc-services") %>>

--- a/website/docs/d/cs_kubernetes_clusters.html.markdown
+++ b/website/docs/d/cs_kubernetes_clusters.html.markdown
@@ -1,0 +1,83 @@
+---
+layout: "alicloud"
+page_title: "Alicloud: alicloud_cs_kubernetes_clusters"
+sidebar_current: "docs-alicloud-datasource-cs-kubernetes-clusters"
+description: |-
+    Provides a list of Container Service Kubernetes Clusters to be used by the alicloud_cs_kubernetes_clusters resource.
+---
+
+# alicloud\_cs\_kubernetes\_clusters
+
+This data source provides a list Container Service Kubernetes Clusters on Alibaba Cloud.
+
+## Example Usage
+
+```
+# Declare the data source
+data "alicloud_cs_kubernetes_clusters" "k8s_clusters" {
+  name_prefix = "my-first-k8s"
+  region_id = "cn-beijing"
+  id = "cc8e8309ca99c43b8a7c93897a35xxxxx"
+  output_file = "my-first-k8s-json"
+}
+
+output "output" {
+  value = "${data.alicloud_cs_kubernetes_clusters.k8s_clusters.clusters}"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `id` - (Optional) Cluster ID.
+* `name` - (Optional) Cluster name, cannot be set together with name_prefix.
+* `name_prefix` - (Optional) Cluster name's Prefix.
+* `region_id` - (Optional) Region id.
+* `output_file` - (Optional) File name where to save data source results (after running `terraform plan`).
+
+## Attributes Reference
+
+The following attributes are exported in addition to the arguments listed above:
+
+* `clusters` - A list of matched Kubernetes clusters. Each element contains the following attributes:
+  * `id` - The ID of the container cluster.
+  * `name` - The name of the container cluster.
+  * `availability_zone` - The ID of availability zone.
+  * `key_name` - The keypair of ssh login cluster node, you have to create it first.
+  * `worker_numbers` - The ECS instance node number in the current container cluster.
+  * `vswitch_ids` - The ID of VSwitches where the current cluster is located.
+  * `vpc_id` - The ID of VPC where the current cluster is located.
+  * `slb_internet_enabled` - Whether internet load balancer for API Server is created
+  * `security_group_id` - The ID of security group where the current cluster worker node is located.
+  * `image_id` - The ID of node image.
+  * `nat_gateway_id` - The ID of nat gateway used to launch kubernetes cluster.
+  * `master_instance_types` - The instance type of master node.
+  * `worker_instance_types` - The instance type of worker node.
+  * `master_disk_category` - The system disk category of master node.
+  * `master_disk_size` - The system disk size of master node.
+  * `worker_disk_category` - The system disk category of worker node.
+  * `worker_disk_size` - The system disk size of worker node.
+  * `worker_data_disk_category` - The data disk size of worker node.
+  * `worker_data_disk_size` - The data disk category of worker node.
+  * `master_nodes` - List of cluster master nodes. It contains several attributes to `Block Nodes`.
+  * `worker_nodes` - List of cluster worker nodes. It contains several attributes to `Block Nodes`.
+  * `connections` - Map of kubernetes cluster connection information. It contains several attributes to `Block Connections`.
+  * `node_cidr_mask` - The network mask used on pods for each node.
+  * `log_config` - A list of one element containing information about the associated log store. It contains the following attributes:
+    * `type` - Type of collecting logs.
+    * `project` - Log Service project name.
+
+### Block Nodes
+
+* `id` - ID of the node.
+* `name` - Node name.
+* `private_ip` - The private IP address of node.
+* `role` - (Deprecated from version 1.9.4)
+
+### Block Connections
+
+* `api_server_internet` - API Server Internet endpoint.
+* `api_server_intranet` - API Server Intranet endpoint.
+* `master_public_ip` - Master node SSH IP address.
+* `service_domain` - Service Access Domain.

--- a/website/docs/d/cs_kubernetes_clusters.html.markdown
+++ b/website/docs/d/cs_kubernetes_clusters.html.markdown
@@ -3,7 +3,7 @@ layout: "alicloud"
 page_title: "Alicloud: alicloud_cs_kubernetes_clusters"
 sidebar_current: "docs-alicloud-datasource-cs-kubernetes-clusters"
 description: |-
-    Provides a list of Container Service Kubernetes Clusters to be used by the alicloud_cs_kubernetes_clusters resource.
+  Provides a list of Container Service Kubernetes Clusters to be used by the alicloud_cs_kubernetes_clusters resource.
 ---
 
 # alicloud\_cs\_kubernetes\_clusters
@@ -30,16 +30,18 @@ output "output" {
 
 The following arguments are supported:
 
-* `id` - (Optional) Cluster ID.
+* `ids` - (Optional) Cluster IDs to filter.
 * `name` - (Optional) Cluster name, cannot be set together with name_prefix.
-* `name_prefix` - (Optional) Cluster name's Prefix.
-* `region_id` - (Optional) Region id.
+* `name_regex` - (Optional) A regex string to filter results by cluster name.
 * `output_file` - (Optional) File name where to save data source results (after running `terraform plan`).
+* `enabled_details` - (Optional) Boolean, set to true if details are needed.
 
 ## Attributes Reference
 
 The following attributes are exported in addition to the arguments listed above:
 
+* `cluster_ids` - A list of matched Kubernetes clusters' ids.
+* `cluster_names` - A list of matched Kubernetes clusters' names.
 * `clusters` - A list of matched Kubernetes clusters. Each element contains the following attributes:
   * `id` - The ID of the container cluster.
   * `name` - The name of the container cluster.

--- a/website/docs/d/cs_kubernetes_clusters.html.markdown
+++ b/website/docs/d/cs_kubernetes_clusters.html.markdown
@@ -31,17 +31,16 @@ output "output" {
 The following arguments are supported:
 
 * `ids` - (Optional) Cluster IDs to filter.
-* `name` - (Optional) Cluster name, cannot be set together with name_prefix.
 * `name_regex` - (Optional) A regex string to filter results by cluster name.
 * `output_file` - (Optional) File name where to save data source results (after running `terraform plan`).
-* `enabled_details` - (Optional) Boolean, set to true if details are needed.
+* `enabled_details` - (Optional) Boolean, set to true if more details are needed, e.g., `master_disk_category`, `slb_internet_enabled`, `connections`. See full list in attributes.
 
 ## Attributes Reference
 
 The following attributes are exported in addition to the arguments listed above:
 
-* `cluster_ids` - A list of matched Kubernetes clusters' ids.
-* `cluster_names` - A list of matched Kubernetes clusters' names.
+* `ids` - A list of matched Kubernetes clusters' ids.
+* `names` - A list of matched Kubernetes clusters' names.
 * `clusters` - A list of matched Kubernetes clusters. Each element contains the following attributes:
   * `id` - The ID of the container cluster.
   * `name` - The name of the container cluster.

--- a/website/docs/d/cs_kubernetes_clusters.html.markdown
+++ b/website/docs/d/cs_kubernetes_clusters.html.markdown
@@ -15,9 +15,7 @@ This data source provides a list Container Service Kubernetes Clusters on Alibab
 ```
 # Declare the data source
 data "alicloud_cs_kubernetes_clusters" "k8s_clusters" {
-  name_prefix = "my-first-k8s"
-  region_id = "cn-beijing"
-  id = "cc8e8309ca99c43b8a7c93897a35xxxxx"
+  name_regex = "my-first-k8s"
   output_file = "my-first-k8s-json"
 }
 
@@ -33,7 +31,7 @@ The following arguments are supported:
 * `ids` - (Optional) Cluster IDs to filter.
 * `name_regex` - (Optional) A regex string to filter results by cluster name.
 * `output_file` - (Optional) File name where to save data source results (after running `terraform plan`).
-* `enabled_details` - (Optional) Boolean, set to true if more details are needed, e.g., `master_disk_category`, `slb_internet_enabled`, `connections`. See full list in attributes.
+* `enabled_details` - (Optional) Boolean, false by default, only `id` and `name` are exported. Set to true if more details are needed, e.g., `master_disk_category`, `slb_internet_enabled`, `connections`. See full list in attributes.
 
 ## Attributes Reference
 


### PR DESCRIPTION
Note: 
* Function csKubernetesClusterDescriptionAttributes is rewritten from alicloud/resource_alicloud_cs_kubernetes.go:583 resourceAlicloudCSKubernetesRead.
* The `connections` field now get data from `/cluster/CLUSTER_ID/endpoints` API.
* Tests was passed under different filter combinations.
