### PR TITLE
Add Common Bandwidth Packages Datasource

### DIFF
--- a/alicloud/data_source_alicloud_common_bandwidth_package_test.go
+++ b/alicloud/data_source_alicloud_common_bandwidth_package_test.go
@@ -1,0 +1,217 @@
+package alicloud
+
+import (
+	"testing"
+
+	"regexp"
+
+	"github.com/hashicorp/terraform/helper/resource"
+)
+
+func TestAccAlicloudCommonBandwidthPackagesDataSourceBasic(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+		},
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCheckAlicloudCommonBandwidthPackagesDataSourceConfig,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAlicloudDataSourceID("data.alicloud_common_bandwidth_packages.foo"),
+					resource.TestCheckResourceAttr("data.alicloud_common_bandwidth_packages.foo", "packages.#", "1"),
+					resource.TestCheckResourceAttrSet("data.alicloud_common_bandwidth_packages.foo", "packages.0.id"),
+					resource.TestCheckResourceAttrSet("data.alicloud_common_bandwidth_packages.foo", "packages.0.isp"),
+					resource.TestCheckResourceAttrSet("data.alicloud_common_bandwidth_packages.foo", "packages.0.creation_time"),
+					resource.TestCheckResourceAttrSet("data.alicloud_common_bandwidth_packages.foo", "packages.0.status"),
+					resource.TestCheckResourceAttrSet("data.alicloud_common_bandwidth_packages.foo", "packages.0.business_status"),
+					resource.TestMatchResourceAttr("data.alicloud_common_bandwidth_packages.foo", "packages.0.name", regexp.MustCompile("^tf-testAcc-for-cbwp-datasourc")),
+					resource.TestMatchResourceAttr("data.alicloud_common_bandwidth_packages.foo", "packages.0.description", regexp.MustCompile("^tf-testAcc-for-cbwp-datasourc")),
+					resource.TestCheckResourceAttr("data.alicloud_common_bandwidth_packages.foo", "packages.0.bandwidth", "2"),
+					resource.TestCheckResourceAttr("data.alicloud_common_bandwidth_packages.foo", "ids.#", "1"),
+					resource.TestCheckResourceAttr("data.alicloud_common_bandwidth_packages.foo", "names.#", "1"),
+				),
+			},
+			{
+				Config: testAccCheckAlicloudCommonBandwidthPackagesDataSourceConfig_mismatch,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAlicloudDataSourceID("data.alicloud_common_bandwidth_packages.foo"),
+					resource.TestCheckResourceAttr("data.alicloud_common_bandwidth_packages.foo", "packages.#", "0"),
+					resource.TestCheckResourceAttr("data.alicloud_common_bandwidth_packages.foo", "ids.#", "0"),
+					resource.TestCheckResourceAttr("data.alicloud_common_bandwidth_packages.foo", "names.#", "0"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAlicloudCommonBandwidthPackagesDataSourceNameRegex(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+		},
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCheckAlicloudCommonBandwidthPackagesDataSourceNameRegex,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAlicloudDataSourceID("data.alicloud_common_bandwidth_packages.foo"),
+					resource.TestCheckResourceAttr("data.alicloud_common_bandwidth_packages.foo", "packages.#", "1"),
+					resource.TestCheckResourceAttrSet("data.alicloud_common_bandwidth_packages.foo", "packages.0.id"),
+					resource.TestCheckResourceAttrSet("data.alicloud_common_bandwidth_packages.foo", "packages.0.isp"),
+					resource.TestCheckResourceAttrSet("data.alicloud_common_bandwidth_packages.foo", "packages.0.creation_time"),
+					resource.TestCheckResourceAttrSet("data.alicloud_common_bandwidth_packages.foo", "packages.0.status"),
+					resource.TestCheckResourceAttrSet("data.alicloud_common_bandwidth_packages.foo", "packages.0.business_status"),
+					resource.TestMatchResourceAttr("data.alicloud_common_bandwidth_packages.foo", "packages.0.name", regexp.MustCompile("^tf-testAcc-for-cbwp-datasourc")),
+					resource.TestMatchResourceAttr("data.alicloud_common_bandwidth_packages.foo", "packages.0.description", regexp.MustCompile("^tf-testAcc-for-cbwp-datasourc")),
+					resource.TestCheckResourceAttr("data.alicloud_common_bandwidth_packages.foo", "packages.0.bandwidth", "2"),
+					resource.TestCheckResourceAttr("data.alicloud_common_bandwidth_packages.foo", "ids.#", "1"),
+					resource.TestCheckResourceAttr("data.alicloud_common_bandwidth_packages.foo", "names.#", "1"),
+				),
+			},
+			{
+				Config: testAccCheckAlicloudCommonBandwidthPackagesDataSourceNameRegex_mismatch,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAlicloudDataSourceID("data.alicloud_common_bandwidth_packages.foo"),
+					resource.TestCheckResourceAttr("data.alicloud_common_bandwidth_packages.foo", "packages.#", "0"),
+					resource.TestCheckResourceAttr("data.alicloud_common_bandwidth_packages.foo", "ids.#", "0"),
+					resource.TestCheckResourceAttr("data.alicloud_common_bandwidth_packages.foo", "names.#", "0"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAlicloudCommonBandwidthPackagesDataSourceIds(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+		},
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCheckAlicloudCommonBandwidthPackagesDataSourceIds,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAlicloudDataSourceID("data.alicloud_common_bandwidth_packages.foo"),
+					resource.TestCheckResourceAttr("data.alicloud_common_bandwidth_packages.foo", "packages.#", "1"),
+					resource.TestCheckResourceAttrSet("data.alicloud_common_bandwidth_packages.foo", "packages.0.id"),
+					resource.TestCheckResourceAttrSet("data.alicloud_common_bandwidth_packages.foo", "packages.0.isp"),
+					resource.TestCheckResourceAttrSet("data.alicloud_common_bandwidth_packages.foo", "packages.0.creation_time"),
+					resource.TestCheckResourceAttrSet("data.alicloud_common_bandwidth_packages.foo", "packages.0.status"),
+					resource.TestCheckResourceAttrSet("data.alicloud_common_bandwidth_packages.foo", "packages.0.business_status"),
+					resource.TestMatchResourceAttr("data.alicloud_common_bandwidth_packages.foo", "packages.0.name", regexp.MustCompile("^tf-testAcc-for-cbwp-datasourc")),
+					resource.TestMatchResourceAttr("data.alicloud_common_bandwidth_packages.foo", "packages.0.description", regexp.MustCompile("^tf-testAcc-for-cbwp-datasourc")),
+					resource.TestCheckResourceAttr("data.alicloud_common_bandwidth_packages.foo", "packages.0.bandwidth", "2"),
+					resource.TestCheckResourceAttr("data.alicloud_common_bandwidth_packages.foo", "ids.#", "1"),
+					resource.TestCheckResourceAttr("data.alicloud_common_bandwidth_packages.foo", "names.#", "1"),
+				),
+			},
+			{
+				Config: testAccCheckAlicloudCommonBandwidthPackagesDataSourceIds_mismatch,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAlicloudDataSourceID("data.alicloud_common_bandwidth_packages.foo"),
+					resource.TestCheckResourceAttr("data.alicloud_common_bandwidth_packages.foo", "packages.#", "0"),
+					resource.TestCheckResourceAttr("data.alicloud_common_bandwidth_packages.foo", "ids.#", "0"),
+					resource.TestCheckResourceAttr("data.alicloud_common_bandwidth_packages.foo", "names.#", "0"),
+				),
+			},
+		},
+	})
+}
+
+const testAccCheckAlicloudCommonBandwidthPackagesDataSourceConfig = `
+variable "name" {
+  default = "tf-testAcc-for-cbwp-datasource"
+}
+
+resource "alicloud_common_bandwidth_package" "foo" {
+  bandwidth = "2"
+  name = "${var.name}"
+  description = "${var.name}"
+}
+
+data "alicloud_common_bandwidth_packages" "foo"  {
+  name_regex = "${alicloud_common_bandwidth_package.foo.name}"
+  ids = ["${alicloud_common_bandwidth_package.foo.id}"]
+}
+`
+const testAccCheckAlicloudCommonBandwidthPackagesDataSourceConfig_mismatch = `
+variable "name" {
+  default = "tf-testAcc-for-cbwp-datasource"
+}
+
+resource "alicloud_common_bandwidth_package" "foo" {
+  bandwidth = "2"
+  name = "${var.name}"
+  description = "${var.name}"
+}
+
+data "alicloud_common_bandwidth_packages" "foo"  {
+  name_regex = "${alicloud_common_bandwidth_package.foo.name}-fake"
+  ids = ["${alicloud_common_bandwidth_package.foo.id}-fake"]
+}
+`
+
+const testAccCheckAlicloudCommonBandwidthPackagesDataSourceNameRegex = `
+variable "name" {
+  default = "tf-testAcc-for-cbwp-datasource"
+}
+
+resource "alicloud_common_bandwidth_package" "foo" {
+  bandwidth = "2"
+  name = "${var.name}"
+  description = "${var.name}"
+}
+
+data "alicloud_common_bandwidth_packages" "foo"  {
+  name_regex = "${alicloud_common_bandwidth_package.foo.name}"
+}
+`
+
+const testAccCheckAlicloudCommonBandwidthPackagesDataSourceNameRegex_mismatch = `
+variable "name" {
+  default = "tf-testAcc-for-cbwp-datasource"
+}
+
+resource "alicloud_common_bandwidth_package" "foo" {
+  bandwidth = "2"
+  name = "${var.name}"
+  description = "${var.name}"
+}
+
+data "alicloud_common_bandwidth_packages" "foo"  {
+  name_regex = "${alicloud_common_bandwidth_package.foo.name}-fake"
+}
+`
+
+const testAccCheckAlicloudCommonBandwidthPackagesDataSourceIds = `
+variable "name" {
+  default = "tf-testAcc-for-cbwp-datasource"
+}
+
+resource "alicloud_common_bandwidth_package" "foo" {
+  bandwidth = "2"
+  name = "${var.name}"
+  description = "${var.name}"
+}
+
+data "alicloud_common_bandwidth_packages" "foo"  {
+  ids = ["${alicloud_common_bandwidth_package.foo.id}"]
+}
+`
+
+const testAccCheckAlicloudCommonBandwidthPackagesDataSourceIds_mismatch = `
+variable "name" {
+  default = "tf-testAcc-for-cbwp-datasource"
+}
+
+resource "alicloud_common_bandwidth_package" "foo" {
+  bandwidth = "2"
+  name = "${var.name}"
+  description = "${var.name}"
+}
+
+data "alicloud_common_bandwidth_packages" "foo"  {
+  ids = ["${alicloud_common_bandwidth_package.foo.id}-fake"]
+}
+`

