### PR TITLE
Add wait method for disk and disk attachment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ FEATURES:
 
 IMPROVEMENTS:
 
+- Add wait method for disk and disk attachment [GH-910]
+- Add wait method for cen instance [GH-909]
 - add dns and dns_group test sweeper [GH-906]
 - fc_function add new schema environment_variables [GH-904]
 - support kv-store auto renewal option  documentation [GH-902]
@@ -24,7 +26,6 @@ IMPROVEMENTS:
 
 BUG FIXES:
 
-- Add wait method for cen instance [GH-909]
 - Fix cen instance deleting bug [GH-908]
 - Fix cen create bug when one resion is China [GH-903]
 - fix cas_certificate sweeper test bug [GH-899]

--- a/alicloud/service_alicloud_cen.go
+++ b/alicloud/service_alicloud_cen.go
@@ -74,8 +74,6 @@ func (s *CenService) WaitForCenInstance(id string, status Status, timeout int) e
 		if time.Now().After(deadline) {
 			return WrapErrorf(err, WaitTimeoutMsg, id, GetFunc(1), timeout, object.Status, string(status), ProviderERROR)
 		}
-		time.Sleep(DefaultIntervalShort * time.Second)
-
 	}
 }
 


### PR DESCRIPTION
```
TF_ACC=1 go test ./alicloud -v -run=TestAccAlicloudDisk  -timeout=240m
=== RUN   TestAccAlicloudDisksDataSource_ids
--- PASS: TestAccAlicloudDisksDataSource_ids (68.14s)
=== RUN   TestAccAlicloudDisksDataSource_name_regex
--- PASS: TestAccAlicloudDisksDataSource_name_regex (69.21s)
=== RUN   TestAccAlicloudDisksDataSource_type
--- PASS: TestAccAlicloudDisksDataSource_type (67.16s)
=== RUN   TestAccAlicloudDisksDataSource_category
--- PASS: TestAccAlicloudDisksDataSource_category (67.33s)
=== RUN   TestAccAlicloudDisksDataSource_encrypted
--- PASS: TestAccAlicloudDisksDataSource_encrypted (72.10s)
=== RUN   TestAccAlicloudDisksDataSource_instance_id
--- PASS: TestAccAlicloudDisksDataSource_instance_id (192.65s)
=== RUN   TestAccAlicloudDisksDataSource_tags
--- PASS: TestAccAlicloudDisksDataSource_tags (81.57s)
=== RUN   TestAccAlicloudDisksDataSource_all
--- PASS: TestAccAlicloudDisksDataSource_all (187.16s)
=== RUN   TestAccAlicloudDisk_importBasic
--- PASS: TestAccAlicloudDisk_importBasic (71.38s)
=== RUN   TestAccAlicloudDisk_importWithTags
--- PASS: TestAccAlicloudDisk_importWithTags (72.26s)
=== RUN   TestAccAlicloudDiskAttachment
--- PASS: TestAccAlicloudDiskAttachment (175.40s)
=== RUN   TestAccAlicloudDiskMultiAttachment
--- PASS: TestAccAlicloudDiskMultiAttachment (377.60s)
=== RUN   TestAccAlicloudDisk_basic
--- PASS: TestAccAlicloudDisk_basic (70.76s)
=== RUN   TestAccAlicloudDisk_multi
--- PASS: TestAccAlicloudDisk_multi (84.82s)
PASS
ok	github.com/terraform-providers/terraform-provider-alicloud/alicloud	1657.608s
```