### PR TITLE
feat(nas): add datasource access groups

### DIFF
--- a/alicloud/data_source_alicloud_nas_access_groups.go
+++ b/alicloud/data_source_alicloud_nas_access_groups.go
@@ -1,0 +1,160 @@
+package alicloud
+
+import (
+	"regexp"
+
+	"github.com/aliyun/alibaba-cloud-sdk-go/sdk/requests"
+	"github.com/aliyun/alibaba-cloud-sdk-go/services/nas"
+	"github.com/hashicorp/terraform/helper/schema"
+	"github.com/terraform-providers/terraform-provider-alicloud/alicloud/connectivity"
+)
+
+func dataSourceAlicloudAccessGroups() *schema.Resource {
+	return &schema.Resource{
+		Read: dataSourceAlicloudAccessGroupsRead,
+
+		Schema: map[string]*schema.Schema{
+			"name_regex": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ValidateFunc: validateNameRegex,
+				ForceNew:     true,
+			},
+			"type": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"description": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"ids": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+			},
+			"output_file": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+
+			// groups values
+			"groups": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"rule_count": {
+							Type:     schema.TypeInt,
+							Computed: true,
+						},
+						"type": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"mount_target_count": {
+							Type:     schema.TypeInt,
+							Computed: true,
+						},
+						"description": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func dataSourceAlicloudAccessGroupsRead(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*connectivity.AliyunClient)
+
+	args := nas.CreateDescribeAccessGroupsRequest()
+	args.RegionId = string(client.Region)
+	args.PageSize = requests.NewInteger(PageSizeLarge)
+	args.PageNumber = requests.NewInteger(1)
+
+	var allAgs []nas.AccessGroup
+	var nameRegex *regexp.Regexp
+	if v, ok := d.GetOk("name_regex"); ok {
+		if r, err := regexp.Compile(Trim(v.(string))); err == nil {
+			nameRegex = r
+		}
+	}
+	invoker := NewInvoker()
+	for {
+		var raw interface{}
+		if err := invoker.Run(func() error {
+			rsp, err := client.WithNasClient(func(nasClient *nas.Client) (interface{}, error) {
+				return nasClient.DescribeAccessGroups(args)
+			})
+			raw = rsp
+			return err
+		}); err != nil {
+			return WrapErrorf(err, DataDefaultErrorMsg, "alicloud_nas_access_groups", args.GetActionName(), AlibabaCloudSdkGoERROR)
+		}
+		resp, _ := raw.(*nas.DescribeAccessGroupsResponse)
+		if resp == nil || len(resp.AccessGroups.AccessGroup) < 1 {
+			break
+		}
+		for _, ag := range resp.AccessGroups.AccessGroup {
+			if v, ok := d.GetOk("type"); ok && ag.AccessGroupType != Trim(v.(string)) {
+				continue
+			}
+
+			if v, ok := d.GetOk("description"); ok && ag.Description != v.(string) {
+				continue
+			}
+			if nameRegex != nil {
+				if !nameRegex.MatchString(ag.AccessGroupName) {
+					continue
+				}
+			}
+			allAgs = append(allAgs, ag)
+		}
+		if len(resp.AccessGroups.AccessGroup) < PageSizeLarge {
+			break
+		}
+
+		if page, err := getNextpageNumber(args.PageNumber); err != nil {
+			return WrapError(err)
+		} else {
+			args.PageNumber = page
+		}
+	}
+	return AccessGroupsDecriptionAttributes(d, allAgs, meta)
+}
+
+func AccessGroupsDecriptionAttributes(d *schema.ResourceData, nasSetTypes []nas.AccessGroup, meta interface{}) error {
+	var ids []string
+	var s []map[string]interface{}
+	for _, ag := range nasSetTypes {
+		mapping := map[string]interface{}{
+			"id":                 ag.AccessGroupName,
+			"type":               ag.AccessGroupType,
+			"description":        ag.Description,
+			"mount_target_count": ag.MountTargetCount,
+			"rule_count":         ag.RuleCount,
+		}
+		ids = append(ids, ag.AccessGroupName)
+		s = append(s, mapping)
+	}
+
+	d.SetId(dataResourceIdHash(ids))
+	if err := d.Set("groups", s); err != nil {
+		return WrapError(err)
+	}
+	if err := d.Set("ids", ids); err != nil {
+		return WrapError(err)
+	}
+	// create a json file in current directory and write data source to it.
+	if output, ok := d.GetOk("output_file"); ok && output.(string) != "" {
+		writeToFile(output.(string), s)
+	}
+	return nil
+}

