### PR TITLE
Add Route Tables Datasource

### DIFF
--- a/alicloud/data_source_alicloud_route_tables.go
+++ b/alicloud/data_source_alicloud_route_tables.go
@@ -1,0 +1,184 @@
+package alicloud
+
+import (
+	"regexp"
+
+	"github.com/aliyun/alibaba-cloud-sdk-go/sdk/requests"
+	"github.com/aliyun/alibaba-cloud-sdk-go/services/vpc"
+	"github.com/hashicorp/terraform/helper/schema"
+	"github.com/terraform-providers/terraform-provider-alicloud/alicloud/connectivity"
+)
+
+func dataSourceAlicloudRouteTables() *schema.Resource {
+	return &schema.Resource{
+		Read: dataSourceAlicloudRouteTablesRead,
+
+		Schema: map[string]*schema.Schema{
+			"name_regex": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ValidateFunc: validateNameRegex,
+				ForceNew:     true,
+			},
+			"output_file": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"vpc_id": {
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: true,
+			},
+			"ids": {
+				Type:     schema.TypeList,
+				Optional: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+				ForceNew: true,
+				Computed: true,
+			},
+			"names": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+			},
+
+			// Computed values
+			"tables": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"router_id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"route_table_type": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"name": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"description": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"creation_time": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+					},
+				},
+			},
+		},
+	}
+}
+func dataSourceAlicloudRouteTablesRead(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*connectivity.AliyunClient)
+
+	request := vpc.CreateDescribeRouteTableListRequest()
+	request.RegionId = string(client.Region)
+	request.PageSize = requests.NewInteger(PageSizeLarge)
+	request.PageNumber = requests.NewInteger(1)
+	idsMap := make(map[string]string)
+	if v, ok := d.GetOk("ids"); ok {
+		for _, vv := range v.([]interface{}) {
+			idsMap[Trim(vv.(string))] = Trim(vv.(string))
+		}
+	}
+
+	var allRouteTables []vpc.RouterTableListType
+	var nameRegex *regexp.Regexp
+	if v, ok := d.GetOk("name_regex"); ok {
+		if r, err := regexp.Compile(Trim(v.(string))); err == nil {
+			nameRegex = r
+		}
+	}
+	invoker := NewInvoker()
+	for {
+		var raw interface{}
+		if err := invoker.Run(func() error {
+			response, err := client.WithVpcClient(func(vpcClient *vpc.Client) (interface{}, error) {
+				return vpcClient.DescribeRouteTableList(request)
+			})
+			raw = response
+			return err
+		}); err != nil {
+			return WrapErrorf(err, DataDefaultErrorMsg, "alicloud_route_tables", request.GetActionName(), AlibabaCloudSdkGoERROR)
+		}
+		resp, _ := raw.(*vpc.DescribeRouteTableListResponse)
+		if resp == nil || len(resp.RouterTableList.RouterTableListType) < 1 {
+			break
+		}
+
+		for _, tables := range resp.RouterTableList.RouterTableListType {
+			if vpc_id, ok := d.GetOk("vpc_id"); ok && tables.VpcId != vpc_id.(string) {
+				continue
+			}
+			if nameRegex != nil {
+				if !nameRegex.MatchString(tables.RouteTableName) {
+					continue
+				}
+			}
+			if len(idsMap) > 0 {
+				if _, ok := idsMap[tables.RouteTableId]; !ok {
+					continue
+				}
+			}
+			allRouteTables = append(allRouteTables, tables)
+		}
+
+		if len(resp.RouterTableList.RouterTableListType) < PageSizeLarge {
+			break
+		}
+
+		if page, err := getNextpageNumber(request.PageNumber); err != nil {
+			return WrapError(err)
+		} else {
+			request.PageNumber = page
+		}
+	}
+
+	return RouteTablesDecriptionAttributes(d, allRouteTables, meta)
+}
+
+func RouteTablesDecriptionAttributes(d *schema.ResourceData, tables []vpc.RouterTableListType, meta interface{}) error {
+	var ids []string
+	var names []string
+	var s []map[string]interface{}
+	for _, table := range tables {
+		mapping := map[string]interface{}{
+			"id":               table.RouteTableId,
+			"router_id":        table.RouterId,
+			"route_table_type": table.RouteTableType,
+			"name":             table.RouteTableName,
+			"description":      table.Description,
+			"creation_time":    table.CreationTime,
+		}
+		names = append(names, table.RouteTableName)
+		ids = append(ids, table.RouteTableId)
+		s = append(s, mapping)
+	}
+	d.SetId(dataResourceIdHash(ids))
+	if err := d.Set("tables", s); err != nil {
+		return WrapError(err)
+	}
+	if err := d.Set("names", names); err != nil {
+		return WrapError(err)
+	}
+	if err := d.Set("ids", ids); err != nil {
+		return WrapError(err)
+	}
+
+	// create a json file in current directory and write data source to it.
+	if output, ok := d.GetOk("output_file"); ok && output.(string) != "" {
+		writeToFile(output.(string), s)
+	}
+	return nil
+
+}