--- a/alicloud/data_source_alicloud_common_bandwidth_packages.go
+++ b/alicloud/data_source_alicloud_common_bandwidth_packages.go
@@ -1,0 +1,206 @@
+package alicloud
+
+import (
+	"regexp"
+
+	"github.com/aliyun/alibaba-cloud-sdk-go/sdk/requests"
+	"github.com/aliyun/alibaba-cloud-sdk-go/services/vpc"
+	"github.com/hashicorp/terraform/helper/schema"
+	"github.com/terraform-providers/terraform-provider-alicloud/alicloud/connectivity"
+)
+
+func dataSourceAlicloudCommonBandwidthPackages() *schema.Resource {
+	return &schema.Resource{
+		Read: dataSourceAlicloudCommonBandwidthPackagesRead,
+
+		Schema: map[string]*schema.Schema{
+			"name_regex": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ValidateFunc: validateNameRegex,
+				ForceNew:     true,
+			},
+			"output_file": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"ids": {
+				Type:     schema.TypeList,
+				Optional: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+				ForceNew: true,
+				Computed: true,
+			},
+			"names": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+			},
+
+			// Computed values
+			"packages": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"bandwidth": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"status": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"name": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"description": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"business_status": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"isp": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"creation_time": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"public_ip_addresses": {
+							Type:     schema.TypeList,
+							Computed: true,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"ip_address": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+									"allocation_id": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+								},
+							},
+							MinItems: 0,
+						},
+					},
+				},
+			},
+		},
+	}
+}
+func dataSourceAlicloudCommonBandwidthPackagesRead(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*connectivity.AliyunClient)
+
+	request := vpc.CreateDescribeCommonBandwidthPackagesRequest()
+	request.RegionId = string(client.Region)
+	request.PageSize = requests.NewInteger(PageSizeLarge)
+	request.PageNumber = requests.NewInteger(1)
+	idsMap := make(map[string]string)
+	if v, ok := d.GetOk("ids"); ok {
+		for _, vv := range v.([]interface{}) {
+			idsMap[Trim(vv.(string))] = Trim(vv.(string))
+		}
+	}
+
+	var allCommonBandwidthPackages []vpc.CommonBandwidthPackage
+	var nameRegex *regexp.Regexp
+	if v, ok := d.GetOk("name_regex"); ok {
+		if r, err := regexp.Compile(Trim(v.(string))); err == nil {
+			nameRegex = r
+		}
+	}
+	invoker := NewInvoker()
+	for {
+		var raw interface{}
+		if err := invoker.Run(func() error {
+			response, err := client.WithVpcClient(func(vpcClient *vpc.Client) (interface{}, error) {
+				return vpcClient.DescribeCommonBandwidthPackages(request)
+			})
+			raw = response
+			return err
+		}); err != nil {
+			return WrapErrorf(err, DataDefaultErrorMsg, "alicloud_common_bandwidth_packages", request.GetActionName(), AlibabaCloudSdkGoERROR)
+		}
+		resp, _ := raw.(*vpc.DescribeCommonBandwidthPackagesResponse)
+		if resp == nil || len(resp.CommonBandwidthPackages.CommonBandwidthPackage) < 1 {
+			break
+		}
+
+		for _, cbwp := range resp.CommonBandwidthPackages.CommonBandwidthPackage {
+			if nameRegex != nil {
+				if !nameRegex.MatchString(cbwp.Name) {
+					continue
+				}
+			}
+			if len(idsMap) > 0 {
+				if _, ok := idsMap[cbwp.BandwidthPackageId]; !ok {
+					continue
+				}
+			}
+			allCommonBandwidthPackages = append(allCommonBandwidthPackages, cbwp)
+		}
+
+		if len(resp.CommonBandwidthPackages.CommonBandwidthPackage) < PageSizeSmall {
+			break
+		}
+
+		if page, err := getNextpageNumber(request.PageNumber); err != nil {
+			return WrapError(err)
+		} else {
+			request.PageNumber = page
+		}
+	}
+
+	return CommonBandwidthPackagesDecriptionAttributes(d, allCommonBandwidthPackages, meta)
+}
+
+func CommonBandwidthPackagesDecriptionAttributes(d *schema.ResourceData, cbwps []vpc.CommonBandwidthPackage, meta interface{}) error {
+	client := meta.(*connectivity.AliyunClient)
+	vpcService := VpcService{client}
+	var ids []string
+	var names []string
+	var s []map[string]interface{}
+	for _, cbwp := range cbwps {
+		mapping := map[string]interface{}{
+			"id":                  cbwp.BandwidthPackageId,
+			"bandwidth":           cbwp.Bandwidth,
+			"description":         cbwp.Description,
+			"status":              cbwp.Status,
+			"business_status":     cbwp.BusinessStatus,
+			"isp":                 cbwp.ISP,
+			"name":                cbwp.Name,
+			"creation_time":       cbwp.CreationTime,
+			"public_ip_addresses": vpcService.FlattenPublicIpAddressesMappings(cbwp.PublicIpAddresses.PublicIpAddresse),
+		}
+		names = append(names, cbwp.Name)
+		ids = append(ids, cbwp.BandwidthPackageId)
+		s = append(s, mapping)
+	}
+	d.SetId(dataResourceIdHash(ids))
+	if err := d.Set("packages", s); err != nil {
+		return WrapError(err)
+	}
+	if err := d.Set("names", names); err != nil {
+		return WrapError(err)
+	}
+	if err := d.Set("ids", ids); err != nil {
+		return WrapError(err)
+	}
+
+	// create a json file in current directory and write data source to it.
+	if output, ok := d.GetOk("output_file"); ok && output.(string) != "" {
+		writeToFile(output.(string), s)
+	}
+	return nil
+
+}

