### PR TITLE
Add Route Entries Datasource​

### DIFF
--- a/alicloud/data_source_alicloud_route_entries.go
+++ b/alicloud/data_source_alicloud_route_entries.go
@@ -1,0 +1,153 @@
+package alicloud
+
+import (
+	"github.com/aliyun/alibaba-cloud-sdk-go/sdk/requests"
+	"github.com/aliyun/alibaba-cloud-sdk-go/services/vpc"
+	"github.com/hashicorp/terraform/helper/schema"
+	"github.com/terraform-providers/terraform-provider-alicloud/alicloud/connectivity"
+)
+
+func dataSourceAlicloudRouteEntries() *schema.Resource {
+	return &schema.Resource{
+		Read: dataSourceAlicloudRouteEntriesRead,
+
+		Schema: map[string]*schema.Schema{
+			"route_table_id": {
+				Type:     schema.TypeString,
+				ForceNew: true,
+				Required: true,
+			},
+			"output_file": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"instance_id": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"type": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"cidr_block": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+
+			// Computed values
+			"entries": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"type": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"next_hop_type": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"status": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"instance_id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"route_table_id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"cidr_block": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+					},
+				},
+			},
+		},
+	}
+}
+func dataSourceAlicloudRouteEntriesRead(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*connectivity.AliyunClient)
+	request := vpc.CreateDescribeRouteTablesRequest()
+	request.RegionId = string(client.Region)
+	request.PageSize = requests.NewInteger(PageSizeLarge)
+	request.PageNumber = requests.NewInteger(1)
+	request.RouteTableId = d.Get("route_table_id").(string)
+
+	var allRouteEntries []vpc.RouteEntry
+	invoker := NewInvoker()
+	for {
+		var raw interface{}
+		if err := invoker.Run(func() error {
+			response, err := client.WithVpcClient(func(vpcClient *vpc.Client) (interface{}, error) {
+				return vpcClient.DescribeRouteTables(request)
+			})
+			raw = response
+			return err
+		}); err != nil {
+			return WrapErrorf(err, DataDefaultErrorMsg, "alicloud_route_entries", request.GetActionName(), AlibabaCloudSdkGoERROR)
+		}
+		resp, _ := raw.(*vpc.DescribeRouteTablesResponse)
+		if resp == nil || len(resp.RouteTables.RouteTable) < 1 {
+			break
+		}
+
+		for _, entries := range resp.RouteTables.RouteTable[0].RouteEntrys.RouteEntry {
+			if instance_id, ok := d.GetOk("instance_id"); ok && entries.InstanceId != instance_id.(string) {
+				continue
+			}
+			if route_entry_type, ok := d.GetOk("type"); ok && entries.Type != route_entry_type.(string) {
+				continue
+			}
+			if cidr_block, ok := d.GetOk("cidr_block"); ok && entries.DestinationCidrBlock != cidr_block.(string) {
+				continue
+			}
+			allRouteEntries = append(allRouteEntries, entries)
+		}
+
+		if len(resp.RouteTables.RouteTable) < PageSizeLarge {
+			break
+		}
+
+		if page, err := getNextpageNumber(request.PageNumber); err != nil {
+			return WrapError(err)
+		} else {
+			request.PageNumber = page
+		}
+	}
+
+	return RouteEntriesDecriptionAttributes(d, allRouteEntries, meta)
+}
+
+func RouteEntriesDecriptionAttributes(d *schema.ResourceData, entries []vpc.RouteEntry, meta interface{}) error {
+	var ids []string
+	var s []map[string]interface{}
+	for _, entry := range entries {
+		mapping := map[string]interface{}{
+			"route_table_id": entry.RouteTableId,
+			"instance_id":    entry.InstanceId,
+			"status":         entry.Status,
+			"next_hop_type":  entry.NextHopType,
+			"type":           entry.Type,
+			"cidr_block":     entry.DestinationCidrBlock,
+		}
+		ids = append(ids, entry.RouteTableId)
+		s = append(s, mapping)
+	}
+
+	d.SetId(dataResourceIdHash(ids))
+	if err := d.Set("entries", s); err != nil {
+		return WrapError(err)
+	}
+
+	// create a json file in current directory and write data source to it.
+	if output, ok := d.GetOk("output_file"); ok && output.(string) != "" {
+		writeToFile(output.(string), s)
+	}
+	return nil
+
+}

