### PR TITLE
set userId as d.Id() rather than userName

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ FEATURES:
 IMPROVEMENTS:
 
 - add new schema environment_variables to fc_function.html.markdown [GH-913]
+- set userId as d.Id() rather than userName [GH-900]
 
 BUG FIXES:
 

--- a/website/docs/d/ram_users.html.markdown
+++ b/website/docs/d/ram_users.html.markdown
@@ -41,7 +41,7 @@ The following arguments are supported:
 The following attributes are exported in addition to the arguments listed above:
 
 * `users` - A list of users. Each element contains the following attributes:
-  * `id` - Id of the user.
+  * `id` - The original id is user name, but it is user id in 1.37.0+.
   * `name` - Name of the user.
   * `create_date` - Creation date of the user.
   * `last_login_date` - Last login date of the user.

--- a/website/docs/r/ram_user.html.markdown
+++ b/website/docs/r/ram_user.html.markdown
@@ -40,7 +40,7 @@ The following arguments are supported:
 
 The following attributes are exported:
 
-* `id` - The user ID.
+* `id` - The original id is user name, but it is user id in 1.37.0+.
 * `name` - The user name.
 * `display_name` - The user display name.
 * `mobile` - The user phone number.


### PR DESCRIPTION
=== RUN   TestAccAlicloudRamUser_basic
--- PASS: TestAccAlicloudRamUser_basic (3.70s)
PASS
=== RUN   TestAccAlicloudRamUsersDataSource_for_group
--- PASS: TestAccAlicloudRamUsersDataSource_for_group (4.49s)
=== RUN   TestAccAlicloudRamUsersDataSource_for_policy
--- PASS: TestAccAlicloudRamUsersDataSource_for_policy (4.52s)
=== RUN   TestAccAlicloudRamUsersDataSource_for_all
--- PASS: TestAccAlicloudRamUsersDataSource_for_all (0.67s)
=== RUN   TestAccAlicloudRamUsersDataSource_user_name_regex
--- PASS: TestAccAlicloudRamUsersDataSource_user_name_regex (2.08s)
=== RUN   TestAccAlicloudRamUsersDataSource_empty
--- PASS: TestAccAlicloudRamUsersDataSource_empty (0.70s)
PASS