### PR TITLE
Add Nat Gateways Datasource

### DIFF
--- a/alicloud/data_source_alicloud_nat_gateways.go
+++ b/alicloud/data_source_alicloud_nat_gateways.go
@@ -1,0 +1,192 @@
+package alicloud
+
+import (
+	"regexp"
+
+	"github.com/aliyun/alibaba-cloud-sdk-go/sdk/requests"
+	"github.com/aliyun/alibaba-cloud-sdk-go/services/vpc"
+	"github.com/hashicorp/terraform/helper/schema"
+	"github.com/terraform-providers/terraform-provider-alicloud/alicloud/connectivity"
+)
+
+func dataSourceAlicloudNatGateways() *schema.Resource {
+	return &schema.Resource{
+		Read: dataSourceAlicloudNatGatewaysRead,
+
+		Schema: map[string]*schema.Schema{
+			"name_regex": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ValidateFunc: validateNameRegex,
+				ForceNew:     true,
+			},
+			"output_file": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"vpc_id": {
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: true,
+			},
+			"ids": {
+				Type:     schema.TypeList,
+				Optional: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+				ForceNew: true,
+				Computed: true,
+			},
+			"names": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+			},
+
+			// Computed values
+			"gateways": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"spec": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"status": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"name": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"description": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"creation_time": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"snat_table_id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"forward_table_id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+					},
+				},
+			},
+		},
+	}
+}
+func dataSourceAlicloudNatGatewaysRead(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*connectivity.AliyunClient)
+
+	request := vpc.CreateDescribeNatGatewaysRequest()
+	request.RegionId = string(client.Region)
+	request.PageSize = requests.NewInteger(PageSizeLarge)
+	request.PageNumber = requests.NewInteger(1)
+	request.VpcId = d.Get("vpc_id").(string)
+	idsMap := make(map[string]string)
+	if v, ok := d.GetOk("ids"); ok {
+		for _, vv := range v.([]interface{}) {
+			idsMap[Trim(vv.(string))] = Trim(vv.(string))
+		}
+	}
+
+	var allNatGateways []vpc.NatGateway
+	var nameRegex *regexp.Regexp
+	if v, ok := d.GetOk("name_regex"); ok {
+		if r, err := regexp.Compile(Trim(v.(string))); err == nil {
+			nameRegex = r
+		}
+	}
+	invoker := NewInvoker()
+	for {
+		var raw interface{}
+		if err := invoker.Run(func() error {
+			response, err := client.WithVpcClient(func(vpcClient *vpc.Client) (interface{}, error) {
+				return vpcClient.DescribeNatGateways(request)
+			})
+			raw = response
+			return err
+		}); err != nil {
+			return WrapErrorf(err, DataDefaultErrorMsg, "alicloud_nat_gateways", request.GetActionName(), AlibabaCloudSdkGoERROR)
+		}
+		resp, _ := raw.(*vpc.DescribeNatGatewaysResponse)
+		if resp == nil || len(resp.NatGateways.NatGateway) < 1 {
+			break
+		}
+
+		for _, gateways := range resp.NatGateways.NatGateway {
+			if nameRegex != nil {
+				if !nameRegex.MatchString(gateways.Name) {
+					continue
+				}
+			}
+			if len(idsMap) > 0 {
+				if _, ok := idsMap[gateways.NatGatewayId]; !ok {
+					continue
+				}
+			}
+			allNatGateways = append(allNatGateways, gateways)
+		}
+
+		if len(resp.NatGateways.NatGateway) < PageSizeLarge {
+			break
+		}
+
+		if page, err := getNextpageNumber(request.PageNumber); err != nil {
+			return WrapError(err)
+		} else {
+			request.PageNumber = page
+		}
+	}
+
+	return NatGatewaysDecriptionAttributes(d, allNatGateways, meta)
+}
+
+func NatGatewaysDecriptionAttributes(d *schema.ResourceData, gateways []vpc.NatGateway, meta interface{}) error {
+	var ids []string
+	var names []string
+	var s []map[string]interface{}
+	for _, gateway := range gateways {
+		mapping := map[string]interface{}{
+			"id":               gateway.NatGatewayId,
+			"spec":             gateway.Spec,
+			"status":           gateway.Status,
+			"name":             gateway.Name,
+			"description":      gateway.Description,
+			"creation_time":    gateway.CreationTime,
+			"snat_table_id":    gateway.SnatTableIds.SnatTableId[0],
+			"forward_table_id": gateway.ForwardTableIds.ForwardTableId[0],
+		}
+		names = append(names, gateway.Name)
+		ids = append(ids, gateway.NatGatewayId)
+		s = append(s, mapping)
+	}
+	d.SetId(dataResourceIdHash(ids))
+	if err := d.Set("gateways", s); err != nil {
+		return WrapError(err)
+	}
+	if err := d.Set("names", names); err != nil {
+		return WrapError(err)
+	}
+	if err := d.Set("ids", ids); err != nil {
+		return WrapError(err)
+	}
+
+	// create a json file in current directory and write data source to it.
+	if output, ok := d.GetOk("output_file"); ok && output.(string) != "" {
+		writeToFile(output.(string), s)
+	}
+	return nil
+
+}