--- a/alicloud/data_source_alicloud_route_entries_test.go
+++ b/alicloud/data_source_alicloud_route_entries_test.go
@@ -1,0 +1,761 @@
+package alicloud
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform/helper/resource"
+)
+
+func TestAccAlicloudRouteEntriesDataSourceBasic(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+		},
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCheckAlicloudRouteEntriesDataSourceConfig,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAlicloudDataSourceID("data.alicloud_route_entries.foo"),
+					resource.TestCheckResourceAttr("data.alicloud_route_entries.foo", "entries.#", "1"),
+					resource.TestCheckResourceAttrSet("data.alicloud_route_entries.foo", "entries.0.route_table_id"),
+					resource.TestCheckResourceAttrSet("data.alicloud_route_entries.foo", "entries.0.cidr_block"),
+					resource.TestCheckResourceAttrSet("data.alicloud_route_entries.foo", "entries.0.instance_id"),
+					resource.TestCheckResourceAttrSet("data.alicloud_route_entries.foo", "entries.0.status"),
+					resource.TestCheckResourceAttr("data.alicloud_route_entries.foo", "entries.0.type", "Custom"),
+					resource.TestCheckResourceAttr("data.alicloud_route_entries.foo", "entries.0.next_hop_type", "Instance"),
+				),
+			},
+			{
+				Config: testAccCheckAlicloudRouteEntriesDataSourceConfig_mismatch,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAlicloudDataSourceID("data.alicloud_route_entries.foo"),
+					resource.TestCheckResourceAttr("data.alicloud_route_entries.foo", "entries.#", "0"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAlicloudRouteEntriesDataSourceRouteEntryType(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+		},
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCheckAlicloudRouteEntriesDataSourceRouteEntryType,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAlicloudDataSourceID("data.alicloud_route_entries.foo"),
+					resource.TestCheckResourceAttr("data.alicloud_route_entries.foo", "entries.#", "1"),
+					resource.TestCheckResourceAttrSet("data.alicloud_route_entries.foo", "entries.0.route_table_id"),
+					resource.TestCheckResourceAttrSet("data.alicloud_route_entries.foo", "entries.0.cidr_block"),
+					resource.TestCheckResourceAttrSet("data.alicloud_route_entries.foo", "entries.0.instance_id"),
+					resource.TestCheckResourceAttrSet("data.alicloud_route_entries.foo", "entries.0.status"),
+					resource.TestCheckResourceAttr("data.alicloud_route_entries.foo", "entries.0.type", "Custom"),
+					resource.TestCheckResourceAttr("data.alicloud_route_entries.foo", "entries.0.next_hop_type", "Instance"),
+				),
+			},
+			{
+				Config: testAccCheckAlicloudRouteEntriesDataSourceRouteEntryType_mismatch,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAlicloudDataSourceID("data.alicloud_route_entries.foo"),
+					// 系统路由条目
+					resource.TestCheckResourceAttr("data.alicloud_route_entries.foo", "entries.#", "2"),
+					resource.TestCheckResourceAttr("data.alicloud_route_entries.foo", "entries.0.type", "System"),
+					resource.TestCheckResourceAttr("data.alicloud_route_entries.foo", "entries.1.type", "System"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAlicloudRouteEntriesDataSourceCidrBlock(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+		},
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCheckAlicloudRouteEntriesDataSourceCidrBlock,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAlicloudDataSourceID("data.alicloud_route_entries.foo"),
+					resource.TestCheckResourceAttr("data.alicloud_route_entries.foo", "entries.#", "1"),
+					resource.TestCheckResourceAttrSet("data.alicloud_route_entries.foo", "entries.0.route_table_id"),
+					resource.TestCheckResourceAttrSet("data.alicloud_route_entries.foo", "entries.0.cidr_block"),
+					resource.TestCheckResourceAttrSet("data.alicloud_route_entries.foo", "entries.0.instance_id"),
+					resource.TestCheckResourceAttrSet("data.alicloud_route_entries.foo", "entries.0.status"),
+					resource.TestCheckResourceAttr("data.alicloud_route_entries.foo", "entries.0.type", "Custom"),
+					resource.TestCheckResourceAttr("data.alicloud_route_entries.foo", "entries.0.next_hop_type", "Instance"),
+				),
+			},
+			{
+				Config: testAccCheckAlicloudRouteEntriesDataSourceCidrBlock_mismatch,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAlicloudDataSourceID("data.alicloud_route_entries.foo"),
+					resource.TestCheckResourceAttr("data.alicloud_route_entries.foo", "entries.#", "0"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAlicloudRouteEntriesDataSourceInstanceId(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+		},
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCheckAlicloudRouteEntriesDataSourceInstanceId,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAlicloudDataSourceID("data.alicloud_route_entries.foo"),
+					resource.TestCheckResourceAttr("data.alicloud_route_entries.foo", "entries.#", "1"),
+					resource.TestCheckResourceAttrSet("data.alicloud_route_entries.foo", "entries.0.route_table_id"),
+					resource.TestCheckResourceAttrSet("data.alicloud_route_entries.foo", "entries.0.cidr_block"),
+					resource.TestCheckResourceAttrSet("data.alicloud_route_entries.foo", "entries.0.instance_id"),
+					resource.TestCheckResourceAttrSet("data.alicloud_route_entries.foo", "entries.0.status"),
+					resource.TestCheckResourceAttr("data.alicloud_route_entries.foo", "entries.0.type", "Custom"),
+					resource.TestCheckResourceAttr("data.alicloud_route_entries.foo", "entries.0.next_hop_type", "Instance"),
+				),
+			},
+			{
+				Config: testAccCheckAlicloudRouteEntriesDataSourceInstanceId_mismatch,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAlicloudDataSourceID("data.alicloud_route_entries.foo"),
+					resource.TestCheckResourceAttr("data.alicloud_route_entries.foo", "entries.#", "0"),
+				),
+			},
+		},
+	})
+}
+
+const testAccCheckAlicloudRouteEntriesDataSourceConfig = `
+data "alicloud_zones" "default" {
+	"available_resource_creation"= "VSwitch"
+}
+data "alicloud_instance_types" "default" {
+ 	availability_zone = "${data.alicloud_zones.default.zones.0.id}"
+	cpu_core_count = 1
+	memory_size = 2
+}
+data "alicloud_images" "default" {
+        name_regex = "^ubuntu_14.*_64"
+	most_recent = true
+	owners = "system"
+}
+
+variable "name" {
+	default = "tf-testAcc-for-route-entries-datasource"
+}
+resource "alicloud_vpc" "foo" {
+	name = "${var.name}"
+	cidr_block = "10.1.0.0/21"
+}
+
+resource "alicloud_vswitch" "foo" {
+	vpc_id = "${alicloud_vpc.foo.id}"
+	cidr_block = "10.1.1.0/24"
+	availability_zone = "${data.alicloud_zones.default.zones.0.id}"
+	name = "${var.name}"
+}
+
+resource "alicloud_route_entry" "foo" {
+	route_table_id = "${alicloud_vpc.foo.route_table_id}"
+	destination_cidrblock = "172.11.1.1/32"
+	nexthop_type = "Instance"
+	nexthop_id = "${alicloud_instance.foo.id}"
+}
+
+resource "alicloud_security_group" "tf_test_foo" {
+	name = "${var.name}"
+	description = "foo"
+	vpc_id = "${alicloud_vpc.foo.id}"
+}
+
+resource "alicloud_security_group_rule" "ingress" {
+	type = "ingress"
+	ip_protocol = "tcp"
+	nic_type = "intranet"
+	policy = "accept"
+	port_range = "22/22"
+	priority = 1
+	security_group_id = "${alicloud_security_group.tf_test_foo.id}"
+	cidr_ip = "0.0.0.0/0"
+}
+
+resource "alicloud_instance" "foo" {
+	# cn-beijing
+	security_groups = ["${alicloud_security_group.tf_test_foo.id}"]
+
+	vswitch_id = "${alicloud_vswitch.foo.id}"
+	allocate_public_ip = true
+
+	# series III
+	instance_charge_type = "PostPaid"
+	instance_type = "${data.alicloud_instance_types.default.instance_types.0.id}"
+	internet_charge_type = "PayByTraffic"
+	internet_max_bandwidth_out = 5
+
+	system_disk_category = "cloud_efficiency"
+	image_id = "${data.alicloud_images.default.images.0.id}"
+	instance_name = "${var.name}"
+}
+
+data "alicloud_route_entries" "foo" {
+  type = "Custom"
+  cidr_block = "${alicloud_route_entry.foo.destination_cidrblock}"
+  instance_id = "${alicloud_instance.foo.id}"
+  route_table_id = "${alicloud_route_entry.foo.route_table_id}"
+}
+`
+const testAccCheckAlicloudRouteEntriesDataSourceConfig_mismatch = `
+data "alicloud_zones" "default" {
+	"available_resource_creation"= "VSwitch"
+}
+data "alicloud_instance_types" "default" {
+ 	availability_zone = "${data.alicloud_zones.default.zones.0.id}"
+	cpu_core_count = 1
+	memory_size = 2
+}
+data "alicloud_images" "default" {
+        name_regex = "^ubuntu_14.*_64"
+	most_recent = true
+	owners = "system"
+}
+
+variable "name" {
+	default = "tf-testAcc-for-route-entries-datasource"
+}
+resource "alicloud_vpc" "foo" {
+	name = "${var.name}"
+	cidr_block = "10.1.0.0/21"
+}
+
+resource "alicloud_vswitch" "foo" {
+	vpc_id = "${alicloud_vpc.foo.id}"
+	cidr_block = "10.1.1.0/24"
+	availability_zone = "${data.alicloud_zones.default.zones.0.id}"
+	name = "${var.name}"
+}
+
+resource "alicloud_route_entry" "foo" {
+	route_table_id = "${alicloud_vpc.foo.route_table_id}"
+	destination_cidrblock = "172.11.1.1/32"
+	nexthop_type = "Instance"
+	nexthop_id = "${alicloud_instance.foo.id}"
+}
+
+resource "alicloud_security_group" "tf_test_foo" {
+	name = "${var.name}"
+	description = "foo"
+	vpc_id = "${alicloud_vpc.foo.id}"
+}
+
+resource "alicloud_security_group_rule" "ingress" {
+	type = "ingress"
+	ip_protocol = "tcp"
+	nic_type = "intranet"
+	policy = "accept"
+	port_range = "22/22"
+	priority = 1
+	security_group_id = "${alicloud_security_group.tf_test_foo.id}"
+	cidr_ip = "0.0.0.0/0"
+}
+
+resource "alicloud_instance" "foo" {
+	# cn-beijing
+	security_groups = ["${alicloud_security_group.tf_test_foo.id}"]
+
+	vswitch_id = "${alicloud_vswitch.foo.id}"
+	allocate_public_ip = true
+
+	# series III
+	instance_charge_type = "PostPaid"
+	instance_type = "${data.alicloud_instance_types.default.instance_types.0.id}"
+	internet_charge_type = "PayByTraffic"
+	internet_max_bandwidth_out = 5
+
+	system_disk_category = "cloud_efficiency"
+	image_id = "${data.alicloud_images.default.images.0.id}"
+	instance_name = "${var.name}"
+}
+
+data "alicloud_route_entries" "foo" {
+  type = "System"
+  cidr_block = "${alicloud_route_entry.foo.destination_cidrblock}-fake"
+  instance_id = "${alicloud_instance.foo.id}-fake"
+  route_table_id = "${alicloud_route_entry.foo.route_table_id}-fake"
+}
+`
+
+const testAccCheckAlicloudRouteEntriesDataSourceRouteEntryType = `
+data "alicloud_zones" "default" {
+	"available_resource_creation"= "VSwitch"
+}
+data "alicloud_instance_types" "default" {
+ 	availability_zone = "${data.alicloud_zones.default.zones.0.id}"
+	cpu_core_count = 1
+	memory_size = 2
+}
+data "alicloud_images" "default" {
+        name_regex = "^ubuntu_14.*_64"
+	most_recent = true
+	owners = "system"
+}
+
+variable "name" {
+	default = "tf-testAcc-for-route-entries-datasource"
+}
+resource "alicloud_vpc" "foo" {
+	name = "${var.name}"
+	cidr_block = "10.1.0.0/21"
+}
+
+resource "alicloud_vswitch" "foo" {
+	vpc_id = "${alicloud_vpc.foo.id}"
+	cidr_block = "10.1.1.0/24"
+	availability_zone = "${data.alicloud_zones.default.zones.0.id}"
+	name = "${var.name}"
+}
+
+resource "alicloud_route_entry" "foo" {
+	route_table_id = "${alicloud_vpc.foo.route_table_id}"
+	destination_cidrblock = "172.11.1.1/32"
+	nexthop_type = "Instance"
+	nexthop_id = "${alicloud_instance.foo.id}"
+}
+
+resource "alicloud_security_group" "tf_test_foo" {
+	name = "${var.name}"
+	description = "foo"
+	vpc_id = "${alicloud_vpc.foo.id}"
+}
+
+resource "alicloud_security_group_rule" "ingress" {
+	type = "ingress"
+	ip_protocol = "tcp"
+	nic_type = "intranet"
+	policy = "accept"
+	port_range = "22/22"
+	priority = 1
+	security_group_id = "${alicloud_security_group.tf_test_foo.id}"
+	cidr_ip = "0.0.0.0/0"
+}
+
+resource "alicloud_instance" "foo" {
+	# cn-beijing
+	security_groups = ["${alicloud_security_group.tf_test_foo.id}"]
+
+	vswitch_id = "${alicloud_vswitch.foo.id}"
+	allocate_public_ip = true
+
+	# series III
+	instance_charge_type = "PostPaid"
+	instance_type = "${data.alicloud_instance_types.default.instance_types.0.id}"
+	internet_charge_type = "PayByTraffic"
+	internet_max_bandwidth_out = 5
+
+	system_disk_category = "cloud_efficiency"
+	image_id = "${data.alicloud_images.default.images.0.id}"
+	instance_name = "${var.name}"
+}
+
+data "alicloud_route_entries" "foo" {
+  type = "Custom"
+  route_table_id = "${alicloud_route_entry.foo.route_table_id}"
+}
+`
+
+const testAccCheckAlicloudRouteEntriesDataSourceRouteEntryType_mismatch = `
+data "alicloud_zones" "default" {
+	"available_resource_creation"= "VSwitch"
+}
+data "alicloud_instance_types" "default" {
+ 	availability_zone = "${data.alicloud_zones.default.zones.0.id}"
+	cpu_core_count = 1
+	memory_size = 2
+}
+data "alicloud_images" "default" {
+        name_regex = "^ubuntu_14.*_64"
+	most_recent = true
+	owners = "system"
+}
+
+variable "name" {
+	default = "tf-testAcc-for-route-entries-datasource"
+}
+resource "alicloud_vpc" "foo" {
+	name = "${var.name}"
+	cidr_block = "10.1.0.0/21"
+}
+
+resource "alicloud_vswitch" "foo" {
+	vpc_id = "${alicloud_vpc.foo.id}"
+	cidr_block = "10.1.1.0/24"
+	availability_zone = "${data.alicloud_zones.default.zones.0.id}"
+	name = "${var.name}"
+}
+
+resource "alicloud_route_entry" "foo" {
+	route_table_id = "${alicloud_vpc.foo.route_table_id}"
+	destination_cidrblock = "172.11.1.1/32"
+	nexthop_type = "Instance"
+	nexthop_id = "${alicloud_instance.foo.id}"
+}
+
+resource "alicloud_security_group" "tf_test_foo" {
+	name = "${var.name}"
+	description = "foo"
+	vpc_id = "${alicloud_vpc.foo.id}"
+}
+
+resource "alicloud_security_group_rule" "ingress" {
+	type = "ingress"
+	ip_protocol = "tcp"
+	nic_type = "intranet"
+	policy = "accept"
+	port_range = "22/22"
+	priority = 1
+	security_group_id = "${alicloud_security_group.tf_test_foo.id}"
+	cidr_ip = "0.0.0.0/0"
+}
+
+resource "alicloud_instance" "foo" {
+	# cn-beijing
+	security_groups = ["${alicloud_security_group.tf_test_foo.id}"]
+
+	vswitch_id = "${alicloud_vswitch.foo.id}"
+	allocate_public_ip = true
+
+	# series III
+	instance_charge_type = "PostPaid"
+	instance_type = "${data.alicloud_instance_types.default.instance_types.0.id}"
+	internet_charge_type = "PayByTraffic"
+	internet_max_bandwidth_out = 5
+
+	system_disk_category = "cloud_efficiency"
+	image_id = "${data.alicloud_images.default.images.0.id}"
+	instance_name = "${var.name}"
+}
+
+data "alicloud_route_entries" "foo" {
+  type = "System"
+  route_table_id = "${alicloud_route_entry.foo.route_table_id}"
+}
+`
+
+const testAccCheckAlicloudRouteEntriesDataSourceCidrBlock = `
+data "alicloud_zones" "default" {
+	"available_resource_creation"= "VSwitch"
+}
+data "alicloud_instance_types" "default" {
+ 	availability_zone = "${data.alicloud_zones.default.zones.0.id}"
+	cpu_core_count = 1
+	memory_size = 2
+}
+data "alicloud_images" "default" {
+        name_regex = "^ubuntu_14.*_64"
+	most_recent = true
+	owners = "system"
+}
+
+variable "name" {
+	default = "tf-testAcc-for-route-entries-datasource"
+}
+resource "alicloud_vpc" "foo" {
+	name = "${var.name}"
+	cidr_block = "10.1.0.0/21"
+}
+
+resource "alicloud_vswitch" "foo" {
+	vpc_id = "${alicloud_vpc.foo.id}"
+	cidr_block = "10.1.1.0/24"
+	availability_zone = "${data.alicloud_zones.default.zones.0.id}"
+	name = "${var.name}"
+}
+
+resource "alicloud_route_entry" "foo" {
+	route_table_id = "${alicloud_vpc.foo.route_table_id}"
+	destination_cidrblock = "172.11.1.1/32"
+	nexthop_type = "Instance"
+	nexthop_id = "${alicloud_instance.foo.id}"
+}
+
+resource "alicloud_security_group" "tf_test_foo" {
+	name = "${var.name}"
+	description = "foo"
+	vpc_id = "${alicloud_vpc.foo.id}"
+}
+
+resource "alicloud_security_group_rule" "ingress" {
+	type = "ingress"
+	ip_protocol = "tcp"
+	nic_type = "intranet"
+	policy = "accept"
+	port_range = "22/22"
+	priority = 1
+	security_group_id = "${alicloud_security_group.tf_test_foo.id}"
+	cidr_ip = "0.0.0.0/0"
+}
+
+resource "alicloud_instance" "foo" {
+	# cn-beijing
+	security_groups = ["${alicloud_security_group.tf_test_foo.id}"]
+
+	vswitch_id = "${alicloud_vswitch.foo.id}"
+	allocate_public_ip = true
+
+	# series III
+	instance_charge_type = "PostPaid"
+	instance_type = "${data.alicloud_instance_types.default.instance_types.0.id}"
+	internet_charge_type = "PayByTraffic"
+	internet_max_bandwidth_out = 5
+
+	system_disk_category = "cloud_efficiency"
+	image_id = "${data.alicloud_images.default.images.0.id}"
+	instance_name = "${var.name}"
+}
+
+data "alicloud_route_entries" "foo" {
+  cidr_block = "${alicloud_route_entry.foo.destination_cidrblock}"
+  route_table_id = "${alicloud_route_entry.foo.route_table_id}"
+}
+`
+
+const testAccCheckAlicloudRouteEntriesDataSourceCidrBlock_mismatch = `
+data "alicloud_zones" "default" {
+	"available_resource_creation"= "VSwitch"
+}
+data "alicloud_instance_types" "default" {
+ 	availability_zone = "${data.alicloud_zones.default.zones.0.id}"
+	cpu_core_count = 1
+	memory_size = 2
+}
+data "alicloud_images" "default" {
+        name_regex = "^ubuntu_14.*_64"
+	most_recent = true
+	owners = "system"
+}
+
+variable "name" {
+	default = "tf-testAcc-for-route-entries-datasource"
+}
+resource "alicloud_vpc" "foo" {
+	name = "${var.name}"
+	cidr_block = "10.1.0.0/21"
+}
+
+resource "alicloud_vswitch" "foo" {
+	vpc_id = "${alicloud_vpc.foo.id}"
+	cidr_block = "10.1.1.0/24"
+	availability_zone = "${data.alicloud_zones.default.zones.0.id}"
+	name = "${var.name}"
+}
+
+resource "alicloud_route_entry" "foo" {
+	route_table_id = "${alicloud_vpc.foo.route_table_id}"
+	destination_cidrblock = "172.11.1.1/32"
+	nexthop_type = "Instance"
+	nexthop_id = "${alicloud_instance.foo.id}"
+}
+
+resource "alicloud_security_group" "tf_test_foo" {
+	name = "${var.name}"
+	description = "foo"
+	vpc_id = "${alicloud_vpc.foo.id}"
+}
+
+resource "alicloud_security_group_rule" "ingress" {
+	type = "ingress"
+	ip_protocol = "tcp"
+	nic_type = "intranet"
+	policy = "accept"
+	port_range = "22/22"
+	priority = 1
+	security_group_id = "${alicloud_security_group.tf_test_foo.id}"
+	cidr_ip = "0.0.0.0/0"
+}
+
+resource "alicloud_instance" "foo" {
+	# cn-beijing
+	security_groups = ["${alicloud_security_group.tf_test_foo.id}"]
+
+	vswitch_id = "${alicloud_vswitch.foo.id}"
+	allocate_public_ip = true
+
+	# series III
+	instance_charge_type = "PostPaid"
+	instance_type = "${data.alicloud_instance_types.default.instance_types.0.id}"
+	internet_charge_type = "PayByTraffic"
+	internet_max_bandwidth_out = 5
+
+	system_disk_category = "cloud_efficiency"
+	image_id = "${data.alicloud_images.default.images.0.id}"
+	instance_name = "${var.name}"
+}
+
+data "alicloud_route_entries" "foo" {
+  cidr_block = "${alicloud_route_entry.foo.destination_cidrblock}-fake"
+  route_table_id = "${alicloud_route_entry.foo.route_table_id}"
+}
+`
+
+const testAccCheckAlicloudRouteEntriesDataSourceInstanceId = `
+data "alicloud_zones" "default" {
+	"available_resource_creation"= "VSwitch"
+}
+data "alicloud_instance_types" "default" {
+ 	availability_zone = "${data.alicloud_zones.default.zones.0.id}"
+	cpu_core_count = 1
+	memory_size = 2
+}
+data "alicloud_images" "default" {
+        name_regex = "^ubuntu_14.*_64"
+	most_recent = true
+	owners = "system"
+}
+
+variable "name" {
+	default = "tf-testAcc-for-route-entries-datasource"
+}
+resource "alicloud_vpc" "foo" {
+	name = "${var.name}"
+	cidr_block = "10.1.0.0/21"
+}
+
+resource "alicloud_vswitch" "foo" {
+	vpc_id = "${alicloud_vpc.foo.id}"
+	cidr_block = "10.1.1.0/24"
+	availability_zone = "${data.alicloud_zones.default.zones.0.id}"
+	name = "${var.name}"
+}
+
+resource "alicloud_route_entry" "foo" {
+	route_table_id = "${alicloud_vpc.foo.route_table_id}"
+	destination_cidrblock = "172.11.1.1/32"
+	nexthop_type = "Instance"
+	nexthop_id = "${alicloud_instance.foo.id}"
+}
+
+resource "alicloud_security_group" "tf_test_foo" {
+	name = "${var.name}"
+	description = "foo"
+	vpc_id = "${alicloud_vpc.foo.id}"
+}
+
+resource "alicloud_security_group_rule" "ingress" {
+	type = "ingress"
+	ip_protocol = "tcp"
+	nic_type = "intranet"
+	policy = "accept"
+	port_range = "22/22"
+	priority = 1
+	security_group_id = "${alicloud_security_group.tf_test_foo.id}"
+	cidr_ip = "0.0.0.0/0"
+}
+
+resource "alicloud_instance" "foo" {
+	# cn-beijing
+	security_groups = ["${alicloud_security_group.tf_test_foo.id}"]
+
+	vswitch_id = "${alicloud_vswitch.foo.id}"
+	allocate_public_ip = true
+
+	# series III
+	instance_charge_type = "PostPaid"
+	instance_type = "${data.alicloud_instance_types.default.instance_types.0.id}"
+	internet_charge_type = "PayByTraffic"
+	internet_max_bandwidth_out = 5
+
+	system_disk_category = "cloud_efficiency"
+	image_id = "${data.alicloud_images.default.images.0.id}"
+	instance_name = "${var.name}"
+}
+
+data "alicloud_route_entries" "foo" {
+  instance_id = "${alicloud_instance.foo.id}"
+  route_table_id = "${alicloud_route_entry.foo.route_table_id}"
+}
+`
+
+const testAccCheckAlicloudRouteEntriesDataSourceInstanceId_mismatch = `
+data "alicloud_zones" "default" {
+	"available_resource_creation"= "VSwitch"
+}
+data "alicloud_instance_types" "default" {
+ 	availability_zone = "${data.alicloud_zones.default.zones.0.id}"
+	cpu_core_count = 1
+	memory_size = 2
+}
+data "alicloud_images" "default" {
+        name_regex = "^ubuntu_14.*_64"
+	most_recent = true
+	owners = "system"
+}
+
+variable "name" {
+	default = "tf-testAcc-for-route-entries-datasource"
+}
+resource "alicloud_vpc" "foo" {
+	name = "${var.name}"
+	cidr_block = "10.1.0.0/21"
+}
+
+resource "alicloud_vswitch" "foo" {
+	vpc_id = "${alicloud_vpc.foo.id}"
+	cidr_block = "10.1.1.0/24"
+	availability_zone = "${data.alicloud_zones.default.zones.0.id}"
+	name = "${var.name}"
+}
+
+resource "alicloud_route_entry" "foo" {
+	route_table_id = "${alicloud_vpc.foo.route_table_id}"
+	destination_cidrblock = "172.11.1.1/32"
+	nexthop_type = "Instance"
+	nexthop_id = "${alicloud_instance.foo.id}"
+}
+
+resource "alicloud_security_group" "tf_test_foo" {
+	name = "${var.name}"
+	description = "foo"
+	vpc_id = "${alicloud_vpc.foo.id}"
+}
+
+resource "alicloud_security_group_rule" "ingress" {
+	type = "ingress"
+	ip_protocol = "tcp"
+	nic_type = "intranet"
+	policy = "accept"
+	port_range = "22/22"
+	priority = 1
+	security_group_id = "${alicloud_security_group.tf_test_foo.id}"
+	cidr_ip = "0.0.0.0/0"
+}
+
+resource "alicloud_instance" "foo" {
+	# cn-beijing
+	security_groups = ["${alicloud_security_group.tf_test_foo.id}"]
+
+	vswitch_id = "${alicloud_vswitch.foo.id}"
+	allocate_public_ip = true
+
+	# series III
+	instance_charge_type = "PostPaid"
+	instance_type = "${data.alicloud_instance_types.default.instance_types.0.id}"
+	internet_charge_type = "PayByTraffic"
+	internet_max_bandwidth_out = 5
+
+	system_disk_category = "cloud_efficiency"
+	image_id = "${data.alicloud_images.default.images.0.id}"
+	instance_name = "${var.name}"
+}
+
+data "alicloud_route_entries" "foo" {
+  instance_id = "${alicloud_instance.foo.id}-fake"
+  route_table_id = "${alicloud_route_entry.foo.route_table_id}"
+}
+`

