### PR TITLE
Bugfix: destroying alicloud_ess_attachment timeout.

### DIFF
--- a/alicloud/resource_alicloud_ess_attachment_test.go
+++ b/alicloud/resource_alicloud_ess_attachment_test.go
@@ -109,11 +109,10 @@ func testAccEssAttachmentConfig(common string, rand int) string {
 	variable "name" {
 		default = "tf-testAccEssAttachmentConfig-%d"
 	}
+
 	data "alicloud_instance_types" "special" {
-		availability_zone = "${data.alicloud_zones.default.zones.0.id}"
 		cpu_core_count    = 2
 		memory_size       = 4
-		instance_type_family = "ecs.sn1ne"
 	}
 
 	resource "alicloud_ess_scaling_group" "foo" {


### PR DESCRIPTION
=== RUN   TestAccAlicloudEssAlarm_import
--- PASS: TestAccAlicloudEssAlarm_import (46.11s)
=== RUN   TestAccAlicloudEssAttachment_import
--- PASS: TestAccAlicloudEssAttachment_import (102.39s)
=== RUN   TestAccAlicloudEssLifecycleHook_import
--- PASS: TestAccAlicloudEssLifecycleHook_import (36.95s)
=== RUN   TestAccAlicloudEssScalingGroup_importBasic
--- PASS: TestAccAlicloudEssScalingGroup_importBasic (41.64s)
=== RUN   TestAccAlicloudEssSchedule_importBasic
--- PASS: TestAccAlicloudEssSchedule_importBasic (37.93s)
=== RUN   TestAccAlicloudEssAlarm_basic
--- PASS: TestAccAlicloudEssAlarm_basic (45.39s)
=== RUN   TestAccAlicloudEssAlarm_with_dimension
--- PASS: TestAccAlicloudEssAlarm_with_dimension (47.06s)
=== RUN   TestAccAlicloudEssAlarm_update
--- PASS: TestAccAlicloudEssAlarm_update (59.59s)
=== RUN   TestAccAlicloudEssAttachment_basic
--- PASS: TestAccAlicloudEssAttachment_basic (124.42s)
=== RUN   TestAccAlicloudEssLifecycleHook_basic
--- PASS: TestAccAlicloudEssLifecycleHook_basic (50.42s)
=== RUN   TestAccAlicloudEssScalingConfiguration_basic
--- PASS: TestAccAlicloudEssScalingConfiguration_basic (41.22s)
=== RUN   TestAccAlicloudEssScalingConfiguration_SystemDisk
--- PASS: TestAccAlicloudEssScalingConfiguration_SystemDisk (45.71s)
=== RUN   TestAccAlicloudEssScalingConfiguration_multiConfig
--- PASS: TestAccAlicloudEssScalingConfiguration_multiConfig (48.12s)
=== RUN   TestAccAlicloudEssScalingConfiguration_active
--- PASS: TestAccAlicloudEssScalingConfiguration_active (40.09s)
=== RUN   TestAccAlicloudEssScalingConfiguration_disable
--- PASS: TestAccAlicloudEssScalingConfiguration_disable (41.52s)
=== RUN   TestAccAlicloudEssScalingGroup_basic
--- PASS: TestAccAlicloudEssScalingGroup_basic (202.90s)
=== RUN   TestAccAlicloudEssScalingGroup_vpc
--- PASS: TestAccAlicloudEssScalingGroup_vpc (41.14s)
=== RUN   TestAccAlicloudEssScalingGroup_slb
--- PASS: TestAccAlicloudEssScalingGroup_slb (67.01s)
=== RUN   TestAccAlicloudEssScalingGroup_slbempty
--- PASS: TestAccAlicloudEssScalingGroup_slbempty (38.66s)
=== RUN   TestAccAlicloudEssScalingRule_basic
--- PASS: TestAccAlicloudEssScalingRule_basic (38.65s)
=== RUN   TestAccAlicloudEssScalingRule_update
--- PASS: TestAccAlicloudEssScalingRule_update (56.26s)
=== RUN   TestAccAlicloudEssSchedule_basic
--- PASS: TestAccAlicloudEssSchedule_basic (40.41s)
PASS
ok      github.com/terraform-providers/terraform-provider-alicloud/alicloud     1293.645s
