### PR TITLE
fix(nas): fix mount targets error handling

### DIFF
--- a/alicloud/errors.go
+++ b/alicloud/errors.go
@@ -312,7 +312,7 @@ var DiskInvalidOperation = []string{"IncorrectDiskStatus", "IncorrectInstanceSta
 var NetworkInterfaceInvalidOperations = []string{"InvalidOperation.InvalidEniState", "InvalidOperation.InvalidEcsState", "OperationConflict", "ServiceUnavailable", "InternalError"}
 var OperationDeniedDBStatus = []string{"OperationDenied.DBStatus", OperationDeniedDBInstanceStatus, DBInternalError, DBOperationDeniedOutofUsage}
 var DBReadInstanceNotReadyStatus = []string{"OperationDenied.ReadDBInstanceStatus", "OperationDenied.MasterDBInstanceState", "ReadDBInstance.Mismatch"}
-var NasNotFound = []string{InvalidFileSystemIDNotFound}
+var NasNotFound = []string{InvalidFileSystemIDNotFound, ForbiddenNasNotFound, InvalidMountTargetNotFound}
 
 // An Error represents a custom error for Terraform failure response
 type ProviderError struct {

--- a/alicloud/resource_alicloud_nas_mount_target.go
+++ b/alicloud/resource_alicloud_nas_mount_target.go
@@ -137,16 +137,17 @@ func resourceAlicloudNasMountTargetDelete(d *schema.ResourceData, meta interface
 			return nasClient.DeleteMountTarget(request)
 		})
 		if err != nil {
-			if IsExceptedErrors(err, []string{InvalidMountTargetNotFound, InvalidFileSystemIDNotFound, ForbiddenNasNotFound}) {
+			if IsExceptedErrors(err, NasNotFound) {
 				return nil
 			}
 			return resource.NonRetryableError(WrapErrorf(err, DefaultErrorMsg, d.Id(), request.GetActionName(), AlibabaCloudSdkGoERROR))
 		}
 
 		if _, err := nasService.DescribeNasMountTarget(d.Id()); err != nil {
-			if NotFoundError(err) {
+			if NotFoundError(err) || IsExceptedErrors(err, NasNotFound) {
 				return nil
 			}
+
 			return resource.NonRetryableError(WrapError(err))
 		}
 		return resource.RetryableError(WrapErrorf(err, DeleteTimeoutMsg, d.Id(), request.GetActionName(), ProviderERROR))


### PR DESCRIPTION
=== RUN   TestAccAlicloudNasMountTargetDataSourceAccessGroupName
--- PASS: TestAccAlicloudNasMountTargetDataSourceAccessGroupName (19.35s)
=== RUN   TestAccAlicloudNasMountTargetDataSourceType
--- PASS: TestAccAlicloudNasMountTargetDataSourceType (47.47s)
=== RUN   TestAccAlicloudNasMountTargetDataSourceMountTargetDomain
--- PASS: TestAccAlicloudNasMountTargetDataSourceMountTargetDomain (35.15s)
=== RUN   TestAccAlicloudNasMountTargetDataSourceVpcId
--- PASS: TestAccAlicloudNasMountTargetDataSourceVpcId (43.77s)
=== RUN   TestAccAlicloudNasMountTargetDataSourceVSwitchId
--- PASS: TestAccAlicloudNasMountTargetDataSourceVSwitchId (52.78s)
=== RUN   TestAccAlicloudNasMountTargetDataSourceAll
--- PASS: TestAccAlicloudNasMountTargetDataSourceAll (49.92s)
=== RUN   TestAccAlicloudNasMountTarget_importBasic
--- PASS: TestAccAlicloudNasMountTarget_importBasic (12.90s)
PASS