--- a/alicloud/provider.go
+++ b/alicloud/provider.go
@@ -151,6 +151,7 @@ func Provider() terraform.ResourceProvider {
 			"alicloud_nas_file_systems":               dataSourceAlicloudFileSystems(),
 			"alicloud_cas_certificates":               dataSourceAlicloudCasCertificates(),
 			"alicloud_actiontrails":                   dataSourceAlicloudActiontrails(),
+			"alicloud_common_bandwidth_packages":      dataSourceAlicloudCommonBandwidthPackages(),
 		},
 		ResourcesMap: map[string]*schema.Resource{
 			"alicloud_instance":                           resourceAliyunInstance(),

--- a/alicloud/service_alicloud_vpc.go
+++ b/alicloud/service_alicloud_vpc.go
@@ -481,3 +481,18 @@ func (s *VpcService) WaitForSnatEntry(tableId, id string, status Status, timeout
 	}
 	return nil
 }
+
+// Flattens an array of vpc.public_ip_addresses into a []map[string]string
+func (s *VpcService) FlattenPublicIpAddressesMappings(list []vpc.PublicIpAddresse) []map[string]interface{} {
+	result := make([]map[string]interface{}, 0, len(list))
+
+	for _, i := range list {
+		l := map[string]interface{}{
+			"ip_address":    i.IpAddress,
+			"allocation_id": i.AllocationId,
+		}
+		result = append(result, l)
+	}
+
+	return result
+}

