### PR TITLE
Add wait method for cen instance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,8 +24,9 @@ IMPROVEMENTS:
 
 BUG FIXES:
 
-- Fix cen instance deleting bug [908]
-- Fix cen create bug when one resion is China [903]
+- Add wait method for cen instance [GH-909]
+- Fix cen instance deleting bug [GH-908]
+- Fix cen create bug when one resion is China [GH-903]
 - fix cas_certificate sweeper test bug [GH-899]
 - Modify ram group's name's ForceNew to true [GH-895]
 - fix mount target deletion bugs [GH-892]

--- a/alicloud/common.go
+++ b/alicloud/common.go
@@ -105,6 +105,8 @@ const (
 
 	PUBLISHED   = Status("Published")
 	NOPUBLISHED = Status("NonPublished")
+
+	Deleted = Status("Deleted")
 )
 
 type IPType string
@@ -551,4 +553,13 @@ func GetFunc(level int) string {
 		return ""
 	}
 	return strings.TrimPrefix(filepath.Ext(runtime.FuncForPC(pc).Name()), ".")
+}
+
+func ParseResourceId(id string, length int) (parts []string, err error) {
+	parts = strings.Split(id, ":")
+
+	if len(parts) != length {
+		err = WrapError(fmt.Errorf("Invalid Resource Id %s. Expected parts' length %d, got %d", id, length, len(parts)))
+	}
+	return parts, err
 }

--- a/alicloud/errors.go
+++ b/alicloud/errors.go
@@ -638,7 +638,7 @@ const DefaultErrorMsg = "Resource %s %s Failed!!! %s"
 const NotFoundMsg = ResourceNotFound + "!!! %s"
 const DefaultTimeoutMsg = "Resource %s %s Timeout!!! %s"
 const DeleteTimeoutMsg = "Resource %s Still Exists. %s Timeout!!! %s"
-const WaitTimeoutMsg = "Resource %s %s Timeout In %d Seconds. Current: %s Target: %s !!! %s"
+const WaitTimeoutMsg = "Resource %s %s Timeout In %d Seconds. Got: %s Expected: %s !!! %s"
 const DataDefaultErrorMsg = "Datasource %s %s Failed!!! %s"
 
 const DefaultDebugMsg = "\n*************** %s Response *************** \n%s\n%s******************************\n\n"

--- a/alicloud/resource_alicloud_cen_instance.go
+++ b/alicloud/resource_alicloud_cen_instance.go
@@ -62,34 +62,35 @@ func resourceAlicloudCenInstance() *schema.Resource {
 func resourceAlicloudCenInstanceCreate(d *schema.ResourceData, meta interface{}) error {
 	client := meta.(*connectivity.AliyunClient)
 	cenService := CenService{client}
+	request := cbn.CreateCreateCenRequest()
+	request.Name = d.Get("name").(string)
+	request.Description = d.Get("description").(string)
+	request.ClientToken = buildClientToken(request.GetActionName())
 
 	var cen *cbn.CreateCenResponse
 	err := resource.Retry(3*time.Minute, func() *resource.RetryError {
-		args := buildAliCloudCenArgs(d, meta)
+		req := *request
 		raw, err := client.WithCenClient(func(cbnClient *cbn.Client) (interface{}, error) {
-			return cbnClient.CreateCen(args)
+			return cbnClient.CreateCen(&req)
 		})
 		if err != nil {
-			if IsExceptedError(err, CenQuotaExceeded) {
-				return resource.NonRetryableError(fmt.Errorf("Create CEN instance, the number of CEN instance exceeds the limit, got an error: %#v", err))
-			}
 			if IsExceptedErrors(err, []string{OperationBlocking, UnknownError}) {
-				return resource.RetryableError(fmt.Errorf("Create CEN instance timeout and got an error: %#v.", err))
+				return resource.RetryableError(WrapError(err))
 			}
-			return resource.NonRetryableError(err)
+			return resource.NonRetryableError(WrapError(err))
 		}
 
 		cen, _ = raw.(*cbn.CreateCenResponse)
 		return nil
 	})
 	if err != nil {
-		return fmt.Errorf("Create CEN Instance and got an error: %#v", err)
+		return WrapErrorf(err, DefaultErrorMsg, "alicloud_cen_instance", request.GetActionName(), AlibabaCloudSdkGoERROR)
 	}
-
+	addDebug(request.GetActionName(), cen)
 	d.SetId(cen.CenId)
 	err = cenService.WaitForCenInstance(d.Id(), Active, DefaultCenTimeout)
 	if err != nil {
-		return fmt.Errorf("WaitForCenInstanceAvailable and got an error, CEN ID %s, error info: %#v", d.Id(), err)
+		return WrapError(err)
 	}
 
 	return resourceAlicloudCenInstanceRead(d, meta)
@@ -103,7 +104,7 @@ func resourceAlicloudCenInstanceRead(d *schema.ResourceData, meta interface{}) e
 			d.SetId("")
 			return nil
 		}
-		return err
+		return WrapError(err)
 	}
 
 	d.Set("name", resp.Name)
