### PR TITLE
Make db_connection resource code more standard

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,13 @@
 ## 1.36.0 (Unreleased)
+
+IMPROVEMENTS:
+
+- Make db_connection resource code more standard [GH-879]
+
+BUG FIXES:
+
+- fix rds instance parameter test case issue [GH-880]
+
 ## 1.35.0 (March 18, 2019)
 
 FEATURES:

--- a/alicloud/errors.go
+++ b/alicloud/errors.go
@@ -633,7 +633,7 @@ const DefaultErrorMsg = "Resource %s %s Failed!!! %s"
 const NotFoundMsg = ResourceNotFound + "!!! %s"
 const DefaultTimeoutMsg = "Resource %s %s Timeout!!! %s"
 const DeleteTimeoutMsg = "Resource %s Still Exists. %s Timeout!!! %s"
-const WaitTimeoutMsg = "Resource %s %s Timeout In %d Seconds. Current: %s. Target: %s.!!! %s"
+const WaitTimeoutMsg = "Resource %s %s Timeout In %d Seconds. Current: %s Target: %s !!! %s"
 const DataDefaultErrorMsg = "Datasource %s %s Failed!!! %s"
 
 const DefaultDebugMsg = "\n*************** %s Response *************** \n%s\n%s******************************\n"

--- a/alicloud/import_alicloud_db_connection_test.go
+++ b/alicloud/import_alicloud_db_connection_test.go
@@ -3,6 +3,7 @@ package alicloud
 import (
 	"testing"
 
+	"github.com/hashicorp/terraform/helper/acctest"
 	"github.com/hashicorp/terraform/helper/resource"
 )
 
