### PR TITLE
Add waiting method to ensure the security group status is ok

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ IMPROVEMENTS:
 
 BUG FIXES:
 
+- Add waiting method to ensure the security group status is ok [GH-873]
 - Fix nas mount target notfound bug and improve nas datasource's testcases [GH-872]
 - Fix dns notfound bug [GH-871]
 - fix creating slb bug [GH-870]

--- a/alicloud/common.go
+++ b/alicloud/common.go
@@ -18,6 +18,9 @@ import (
 
 	"runtime/debug"
 
+	"path/filepath"
+	"runtime"
+
 	"github.com/aliyun/alibaba-cloud-sdk-go/sdk/requests"
 	"github.com/denverdino/aliyungo/common"
 	"github.com/google/uuid"
@@ -158,6 +161,8 @@ const DefaultTimeoutMedium = 500
 
 // timeout for long time progerss product, rds e.g.
 const DefaultLongTimeout = 1000
+
+const DefaultIntervalMini = 2
 
 const DefaultIntervalShort = 5
 
@@ -531,4 +536,14 @@ func addDebug(action, content interface{}) {
 		fmt.Printf(DefaultDebugMsg, action, content, debug.Stack())
 		log.Printf(DefaultDebugMsg, action, content, debug.Stack())
 	}
+}
+
+// Return a ComplexError which including extra error message, error occurred file and path
+func GetFunc(level int) string {
+	pc, _, _, ok := runtime.Caller(level)
+	if !ok {
+		log.Printf("[ERROR] runtime.Caller error in GetFuncName.")
+		return ""
+	}
+	return strings.TrimPrefix(filepath.Ext(runtime.FuncForPC(pc).Name()), ".")
 }

--- a/alicloud/errors.go
+++ b/alicloud/errors.go
@@ -632,6 +632,7 @@ const DefaultErrorMsg = "Resource %s %s Failed!!! %s"
 const NotFoundMsg = ResourceNotFound + "!!! %s"
 const DefaultTimeoutMsg = "Resource %s %s Timeout!!! %s"
 const DeleteTimeoutMsg = "Resource %s Still Exists. %s Timeout!!! %s"
+const WaitTimeoutMsg = "Resource %s %s Timeout In %d Seconds. Current: %s. Target: %s.!!! %s"
 const DataDefaultErrorMsg = "Datasource %s %s Failed!!! %s"
 
 const DefaultDebugMsg = "\n*************** %s Response *************** \n%s\n%s******************************\n"

