### PR TITLE
Make dns resource code more standard

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ FEATURES:
 
 IMPROVEMENTS:
 
+- Make dns resource code more standard [GH-876]
 - Improve dns resources' testcases [GH-859]
 - Add client token for vpn services [GH-855]
 - reback the lossing datasource [GH-866]

--- a/alicloud/data_source_alicloud_dns_domains.go
+++ b/alicloud/data_source_alicloud_dns_domains.go
@@ -116,11 +116,11 @@ func dataSourceAlicloudDnsDomainsRead(d *schema.ResourceData, meta interface{}) 
 			return dnsClient.DescribeDomains(request)
 		})
 		if err != nil {
-			return WrapErrorf(err, DataDefaultErrorMsg, "dns_domains", request.GetActionName(), AlibabaCloudSdkGoERROR)
+			return WrapErrorf(err, DataDefaultErrorMsg, "alicloud_dns_domains", request.GetActionName(), AlibabaCloudSdkGoERROR)
 		}
 		addDebug(request.GetActionName(), raw)
-		resp, _ := raw.(*alidns.DescribeDomainsResponse)
-		domains := resp.Domains.Domain
+		response, _ := raw.(*alidns.DescribeDomainsResponse)
+		domains := response.Domains.Domain
 		for _, domain := range domains {
 			allDomains = append(allDomains, domain)
 		}

--- a/alicloud/data_source_alicloud_dns_groups.go
+++ b/alicloud/data_source_alicloud_dns_groups.go
@@ -58,11 +58,11 @@ func dataSourceAlicloudDnsGroupsRead(d *schema.ResourceData, meta interface{}) e
 			return dnsClient.DescribeDomainGroups(request)
 		})
 		if err != nil {
-			return WrapErrorf(err, DataDefaultErrorMsg, "dns_groups", request.GetActionName(), AlibabaCloudSdkGoERROR)
+			return WrapErrorf(err, DataDefaultErrorMsg, "alicloud_dns_groups", request.GetActionName(), AlibabaCloudSdkGoERROR)
 		}
 		addDebug(request.GetActionName(), raw)
-		resp, _ := raw.(*alidns.DescribeDomainGroupsResponse)
-		groups := resp.DomainGroups.DomainGroup
+		response, _ := raw.(*alidns.DescribeDomainGroupsResponse)
+		groups := response.DomainGroups.DomainGroup
 		for _, domainGroup := range groups {
 			allGroups = append(allGroups, domainGroup)
 		}

--- a/alicloud/data_source_alicloud_dns_records.go
+++ b/alicloud/data_source_alicloud_dns_records.go
@@ -136,11 +136,11 @@ func dataSourceAlicloudDnsRecordsRead(d *schema.ResourceData, meta interface{}) 
 			return dnsClient.DescribeDomainRecords(request)
 		})
 		if err != nil {
-			return WrapErrorf(err, DataDefaultErrorMsg, "dns_records", request.GetActionName(), AlibabaCloudSdkGoERROR)
+			return WrapErrorf(err, DataDefaultErrorMsg, "alicloud_dns_records", request.GetActionName(), AlibabaCloudSdkGoERROR)
 		}
 		addDebug(request.GetActionName(), raw)
-		resp, _ := raw.(*alidns.DescribeDomainRecordsResponse)
-		records := resp.DomainRecords.Record
+		response, _ := raw.(*alidns.DescribeDomainRecordsResponse)
+		records := response.DomainRecords.Record
 		for _, record := range records {
 			allRecords = append(allRecords, record)
 		}

--- a/alicloud/resource_alicloud_dns_group.go
+++ b/alicloud/resource_alicloud_dns_group.go
@@ -34,7 +34,7 @@ func resourceAlicloudDnsGroupCreate(d *schema.ResourceData, meta interface{}) er
 		return dnsClient.AddDomainGroup(request)
 	})
 	if err != nil {
-		return WrapErrorf(err, DefaultErrorMsg, "dns_group", request.GetActionName(), AlibabaCloudSdkGoERROR)
+		return WrapErrorf(err, DefaultErrorMsg, "alicloud_dns_group", request.GetActionName(), AlibabaCloudSdkGoERROR)
 	}
 	addDebug(request.GetActionName(), raw)
 	response, _ := raw.(*alidns.AddDomainGroupResponse)