@@ -15,7 +16,7 @@ func TestAccAlicloudDBConnection_import(t *testing.T) {
 		CheckDestroy: testAccCheckDBConnectionDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccDBConnection_basic(RdsCommonTestCase),
+				Config: testAccDBConnection_basic(RdsCommonTestCase, acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum)),
 			},
 
 			{

--- a/alicloud/resource_alicloud_db_connection_test.go
+++ b/alicloud/resource_alicloud_db_connection_test.go
@@ -2,12 +2,12 @@ package alicloud
 
 import (
 	"fmt"
-	"strings"
 	"testing"
 
 	"regexp"
 
 	"github.com/aliyun/alibaba-cloud-sdk-go/services/rds"
+	"github.com/hashicorp/terraform/helper/acctest"
 	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/terraform"
 	"github.com/terraform-providers/terraform-provider-alicloud/alicloud/connectivity"
@@ -15,8 +15,8 @@ import (
 
 func TestAccAlicloudDBConnection_basic(t *testing.T) {
 	var connection rds.DBInstanceNetInfo
-
-	connectionStringRegexp := regexp.MustCompile("^test-connection.mysql.([a-z-A-Z-0-9]+.){0,1}rds.aliyuncs.com")
+	rand := acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum)
+	connectionStringRegexp := regexp.MustCompile(fmt.Sprintf("^tf-testacc%s.mysql.([a-z-A-Z-0-9]+.){0,1}rds.aliyuncs.com", rand))
 
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
@@ -30,7 +30,7 @@ func TestAccAlicloudDBConnection_basic(t *testing.T) {
 		CheckDestroy: testAccCheckDBConnectionDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccDBConnection_basic(RdsCommonTestCase),
+				Config: testAccDBConnection_basic(RdsCommonTestCase, rand),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckDBConnectionExists(
 						"alicloud_db_connection.foo", &connection),
@@ -44,7 +44,7 @@ func TestAccAlicloudDBConnection_basic(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccDBConnection_update(RdsCommonTestCase),
+				Config: testAccDBConnection_update(RdsCommonTestCase, rand),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckDBConnectionExists(
 						"alicloud_db_connection.foo", &connection),
@@ -75,18 +75,13 @@ func testAccCheckDBConnectionExists(n string, d *rds.DBInstanceNetInfo) resource
 
 		client := testAccProvider.Meta().(*connectivity.AliyunClient)
 		rdsService := RdsService{client}
-		parts := strings.Split(rs.Primary.ID, COLON_SEPARATED)
-		conn, err := rdsService.DescribeDBInstanceNetInfoByIpType(parts[0], Public)
+		object, err := rdsService.DescribeDBConnection(rs.Primary.ID)
 
 		if err != nil {
-			return err
+			return WrapError(err)
 		}
 
-		if conn == nil {
-			return fmt.Errorf("Connection string is not found in the instance %s.", parts[0])
-		}
-
-		*d = *conn
+		*d = *object
 		return nil
 	}
 }
@@ -100,26 +95,22 @@ func testAccCheckDBConnectionDestroy(s *terraform.State) error {
 			continue
 		}
 
-		parts := strings.Split(rs.Primary.ID, COLON_SEPARATED)
-
-		conn, err := rdsService.DescribeDBInstanceNetInfoByIpType(parts[0], Public)
+		_, err := rdsService.DescribeDBConnection(rs.Primary.ID)
 
 		if err != nil {
-			if NotFoundError(err) || IsExceptedError(err, InvalidDBInstanceIdNotFound) || IsExceptedError(err, InvalidCurrentConnectionStringNotFound) {
+			if rdsService.NotFoundDBInstance(err) {
 				continue
 			}
-			return err
+			return WrapError(err)
 		}
 
-		if conn != nil {
-			return fmt.Errorf("Error db connection string prefix %s is still existing.", parts[1])
-		}
+		return WrapError(fmt.Errorf("Error db connection %s still existed.", rs.Primary.ID))
 	}
 
 	return nil
 }
 
-func testAccDBConnection_basic(common string) string {
+func testAccDBConnection_basic(common, rand string) string {
 	return fmt.Sprintf(`
 	%s
 	variable "creation" {
@@ -141,11 +132,11 @@ func testAccDBConnection_basic(common string) string {
 
 	resource "alicloud_db_connection" "foo" {
 	  instance_id = "${alicloud_db_instance.instance.id}"
-	  connection_prefix = "test-connection"
+	  connection_prefix = "tf-testacc%s"
 	}
-	`, common)
+	`, common, rand)
 }
-func testAccDBConnection_update(common string) string {
+func testAccDBConnection_update(common, rand string) string {
 	return fmt.Sprintf(`
 	%s
 	variable "creation" {
@@ -167,8 +158,8 @@ func testAccDBConnection_update(common string) string {
 
 	resource "alicloud_db_connection" "foo" {
 	  instance_id = "${alicloud_db_instance.instance.id}"
-	  connection_prefix = "test-connection"
+	  connection_prefix = "tf-testacc%s"
 	  port = 3333
 	}
-	`, common)
+	`, common, rand)
 }

--- a/alicloud/service_alicloud_ecs.go
+++ b/alicloud/service_alicloud_ecs.go
@@ -186,7 +186,7 @@ func (s *EcsService) DescribeSecurityGroupAttribute(securityGroupId string) (gro
 	addDebug(request.GetActionName(), raw)
 	resp, _ := raw.(*ecs.DescribeSecurityGroupAttributeResponse)
 	if resp == nil {
-		err = WrapError(Error(GetNotFoundMessage("Security Group", securityGroupId)))
+		err = WrapErrorf(Error(GetNotFoundMessage("Security Group", securityGroupId)), NotFoundMsg, ProviderERROR)
 		return
 	}
 


### PR DESCRIPTION
```
TF_ACC=1 go test ./alicloud -v -run=TestAccAlicloudDBConnection -timeout=240m
=== RUN   TestAccAlicloudDBConnection_import
--- PASS: TestAccAlicloudDBConnection_import (332.07s)
=== RUN   TestAccAlicloudDBConnection_basic
--- PASS: TestAccAlicloudDBConnection_basic (675.54s)
PASS
ok  	github.com/terraform-providers/terraform-provider-alicloud/alicloud	1007.673s
```