--- a/alicloud/data_source_alicloud_route_tables_test.go
+++ b/alicloud/data_source_alicloud_route_tables_test.go
@@ -1,0 +1,319 @@
+package alicloud
+
+import (
+	"regexp"
+	"testing"
+
+	"github.com/hashicorp/terraform/helper/resource"
+)
+
+func TestAccAlicloudRouteTablesDataSourceBasic(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+		},
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCheckAlicloudRouteTablesDataSourceConfig,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAlicloudDataSourceID("data.alicloud_route_tables.foo"),
+					resource.TestCheckResourceAttr("data.alicloud_route_tables.foo", "tables.#", "1"),
+					resource.TestCheckResourceAttrSet("data.alicloud_route_tables.foo", "tables.0.id"),
+					resource.TestCheckResourceAttrSet("data.alicloud_route_tables.foo", "tables.0.route_table_type"),
+					resource.TestCheckResourceAttrSet("data.alicloud_route_tables.foo", "tables.0.creation_time"),
+					resource.TestCheckResourceAttrSet("data.alicloud_route_tables.foo", "tables.0.router_id"),
+					resource.TestMatchResourceAttr("data.alicloud_route_tables.foo", "tables.0.name", regexp.MustCompile("^tf-testAcc-for-route-tables-datasourc")),
+					resource.TestMatchResourceAttr("data.alicloud_route_tables.foo", "tables.0.description", regexp.MustCompile("^tf-testAcc-for-route-tables-datasourc")),
+					resource.TestCheckResourceAttr("data.alicloud_route_tables.foo", "ids.#", "1"),
+					resource.TestCheckResourceAttr("data.alicloud_route_tables.foo", "names.#", "1"),
+				),
+			},
+			{
+				Config: testAccCheckAlicloudRouteTablesDataSourceConfig_mismatch,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAlicloudDataSourceID("data.alicloud_route_tables.foo"),
+					resource.TestCheckResourceAttr("data.alicloud_route_tables.foo", "tables.#", "0"),
+					resource.TestCheckResourceAttr("data.alicloud_route_tables.foo", "ids.#", "0"),
+					resource.TestCheckResourceAttr("data.alicloud_route_tables.foo", "names.#", "0"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAlicloudRouteTablesDataSourceNameRegex(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+		},
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCheckAlicloudRouteTablesDataSourceNameRegex,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAlicloudDataSourceID("data.alicloud_route_tables.foo"),
+					resource.TestCheckResourceAttr("data.alicloud_route_tables.foo", "tables.#", "1"),
+					resource.TestCheckResourceAttrSet("data.alicloud_route_tables.foo", "tables.0.id"),
+					resource.TestCheckResourceAttrSet("data.alicloud_route_tables.foo", "tables.0.route_table_type"),
+					resource.TestCheckResourceAttrSet("data.alicloud_route_tables.foo", "tables.0.creation_time"),
+					resource.TestCheckResourceAttrSet("data.alicloud_route_tables.foo", "tables.0.router_id"),
+					resource.TestMatchResourceAttr("data.alicloud_route_tables.foo", "tables.0.name", regexp.MustCompile("^tf-testAcc-for-route-tables-datasourc")),
+					resource.TestMatchResourceAttr("data.alicloud_route_tables.foo", "tables.0.description", regexp.MustCompile("^tf-testAcc-for-route-tables-datasourc")),
+					resource.TestCheckResourceAttr("data.alicloud_route_tables.foo", "ids.#", "1"),
+					resource.TestCheckResourceAttr("data.alicloud_route_tables.foo", "names.#", "1"),
+				),
+			},
+			{
+				Config: testAccCheckAlicloudRouteTablesDataSourceNameRegex_mismatch,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAlicloudDataSourceID("data.alicloud_route_tables.foo"),
+					resource.TestCheckResourceAttr("data.alicloud_route_tables.foo", "tables.#", "0"),
+					resource.TestCheckResourceAttr("data.alicloud_route_tables.foo", "ids.#", "0"),
+					resource.TestCheckResourceAttr("data.alicloud_route_tables.foo", "names.#", "0"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAlicloudRouteTablesDataSourceIds(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+		},
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCheckAlicloudRouteTablesDataSourceIds,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAlicloudDataSourceID("data.alicloud_route_tables.foo"),
+					resource.TestCheckResourceAttr("data.alicloud_route_tables.foo", "tables.#", "1"),
+					resource.TestCheckResourceAttrSet("data.alicloud_route_tables.foo", "tables.0.id"),
+					resource.TestCheckResourceAttrSet("data.alicloud_route_tables.foo", "tables.0.route_table_type"),
+					resource.TestCheckResourceAttrSet("data.alicloud_route_tables.foo", "tables.0.creation_time"),
+					resource.TestCheckResourceAttrSet("data.alicloud_route_tables.foo", "tables.0.router_id"),
+					resource.TestMatchResourceAttr("data.alicloud_route_tables.foo", "tables.0.name", regexp.MustCompile("^tf-testAcc-for-route-tables-datasourc")),
+					resource.TestMatchResourceAttr("data.alicloud_route_tables.foo", "tables.0.description", regexp.MustCompile("^tf-testAcc-for-route-tables-datasourc")),
+					resource.TestCheckResourceAttr("data.alicloud_route_tables.foo", "ids.#", "1"),
+					resource.TestCheckResourceAttr("data.alicloud_route_tables.foo", "names.#", "1"),
+				),
+			},
+			{
+				Config: testAccCheckAlicloudRouteTablesDataSourceIds_mismatch,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAlicloudDataSourceID("data.alicloud_route_tables.foo"),
+					resource.TestCheckResourceAttr("data.alicloud_route_tables.foo", "tables.#", "0"),
+					resource.TestCheckResourceAttr("data.alicloud_route_tables.foo", "ids.#", "0"),
+					resource.TestCheckResourceAttr("data.alicloud_route_tables.foo", "names.#", "0"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAlicloudRouteTablesDataSourceVpcId(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+		},
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCheckAlicloudRouteTablesDataSourceVpcId,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAlicloudDataSourceID("data.alicloud_route_tables.foo"),
+					resource.TestCheckResourceAttr("data.alicloud_route_tables.foo", "tables.#", "1"),
+					resource.TestCheckResourceAttrSet("data.alicloud_route_tables.foo", "tables.0.id"),
+					resource.TestCheckResourceAttrSet("data.alicloud_route_tables.foo", "tables.0.route_table_type"),
+					resource.TestCheckResourceAttrSet("data.alicloud_route_tables.foo", "tables.0.creation_time"),
+					resource.TestCheckResourceAttrSet("data.alicloud_route_tables.foo", "tables.0.router_id"),
+					resource.TestMatchResourceAttr("data.alicloud_route_tables.foo", "tables.0.name", regexp.MustCompile("^tf-testAcc-for-route-tables-datasourc")),
+					resource.TestMatchResourceAttr("data.alicloud_route_tables.foo", "tables.0.description", regexp.MustCompile("^tf-testAcc-for-route-tables-datasourc")),
+					resource.TestCheckResourceAttr("data.alicloud_route_tables.foo", "ids.#", "1"),
+					resource.TestCheckResourceAttr("data.alicloud_route_tables.foo", "names.#", "1"),
+				),
+			},
+			{
+				Config: testAccCheckAlicloudRouteTablesDataSourceVpcId_mismatch,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAlicloudDataSourceID("data.alicloud_route_tables.foo"),
+					resource.TestCheckResourceAttr("data.alicloud_route_tables.foo", "tables.#", "0"),
+					resource.TestCheckResourceAttr("data.alicloud_route_tables.foo", "ids.#", "0"),
+					resource.TestCheckResourceAttr("data.alicloud_route_tables.foo", "names.#", "0"),
+				),
+			},
+		},
+	})
+}
+
+const testAccCheckAlicloudRouteTablesDataSourceConfig = `
+variable "name" {
+  default = "tf-testAcc-for-route-tables-datasource"
+}
+
+resource "alicloud_vpc" "foo" {
+	cidr_block = "172.16.0.0/12"
+	name = "${var.name}"
+}
+
+resource "alicloud_route_table" "foo" {
+  vpc_id = "${alicloud_vpc.foo.id}"
+  name = "${var.name}"
+  description = "${var.name}"
+}
+
+data "alicloud_route_tables" "foo" {
+  vpc_id = "${alicloud_vpc.foo.id}"
+  name_regex = "${alicloud_route_table.foo.name}"
+  ids = ["${alicloud_route_table.foo.id}"]
+}
+`
+const testAccCheckAlicloudRouteTablesDataSourceConfig_mismatch = `
+variable "name" {
+  default = "tf-testAcc-for-route-tables-datasource"
+}
+
+resource "alicloud_vpc" "foo" {
+	cidr_block = "172.16.0.0/12"
+	name = "${var.name}"
+}
+
+resource "alicloud_route_table" "foo" {
+  vpc_id = "${alicloud_vpc.foo.id}"
+  name = "${var.name}"
+  description = "${var.name}"
+}
+
+data "alicloud_route_tables" "foo" {
+  vpc_id = "${alicloud_vpc.foo.id}-fake"
+  name_regex = "${alicloud_route_table.foo.name}-fake"
+  ids = ["${alicloud_route_table.foo.id}-fake"]
+}
+`
+
+const testAccCheckAlicloudRouteTablesDataSourceNameRegex = `
+variable "name" {
+  default = "tf-testAcc-for-route-tables-datasource"
+}
+
+resource "alicloud_vpc" "foo" {
+	cidr_block = "172.16.0.0/12"
+	name = "${var.name}"
+}
+
+resource "alicloud_route_table" "foo" {
+  vpc_id = "${alicloud_vpc.foo.id}"
+  name = "${var.name}"
+  description = "${var.name}"
+}
+
+data "alicloud_route_tables" "foo" {
+  name_regex = "${alicloud_route_table.foo.name}"
+}
+`
+
+const testAccCheckAlicloudRouteTablesDataSourceNameRegex_mismatch = `
+variable "name" {
+  default = "tf-testAcc-for-route-tables-datasource"
+}
+
+resource "alicloud_vpc" "foo" {
+	cidr_block = "172.16.0.0/12"
+	name = "${var.name}"
+}
+
+resource "alicloud_route_table" "foo" {
+  vpc_id = "${alicloud_vpc.foo.id}"
+  name = "${var.name}"
+  description = "${var.name}"
+}
+
+data "alicloud_route_tables" "foo" {
+  name_regex = "${alicloud_route_table.foo.name}-fake"
+}
+`
+
+const testAccCheckAlicloudRouteTablesDataSourceIds = `
+variable "name" {
+  default = "tf-testAcc-for-route-tables-datasource"
+}
+
+resource "alicloud_vpc" "foo" {
+	cidr_block = "172.16.0.0/12"
+	name = "${var.name}"
+}
+
+resource "alicloud_route_table" "foo" {
+  vpc_id = "${alicloud_vpc.foo.id}"
+  name = "${var.name}"
+  description = "${var.name}"
+}
+
+data "alicloud_route_tables" "foo" {
+  ids = ["${alicloud_route_table.foo.id}"]
+}
+`
+
+const testAccCheckAlicloudRouteTablesDataSourceIds_mismatch = `
+variable "name" {
+  default = "tf-testAcc-for-route-tables-datasource"
+}
+
+resource "alicloud_vpc" "foo" {
+	cidr_block = "172.16.0.0/12"
+	name = "${var.name}"
+}
+
+resource "alicloud_route_table" "foo" {
+  vpc_id = "${alicloud_vpc.foo.id}"
+  name = "${var.name}"
+  description = "${var.name}"
+}
+
+data "alicloud_route_tables" "foo" {
+  ids = ["${alicloud_route_table.foo.id}-fake"]
+}
+`
+const testAccCheckAlicloudRouteTablesDataSourceVpcId = `
+variable "name" {
+  default = "tf-testAcc-for-route-tables-datasource"
+}
+
+resource "alicloud_vpc" "foo" {
+	cidr_block = "172.16.0.0/12"
+	name = "${var.name}"
+}
+
+resource "alicloud_route_table" "foo" {
+  vpc_id = "${alicloud_vpc.foo.id}"
+  name = "${var.name}"
+  description = "${var.name}"
+}
+
+data "alicloud_route_tables" "foo" {
+  vpc_id = "${alicloud_vpc.foo.id}"
+  name_regex = "${alicloud_route_table.foo.name}"
+}
+`
+const testAccCheckAlicloudRouteTablesDataSourceVpcId_mismatch = `
+variable "name" {
+  default = "tf-testAcc-for-route-tables-datasource"
+}
+
+resource "alicloud_vpc" "foo" {
+	cidr_block = "172.16.0.0/12"
+	name = "${var.name}"
+}
+
+resource "alicloud_route_table" "foo" {
+  vpc_id = "${alicloud_vpc.foo.id}"
+  name = "${var.name}"
+  description = "${var.name}"
+}
+
+data "alicloud_route_tables" "foo" {
+  vpc_id = "${alicloud_vpc.foo.id}-fake"
+  name_regex = "${alicloud_route_table.foo.name}-fake"
+}
+`