@@ -113,27 +114,27 @@ func resourceAlicloudCenInstanceRead(d *schema.ResourceData, meta interface{}) e
 }
 
 func resourceAlicloudCenInstanceUpdate(d *schema.ResourceData, meta interface{}) error {
-	attributeUpdate := false
+	update := false
 	request := cbn.CreateModifyCenAttributeRequest()
 	request.CenId = d.Id()
 
 	if d.HasChange("name") {
 		request.Name = d.Get("name").(string)
-		attributeUpdate = true
+		update = true
 	}
 
 	if d.HasChange("description") {
 		request.Description = d.Get("description").(string)
-		attributeUpdate = true
+		update = true
 	}
 
-	if attributeUpdate {
+	if update {
 		client := meta.(*connectivity.AliyunClient)
 		_, err := client.WithCenClient(func(cbnClient *cbn.Client) (interface{}, error) {
 			return cbnClient.ModifyCenAttribute(request)
 		})
 		if err != nil {
-			return err
+			return WrapErrorf(err, DefaultErrorMsg, d.Id(), request.GetActionName(), AlibabaCloudSdkGoERROR)
 		}
 	}
 
@@ -146,45 +147,16 @@ func resourceAlicloudCenInstanceDelete(d *schema.ResourceData, meta interface{})
 	request := cbn.CreateDeleteCenRequest()
 	request.CenId = d.Id()
 
-	err := resource.Retry(5*time.Minute, func() *resource.RetryError {
-		_, err := client.WithCenClient(func(cbnClient *cbn.Client) (interface{}, error) {
-			return cbnClient.DeleteCen(request)
-		})
-
-		if err != nil {
-			if IsExceptedError(err, ParameterCenInstanceIdNotExist) {
-				return nil
-			}
-			return resource.NonRetryableError(WrapError(err))
-		}
-
-		if _, err := cenService.DescribeCenInstance(d.Id()); err != nil {
-			if NotFoundError(err) {
-				return nil
-			}
-			return resource.NonRetryableError(err)
-		}
-
-		return resource.RetryableError(WrapError(err))
+	raw, err := client.WithCenClient(func(cbnClient *cbn.Client) (interface{}, error) {
+		return cbnClient.DeleteCen(request)
 	})
+
 	if err != nil {
+		if IsExceptedError(err, ParameterCenInstanceIdNotExist) {
+			return nil
+		}
 		return WrapErrorf(err, DefaultErrorMsg, d.Id(), request.GetActionName(), AlibabaCloudSdkGoERROR)
 	}
-	return nil
-}
-
-func buildAliCloudCenArgs(d *schema.ResourceData, meta interface{}) *cbn.CreateCenRequest {
-	request := cbn.CreateCreateCenRequest()
-
-	if v := d.Get("name").(string); v != "" {
-		request.Name = v
-	}
-
-	if v := d.Get("description").(string); v != "" {
-		request.Description = v
-	}
-
-	request.ClientToken = buildClientToken(request.GetActionName())
-
-	return request
+	addDebug(request.GetActionName(), raw)
+	return WrapError(cenService.WaitForCenInstance(d.Id(), Deleted, DefaultCenTimeout))
 }

--- a/alicloud/service_alicloud_cen.go
+++ b/alicloud/service_alicloud_cen.go
@@ -43,7 +43,8 @@ func (s *CenService) DescribeCenInstance(cenId string) (c cbn.Cen, err error) {
 			}
 			return err
 		}
-		if resp == nil || len(resp.Cens.Cen) <= 0 || resp.Cens.Cen[0].CenId != cenId {
+		addDebug(request.GetActionName(), raw)
+		if len(resp.Cens.Cen) <= 0 || resp.Cens.Cen[0].CenId != cenId {
 			return GetNotFoundErrorFromString(GetNotFoundMessage("CEN Instance", cenId))
 		}
 		c = resp.Cens.Cen[0]
@@ -53,27 +54,29 @@ func (s *CenService) DescribeCenInstance(cenId string) (c cbn.Cen, err error) {
 	return
 }
 
-func (s *CenService) WaitForCenInstance(cenId string, status Status, timeout int) error {
-	if timeout <= 0 {
-		timeout = DefaultTimeout
-	}
+func (s *CenService) WaitForCenInstance(id string, status Status, timeout int) error {
+	deadline := time.Now().Add(time.Duration(timeout) * time.Second)
 
 	for {
-		cen, err := s.DescribeCenInstance(cenId)
+		object, err := s.DescribeCenInstance(id)
 		if err != nil {
-			return err
+			if NotFoundError(err) {
+				if status == Deleted {
+					return nil
+				}
+			} else {
+				return WrapError(err)
+			}
 		}
-		if cen.Status == string(status) {
-			break
+		if object.Status == string(status) {
+			return nil
 		}
-		timeout = timeout - DefaultIntervalShort
-		if timeout <= 0 {
-			return GetTimeErrorFromString(GetTimeoutMessage("CEN", string(status)))
+		if time.Now().After(deadline) {
+			return WrapErrorf(err, WaitTimeoutMsg, id, GetFunc(1), timeout, object.Status, string(status), ProviderERROR)
 		}
 		time.Sleep(DefaultIntervalShort * time.Second)
-	}
 
-	return nil
+	}
 }
 
 func (s *CenService) DescribeCenAttachedChildInstanceById(instanceId, cenId string) (c cbn.ChildInstance, err error) {


### PR DESCRIPTION
```
TF_ACC=1 go test ./alicloud -v -run=TestAccAlicloudCen -timeout=240m
=== RUN   TestAccAlicloudCenBandwidthLimitsDataSource_instance_id
--- PASS: TestAccAlicloudCenBandwidthLimitsDataSource_instance_id (111.49s)
=== RUN   TestAccAlicloudCenBandwidthLimitsDataSource_empty
--- PASS: TestAccAlicloudCenBandwidthLimitsDataSource_empty (1.32s)
=== RUN   TestAccAlicloudCenBandwidthPackagesDataSource_instance_id
--- PASS: TestAccAlicloudCenBandwidthPackagesDataSource_instance_id (16.57s)
=== RUN   TestAccAlicloudCenBandwidthPackagesDataSource_bandwidth_package_nameRegex
--- PASS: TestAccAlicloudCenBandwidthPackagesDataSource_bandwidth_package_nameRegex (10.98s)
=== RUN   TestAccAlicloudCenBandwidthPackagesDataSource_multi_bandwith_packages
--- PASS: TestAccAlicloudCenBandwidthPackagesDataSource_multi_bandwith_packages (25.65s)
=== RUN   TestAccAlicloudCenBandwidthPackagesDataSource_empty
--- PASS: TestAccAlicloudCenBandwidthPackagesDataSource_empty (3.90s)
=== RUN   TestAccAlicloudCenInstancesDataSource_cen_id
--- PASS: TestAccAlicloudCenInstancesDataSource_cen_id (13.91s)
=== RUN   TestAccAlicloudCenInstancesDataSource_name_regex
--- PASS: TestAccAlicloudCenInstancesDataSource_name_regex (13.33s)
=== RUN   TestAccAlicloudCenInstancesDataSource_multi_cen_ids
--- PASS: TestAccAlicloudCenInstancesDataSource_multi_cen_ids (33.41s)
=== RUN   TestAccAlicloudCenInstancesDataSource_empty
--- PASS: TestAccAlicloudCenInstancesDataSource_empty (2.41s)
=== RUN   TestAccAlicloudCenRegionRouteEntriesDataSource_basic
--- PASS: TestAccAlicloudCenRegionRouteEntriesDataSource_basic (286.31s)
=== RUN   TestAccAlicloudCenRegionRouteEntriesDataSource_empty
--- PASS: TestAccAlicloudCenRegionRouteEntriesDataSource_empty (6.06s)
=== RUN   TestAccAlicloudCenRouteEntriesDataSource_basic
--- PASS: TestAccAlicloudCenRouteEntriesDataSource_basic (292.75s)
=== RUN   TestAccAlicloudCenRouteEntriesDataSource_empty
--- PASS: TestAccAlicloudCenRouteEntriesDataSource_empty (277.34s)
=== RUN   TestAccAlicloudCenBandwidthPackageAttachment_importBasic
--- PASS: TestAccAlicloudCenBandwidthPackageAttachment_importBasic (16.17s)
=== RUN   TestAccAlicloudCenBandwidthPackage_importBasic
--- PASS: TestAccAlicloudCenBandwidthPackage_importBasic (11.59s)
=== RUN   TestAccAlicloudCenInstanceAttachment_importBasic
--- PASS: TestAccAlicloudCenInstanceAttachment_importBasic (70.09s)
=== RUN   TestAccAlicloudCenInstance_importBasic
--- PASS: TestAccAlicloudCenInstance_importBasic (11.57s)
=== RUN   TestAccAlicloudCenRouteEntry_importBasic
--- PASS: TestAccAlicloudCenRouteEntry_importBasic (254.24s)
=== RUN   TestAccAlicloudCenBandwidthLimit_basic
--- PASS: TestAccAlicloudCenBandwidthLimit_basic (159.67s)
=== RUN   TestAccAlicloudCenBandwidthLimit_update
--- PASS: TestAccAlicloudCenBandwidthLimit_update (196.46s)
=== RUN   TestAccAlicloudCenBandwidthLimit_multi
--- PASS: TestAccAlicloudCenBandwidthLimit_multi (166.03s)
=== RUN   TestAccAlicloudCenBandwidthPackageAttachment_basic
--- PASS: TestAccAlicloudCenBandwidthPackageAttachment_basic (21.54s)
=== RUN   TestAccAlicloudCenBandwidthPackage_basic
--- PASS: TestAccAlicloudCenBandwidthPackage_basic (9.68s)
=== RUN   TestAccAlicloudCenBandwidthPackage_update
--- PASS: TestAccAlicloudCenBandwidthPackage_update (18.94s)
=== RUN   TestAccAlicloudCenBandwidthPackage_muti
--- PASS: TestAccAlicloudCenBandwidthPackage_muti (14.41s)
=== RUN   TestAccAlicloudCenInstanceAttachment_basic
--- PASS: TestAccAlicloudCenInstanceAttachment_basic (69.80s)
=== RUN   TestAccAlicloudCenInstanceAttachment_multi_same_regions
--- PASS: TestAccAlicloudCenInstanceAttachment_multi_same_regions (82.57s)
=== RUN   TestAccAlicloudCenInstanceAttachment_multi_different_regions
--- PASS: TestAccAlicloudCenInstanceAttachment_multi_different_regions (106.62s)
=== RUN   TestAccAlicloudCenInstance_basic
--- PASS: TestAccAlicloudCenInstance_basic (11.06s)
=== RUN   TestAccAlicloudCenInstance_update
--- PASS: TestAccAlicloudCenInstance_update (15.31s)
=== RUN   TestAccAlicloudCenInstance_multi
--- PASS: TestAccAlicloudCenInstance_multi (22.14s)
=== RUN   TestAccAlicloudCenRouteEntry_basic
--- PASS: TestAccAlicloudCenRouteEntry_basic (245.11s)
PASS
ok  	github.com/terraform-providers/terraform-provider-alicloud/alicloud	2598.516s
```