--- a/alicloud/data_source_alicloud_nas_access_groups_test.go
+++ b/alicloud/data_source_alicloud_nas_access_groups_test.go
@@ -1,0 +1,210 @@
+package alicloud
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform/helper/acctest"
+	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/terraform-providers/terraform-provider-alicloud/alicloud/connectivity"
+)
+
+func TestAccAlicloudNasAccessGroupDataSource_all(t *testing.T) {
+	rand := acctest.RandIntRange(10000, 999999)
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheckWithRegions(t, true, connectivity.NasClassicSupportedRegions)
+		},
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCheckAlicloudAccessGroupsDataSourceAll(rand),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAlicloudDataSourceID("data.alicloud_nas_access_groups.ag"),
+					resource.TestCheckResourceAttr("data.alicloud_nas_access_groups.ag", "groups.#", "1"),
+					resource.TestCheckResourceAttrSet("data.alicloud_nas_access_groups.ag", "groups.0.rule_count"),
+					resource.TestCheckResourceAttr("data.alicloud_nas_access_groups.ag", "groups.0.type", "Classic"),
+					resource.TestCheckResourceAttr("data.alicloud_nas_access_groups.ag", "groups.0.description", "tf-testAccAccessGroupsdatasource"),
+					resource.TestCheckResourceAttr("data.alicloud_nas_access_groups.ag", "groups.0.id", fmt.Sprintf("tf-testAccAccessGroupsdatasource-%d", rand)),
+					resource.TestCheckResourceAttrSet("data.alicloud_nas_access_groups.ag", "groups.0.mount_target_count"),
+					resource.TestCheckResourceAttr("data.alicloud_nas_access_groups.ag", "ids.#", "1"),
+					resource.TestCheckResourceAttr("data.alicloud_nas_access_groups.ag", "ids.0", fmt.Sprintf("tf-testAccAccessGroupsdatasource-%d", rand)),
+				),
+			},
+			{
+				Config: testAccCheckAlicloudAccessGroupsDataSourceAllEmpty(rand),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAlicloudDataSourceID("data.alicloud_nas_access_groups.ag"),
+					resource.TestCheckResourceAttr("data.alicloud_nas_access_groups.ag", "groups.#", "0"),
+					resource.TestCheckResourceAttr("data.alicloud_nas_access_groups.ag", "ids.#", "0"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAlicloudNasAccessGroupDataSource_type(t *testing.T) {
+	rand := acctest.RandIntRange(10000, 999999)
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+		},
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCheckAlicloudAccessGroupsDataSourceType(rand),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAlicloudDataSourceID("data.alicloud_nas_access_groups.ag"),
+					resource.TestCheckResourceAttr("data.alicloud_nas_access_groups.ag", "groups.#", "1"),
+					resource.TestCheckResourceAttrSet("data.alicloud_nas_access_groups.ag", "groups.0.rule_count"),
+					resource.TestCheckResourceAttr("data.alicloud_nas_access_groups.ag", "groups.0.type", "Vpc"),
+					resource.TestCheckResourceAttr("data.alicloud_nas_access_groups.ag", "groups.0.description", "tf-testAccAccessGroupsdatasource"),
+					resource.TestCheckResourceAttr("data.alicloud_nas_access_groups.ag", "groups.0.id", fmt.Sprintf("tf-testAccAccessGroupsdatasource-%d", rand)),
+					resource.TestCheckResourceAttrSet("data.alicloud_nas_access_groups.ag", "groups.0.mount_target_count"),
+					resource.TestCheckResourceAttr("data.alicloud_nas_access_groups.ag", "ids.#", "1"),
+					resource.TestCheckResourceAttr("data.alicloud_nas_access_groups.ag", "ids.0", fmt.Sprintf("tf-testAccAccessGroupsdatasource-%d", rand)),
+				),
+			},
+			{
+				Config: testAccCheckAlicloudAccessGroupsDataSourceTypeEmpty(rand),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAlicloudDataSourceID("data.alicloud_nas_access_groups.ag"),
+					resource.TestCheckResourceAttr("data.alicloud_nas_access_groups.ag", "groups.#", "0"),
+					resource.TestCheckResourceAttr("data.alicloud_nas_access_groups.ag", "ids.#", "0"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAlicloudNasAccessGroupDataSource_description(t *testing.T) {
+	rand := acctest.RandIntRange(10000, 999999)
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+		},
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCheckAlicloudAccessGroupsDataSourceDescription(rand),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAlicloudDataSourceID("data.alicloud_nas_access_groups.ag"),
+					resource.TestCheckResourceAttr("data.alicloud_nas_access_groups.ag", "groups.#", "1"),
+					resource.TestCheckResourceAttrSet("data.alicloud_nas_access_groups.ag", "groups.0.rule_count"),
+					resource.TestCheckResourceAttr("data.alicloud_nas_access_groups.ag", "groups.0.type", "Vpc"),
+					resource.TestCheckResourceAttr("data.alicloud_nas_access_groups.ag", "groups.0.description", "tf-testAccAccessGroupsdatasource"),
+					resource.TestCheckResourceAttr("data.alicloud_nas_access_groups.ag", "groups.0.id", fmt.Sprintf("tf-testAccAccessGroupsdatasource-%d", rand)),
+					resource.TestCheckResourceAttrSet("data.alicloud_nas_access_groups.ag", "groups.0.mount_target_count"),
+					resource.TestCheckResourceAttr("data.alicloud_nas_access_groups.ag", "ids.#", "1"),
+					resource.TestCheckResourceAttr("data.alicloud_nas_access_groups.ag", "ids.0", fmt.Sprintf("tf-testAccAccessGroupsdatasource-%d", rand)),
+				),
+			},
+			{
+				Config: testAccCheckAlicloudAccessGroupsDataSourceDescriptionEmpty(rand),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAlicloudDataSourceID("data.alicloud_nas_access_groups.ag"),
+					resource.TestCheckResourceAttr("data.alicloud_nas_access_groups.ag", "groups.#", "0"),
+					resource.TestCheckResourceAttr("data.alicloud_nas_access_groups.ag", "ids.#", "0"),
+				),
+			},
+		},
+	})
+}
+
+func testAccCheckAlicloudAccessGroupsDataSourceAll(rand int) string {
+	return fmt.Sprintf(`
+	variable "name" {
+		default = "tf-testAccAccessGroupsdatasource-%d"
+	}
+	resource "alicloud_nas_access_group" "foo" {
+		name = "${var.name}"
+		type = "Classic"
+		description = "tf-testAccAccessGroupsdatasource"
+	}
+	data "alicloud_nas_access_groups" "ag" {
+		name_regex = "testAccAccessGroupsdatasource*"
+		type = "${alicloud_nas_access_group.foo.type}"
+		description = "tf-testAccAccessGroupsdatasource"
+	}`, rand)
+}
+
+func testAccCheckAlicloudAccessGroupsDataSourceType(rand int) string {
+	return fmt.Sprintf(`
+	variable "name" {
+        	default = "tf-testAccAccessGroupsdatasource-%d"
+	}
+	resource "alicloud_nas_access_group" "foo" {
+        	name = "${var.name}"
+	        type = "Vpc"
+	        description = "tf-testAccAccessGroupsdatasource"
+	}
+	data "alicloud_nas_access_groups" "ag" {
+        	name_regex = "testAccAccessGroupsdatasource*"
+	        type = "${alicloud_nas_access_group.foo.type}"
+	}`, rand)
+}
+
+func testAccCheckAlicloudAccessGroupsDataSourceDescription(rand int) string {
+	return fmt.Sprintf(`
+	variable "name" {
+        	default = "tf-testAccAccessGroupsdatasource-%d"
+	}
+	resource "alicloud_nas_access_group" "foo" {
+        	name = "${var.name}"
+	        type = "Vpc"
+	        description = "tf-testAccAccessGroupsdatasource"
+	}
+	data "alicloud_nas_access_groups" "ag" {
+        	name_regex = "testAccAccessGroupsdatasource*"
+	        description = "${alicloud_nas_access_group.foo.description}"
+	}`, rand)
+}
+
+func testAccCheckAlicloudAccessGroupsDataSourceAllEmpty(rand int) string {
+	return fmt.Sprintf(`
+	variable "name" {
+                 default = "tf-testAccAccessGroupsdatasource-%d"
+        }
+        resource "alicloud_nas_access_group" "foo" {
+                name = "${var.name}"
+                type = "Classic"
+                description = "tf-testAccAccessGroupsdatasource"
+        }
+        data "alicloud_nas_access_groups" "ag" {
+                name_regex = "testAccAccessGroupsdatasource*"
+                type = "Vpc"
+                description = "tf-testAccAccessGroups"
+        }`, rand)
+}
+
+func testAccCheckAlicloudAccessGroupsDataSourceTypeEmpty(rand int) string {
+	return fmt.Sprintf(`
+        variable "name" {
+                default = "tf-testAccAccessGroupsdatasource-%d"
+        }
+        resource "alicloud_nas_access_group" "foo" {
+                name = "${var.name}"
+                type = "Vpc"
+                description = "tf-testAccAccessGroupsdatasource"
+        }
+        data "alicloud_nas_access_groups" "ag" {
+                name_regex = "testAccAccessGroupsdatasource*"
+                type = "Classis"
+        }`, rand)
+}
+
+func testAccCheckAlicloudAccessGroupsDataSourceDescriptionEmpty(rand int) string {
+	return fmt.Sprintf(`
+        variable "name" {
+                default = "tf-testAccAccessGroupsdatasource-%d"
+        }
+        resource "alicloud_nas_access_group" "foo" {
+                name = "${var.name}"
+                type = "Vpc"
+                description = "tf-testAccAccessGroupsdatasource"
+        }
+        data "alicloud_nas_access_groups" "ag" {
+                name_regex = "testAccAccessGroupsdatasource*"
+                description = "tf-testAccAccessGroups"
+        }`, rand)
+}