--- a/alicloud/provider.go
+++ b/alicloud/provider.go
@@ -152,6 +152,7 @@ func Provider() terraform.ResourceProvider {
 			"alicloud_cas_certificates":               dataSourceAlicloudCasCertificates(),
 			"alicloud_actiontrails":                   dataSourceAlicloudActiontrails(),
 			"alicloud_common_bandwidth_packages":      dataSourceAlicloudCommonBandwidthPackages(),
+			"alicloud_route_tables":                   dataSourceAlicloudRouteTables(),
 		},
 		ResourcesMap: map[string]*schema.Resource{
 			"alicloud_instance":                           resourceAliyunInstance(),

--- a/website/alicloud.erb
+++ b/website/alicloud.erb
@@ -235,6 +235,9 @@
                         <li<%= sidebar_current("docs-alicloud-datasource-common-bandwidth-packages") %>>
                             <a href="/docs/providers/alicloud/d/common_bandwidth_packages.html">alicloud_common_bandwidth_packages</a>
                         </li>
+                        <li<%= sidebar_current("docs-alicloud-datasource-route-tables") %>>
+                            <a href="/docs/providers/alicloud/d/route_tables.html">alicloud_route_tables</a>
+                        </li>
                     </ul>
                 </li>
 

--- a/website/docs/d/route_tables.html.markdown
+++ b/website/docs/d/route_tables.html.markdown
@@ -1,0 +1,58 @@
+---
+layout: "alicloud"
+page_title: "Alicloud: alicloud_route_tables"
+sidebar_current: "docs-alicloud-datasource-route-tables"
+description: |-
+    Provides a list of Route Tables owned by an Alibaba Cloud account.
+---
+
+# alicloud\_route\_tables
+
+This data source provides a list of Route Tables owned by an Alibaba Cloud account.
+
+## Example Usage
+
+```
+variable "name" {
+  default = "tf-testAcc-for-route-tables-datasource"
+}
+
+resource "alicloud_vpc" "foo" {
+	cidr_block = "172.16.0.0/12"
+	name = "${var.name}"
+}
+
+resource "alicloud_route_table" "foo" {
+  vpc_id = "${alicloud_vpc.foo.id}"
+  name = "${var.name}"
+  description = "${var.name}"
+}
+
+data "alicloud_route_tables" "foo" {
+  ids = ["${alicloud_route_table.foo.id}"]
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `ids` - (Optional) A list of Route Tables IDs.
+* `name_regex` - (Optional) A regex string to filter route tables by name.
+* `vpc_id` - (Optional) Vpc id of the route table.
+* `output_file` - (Optional) File name where to save data source results (after running `terraform plan`).
+
+## Attributes Reference
+
+The following attributes are exported in addition to the arguments listed above:
+
+* `ids` - (Optional) A list of Route Tables IDs.
+* `names` - A list of Route Tables names.
+* `tables` - A list of Route Tables. Each element contains the following attributes:
+  * `id` - ID of the Route Table.
+  * `router_id` - Router Id of the route table.
+  * `route_table_type` - The type of route table.
+  * `name` - Name of the route table.
+  * `description` - The description of the route table instance.
+  * `creation_time` - Time of creation.
+


### PR DESCRIPTION
MacBook-Pro-2:terraform-provider-alicloud jince$ TF_ACC=1 go test ./alicloud -v -run=TestAccAlicloudRouteTablesDataSource -timeout=300m
=== RUN   TestAccAlicloudRouteTablesDataSourceBasic
--- PASS: TestAccAlicloudRouteTablesDataSourceBasic (20.29s)
=== RUN   TestAccAlicloudRouteTablesDataSourceNameRegex
--- PASS: TestAccAlicloudRouteTablesDataSourceNameRegex (19.99s)
=== RUN   TestAccAlicloudRouteTablesDataSourceIds
--- PASS: TestAccAlicloudRouteTablesDataSourceIds (19.36s)
PASS
ok  	github.com/terraform-providers/terraform-provider-alicloud/alicloud	59.688s