### PR TITLE
change bool to *bool in parameters of k8s clusters

### DIFF
--- a/alicloud/data_source_alicloud_cs_kubernetes_clusters.go
+++ b/alicloud/data_source_alicloud_cs_kubernetes_clusters.go
@@ -384,7 +384,9 @@ func csKubernetesClusterDescriptionAttributes(d *schema.ResourceData, clusterTyp
 		mapping["key_name"] = ct.Parameters.KeyPair
 		mapping["master_disk_category"] = ct.Parameters.MasterSystemDiskCategory
 		mapping["worker_disk_category"] = ct.Parameters.WorkerSystemDiskCategory
-		mapping["slb_internet_enabled"] = ct.Parameters.PublicSLB
+		if ct.Parameters.PublicSLB != nil {
+			mapping["slb_internet_enabled"] = *ct.Parameters.PublicSLB
+		}
 
 		if ct.Parameters.ImageId != "" {
 			mapping["image_id"] = ct.Parameters.ImageId
@@ -412,7 +414,9 @@ func csKubernetesClusterDescriptionAttributes(d *schema.ResourceData, clusterTyp
 				mapping["master_period"] = period
 			}
 			mapping["master_period_unit"] = ct.Parameters.MasterPeriodUnit
-			mapping["master_auto_renew"] = ct.Parameters.MasterAutoRenew
+			if ct.Parameters.MasterAutoRenew != nil {
+				mapping["master_auto_renew"] = *ct.Parameters.MasterAutoRenew
+			}
 			if period, err := strconv.Atoi(ct.Parameters.MasterAutoRenewPeriod); err != nil {
 				return BuildWrapError("strconv.Atoi", d.Id(), ProviderERROR, err, "")
 			} else {
@@ -430,7 +434,9 @@ func csKubernetesClusterDescriptionAttributes(d *schema.ResourceData, clusterTyp
 				mapping["worker_period"] = period
 			}
 			mapping["worker_period_unit"] = ct.Parameters.WorkerPeriodUnit
-			mapping["worker_auto_renew"] = ct.Parameters.WorkerAutoRenew
+			if ct.Parameters.WorkerAutoRenew != nil {
+				mapping["worker_auto_renew"] = *ct.Parameters.WorkerAutoRenew
+			}
 			if period, err := strconv.Atoi(ct.Parameters.WorkerAutoRenewPeriod); err != nil {
 				return BuildWrapError("strconv.Atoi", d.Id(), ProviderERROR, err, "")
 			} else {
@@ -446,7 +452,7 @@ func csKubernetesClusterDescriptionAttributes(d *schema.ResourceData, clusterTyp
 			return BuildWrapError("strconv.Atoi", d.Id(), ProviderERROR, err, "")
 		}
 
-		if ct.Parameters.WorkerDataDisk {
+		if ct.Parameters.WorkerDataDisk != nil && *ct.Parameters.WorkerDataDisk {
 			if size, err := strconv.Atoi(ct.Parameters.WorkerDataDiskSize); err != nil {
 				return BuildWrapError("strconv.Atoi", d.Id(), ProviderERROR, err, "")
 			} else {

--- a/alicloud/resource_alicloud_cs_kubernetes.go
+++ b/alicloud/resource_alicloud_cs_kubernetes.go
@@ -624,7 +624,9 @@ func resourceAlicloudCSKubernetesRead(d *schema.ResourceData, meta interface{}) 
 	}
 	d.Set("worker_disk_category", cluster.Parameters.WorkerSystemDiskCategory)
 	d.Set("availability_zone", cluster.ZoneId)
-	d.Set("slb_internet_enabled", cluster.Parameters.PublicSLB)
+	if cluster.Parameters.PublicSLB != nil {
+		d.Set("slb_internet_enabled", *cluster.Parameters.PublicSLB)
+	}
 
 	if cluster.Parameters.MasterInstanceChargeType == string(PrePaid) {
 		d.Set("master_instance_charge_type", string(PrePaid))
@@ -634,7 +636,9 @@ func resourceAlicloudCSKubernetesRead(d *schema.ResourceData, meta interface{}) 
 			d.Set("master_period", period)
 		}
 		d.Set("master_period_unit", cluster.Parameters.MasterPeriodUnit)
-		d.Set("master_auto_renew", cluster.Parameters.MasterAutoRenew)
+		if cluster.Parameters.MasterAutoRenew != nil {
+			d.Set("master_auto_renew", *cluster.Parameters.MasterAutoRenew)
+		}
 		if period, err := strconv.Atoi(cluster.Parameters.MasterAutoRenewPeriod); err != nil {
 			return BuildWrapError("strconv.Atoi", d.Id(), ProviderERROR, err, "")
 		} else {
@@ -652,7 +656,9 @@ func resourceAlicloudCSKubernetesRead(d *schema.ResourceData, meta interface{}) 
 			d.Set("worker_period", period)
 		}
 		d.Set("worker_period_unit", cluster.Parameters.WorkerPeriodUnit)
-		d.Set("worker_auto_renew", cluster.Parameters.WorkerAutoRenew)
+		if cluster.Parameters.WorkerAutoRenew != nil {
+			d.Set("worker_auto_renew", *cluster.Parameters.WorkerAutoRenew)
+		}
 		if period, err := strconv.Atoi(cluster.Parameters.WorkerAutoRenewPeriod); err != nil {
 			return BuildWrapError("strconv.Atoi", d.Id(), ProviderERROR, err, "")
 		} else {
@@ -668,7 +674,7 @@ func resourceAlicloudCSKubernetesRead(d *schema.ResourceData, meta interface{}) 
 		return BuildWrapError("strconv.Atoi", d.Id(), ProviderERROR, err, "")
 	}
 
-	if cluster.Parameters.WorkerDataDisk {
+	if cluster.Parameters.WorkerDataDisk != nil && *cluster.Parameters.WorkerDataDisk {
 		if size, err := strconv.Atoi(cluster.Parameters.WorkerDataDiskSize); err != nil {
 			return BuildWrapError("strconv.Atoi", d.Id(), ProviderERROR, err, "")
 		} else {

--- a/alicloud/resource_alicloud_cs_managed_kubernetes.go
+++ b/alicloud/resource_alicloud_cs_managed_kubernetes.go
@@ -395,8 +395,10 @@ func resourceAlicloudCSManagedKubernetesRead(d *schema.ResourceData, meta interf
 		} else {
 			d.Set("worker_period", period)
 		}
+		if cluster.Parameters.WorkerAutoRenew != nil {
+			d.Set("worker_auto_renew", *cluster.Parameters.WorkerAutoRenew)
+		}
 		d.Set("worker_period_unit", cluster.Parameters.WorkerPeriodUnit)
-		d.Set("worker_auto_renew", cluster.Parameters.WorkerAutoRenew)
 		if period, err := strconv.Atoi(cluster.Parameters.WorkerAutoRenewPeriod); err != nil {
 			return BuildWrapError("strconv.Atoi", d.Id(), ProviderERROR, err, "")
 		} else {
@@ -406,7 +408,7 @@ func resourceAlicloudCSManagedKubernetesRead(d *schema.ResourceData, meta interf
 		d.Set("worker_instance_charge_type", string(PostPaid))
 	}
 
-	if cluster.Parameters.WorkerDataDisk {
+	if cluster.Parameters.WorkerDataDisk != nil && *cluster.Parameters.WorkerDataDisk {
 		if size, err := strconv.Atoi(cluster.Parameters.WorkerDataDiskSize); err != nil {
 			return BuildWrapError("strconv.Atoi", d.Id(), ProviderERROR, err, "")
 		} else {

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -473,10 +473,10 @@
 			"revisionTime": "2018-03-30T09:12:25Z"
 		},
 		{
-			"checksumSHA1": "ldU9GR25GmX0+0CP+3LWAfslqHo=",
+			"checksumSHA1": "w1VKRFUkkiOUridp2Z6YWWBfJ6M=",
 			"path": "github.com/denverdino/aliyungo/cs",
-			"revision": "d68d11b0dce7c515f2dab0298506496a19661050",
-			"revisionTime": "2019-03-04T07:04:24Z"
+			"revision": "249f2b04395bcb9079ce0966b23a905a23e0881d",
+			"revisionTime": "2019-03-05T07:31:55Z"
 		},
 		{
 			"checksumSHA1": "at2TCvaAzU3jBW7yngHYVD9e7EI=",


### PR DESCRIPTION
When a cluster is creating, it will not return most values, including bool values like `PublicSLB`, `MasterAutoRenew`, it will throw a parse panic in sdk.

So if we use `alicloud_cs_kubernetes_clusters` against creating clusters, terraform will throw error out.

This is related to changes in sdk, see https://github.com/denverdino/aliyungo/pull/328