--- a/alicloud/resource_alicloud_instance.go
+++ b/alicloud/resource_alicloud_instance.go
@@ -785,10 +785,10 @@ func buildAliyunInstanceArgs(d *schema.ResourceData, meta interface{}) (*ecs.Run
 		sg0 := sgList[0]
 		// check security group instance exist
 		resp, err := ecsService.DescribeSecurityGroupAttribute(sg0)
-		if err == nil {
-			args.SecurityGroupId = sg0
+		if err != nil {
+			return nil, WrapError(err)
 		}
-
+		args.SecurityGroupId = resp.SecurityGroupId
 		if resp.VpcId != "" && d.Get("vswitch_id").(string) == "" {
 			return nil, fmt.Errorf("The specified security_group_id %s is in a VPC %s, and `vswitch_id` is required when creating a new instance resource in a VPC.", sg0, resp.VpcId)
 		}

--- a/alicloud/resource_alicloud_security_group.go
+++ b/alicloud/resource_alicloud_security_group.go
@@ -50,6 +50,7 @@ func resourceAliyunSecurityGroup() *schema.Resource {
 
 func resourceAliyunSecurityGroupCreate(d *schema.ResourceData, meta interface{}) error {
 	client := meta.(*connectivity.AliyunClient)
+	ecsService := EcsService{client}
 
 	request := ecs.CreateCreateSecurityGroupRequest()
 
@@ -70,13 +71,16 @@ func resourceAliyunSecurityGroupCreate(d *schema.ResourceData, meta interface{})
 		return ecsClient.CreateSecurityGroup(request)
 	})
 	if err != nil {
-		return WrapErrorf(err, DefaultErrorMsg, "security_group:", request.GetActionName(), AlibabaCloudSdkGoERROR)
+		return WrapErrorf(err, DefaultErrorMsg, "security_group", request.GetActionName(), AlibabaCloudSdkGoERROR)
 	}
 	resp, _ := raw.(*ecs.CreateSecurityGroupResponse)
 	if resp == nil {
 		return WrapError(fmt.Errorf("Creating security group got a nil response."))
 	}
 	d.SetId(resp.SecurityGroupId)
+	if err := ecsService.WaitForCreateSecurityGroup(d.Id(), DefaultTimeout); err != nil {
+		return WrapError(err)
+	}
 	return resourceAliyunSecurityGroupUpdate(d, meta)
 }
 
@@ -84,31 +88,18 @@ func resourceAliyunSecurityGroupRead(d *schema.ResourceData, meta interface{}) e
 	client := meta.(*connectivity.AliyunClient)
 	ecsService := EcsService{client}
 
-	var sg *ecs.DescribeSecurityGroupAttributeResponse
-	err := resource.Retry(1*time.Minute, func() *resource.RetryError {
-		group, e := ecsService.DescribeSecurityGroupAttribute(d.Id())
-		if e != nil {
-			if NotFoundError(e) || IsExceptedErrors(e, []string{InvalidSecurityGroupIdNotFound}) {
-				return nil
-			}
-			return resource.NonRetryableError(fmt.Errorf("Error DescribeSecurityGroupAttribute: %#v", e))
-		}
-		if group.SecurityGroupId != "" {
-			sg = &group
+	object, err := ecsService.DescribeSecurityGroupAttribute(d.Id())
+	if err != nil {
+		if NotFoundError(err) {
+			d.SetId("")
 			return nil
 		}
-		return resource.RetryableError(fmt.Errorf("Create security group timeout and got an error: %#v", e))
-	})
-
-	if sg == nil {
-		d.SetId("")
-		return nil
 	}
 
-	d.Set("name", sg.SecurityGroupName)
-	d.Set("description", sg.Description)
-	d.Set("vpc_id", sg.VpcId)
-	d.Set("inner_access", sg.InnerAccessPolicy == string(GroupInnerAccept))
+	d.Set("name", object.SecurityGroupName)
+	d.Set("description", object.Description)
+	d.Set("vpc_id", object.VpcId)
+	d.Set("inner_access", object.InnerAccessPolicy == string(GroupInnerAccept))
 
 	tags, err := ecsService.DescribeTags(d.Id(), TagResourceSecurityGroup)
 	if err != nil && !NotFoundError(err) {
@@ -123,11 +114,9 @@ func resourceAliyunSecurityGroupRead(d *schema.ResourceData, meta interface{}) e
 
 func resourceAliyunSecurityGroupUpdate(d *schema.ResourceData, meta interface{}) error {
 	client := meta.(*connectivity.AliyunClient)
+	ecsService := EcsService{client}
 
 	d.Partial(true)
-	attributeUpdate := false
-	args := ecs.CreateModifySecurityGroupAttributeRequest()
-	args.SecurityGroupId = d.Id()
 
 	if err := setTags(client, TagResourceSecurityGroup, d); err != nil {
 		return WrapError(err)
@@ -135,42 +124,56 @@ func resourceAliyunSecurityGroupUpdate(d *schema.ResourceData, meta interface{})
 		d.SetPartial("tags")
 	}
 
-	if d.HasChange("name") && !d.IsNewResource() {
-		args.SecurityGroupName = d.Get("name").(string)
-		attributeUpdate = true
+	if d.HasChange("inner_access") || d.IsNewResource() {
+		if !(d.Get("inner_access").(bool) && d.IsNewResource()) {
+			policy := GroupInnerAccept
+			if !d.Get("inner_access").(bool) {
+				policy = GroupInnerDrop
+			}
+			request := ecs.CreateModifySecurityGroupPolicyRequest()
+			request.SecurityGroupId = d.Id()
+			request.InnerAccessPolicy = string(policy)
+			request.ClientToken = buildClientToken(request.GetActionName())
+
+			_, err := client.WithEcsClient(func(ecsClient *ecs.Client) (interface{}, error) {
+				return ecsClient.ModifySecurityGroupPolicy(request)
+			})
+			if err != nil {
+				return WrapErrorf(err, DefaultErrorMsg, d.Id(), request.GetActionName(), AlibabaCloudSdkGoERROR)
+			}
+			if err := ecsService.WaitForModifySecurityGroupPolicy(d.Id(), request.InnerAccessPolicy, DefaultTimeout); err != nil {
+				return WrapError(err)
+			}
+			d.SetPartial("inner_access")
+		}
 	}
 
-	if d.HasChange("description") && !d.IsNewResource() {
-		args.Description = d.Get("description").(string)
-		attributeUpdate = true
+	if d.IsNewResource() {
+		d.Partial(false)
+		return resourceAliyunSecurityGroupRead(d, meta)
 	}
-	if attributeUpdate {
+
+	update := false
+	request := ecs.CreateModifySecurityGroupAttributeRequest()
+	request.SecurityGroupId = d.Id()
+	if d.HasChange("name") {
+		request.SecurityGroupName = d.Get("name").(string)
+		update = true
+	}
+
+	if d.HasChange("description") {
+		request.Description = d.Get("description").(string)
+		update = true
+	}
+	if update {
 		_, err := client.WithEcsClient(func(ecsClient *ecs.Client) (interface{}, error) {
-			return ecsClient.ModifySecurityGroupAttribute(args)
+			return ecsClient.ModifySecurityGroupAttribute(request)
 		})
 		if err != nil {
-			return WrapErrorf(err, DefaultErrorMsg, d.Id(), args.GetActionName(), AlibabaCloudSdkGoERROR)
+			return WrapErrorf(err, DefaultErrorMsg, d.Id(), request.GetActionName(), AlibabaCloudSdkGoERROR)
 		}
 		d.SetPartial("name")
 		d.SetPartial("description")
-	}
-
-	if d.HasChange("inner_access") || d.IsNewResource() {
-		policy := GroupInnerAccept
-		if !d.Get("inner_access").(bool) {
-			policy = GroupInnerDrop
-		}
-		args := ecs.CreateModifySecurityGroupPolicyRequest()
-		args.SecurityGroupId = d.Id()
-		args.InnerAccessPolicy = string(policy)
-
-		_, err := client.WithEcsClient(func(ecsClient *ecs.Client) (interface{}, error) {
-			return ecsClient.ModifySecurityGroupPolicy(args)
-		})
-		if err != nil {
-			return WrapErrorf(err, DefaultErrorMsg, d.Id(), args.GetActionName(), AlibabaCloudSdkGoERROR)
-		}
-		d.SetPartial("inner_access")
 	}
 
 	d.Partial(false)
@@ -181,32 +184,31 @@ func resourceAliyunSecurityGroupUpdate(d *schema.ResourceData, meta interface{})
 func resourceAliyunSecurityGroupDelete(d *schema.ResourceData, meta interface{}) error {
 	client := meta.(*connectivity.AliyunClient)
 	ecsService := EcsService{client}
-	req := ecs.CreateDeleteSecurityGroupRequest()
-	req.SecurityGroupId = d.Id()
+	request := ecs.CreateDeleteSecurityGroupRequest()
+	request.SecurityGroupId = d.Id()
 
 	return resource.Retry(6*time.Minute, func() *resource.RetryError {
 		_, err := client.WithEcsClient(func(ecsClient *ecs.Client) (interface{}, error) {
-			return ecsClient.DeleteSecurityGroup(req)
+			return ecsClient.DeleteSecurityGroup(request)
 		})
 
 		if err != nil {
 			if IsExceptedError(err, SgDependencyViolation) {
-				return resource.RetryableError(fmt.Errorf("Delete security group timeout and got an error: %#v", err))
-			}
-		}
-
-		sg, err := ecsService.DescribeSecurityGroupAttribute(d.Id())
-
-		if err != nil {
-			if NotFoundError(err) || IsExceptedError(err, InvalidSecurityGroupIdNotFound) {
-				return nil
+				return resource.RetryableError(WrapErrorf(err, DefaultErrorMsg, d.Id(), request.GetActionName(), AlibabaCloudSdkGoERROR))
 			}
 			return resource.NonRetryableError(err)
-		} else if sg.SecurityGroupId == "" {
-			return nil
 		}
 
-		return resource.RetryableError(fmt.Errorf("Delete security group timeout and got an error: %#v", err))
+		_, err = ecsService.DescribeSecurityGroupAttribute(d.Id())
+
+		if err != nil {
+			if NotFoundError(err) {
+				return nil
+			}
+			return resource.NonRetryableError(WrapError(err))
+		}
+
+		return resource.RetryableError(WrapErrorf(err, DefaultTimeoutMsg, d.Id(), request.GetActionName(), ProviderERROR))
 	})
 
 }

--- a/alicloud/resource_alicloud_security_group_rule.go
+++ b/alicloud/resource_alicloud_security_group_rule.go
@@ -330,7 +330,7 @@ func buildAliyunSGRuleRequest(d *schema.ResourceData, meta interface{}) (*reques
 
 	group, err := ecsService.DescribeSecurityGroupAttribute(sgId)
 	if err != nil {
-		return nil, fmt.Errorf("Error get security group %s error: %#v", sgId, err)
+		return nil, WrapError(err)
 	}
 
 	if v, ok := d.GetOk("nic_type"); ok {


### PR DESCRIPTION
```
TF_ACC=1 go test ./alicloud -v -run=TestAccAlicloudSecurityGroup -timeout=240m
=== RUN   TestAccAlicloudSecurityGroupRulesDataSourceWithDirection
--- PASS: TestAccAlicloudSecurityGroupRulesDataSourceWithDirection (20.94s)
=== RUN   TestAccAlicloudSecurityGroupRulesDataSourceWithGroupId
--- PASS: TestAccAlicloudSecurityGroupRulesDataSourceWithGroupId (24.03s)
=== RUN   TestAccAlicloudSecurityGroupRulesDataSourceWithNic_Type
--- PASS: TestAccAlicloudSecurityGroupRulesDataSourceWithNic_Type (9.65s)
=== RUN   TestAccAlicloudSecurityGroupRulesDataSourceWithPolicy
--- PASS: TestAccAlicloudSecurityGroupRulesDataSourceWithPolicy (20.10s)
=== RUN   TestAccAlicloudSecurityGroupRulesDataSourceWithIp_Protocol
--- PASS: TestAccAlicloudSecurityGroupRulesDataSourceWithIp_Protocol (20.62s)
=== RUN   TestAccAlicloudSecurityGroupRulesDataSourceEmpty
--- PASS: TestAccAlicloudSecurityGroupRulesDataSourceEmpty (15.16s)
=== RUN   TestAccAlicloudSecurityGroupsDataSource
--- PASS: TestAccAlicloudSecurityGroupsDataSource (18.75s)
=== RUN   TestAccAlicloudSecurityGroupsDataSource_vpc
--- PASS: TestAccAlicloudSecurityGroupsDataSource_vpc (24.27s)
=== RUN   TestAccAlicloudSecurityGroupsDataSource_tags
--- PASS: TestAccAlicloudSecurityGroupsDataSource_tags (19.24s)
=== RUN   TestAccAlicloudSecurityGroupsDataSource_empty
--- PASS: TestAccAlicloudSecurityGroupsDataSource_empty (1.38s)
=== RUN   TestAccAlicloudSecurityGroup_importBasic
--- PASS: TestAccAlicloudSecurityGroup_importBasic (4.53s)
=== RUN   TestAccAlicloudSecurityGroup_importWithVpc
--- PASS: TestAccAlicloudSecurityGroup_importWithVpc (15.27s)
=== RUN   TestAccAlicloudSecurityGroupRule_Ingress
--- PASS: TestAccAlicloudSecurityGroupRule_Ingress (17.69s)
=== RUN   TestAccAlicloudSecurityGroupRule_Egress
--- PASS: TestAccAlicloudSecurityGroupRule_Egress (17.62s)
=== RUN   TestAccAlicloudSecurityGroupRule_EgressWithPolicy
--- PASS: TestAccAlicloudSecurityGroupRule_EgressWithPolicy (17.46s)
=== RUN   TestAccAlicloudSecurityGroupRule_IngressWithNic_Type
--- PASS: TestAccAlicloudSecurityGroupRule_IngressWithNic_Type (17.49s)
=== RUN   TestAccAlicloudSecurityGroupRule_EgressWithPriority
--- PASS: TestAccAlicloudSecurityGroupRule_EgressWithPriority (17.50s)
=== RUN   TestAccAlicloudSecurityGroupRule_EgressWithAll
--- PASS: TestAccAlicloudSecurityGroupRule_EgressWithAll (17.04s)
=== RUN   TestAccAlicloudSecurityGroupRule_IngressWithAll
--- PASS: TestAccAlicloudSecurityGroupRule_IngressWithAll (17.59s)
=== RUN   TestAccAlicloudSecurityGroupRule_IngressWithSourceSecurityGroup
--- PASS: TestAccAlicloudSecurityGroupRule_IngressWithSourceSecurityGroup (20.55s)
=== RUN   TestAccAlicloudSecurityGroupRule_WithMulti
--- PASS: TestAccAlicloudSecurityGroupRule_WithMulti (33.25s)
=== RUN   TestAccAlicloudSecurityGroupRule_MultiAttri
--- PASS: TestAccAlicloudSecurityGroupRule_MultiAttri (36.87s)
=== RUN   TestAccAlicloudSecurityGroup_basic
--- PASS: TestAccAlicloudSecurityGroup_basic (10.34s)
=== RUN   TestAccAlicloudSecurityGroup_withVpc
--- PASS: TestAccAlicloudSecurityGroup_withVpc (15.18s)
=== RUN   TestAccAlicloudSecurityGroup_tags
--- PASS: TestAccAlicloudSecurityGroup_tags (28.71s)
=== RUN   TestAccAlicloudSecurityGroup_inner_access
--- PASS: TestAccAlicloudSecurityGroup_inner_access (198.33s)
PASS
ok  	github.com/terraform-providers/terraform-provider-alicloud/alicloud	659.661s
```