--- a/alicloud/data_source_alicloud_nat_gateways_test.go
+++ b/alicloud/data_source_alicloud_nat_gateways_test.go
@@ -1,0 +1,370 @@
+package alicloud
+
+import (
+	"regexp"
+	"testing"
+
+	"github.com/hashicorp/terraform/helper/resource"
+)
+
+func TestAccAlicloudNatGatewaysDataSourceBasic(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+		},
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCheckAlicloudNatGatewaysDataSourceConfig,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAlicloudDataSourceID("data.alicloud_nat_gateways.foo"),
+					resource.TestCheckResourceAttr("data.alicloud_nat_gateways.foo", "gateways.#", "1"),
+					resource.TestCheckResourceAttrSet("data.alicloud_nat_gateways.foo", "gateways.0.id"),
+					resource.TestCheckResourceAttr("data.alicloud_nat_gateways.foo", "gateways.0.spec", "Small"),
+					resource.TestCheckResourceAttr("data.alicloud_nat_gateways.foo", "gateways.0.status", "Available"),
+					resource.TestCheckResourceAttrSet("data.alicloud_nat_gateways.foo", "gateways.0.creation_time"),
+					resource.TestCheckResourceAttrSet("data.alicloud_nat_gateways.foo", "gateways.0.forward_table_id"),
+					resource.TestCheckResourceAttrSet("data.alicloud_nat_gateways.foo", "gateways.0.snat_table_id"),
+					resource.TestMatchResourceAttr("data.alicloud_nat_gateways.foo", "gateways.0.name", regexp.MustCompile("^tf-testAcc-for-nat-gateways-datasourc")),
+					resource.TestMatchResourceAttr("data.alicloud_nat_gateways.foo", "gateways.0.description", regexp.MustCompile("^tf-testAcc-for-nat-gateways-datasourc")),
+					resource.TestCheckResourceAttr("data.alicloud_nat_gateways.foo", "ids.#", "1"),
+					resource.TestCheckResourceAttr("data.alicloud_nat_gateways.foo", "names.#", "1"),
+				),
+			},
+			{
+				Config: testAccCheckAlicloudNatGatewaysDataSourceConfig_mismatch,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAlicloudDataSourceID("data.alicloud_nat_gateways.foo"),
+					resource.TestCheckResourceAttr("data.alicloud_nat_gateways.foo", "gateways.#", "0"),
+					resource.TestCheckResourceAttr("data.alicloud_nat_gateways.foo", "ids.#", "0"),
+					resource.TestCheckResourceAttr("data.alicloud_nat_gateways.foo", "names.#", "0"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAlicloudNatGatewaysDataSourceNameRegex(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+		},
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCheckAlicloudNatGatewaysDataSourceNameRegex,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAlicloudDataSourceID("data.alicloud_nat_gateways.foo"),
+					resource.TestCheckResourceAttr("data.alicloud_nat_gateways.foo", "gateways.#", "1"),
+					resource.TestCheckResourceAttrSet("data.alicloud_nat_gateways.foo", "gateways.0.id"),
+					resource.TestCheckResourceAttr("data.alicloud_nat_gateways.foo", "gateways.0.spec", "Small"),
+					resource.TestCheckResourceAttr("data.alicloud_nat_gateways.foo", "gateways.0.status", "Available"),
+					resource.TestCheckResourceAttrSet("data.alicloud_nat_gateways.foo", "gateways.0.creation_time"),
+					resource.TestCheckResourceAttrSet("data.alicloud_nat_gateways.foo", "gateways.0.forward_table_id"),
+					resource.TestCheckResourceAttrSet("data.alicloud_nat_gateways.foo", "gateways.0.snat_table_id"),
+					resource.TestMatchResourceAttr("data.alicloud_nat_gateways.foo", "gateways.0.name", regexp.MustCompile("^tf-testAcc-for-nat-gateways-datasourc")),
+					resource.TestMatchResourceAttr("data.alicloud_nat_gateways.foo", "gateways.0.description", regexp.MustCompile("^tf-testAcc-for-nat-gateways-datasourc")),
+					resource.TestCheckResourceAttr("data.alicloud_nat_gateways.foo", "ids.#", "1"),
+					resource.TestCheckResourceAttr("data.alicloud_nat_gateways.foo", "names.#", "1"),
+				),
+			},
+			{
+				Config: testAccCheckAlicloudNatGatewaysDataSourceNameRegex_mismatch,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAlicloudDataSourceID("data.alicloud_nat_gateways.foo"),
+					resource.TestCheckResourceAttr("data.alicloud_nat_gateways.foo", "gateways.#", "0"),
+					resource.TestCheckResourceAttr("data.alicloud_nat_gateways.foo", "ids.#", "0"),
+					resource.TestCheckResourceAttr("data.alicloud_nat_gateways.foo", "names.#", "0"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAlicloudNatGatewaysDataSourceIds(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+		},
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCheckAlicloudNatGatewaysDataSourceIds,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAlicloudDataSourceID("data.alicloud_nat_gateways.foo"),
+					resource.TestCheckResourceAttr("data.alicloud_nat_gateways.foo", "gateways.#", "1"),
+					resource.TestCheckResourceAttrSet("data.alicloud_nat_gateways.foo", "gateways.0.id"),
+					resource.TestCheckResourceAttr("data.alicloud_nat_gateways.foo", "gateways.0.spec", "Small"),
+					resource.TestCheckResourceAttr("data.alicloud_nat_gateways.foo", "gateways.0.status", "Available"),
+					resource.TestCheckResourceAttrSet("data.alicloud_nat_gateways.foo", "gateways.0.creation_time"),
+					resource.TestCheckResourceAttrSet("data.alicloud_nat_gateways.foo", "gateways.0.forward_table_id"),
+					resource.TestCheckResourceAttrSet("data.alicloud_nat_gateways.foo", "gateways.0.snat_table_id"),
+					resource.TestMatchResourceAttr("data.alicloud_nat_gateways.foo", "gateways.0.name", regexp.MustCompile("^tf-testAcc-for-nat-gateways-datasourc")),
+					resource.TestMatchResourceAttr("data.alicloud_nat_gateways.foo", "gateways.0.description", regexp.MustCompile("^tf-testAcc-for-nat-gateways-datasourc")),
+					resource.TestCheckResourceAttr("data.alicloud_nat_gateways.foo", "ids.#", "1"),
+					resource.TestCheckResourceAttr("data.alicloud_nat_gateways.foo", "names.#", "1"),
+				),
+			},
+			{
+				Config: testAccCheckAlicloudNatGatewaysDataSourceIds_mismatch,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAlicloudDataSourceID("data.alicloud_nat_gateways.foo"),
+					resource.TestCheckResourceAttr("data.alicloud_nat_gateways.foo", "gateways.#", "0"),
+					resource.TestCheckResourceAttr("data.alicloud_nat_gateways.foo", "ids.#", "0"),
+					resource.TestCheckResourceAttr("data.alicloud_nat_gateways.foo", "names.#", "0"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAlicloudNatGatewaysDataSourceVpcId(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+		},
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCheckAlicloudNatGatewaysDataSourceVpcId,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAlicloudDataSourceID("data.alicloud_nat_gateways.foo"),
+					resource.TestCheckResourceAttr("data.alicloud_nat_gateways.foo", "gateways.#", "1"),
+					resource.TestCheckResourceAttrSet("data.alicloud_nat_gateways.foo", "gateways.0.id"),
+					resource.TestCheckResourceAttr("data.alicloud_nat_gateways.foo", "gateways.0.spec", "Small"),
+					resource.TestCheckResourceAttr("data.alicloud_nat_gateways.foo", "gateways.0.status", "Available"),
+					resource.TestCheckResourceAttrSet("data.alicloud_nat_gateways.foo", "gateways.0.creation_time"),
+					resource.TestCheckResourceAttrSet("data.alicloud_nat_gateways.foo", "gateways.0.forward_table_id"),
+					resource.TestCheckResourceAttrSet("data.alicloud_nat_gateways.foo", "gateways.0.snat_table_id"),
+					resource.TestMatchResourceAttr("data.alicloud_nat_gateways.foo", "gateways.0.name", regexp.MustCompile("^tf-testAcc-for-nat-gateways-datasourc")),
+					resource.TestMatchResourceAttr("data.alicloud_nat_gateways.foo", "gateways.0.description", regexp.MustCompile("^tf-testAcc-for-nat-gateways-datasourc")),
+					resource.TestCheckResourceAttr("data.alicloud_nat_gateways.foo", "ids.#", "1"),
+					resource.TestCheckResourceAttr("data.alicloud_nat_gateways.foo", "names.#", "1"),
+				),
+			},
+			{
+				Config: testAccCheckAlicloudNatGatewaysDataSourceVpcId_mismatch,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAlicloudDataSourceID("data.alicloud_nat_gateways.foo"),
+					resource.TestCheckResourceAttr("data.alicloud_nat_gateways.foo", "gateways.#", "0"),
+					resource.TestCheckResourceAttr("data.alicloud_nat_gateways.foo", "ids.#", "0"),
+					resource.TestCheckResourceAttr("data.alicloud_nat_gateways.foo", "names.#", "0"),
+				),
+			},
+		},
+	})
+}
+
+const testAccCheckAlicloudNatGatewaysDataSourceConfig = `
+variable "name" {
+  default = "tf-testAcc-for-nat-gateways-datasource"
+}
+
+data "alicloud_zones" "default" {
+	"available_resource_creation"= "VSwitch"
+}
+
+resource "alicloud_vpc" "foo" {
+	name = "${var.name}"
+	cidr_block = "172.16.0.0/12"
+}
+
+resource "alicloud_nat_gateway" "foo" {
+	vpc_id = "${alicloud_vpc.foo.id}"
+	specification = "Small"
+	name = "${var.name}"
+    description = "${var.name}"
+}
+
+data "alicloud_nat_gateways" "foo" {
+	vpc_id = "${alicloud_vpc.foo.id}"
+    name_regex = "${alicloud_nat_gateway.foo.name}"
+    ids = ["${alicloud_nat_gateway.foo.id}"]
+}
+`
+
+const testAccCheckAlicloudNatGatewaysDataSourceConfig_mismatch = `
+variable "name" {
+  default = "tf-testAcc-for-nat-gateways-datasource"
+}
+
+data "alicloud_zones" "default" {
+	"available_resource_creation"= "VSwitch"
+}
+
+resource "alicloud_vpc" "foo" {
+	name = "${var.name}"
+	cidr_block = "172.16.0.0/12"
+}
+
+resource "alicloud_nat_gateway" "foo" {
+	vpc_id = "${alicloud_vpc.foo.id}"
+	specification = "Small"
+	name = "${var.name}"
+    description = "${var.name}"
+}
+
+data "alicloud_nat_gateways" "foo" {
+	vpc_id = "${alicloud_vpc.foo.id}-fake"
+    name_regex = "${alicloud_nat_gateway.foo.name}-fake"
+    ids = ["${alicloud_nat_gateway.foo.id}-fake"]
+}
+`
+
+const testAccCheckAlicloudNatGatewaysDataSourceNameRegex = `
+variable "name" {
+  default = "tf-testAcc-for-nat-gateways-datasource"
+}
+
+data "alicloud_zones" "default" {
+	"available_resource_creation"= "VSwitch"
+}
+
+resource "alicloud_vpc" "foo" {
+	name = "${var.name}"
+	cidr_block = "172.16.0.0/12"
+}
+
+resource "alicloud_nat_gateway" "foo" {
+	vpc_id = "${alicloud_vpc.foo.id}"
+	specification = "Small"
+	name = "${var.name}"
+    description = "${var.name}"
+}
+
+data "alicloud_nat_gateways" "foo" {
+    name_regex = "${alicloud_nat_gateway.foo.name}"
+}
+`
+
+const testAccCheckAlicloudNatGatewaysDataSourceNameRegex_mismatch = `
+variable "name" {
+  default = "tf-testAcc-for-nat-gateways-datasource"
+}
+
+data "alicloud_zones" "default" {
+	"available_resource_creation"= "VSwitch"
+}
+
+resource "alicloud_vpc" "foo" {
+	name = "${var.name}"
+	cidr_block = "172.16.0.0/12"
+}
+
+resource "alicloud_nat_gateway" "foo" {
+	vpc_id = "${alicloud_vpc.foo.id}"
+	specification = "Small"
+	name = "${var.name}"
+    description = "${var.name}"
+}
+
+data "alicloud_nat_gateways" "foo" {
+    name_regex = "${alicloud_nat_gateway.foo.name}-fake"
+}
+`
+
+const testAccCheckAlicloudNatGatewaysDataSourceIds = `
+variable "name" {
+  default = "tf-testAcc-for-nat-gateways-datasource"
+}
+
+data "alicloud_zones" "default" {
+	"available_resource_creation"= "VSwitch"
+}
+
+resource "alicloud_vpc" "foo" {
+	name = "${var.name}"
+	cidr_block = "172.16.0.0/12"
+}
+
+resource "alicloud_nat_gateway" "foo" {
+	vpc_id = "${alicloud_vpc.foo.id}"
+	specification = "Small"
+	name = "${var.name}"
+    description = "${var.name}"
+}
+
+data "alicloud_nat_gateways" "foo" {
+    ids = ["${alicloud_nat_gateway.foo.id}"]
+}
+`
+
+const testAccCheckAlicloudNatGatewaysDataSourceIds_mismatch = `
+variable "name" {
+  default = "tf-testAcc-for-nat-gateways-datasource"
+}
+
+data "alicloud_zones" "default" {
+	"available_resource_creation"= "VSwitch"
+}
+
+resource "alicloud_vpc" "foo" {
+	name = "${var.name}"
+	cidr_block = "172.16.0.0/12"
+}
+
+resource "alicloud_nat_gateway" "foo" {
+	vpc_id = "${alicloud_vpc.foo.id}"
+	specification = "Small"
+	name = "${var.name}"
+    description = "${var.name}"
+}
+
+data "alicloud_nat_gateways" "foo" {
+    ids = ["${alicloud_nat_gateway.foo.id}-fake"]
+}
+`
+
+const testAccCheckAlicloudNatGatewaysDataSourceVpcId = `
+variable "name" {
+  default = "tf-testAcc-for-nat-gateways-datasource"
+}
+
+data "alicloud_zones" "default" {
+	"available_resource_creation"= "VSwitch"
+}
+
+resource "alicloud_vpc" "foo" {
+	name = "${var.name}"
+	cidr_block = "172.16.0.0/12"
+}
+
+resource "alicloud_nat_gateway" "foo" {
+	vpc_id = "${alicloud_vpc.foo.id}"
+	specification = "Small"
+	name = "${var.name}"
+    description = "${var.name}"
+}
+
+data "alicloud_nat_gateways" "foo" {
+	vpc_id = "${alicloud_vpc.foo.id}"
+    name_regex = "${alicloud_nat_gateway.foo.name}"
+}
+`
+
+const testAccCheckAlicloudNatGatewaysDataSourceVpcId_mismatch = `
+variable "name" {
+  default = "tf-testAcc-for-nat-gateways-datasource"
+}
+
+data "alicloud_zones" "default" {
+	"available_resource_creation"= "VSwitch"
+}
+
+resource "alicloud_vpc" "foo" {
+	name = "${var.name}"
+	cidr_block = "172.16.0.0/12"
+}
+
+resource "alicloud_nat_gateway" "foo" {
+	vpc_id = "${alicloud_vpc.foo.id}"
+	specification = "Small"
+	name = "${var.name}"
+    description = "${var.name}"
+}
+
+data "alicloud_nat_gateways" "foo" {
+	vpc_id = "${alicloud_vpc.foo.id}-fake"
+    name_regex = "${alicloud_nat_gateway.foo.name}-fake"
+}
+`

