### PR TITLE
fix rds instance parameter test case issue

### DIFF
--- a/alicloud/resource_alicloud_db_instance_test.go
+++ b/alicloud/resource_alicloud_db_instance_test.go
@@ -6,8 +6,6 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/hashicorp/terraform/helper/hashcode"
-
 	"time"
 
 	"github.com/aliyun/alibaba-cloud-sdk-go/sdk/requests"
@@ -313,7 +311,10 @@ func TestAccAlicloudDBInstance_CreateWithParameter(t *testing.T) {
 						"5.6"),
 					resource.TestCheckResourceAttr("alicloud_db_instance.foo",
 						fmt.Sprintf("parameters.%d.value",
-							hashcode.String("innodb_large_prefix")), "ON"),
+							parameterToHash(map[string]interface{}{
+								"name":  "innodb_large_prefix",
+								"value": "ON",
+							})), "ON"),
 				),
 			},
 		},


### PR DESCRIPTION
```
GOROOT=/usr/local/Cellar/go/1.11.1/libexec #gosetup
GOPATH=/Users/panjiabang/Projects/GOPATH #gosetup
/usr/local/Cellar/go/1.11.1/libexec/bin/go test -c -o /private/var/folders/tt/t72n_q9s77l82s54_c_73rsc0000gn/T/___TestAccAlicloudDBInstance_CreateWithParameter_in_github_com_terraform_providers_terraform_provider_alicloud_alicloud github.com/terraform-providers/terraform-provider-alicloud/alicloud #gosetup
/usr/local/Cellar/go/1.11.1/libexec/bin/go tool test2json -t /private/var/folders/tt/t72n_q9s77l82s54_c_73rsc0000gn/T/___TestAccAlicloudDBInstance_CreateWithParameter_in_github_com_terraform_providers_terraform_provider_alicloud_alicloud -test.v -test.run ^TestAccAlicloudDBInstance_CreateWithParameter$ #gosetup
=== RUN   TestAccAlicloudDBInstance_CreateWithParameter
--- PASS: TestAccAlicloudDBInstance_CreateWithParameter (93.39s)
PASS
```