### PR TITLE
Skipping bandwidth package related test for international site account

### DIFF
--- a/alicloud/data_source_alicloud_cen_bandwidth_limits_test.go
+++ b/alicloud/data_source_alicloud_cen_bandwidth_limits_test.go
@@ -22,6 +22,7 @@ func TestAccAlicloudCenBandwidthLimitsDataSource_instance_id(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			testAccPreCheck(t)
+			testAccPreCheckWithAccountSiteType(t, DomesticSite)
 		},
 
 		// module name
@@ -57,6 +58,7 @@ func TestAccAlicloudCenBandwidthLimitsDataSource_empty(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			testAccPreCheck(t)
+			testAccPreCheckWithAccountSiteType(t, DomesticSite)
 		},
 
 		// module name

--- a/alicloud/data_source_alicloud_cen_bandwidth_packages_test.go
+++ b/alicloud/data_source_alicloud_cen_bandwidth_packages_test.go
@@ -13,6 +13,7 @@ func TestAccAlicloudCenBandwidthPackagesDataSource_instance_id(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			testAccPreCheck(t)
+			testAccPreCheckWithAccountSiteType(t, DomesticSite)
 		},
 		Providers: testAccProviders,
 		Steps: []resource.TestStep{
@@ -42,6 +43,7 @@ func TestAccAlicloudCenBandwidthPackagesDataSource_bandwidth_package_nameRegex(t
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			testAccPreCheck(t)
+			testAccPreCheckWithAccountSiteType(t, DomesticSite)
 		},
 		Providers: testAccProviders,
 		Steps: []resource.TestStep{
@@ -71,6 +73,7 @@ func TestAccAlicloudCenBandwidthPackagesDataSource_multi_bandwith_packages(t *te
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			testAccPreCheck(t)
+			testAccPreCheckWithAccountSiteType(t, DomesticSite)
 		},
 		Providers: testAccProviders,
 		Steps: []resource.TestStep{
@@ -100,6 +103,7 @@ func TestAccAlicloudCenBandwidthPackagesDataSource_empty(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			testAccPreCheck(t)
+			testAccPreCheckWithAccountSiteType(t, DomesticSite)
 		},
 		Providers: testAccProviders,
 		Steps: []resource.TestStep{

--- a/alicloud/import_alicloud_cen_bandwidth_limit_test.go
+++ b/alicloud/import_alicloud_cen_bandwidth_limit_test.go
@@ -26,6 +26,7 @@ func SkipTestAccAlicloudCenBandwidthLimit_importBasic(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			testAccPreCheck(t)
+			testAccPreCheckWithAccountSiteType(t, DomesticSite)
 		},
 
 		// module name

--- a/alicloud/import_alicloud_cen_bandwidth_package_attachment_test.go
+++ b/alicloud/import_alicloud_cen_bandwidth_package_attachment_test.go
@@ -10,7 +10,10 @@ func TestAccAlicloudCenBandwidthPackageAttachment_importBasic(t *testing.T) {
 	resourceName := "alicloud_cen_bandwidth_package_attachment.foo"
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck: func() {
+			testAccPreCheck(t)
+			testAccPreCheckWithAccountSiteType(t, DomesticSite)
+		},
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckCenBandwidthPackageAttachmentDestroy,
 		Steps: []resource.TestStep{

--- a/alicloud/import_alicloud_cen_bandwidth_package_test.go
+++ b/alicloud/import_alicloud_cen_bandwidth_package_test.go
@@ -11,7 +11,10 @@ func TestAccAlicloudCenBandwidthPackage_importBasic(t *testing.T) {
 	ignoreFields := []string{"period"}
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck: func() {
+			testAccPreCheck(t)
+			testAccPreCheckWithAccountSiteType(t, DomesticSite)
+		},
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckCenBandwidthPackageDestroy,
 		Steps: []resource.TestStep{

--- a/alicloud/resource_alicloud_cen_bandwidth_limit_test.go
+++ b/alicloud/resource_alicloud_cen_bandwidth_limit_test.go
@@ -27,6 +27,7 @@ func TestAccAlicloudCenBandwidthLimit_basic(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			testAccPreCheck(t)
+			testAccPreCheckWithAccountSiteType(t, DomesticSite)
 		},
 
 		// module name
@@ -64,6 +65,7 @@ func TestAccAlicloudCenBandwidthLimit_update(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			testAccPreCheck(t)
+			testAccPreCheckWithAccountSiteType(t, DomesticSite)
 		},
 
 		ProviderFactories: providerFactories,
@@ -111,6 +113,7 @@ func TestAccAlicloudCenBandwidthLimit_multi(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			testAccPreCheck(t)
+			testAccPreCheckWithAccountSiteType(t, DomesticSite)
 		},
 
 		ProviderFactories: providerFactories,

--- a/alicloud/resource_alicloud_cen_bandwidth_package_attachment_test.go
+++ b/alicloud/resource_alicloud_cen_bandwidth_package_attachment_test.go
@@ -16,6 +16,7 @@ func TestAccAlicloudCenBandwidthPackageAttachment_basic(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			testAccPreCheck(t)
+			testAccPreCheckWithAccountSiteType(t, DomesticSite)
 		},
 
 		// module name

--- a/alicloud/resource_alicloud_cen_bandwidth_package_test.go
+++ b/alicloud/resource_alicloud_cen_bandwidth_package_test.go
@@ -113,6 +113,7 @@ func TestAccAlicloudCenBandwidthPackage_basic(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			testAccPreCheck(t)
+			testAccPreCheckWithAccountSiteType(t, DomesticSite)
 		},
 
 		// module name
@@ -147,6 +148,7 @@ func TestAccAlicloudCenBandwidthPackage_update(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			testAccPreCheck(t)
+			testAccPreCheckWithAccountSiteType(t, DomesticSite)
 		},
 
 		// module name
@@ -197,6 +199,7 @@ func TestAccAlicloudCenBandwidthPackage_muti(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			testAccPreCheck(t)
+			testAccPreCheckWithAccountSiteType(t, DomesticSite)
 		},
 
 		// module name


### PR DESCRIPTION
$TF_ACC=1 go test ./alicloud -v -run=TestAccAlicloudCenBandwidth
=== RUN   TestAccAlicloudCenBandwidthLimitsDataSource_instance_id
--- SKIP: TestAccAlicloudCenBandwidthLimitsDataSource_instance_id (0.00s)
    provider_test.go:60: Skipping unsupported account type International-Site. It only supports Domestic-Site.
=== RUN   TestAccAlicloudCenBandwidthLimitsDataSource_empty
--- SKIP: TestAccAlicloudCenBandwidthLimitsDataSource_empty (0.00s)
    provider_test.go:60: Skipping unsupported account type International-Site. It only supports Domestic-Site.
=== RUN   TestAccAlicloudCenBandwidthPackagesDataSource_instance_id
--- SKIP: TestAccAlicloudCenBandwidthPackagesDataSource_instance_id (0.00s)
    provider_test.go:60: Skipping unsupported account type International-Site. It only supports Domestic-Site.
=== RUN   TestAccAlicloudCenBandwidthPackagesDataSource_bandwidth_package_nameRegex
--- SKIP: TestAccAlicloudCenBandwidthPackagesDataSource_bandwidth_package_nameRegex (0.00s)
    provider_test.go:60: Skipping unsupported account type International-Site. It only supports Domestic-Site.
=== RUN   TestAccAlicloudCenBandwidthPackagesDataSource_multi_bandwith_packages
--- SKIP: TestAccAlicloudCenBandwidthPackagesDataSource_multi_bandwith_packages (0.00s)
    provider_test.go:60: Skipping unsupported account type International-Site. It only supports Domestic-Site.
=== RUN   TestAccAlicloudCenBandwidthPackagesDataSource_empty
--- SKIP: TestAccAlicloudCenBandwidthPackagesDataSource_empty (0.00s)
    provider_test.go:60: Skipping unsupported account type International-Site. It only supports Domestic-Site.
=== RUN   TestAccAlicloudCenBandwidthPackageAttachment_importBasic
--- SKIP: TestAccAlicloudCenBandwidthPackageAttachment_importBasic (0.00s)
    provider_test.go:60: Skipping unsupported account type International-Site. It only supports Domestic-Site.
=== RUN   TestAccAlicloudCenBandwidthPackage_importBasic
--- SKIP: TestAccAlicloudCenBandwidthPackage_importBasic (0.00s)
    provider_test.go:60: Skipping unsupported account type International-Site. It only supports Domestic-Site.
=== RUN   TestAccAlicloudCenBandwidthLimit_basic
--- SKIP: TestAccAlicloudCenBandwidthLimit_basic (0.00s)
    provider_test.go:60: Skipping unsupported account type International-Site. It only supports Domestic-Site.
=== RUN   TestAccAlicloudCenBandwidthLimit_update
--- SKIP: TestAccAlicloudCenBandwidthLimit_update (0.00s)
    provider_test.go:60: Skipping unsupported account type International-Site. It only supports Domestic-Site.
=== RUN   TestAccAlicloudCenBandwidthLimit_multi
--- SKIP: TestAccAlicloudCenBandwidthLimit_multi (0.00s)
    provider_test.go:60: Skipping unsupported account type International-Site. It only supports Domestic-Site.
=== RUN   TestAccAlicloudCenBandwidthPackageAttachment_basic
--- SKIP: TestAccAlicloudCenBandwidthPackageAttachment_basic (0.00s)
    provider_test.go:60: Skipping unsupported account type International-Site. It only supports Domestic-Site.
=== RUN   TestAccAlicloudCenBandwidthPackage_basic
--- SKIP: TestAccAlicloudCenBandwidthPackage_basic (0.00s)
    provider_test.go:60: Skipping unsupported account type International-Site. It only supports Domestic-Site.
=== RUN   TestAccAlicloudCenBandwidthPackage_update
--- SKIP: TestAccAlicloudCenBandwidthPackage_update (0.00s)
    provider_test.go:60: Skipping unsupported account type International-Site. It only supports Domestic-Site.
=== RUN   TestAccAlicloudCenBandwidthPackage_muti
--- SKIP: TestAccAlicloudCenBandwidthPackage_muti (0.00s)
    provider_test.go:60: Skipping unsupported account type International-Site. It only supports Domestic-Site.
PASS
ok      github.com/terraform-providers/terraform-provider-alicloud/alicloud     0.055s