--- a/alicloud/provider.go
+++ b/alicloud/provider.go
@@ -153,6 +153,7 @@ func Provider() terraform.ResourceProvider {
 			"alicloud_actiontrails":                   dataSourceAlicloudActiontrails(),
 			"alicloud_common_bandwidth_packages":      dataSourceAlicloudCommonBandwidthPackages(),
 			"alicloud_route_tables":                   dataSourceAlicloudRouteTables(),
+			"alicloud_route_entries":                  dataSourceAlicloudRouteEntries(),
 		},
 		ResourcesMap: map[string]*schema.Resource{
 			"alicloud_instance":                           resourceAliyunInstance(),

--- a/website/alicloud.erb
+++ b/website/alicloud.erb
@@ -238,6 +238,9 @@
                         <li<%= sidebar_current("docs-alicloud-datasource-route-tables") %>>
                             <a href="/docs/providers/alicloud/d/route_tables.html">alicloud_route_tables</a>
                         </li>
+                        <li<%= sidebar_current("docs-alicloud-datasource-route-entries") %>>
+                            <a href="/docs/providers/alicloud/d/route_entries.html">alicloud_route_entries</a>
+                        </li>
                     </ul>
                 </li>
 

--- a/website/docs/d/route_entries.html.markdown
+++ b/website/docs/d/route_entries.html.markdown
@@ -1,0 +1,114 @@
+---
+layout: "alicloud"
+page_title: "Alicloud: alicloud_route_entries"
+sidebar_current: "docs-alicloud-datasource-route-entries"
+description: |-
+    Provides a list of Route Entries owned by an Alibaba Cloud account.
+---
+
+# alicloud\_route\_entries
+
+This data source provides a list of Route Entries owned by an Alibaba Cloud account.
+
+## Example Usage
+
+```
+data "alicloud_zones" "default" {
+	"available_resource_creation"= "VSwitch"
+}
+data "alicloud_instance_types" "default" {
+ 	availability_zone = "${data.alicloud_zones.default.zones.0.id}"
+	cpu_core_count = 1
+	memory_size = 2
+}
+data "alicloud_images" "default" {
+        name_regex = "^ubuntu_14.*_64"
+	most_recent = true
+	owners = "system"
+}
+
+variable "name" {
+	default = "tf-testAccRouteEntryConfig"
+}
+resource "alicloud_vpc" "foo" {
+	name = "${var.name}"
+	cidr_block = "10.1.0.0/21"
+}
+
+resource "alicloud_vswitch" "foo" {
+	vpc_id = "${alicloud_vpc.foo.id}"
+	cidr_block = "10.1.1.0/24"
+	availability_zone = "${data.alicloud_zones.default.zones.0.id}"
+	name = "${var.name}"
+}
+
+resource "alicloud_route_entry" "foo" {
+	route_table_id = "${alicloud_vpc.foo.route_table_id}"
+	destination_cidrblock = "172.11.1.1/32"
+	nexthop_type = "Instance"
+	nexthop_id = "${alicloud_instance.foo.id}"
+}
+
+resource "alicloud_security_group" "tf_test_foo" {
+	name = "${var.name}"
+	description = "foo"
+	vpc_id = "${alicloud_vpc.foo.id}"
+}
+
+resource "alicloud_security_group_rule" "ingress" {
+	type = "ingress"
+	ip_protocol = "tcp"
+	nic_type = "intranet"
+	policy = "accept"
+	port_range = "22/22"
+	priority = 1
+	security_group_id = "${alicloud_security_group.tf_test_foo.id}"
+	cidr_ip = "0.0.0.0/0"
+}
+
+resource "alicloud_instance" "foo" {
+	# cn-beijing
+	security_groups = ["${alicloud_security_group.tf_test_foo.id}"]
+
+	vswitch_id = "${alicloud_vswitch.foo.id}"
+	allocate_public_ip = true
+
+	# series III
+	instance_charge_type = "PostPaid"
+	instance_type = "${data.alicloud_instance_types.default.instance_types.0.id}"
+	internet_charge_type = "PayByTraffic"
+	internet_max_bandwidth_out = 5
+
+	system_disk_category = "cloud_efficiency"
+	image_id = "${data.alicloud_images.default.images.0.id}"
+	instance_name = "${var.name}"
+}
+
+data "alicloud_route_entries" "foo" {
+  route_table_id = "${alicloud_route_entry.foo.route_table_id}"
+}
+
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `route_table_id` - (Required, ForceNew) The ID of the router table to which the route entry belongs.
+* `instance_id` - (Optional) The instance ID of the next hop.
+* `type` - (Optional) The type of the route entry.
+* `cidr_block` - (Optional) The destination CIDR block of the route entry.
+* `output_file` - (Optional) File name where to save data source results (after running `terraform plan`).
+
+## Attributes Reference
+
+The following attributes are exported in addition to the arguments listed above:
+
+* `entries` - A list of Route Entries. Each element contains the following attributes:
+  * `type` - The type of the route entry.
+  * `next_hop_type` - The type of the next hop.
+  * `status` - The status of the route entry.
+  * `instance_id` - The instance ID of the next hop.
+  * `route_table_id` - The ID of the router table to which the route entry belongs.
+  * `cidr_block` - The destination CIDR block of the route entry.
+


### PR DESCRIPTION
MacBook-Pro-2:terraform-provider-alicloud jince$ TF_ACC=1 go test ./alicloud -v -run=TestAccAlicloudRouteEntries -timeout=300m
=== RUN   TestAccAlicloudRouteEntriesDataSourceBasic
--- PASS: TestAccAlicloudRouteEntriesDataSourceBasic (158.16s)
=== RUN   TestAccAlicloudRouteEntriesDataSourceRouteEntryType
--- PASS: TestAccAlicloudRouteEntriesDataSourceRouteEntryType (161.10s)
=== RUN   TestAccAlicloudRouteEntriesDataSourceCidrBlock
--- PASS: TestAccAlicloudRouteEntriesDataSourceCidrBlock (155.18s)
=== RUN   TestAccAlicloudRouteEntriesDataSourceInstanceId
--- PASS: TestAccAlicloudRouteEntriesDataSourceInstanceId (160.87s)
PASS
ok  	github.com/terraform-providers/terraform-provider-alicloud/alicloud	635.366s