--- a/website/alicloud.erb
+++ b/website/alicloud.erb
@@ -232,6 +232,9 @@
                         <li<%= sidebar_current("docs-alicloud-datasource-actiontrails") %>>
                             <a href="/docs/providers/alicloud/d/actiontrails.html">alicloud_actiontrails</a>
                         </li>
+                        <li<%= sidebar_current("docs-alicloud-datasource-common-bandwidth-packages") %>>
+                            <a href="/docs/providers/alicloud/d/common_bandwidth_packages.html">alicloud_common_bandwidth_packages</a>
+                        </li>
                     </ul>
                 </li>
 

--- a/website/docs/d/common_bandwidth_packages.html.markdown
+++ b/website/docs/d/common_bandwidth_packages.html.markdown
@@ -1,0 +1,58 @@
+---
+layout: "alicloud"
+page_title: "Alicloud: alicloud_common_bandwidth_packages"
+sidebar_current: "docs-alicloud-datasource-common-bandwidth-packages"
+description: |-
+    Provides a list of Common Bandwidth Packages owned by an Alibaba Cloud account.
+---
+
+# alicloud\_common\_bandwidth\_packages
+
+This data source provides a list of Common Bandwidth Packages owned by an Alibaba Cloud account.
+
+## Example Usage
+
+```
+data "alicloud_common_bandwidth_packages" "foo"  {
+  name_regex = "^tf-testAcc.*"
+  ids = ["${alicloud_common_bandwidth_package.foo.id}"]
+}
+
+resource "alicloud_common_bandwidth_package" "foo" {
+  bandwidth = "2"
+  name = "tf-testAccCommonBandwidthPackage"
+  description = "tf-testAcc-CommonBandwidthPackage"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `ids` - (Optional) A list of Common Bandwidth Packages IDs.
+* `name_regex` - (Optional) A regex string to filter results by name.
+* `output_file` - (Optional) File name where to save data source results (after running `terraform plan`).
+
+## Attributes Reference
+
+The following attributes are exported in addition to the arguments listed above:
+
+* `ids` - (Optional) A list of Common Bandwidth Packages IDs.
+* `names` - A list of Common Bandwidth Packages names.
+* `packages` - A list of Common Bandwidth Packages. Each element contains the following attributes:
+  * `id` - ID of the Common Bandwidth Package.
+  * `bandwidth` - The peak bandwidth of the Internet Shared Bandwidth instance.
+  * `status` - Status of the Common Bandwidth Package.
+  * `name` - Name of the Common Bandwidth Package.
+  * `description` - The description of the Common Bandwidth Package instance.
+  * `business_status` - The business status of the Common Bandwidth Package instance.
+  * `isp` - ISP of the Common Bandwidth Package.
+  * `creation_time` - Time of creation.
+  * `public_ip_addresses` - Public ip addresses that in the Common Bandwidth Pakcage.
+  
+## Public ip addresses Block
+  
+  The public ip addresses mapping supports the following:
+  
+  * `ip_address`   - The address of the EIP.
+  * `allocation_id` - The ID of the EIP instance.


### PR DESCRIPTION
MacBook-Pro-2:terraform-provider-alicloud jince$ TF_ACC=1 go test ./alicloud -v -run=TestAccAlicloudCommonBandwidthPackagesDataSource -timeout=300m
=== RUN   TestAccAlicloudCommonBandwidthPackagesDataSource
--- PASS: TestAccAlicloudCommonBandwidthPackagesDataSource (8.32s)
=== RUN   TestAccAlicloudCommonBandwidthPackagesDataSourceEmpty
--- PASS: TestAccAlicloudCommonBandwidthPackagesDataSourceEmpty (2.97s)
PASS
ok  	github.com/terraform-providers/terraform-provider-alicloud/alicloud	11.348s