### PR TITLE
RDS auto-renewal option

### DIFF
--- a/website/docs/r/db_instance.html.markdown
+++ b/website/docs/r/db_instance.html.markdown
@@ -95,6 +95,8 @@ The following arguments are supported:
 * `instance_name` - (Optional) The name of DB instance. It a string of 2 to 256 characters.
 * `instance_charge_type` - (Optional) Valid values are `Prepaid`, `Postpaid`, Default to `Postpaid`.
 * `period` - (Optional) The duration that you will buy DB instance (in month). It is valid when instance_charge_type is `PrePaid`. Valid values: [1~9], 12, 24, 36. Default to 1.
+* `auto_renew` - (Optional) Whether to renewal a DB instance automatically or not. It is valid when instance_charge_type is `PrePaid`.Default to `false`.
+* `auto_renew_period` - (Optional) Auto-renewal period of an instance, in the unit of the month. It is valid when instance_charge_type is `PrePaid`. Valid value:[1~12], Default to 1.
 * `zone_id` - (Optional) The Zone to launch the DB instance. From version 1.8.1, it supports multiple zone.
 If it is a multi-zone and `vswitch_id` is specified, the vswitch must in the one of them.
 The multiple zone ID can be retrieved by setting `multi` to "true" in the data source `alicloud_zones`.


### PR DESCRIPTION
RDS auto-renewal option is only available when instance charge type is prepaid,
and the test will fail at the sweep when the test finish
so I deleted the code of the test as you said.