@@ -66,7 +66,7 @@ func resourceAlicloudDnsGroupRead(d *schema.ResourceData, meta interface{}) erro
 	client := meta.(*connectivity.AliyunClient)
 
 	dnsService := &DnsService{client: client}
-	domainGroup, err := dnsService.DescribeDnsGroup(d.Get("name").(string))
+	object, err := dnsService.DescribeDnsGroup(d.Get("name").(string))
 	if err != nil {
 		if NotFoundError(err) {
 			d.SetId("")
@@ -74,7 +74,7 @@ func resourceAlicloudDnsGroupRead(d *schema.ResourceData, meta interface{}) erro
 		}
 		return WrapError(err)
 	}
-	d.Set("name", domainGroup.GroupName)
+	d.Set("name", object.GroupName)
 	return nil
 }
 
@@ -90,7 +90,7 @@ func resourceAlicloudDnsGroupDelete(d *schema.ResourceData, meta interface{}) er
 		})
 		if err != nil {
 			if IsExceptedError(err, FobiddenNotEmptyGroup) {
-				return resource.RetryableError(WrapErrorf(err, DeleteTimeoutMsg, d.Id(), request.GetActionName(), AlibabaCloudSdkGoERROR))
+				return resource.RetryableError(WrapErrorf(err, DefaultTimeoutMsg, d.Id(), request.GetActionName(), AlibabaCloudSdkGoERROR))
 			}
 			return resource.NonRetryableError(WrapErrorf(err, DefaultErrorMsg, d.Id(), request.GetActionName(), AlibabaCloudSdkGoERROR))
 		}

--- a/alicloud/resource_alicloud_slb_test.go
+++ b/alicloud/resource_alicloud_slb_test.go
@@ -140,6 +140,7 @@ func TestAccAlicloudSlb_vpc(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			testAccPreCheck(t)
+			testAccPreCheckWithAccountSiteType(t, DomesticSite)
 		},
 
 		// module name

