### PR TITLE
fix kubernetes data resource ut and import error

### DIFF
--- a/alicloud/data_source_alicloud_cs_kubernetes_clusters.go
+++ b/alicloud/data_source_alicloud_cs_kubernetes_clusters.go
@@ -371,7 +371,7 @@ func csKubernetesClusterDescriptionAttributes(d *schema.ResourceData, clusterTyp
 			"name": ct.Name,
 		}
 
-		if detailedEnabled, ok := d.GetOk("enable_details"); ok && detailedEnabled.(bool) {
+		if detailedEnabled, ok := d.GetOk("enable_details"); ok && !detailedEnabled.(bool) {
 			ids = append(ids, ct.ClusterID)
 			names = append(names, ct.Name)
 			s = append(s, mapping)

--- a/vendor/github.com/denverdino/aliyungo/cs/clusters.go
+++ b/vendor/github.com/denverdino/aliyungo/cs/clusters.go
@@ -371,21 +371,20 @@ func (client *Client) DescribeKubernetesCluster(id string) (cluster KubernetesCl
 	cluster.MetaData = metaData
 	cluster.RawMetaData = ""
 
-	parseBoolOrNil(cluster.Parameters.RawWorkerDataDisk, cluster.Parameters.WorkerDataDisk)
-	parseBoolOrNil(cluster.Parameters.RawPublicSLB, cluster.Parameters.PublicSLB)
-	parseBoolOrNil(cluster.Parameters.RawMasterAutoRenew, cluster.Parameters.MasterAutoRenew)
-	parseBoolOrNil(cluster.Parameters.RawWorkerAutoRenew, cluster.Parameters.WorkerAutoRenew)
+	cluster.Parameters.WorkerDataDisk = parseBoolOrNil(cluster.Parameters.RawWorkerDataDisk)
+	cluster.Parameters.PublicSLB = parseBoolOrNil(cluster.Parameters.RawPublicSLB)
+	cluster.Parameters.MasterAutoRenew = parseBoolOrNil(cluster.Parameters.RawMasterAutoRenew)
+	cluster.Parameters.WorkerAutoRenew = parseBoolOrNil(cluster.Parameters.RawWorkerAutoRenew)
 
 	return
 }
 
-func parseBoolOrNil(rawField string, field *bool) {
+func parseBoolOrNil(rawField string) *bool {
 	boolVal, err := strconv.ParseBool(rawField)
 	if err == nil {
-		field = &boolVal
-	} else {
-		field = nil
+		return &boolVal
 	}
+	return nil
 }
 
 type ClusterResizeArgs struct {

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -479,10 +479,10 @@
 			"revisionTime": "2018-03-30T09:12:25Z"
 		},
 		{
-			"checksumSHA1": "w1VKRFUkkiOUridp2Z6YWWBfJ6M=",
+			"checksumSHA1": "5MJSrIYW63bUoXAMYi/fobu3Va0=",
 			"path": "github.com/denverdino/aliyungo/cs",
-			"revision": "249f2b04395bcb9079ce0966b23a905a23e0881d",
-			"revisionTime": "2019-03-05T07:31:55Z"
+			"revision": "f1fa5f5452eecbd698451e4f2c126c340aa9dbe4",
+			"revisionTime": "2019-03-08T22:55:17Z"
 		},
 		{
 			"checksumSHA1": "at2TCvaAzU3jBW7yngHYVD9e7EI=",


### PR DESCRIPTION
fixed following error, one is related to the https://github.com/denverdino/aliyungo/pull/329
```
=== RUN   TestAccAlicloudCSKubernetesClustersDataSource_AutoVpc
--- FAIL: TestAccAlicloudCSKubernetesClustersDataSource_AutoVpc (1159.01s)
testing.go:434: Step 0 error: Check failed: Check 4/15 error: data.alicloud_cs_kubernetes_clusters.k8s_clusters: Attribute 'clusters.0.worker_numbers.#' expected "1", got "0"
=== RUN   TestAccAlicloudCSKubernetes_import
--- FAIL: TestAccAlicloudCSKubernetes_import (1179.20s)
testing.go:434: Step 1 error: ImportStateVerify attributes not equivalent. Difference is shown below. Top is actual, bottom is expected.

(map[string]string) {
}


(map[string]string) (len=1) {
(string) (len=20) "slb_internet_enabled": (string) (len=4) "true"
}
```