--- a/alicloud/import_alicloud_nas_access_group_test.go
+++ b/alicloud/import_alicloud_nas_access_group_test.go
@@ -3,19 +3,20 @@ package alicloud
 import (
 	"testing"
 
+	"github.com/hashicorp/terraform/helper/acctest"
 	"github.com/hashicorp/terraform/helper/resource"
 )
 
 func TestAccAlicloudNasAccessGroup_importBasic(t *testing.T) {
 	resourceName := "alicloud_nas_access_group.foo"
-
+	rand := acctest.RandIntRange(10000, 999999)
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAccessGroupDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccNasAccessGroupConfig,
+				Config: testAccNasAccessGroupVpcConfig(rand),
 			},
 
 			{

--- a/alicloud/import_alicloud_nas_access_rule_test.go
+++ b/alicloud/import_alicloud_nas_access_rule_test.go
@@ -3,19 +3,20 @@ package alicloud
 import (
 	"testing"
 
+	"github.com/hashicorp/terraform/helper/acctest"
 	"github.com/hashicorp/terraform/helper/resource"
 )
 
 func TestAccAlicloudNasAccessRule_importBasic(t *testing.T) {
 	resourceName := "alicloud_nas_access_rule.foo"
-
+	rand := acctest.RandIntRange(10000, 999999)
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAccessRuleDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccNasAccessRuleConfig,
+				Config: testAccNasAccessRuleVpcConfig(rand),
 			},
 
 			{

--- a/alicloud/provider.go
+++ b/alicloud/provider.go
@@ -141,6 +141,10 @@ func Provider() terraform.ResourceProvider {
 			"alicloud_api_gateway_groups":       dataSourceAlicloudApiGatewayGroups(),
 			"alicloud_api_gateway_apps":         dataSourceAlicloudApiGatewayApps(),
 			"alicloud_elasticsearch_instances":  dataSourceAlicloudElasticsearch(),
+			"alicloud_nas_access_groups":        dataSourceAlicloudAccessGroups(),
+			//"alicloud_nas_access_rules":         dataSourceAlicloudAccessRules(),
+			//"alicloud_nas_mount_targets":        dataSourceAlicloudMountTargets(),
+			//"alicloud_nas_file_systems":         dataSourceAlicloudFileSystems(),
 		},
 		ResourcesMap: map[string]*schema.Resource{
 			"alicloud_instance":                           resourceAliyunInstance(),

--- a/website/alicloud.erb
+++ b/website/alicloud.erb
@@ -202,6 +202,9 @@
                         <li<%= sidebar_current("docs-alicloud-datasource-elasticsearch-instances") %>>
                             <a href="/docs/providers/alicloud/d/elasticsearch.html">alicloud_elasticsearch_instances</a>
                         </li>
+			<li<%= sidebar_current("docs-alicloud-datasource-nas-access-groups") %>>
+                            <a href="/docs/providers/alicloud/d/nas_access_groups.html">alicloud_nas_access_groups</a>
+                        </li>
                     </ul>
                 </li>
 

--- a/website/docs/d/nas_access_groups.html.markdown
+++ b/website/docs/d/nas_access_groups.html.markdown
@@ -1,0 +1,48 @@
+---
+layout: "alicloud"
+page_title: "Alicloud: alicloud_nas_access_groups"
+sidebar_current: "docs-alicloud-datasource-nas-access-groups"
+description: |-
+  Provides a list of Access Groups owned by an Alibaba Cloud account.
+---
+
+# alicloud\_nas_access_groups
+
+This data source provides user-available access groups. Use when you can create mount points
+
+-> NOTE: Available in 1.35.0+
+
+## Example Usage
+
+```
+data "alicloud_nas_access_groups" "ag" {
+  name_regex = "^foo"
+  type = "Classic"
+  description = "tf-testAccAccessGroupsdatasource"
+}
+
+output "first_nas_access_groups_id" {
+  value = "${data.alicloud_nas_access_groups.nas_access_groups_ds.access_groups.0.id}"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `name_regex` - (Required) A regex string to filter AccessGroups by name. 
+* `type` - (Optional) Filter results by a specific AccessGroupType.
+* `description` - (Optional) Filter results by a specific Description.
+* `output_file` - (Optional) File name where to save data source results (after running `terraform plan`).
+
+## Attributes Reference
+
+The following attributes are exported in addition to the arguments listed above:
+
+* `ids` - A list of AccessGroup IDs.
+* `groups` - A list of AccessGroups. Each element contains the following attributes:
+ * `id` - AccessGroupName of the AccessGroup.
+ * `rule_count` - RuleCount of the AccessGroup.
+ * `type` - AccessGroupType of the AccessGroup.
+ * `mount_target_count` - MountTargetCount block of the AccessGroup
+ * `description` - Destription of the AccessGroup.


### PR DESCRIPTION
=== RUN   TestAccAlicloudNasAccessGroupDataSource_all
--- PASS: TestAccAlicloudNasAccessGroupDataSource_all (1.26s)
=== RUN   TestAccAlicloudNasAccessGroupDataSource_type
--- PASS: TestAccAlicloudNasAccessGroupDataSource_type (0.90s)
=== RUN   TestAccAlicloudNasAccessGroupDataSource_description
--- PASS: TestAccAlicloudNasAccessGroupDataSource_description (0.89s)
=== RUN   TestAccAlicloudNasAccessGroupDataSource_empty
--- PASS: TestAccAlicloudNasAccessGroupDataSource_empty (0.44s)
PASS


=== RUN   TestAccAlicloudNas_AccessRule_basic
--- PASS: TestAccAlicloudNas_AccessRule_basic (1.68s)
=== RUN   TestAccAlicloudNas_AccessRule_update
--- PASS: TestAccAlicloudNas_AccessRule_update (2.27s)
PASS