--- a/alicloud/service_alicloud_dns.go
+++ b/alicloud/service_alicloud_dns.go
@@ -19,12 +19,12 @@ func (s *DnsService) DescribeDns(id string) (*alidns.DescribeDomainInfoResponse,
 	if err != nil {
 		return nil, WrapErrorf(err, DefaultErrorMsg, id, request.GetActionName(), AlibabaCloudSdkGoERROR)
 	}
-	domain, _ := raw.(*alidns.DescribeDomainInfoResponse)
+	response, _ := raw.(*alidns.DescribeDomainInfoResponse)
 	addDebug(request.GetActionName(), raw)
-	if domain.DomainName != id {
+	if response.DomainName != id {
 		return nil, WrapErrorf(Error(GetNotFoundMessage("Dns", id)), NotFoundMsg, ProviderERROR)
 	}
-	return domain, nil
+	return response, nil
 }
 
 func (dns *DnsService) DescribeDnsGroup(id string) (group alidns.DomainGroup, err error) {
@@ -38,9 +38,8 @@ func (dns *DnsService) DescribeDnsGroup(id string) (group alidns.DomainGroup, er
 		return group, WrapErrorf(err, DefaultErrorMsg, id, request.GetActionName(), AlibabaCloudSdkGoERROR)
 	}
 	addDebug(request.GetActionName(), raw)
-	groups, _ := raw.(*alidns.DescribeDomainGroupsResponse)
-	domainGroup := groups.DomainGroups.DomainGroup
-	for _, v := range domainGroup {
+	response, _ := raw.(*alidns.DescribeDomainGroupsResponse)
+	for _, v := range response.DomainGroups.DomainGroup {
 		if v.GroupName == id {
 			group = v
 			return group, nil
@@ -63,9 +62,9 @@ func (dns *DnsService) DescribeDnsRecord(id string) (*alidns.DescribeDomainRecor
 		return nil, WrapErrorf(err, DefaultErrorMsg, id, request.GetActionName(), AlibabaCloudSdkGoERROR)
 	}
 	addDebug(request.GetActionName(), raw)
-	recordInfo, _ := raw.(*alidns.DescribeDomainRecordInfoResponse)
-	if recordInfo.RecordId != id {
+	response, _ := raw.(*alidns.DescribeDomainRecordInfoResponse)
+	if response.RecordId != id {
 		return nil, WrapErrorf(Error(GetNotFoundMessage("DnsRecord", id)), NotFoundMsg, ProviderERROR)
 	}
-	return recordInfo, nil
+	return response, nil
 }


### PR DESCRIPTION
```
TF_ACC=1 go test ./alicloud -v -run=TestAccAlicloudDns -timeout=240m
=== RUN   TestAccAlicloudDnsDomainsDataSource_ali_domain
--- PASS: TestAccAlicloudDnsDomainsDataSource_ali_domain (5.96s)
=== RUN   TestAccAlicloudDnsDomainsDataSource_group_name_regex
--- PASS: TestAccAlicloudDnsDomainsDataSource_group_name_regex (5.62s)
=== RUN   TestAccAlicloudDnsDomainsDataSource_instance_id
--- PASS: TestAccAlicloudDnsDomainsDataSource_instance_id (5.69s)
=== RUN   TestAccAlicloudDnsDomainsDataSource_version_code
--- PASS: TestAccAlicloudDnsDomainsDataSource_version_code (5.93s)
=== RUN   TestAccAlicloudDnsDomainsDataSource_all
--- PASS: TestAccAlicloudDnsDomainsDataSource_all (4.43s)
=== RUN   TestAccAlicloudDnsGroupsDataSource_nameregexAll
--- PASS: TestAccAlicloudDnsGroupsDataSource_nameregexAll (0.83s)
=== RUN   TestAccAlicloudDnsGroupsDataSource_name_regex
--- PASS: TestAccAlicloudDnsGroupsDataSource_name_regex (4.46s)
=== RUN   TestAccAlicloudDnsGroupsDataSource_empty
--- PASS: TestAccAlicloudDnsGroupsDataSource_empty (0.83s)
=== RUN   TestAccAlicloudDnsRecordsDataSource_domain_name
--- PASS: TestAccAlicloudDnsRecordsDataSource_domain_name (5.11s)
=== RUN   TestAccAlicloudDnsRecordsDataSource_host_record_regex
--- PASS: TestAccAlicloudDnsRecordsDataSource_host_record_regex (6.45s)
=== RUN   TestAccAlicloudDnsRecordsDataSource_type
--- PASS: TestAccAlicloudDnsRecordsDataSource_type (6.17s)
=== RUN   TestAccAlicloudDnsRecordsDataSource_value_regex
--- PASS: TestAccAlicloudDnsRecordsDataSource_value_regex (5.95s)
=== RUN   TestAccAlicloudDnsRecordsDataSource_line
--- PASS: TestAccAlicloudDnsRecordsDataSource_line (6.40s)
=== RUN   TestAccAlicloudDnsRecordsDataSource_status
--- PASS: TestAccAlicloudDnsRecordsDataSource_status (6.24s)
=== RUN   TestAccAlicloudDnsRecordsDataSource_is_locked
--- PASS: TestAccAlicloudDnsRecordsDataSource_is_locked (6.07s)
=== RUN   TestAccAlicloudDnsRecordsDataSource_all
--- PASS: TestAccAlicloudDnsRecordsDataSource_all (4.80s)
=== RUN   TestAccAlicloudDnsDomainRecord_importBasic
--- PASS: TestAccAlicloudDnsDomainRecord_importBasic (4.64s)
=== RUN   TestAccAlicloudDnsDomain_importBasic
--- PASS: TestAccAlicloudDnsDomain_importBasic (4.11s)
=== RUN   TestAccAlicloudDnsGroup_basic
--- PASS: TestAccAlicloudDnsGroup_basic (2.75s)
=== RUN   TestAccAlicloudDnsRecord_basic
--- PASS: TestAccAlicloudDnsRecord_basic (21.86s)
=== RUN   TestAccAlicloudDnsRecord_multi
--- PASS: TestAccAlicloudDnsRecord_multi (27.24s)
=== RUN   TestAccAlicloudDns_basic
--- PASS: TestAccAlicloudDns_basic (4.71s)
PASS
ok  	github.com/terraform-providers/terraform-provider-alicloud/alicloud	146.316s

```