### PR TITLE
return after the instance deleted when destroy the resource cen instance

### DIFF
--- a/alicloud/service_alicloud_cen.go
+++ b/alicloud/service_alicloud_cen.go
@@ -76,6 +76,30 @@ func (s *CenService) WaitForCenInstance(cenId string, status Status, timeout int
 	return nil
 }
 
+func (s *CenService) WaitForCenInstanceDeleted(cenId string, timeout int) error {
+	if timeout <= 0 {
+		timeout = DefaultTimeout
+	}
+
+	for {
+		_, err := s.DescribeCenInstance(cenId)
+		if err != nil {
+			if NotFoundError(err) {
+				break
+			}
+			return err
+		}
+
+		timeout = timeout - DefaultIntervalShort
+		if timeout <= 0 {
+			return GetTimeErrorFromString(GetTimeoutMessage("CEN", "Deleted"))
+		}
+		time.Sleep(DefaultIntervalShort * time.Second)
+	}
+
+	return nil
+}
+
 func (s *CenService) DescribeCenAttachedChildInstanceById(instanceId, cenId string) (c cbn.ChildInstance, err error) {
 	request := cbn.CreateDescribeCenAttachedChildInstancesRequest()
 	request.CenId = cenId


### PR DESCRIPTION
$TF_ACC=1 go test ./alicloud -v -run=TestAccAlicloudCenInstance
=== RUN   TestAccAlicloudCenInstancesDataSource_cen_id
--- PASS: TestAccAlicloudCenInstancesDataSource_cen_id (12.05s)
=== RUN   TestAccAlicloudCenInstancesDataSource_name_regex
--- PASS: TestAccAlicloudCenInstancesDataSource_name_regex (18.75s)
=== RUN   TestAccAlicloudCenInstancesDataSource_multi_cen_ids
--- PASS: TestAccAlicloudCenInstancesDataSource_multi_cen_ids (29.72s)
=== RUN   TestAccAlicloudCenInstancesDataSource_empty
--- PASS: TestAccAlicloudCenInstancesDataSource_empty (4.09s)
=== RUN   TestAccAlicloudCenInstanceAttachment_importBasic
--- PASS: TestAccAlicloudCenInstanceAttachment_importBasic (47.11s)
=== RUN   TestAccAlicloudCenInstance_importBasic
--- PASS: TestAccAlicloudCenInstance_importBasic (10.53s)
=== RUN   TestAccAlicloudCenInstanceAttachment_basic
--- PASS: TestAccAlicloudCenInstanceAttachment_basic (47.53s)
=== RUN   TestAccAlicloudCenInstanceAttachment_multi_same_regions
--- PASS: TestAccAlicloudCenInstanceAttachment_multi_same_regions (43.83s)
=== RUN   TestAccAlicloudCenInstanceAttachment_multi_different_regions
--- PASS: TestAccAlicloudCenInstanceAttachment_multi_different_regions (91.01s)
=== RUN   TestAccAlicloudCenInstance_basic
--- PASS: TestAccAlicloudCenInstance_basic (10.47s)
=== RUN   TestAccAlicloudCenInstance_update
--- PASS: TestAccAlicloudCenInstance_update (12.91s)
=== RUN   TestAccAlicloudCenInstance_multi
--- PASS: TestAccAlicloudCenInstance_multi (20.80s)
PASS
ok      github.com/terraform-providers/terraform-provider-alicloud/alicloud     348.860s