--- a/alicloud/provider.go
+++ b/alicloud/provider.go
@@ -154,6 +154,7 @@ func Provider() terraform.ResourceProvider {
 			"alicloud_common_bandwidth_packages":      dataSourceAlicloudCommonBandwidthPackages(),
 			"alicloud_route_tables":                   dataSourceAlicloudRouteTables(),
 			"alicloud_route_entries":                  dataSourceAlicloudRouteEntries(),
+			"alicloud_nat_gateways":                   dataSourceAlicloudNatGateways(),
 		},
 		ResourcesMap: map[string]*schema.Resource{
 			"alicloud_instance":                           resourceAliyunInstance(),

--- a/website/alicloud.erb
+++ b/website/alicloud.erb
@@ -241,6 +241,9 @@
                         <li<%= sidebar_current("docs-alicloud-datasource-route-entries") %>>
                             <a href="/docs/providers/alicloud/d/route_entries.html">alicloud_route_entries</a>
                         </li>
+                        <li<%= sidebar_current("docs-alicloud-datasource-nat-gateways") %>>
+                            <a href="/docs/providers/alicloud/d/nat_gateways.html">alicloud_nat_gateways</a>
+                        </li>
                     </ul>
                 </li>
 

--- a/website/docs/d/nat_gateways.html.markdown
+++ b/website/docs/d/nat_gateways.html.markdown
@@ -1,0 +1,66 @@
+---
+layout: "alicloud"
+page_title: "Alicloud: alicloud_nat_gateways"
+sidebar_current: "docs-alicloud-datasource-nat-gateways"
+description: |-
+    Provides a list of Nat Gateways owned by an Alibaba Cloud account.
+---
+
+# alicloud\_nat\_gateways
+
+This data source provides a list of Nat Gateways owned by an Alibaba Cloud account.
+
+## Example Usage
+
+```
+variable "name" {
+  default = "tf-testAcc-for-nat-gateways-datasource"
+}
+
+data "alicloud_zones" "default" {
+	"available_resource_creation"= "VSwitch"
+}
+
+resource "alicloud_vpc" "foo" {
+	name = "${var.name}"
+	cidr_block = "172.16.0.0/12"
+}
+
+resource "alicloud_nat_gateway" "foo" {
+	vpc_id = "${alicloud_vpc.foo.id}"
+	specification = "Small"
+	name = "${var.name}"
+}
+
+data "alicloud_nat_gateways" "foo" {
+	vpc_id = "${alicloud_vpc.foo.id}"
+    name_regex = "${alicloud_nat_gateway.foo.name}"
+    ids = ["${alicloud_nat_gateway.foo.id}"]
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `ids` - (Optional) A list of NAT gateways IDs.
+* `name_regex` - (Optional) A regex string to filter nat gateways by name.
+* `vpc_id` - (Optional) The ID of the VPC.
+* `output_file` - (Optional) File name where to save data source results (after running `terraform plan`).
+
+## Attributes Reference
+
+The following attributes are exported in addition to the arguments listed above:
+
+* `ids` - (Optional) A list of Nat gateways IDs.
+* `names` - A list of Nat gateways names.
+* `gateways` - A list of Nat gateways. Each element contains the following attributes:
+  * `id` - The ID of the NAT gateway.
+  * `name` - Name of the NAT gateway.
+  * `description` - The description of the NAT gateway.
+  * `creation_time` - Time of creation.
+  * `spec` - The specification of the NAT gateway.
+  * `status` - The status of the NAT gateway.
+  * `snat_table_id` - The snat table id.
+  * `forward_table_id` - The forward table id. 
+


### PR DESCRIPTION
MacBook-Pro-2:terraform-provider-alicloud jince$ TF_ACC=1 go test ./alicloud -v -run=TestAccAlicloudNatGatewaysDataSource -timeout=300m
=== RUN   TestAccAlicloudNatGatewaysDataSourceBasic
--- PASS: TestAccAlicloudNatGatewaysDataSourceBasic (41.30s)
=== RUN   TestAccAlicloudNatGatewaysDataSourceNameRegex
--- PASS: TestAccAlicloudNatGatewaysDataSourceNameRegex (39.30s)
=== RUN   TestAccAlicloudNatGatewaysDataSourceIds
--- PASS: TestAccAlicloudNatGatewaysDataSourceIds (38.40s)
=== RUN   TestAccAlicloudNatGatewaysDataSourceVpcId
--- PASS: TestAccAlicloudNatGatewaysDataSourceVpcId (36.99s)
PASS
ok  	github.com/terraform-providers/terraform-provider-alicloud/alicloud	156.053s