### PR TITLE
Add Snat Entries Datasource

### DIFF
--- a/alicloud/data_source_alicloud_snat_entries.go
+++ b/alicloud/data_source_alicloud_snat_entries.go
@@ -1,0 +1,157 @@
+package alicloud
+
+import (
+	"github.com/aliyun/alibaba-cloud-sdk-go/sdk/requests"
+	"github.com/aliyun/alibaba-cloud-sdk-go/services/vpc"
+	"github.com/hashicorp/terraform/helper/schema"
+	"github.com/terraform-providers/terraform-provider-alicloud/alicloud/connectivity"
+)
+
+func dataSourceAlicloudSnatEntries() *schema.Resource {
+	return &schema.Resource{
+		Read: dataSourceAlicloudSnatEntriesRead,
+
+		Schema: map[string]*schema.Schema{
+			"snat_table_id": {
+				Type:     schema.TypeString,
+				ForceNew: true,
+				Required: true,
+			},
+			"output_file": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"snat_ip": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"source_cidr": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"ids": {
+				Type:     schema.TypeList,
+				Optional: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+				ForceNew: true,
+				Computed: true,
+			},
+
+			// Computed values
+			"entries": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"snat_ip": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"source_cidr": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"status": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+					},
+				},
+			},
+		},
+	}
+}
+func dataSourceAlicloudSnatEntriesRead(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*connectivity.AliyunClient)
+
+	request := vpc.CreateDescribeSnatTableEntriesRequest()
+	request.RegionId = string(client.Region)
+	request.PageSize = requests.NewInteger(PageSizeLarge)
+	request.PageNumber = requests.NewInteger(1)
+	request.SnatTableId = d.Get("snat_table_id").(string)
+	idsMap := make(map[string]string)
+	if v, ok := d.GetOk("ids"); ok {
+		for _, vv := range v.([]interface{}) {
+			idsMap[Trim(vv.(string))] = Trim(vv.(string))
+		}
+	}
+
+	var allSnatEntries []vpc.SnatTableEntry
+	invoker := NewInvoker()
+	for {
+		var raw interface{}
+		if err := invoker.Run(func() error {
+			response, err := client.WithVpcClient(func(vpcClient *vpc.Client) (interface{}, error) {
+				return vpcClient.DescribeSnatTableEntries(request)
+			})
+			raw = response
+			return err
+		}); err != nil {
+			return WrapErrorf(err, DataDefaultErrorMsg, "alicloud_snat_entries", request.GetActionName(), AlibabaCloudSdkGoERROR)
+		}
+		resp, _ := raw.(*vpc.DescribeSnatTableEntriesResponse)
+		if resp == nil || len(resp.SnatTableEntries.SnatTableEntry) < 1 {
+			break
+		}
+
+		for _, entries := range resp.SnatTableEntries.SnatTableEntry {
+			if snat_ip, ok := d.GetOk("snat_ip"); ok && entries.SnatIp != snat_ip.(string) {
+				continue
+			}
+			if source_cidr, ok := d.GetOk("source_cidr"); ok && entries.SourceCIDR != source_cidr.(string) {
+				continue
+			}
+			if len(idsMap) > 0 {
+				if _, ok := idsMap[entries.SnatTableId]; !ok {
+					continue
+				}
+			}
+			allSnatEntries = append(allSnatEntries, entries)
+		}
+
+		if len(resp.SnatTableEntries.SnatTableEntry) < PageSizeLarge {
+			break
+		}
+
+		if page, err := getNextpageNumber(request.PageNumber); err != nil {
+			return WrapError(err)
+		} else {
+			request.PageNumber = page
+		}
+	}
+
+	return SnatEntriesDecriptionAttributes(d, allSnatEntries, meta)
+}
+
+func SnatEntriesDecriptionAttributes(d *schema.ResourceData, entries []vpc.SnatTableEntry, meta interface{}) error {
+	var ids []string
+	var s []map[string]interface{}
+	for _, entry := range entries {
+		mapping := map[string]interface{}{
+			"id":          entry.SnatEntryId,
+			"snat_ip":     entry.SnatIp,
+			"source_cidr": entry.SourceCIDR,
+			"status":      entry.Status,
+		}
+		ids = append(ids, entry.SnatEntryId)
+		s = append(s, mapping)
+	}
+	d.SetId(dataResourceIdHash(ids))
+	if err := d.Set("entries", s); err != nil {
+		return WrapError(err)
+	}
+	if err := d.Set("ids", ids); err != nil {
+		return WrapError(err)
+	}
+
+	// create a json file in current directory and write data source to it.
+	if output, ok := d.GetOk("output_file"); ok && output.(string) != "" {
+		writeToFile(output.(string), s)
+	}
+	return nil
+
+}

--- a/alicloud/data_source_alicloud_snat_entries_test.go
+++ b/alicloud/data_source_alicloud_snat_entries_test.go
@@ -1,0 +1,380 @@
+package alicloud
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform/helper/resource"
+)
+
+func TestAccAlicloudSnatEntriesDataSourceBasic(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+		},
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCheckAlicloudSnatEntriesDataSourceConfig,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAlicloudDataSourceID("data.alicloud_snat_entries.foo"),
+					resource.TestCheckResourceAttr("data.alicloud_snat_entries.foo", "entries.#", "1"),
+					resource.TestCheckResourceAttrSet("data.alicloud_snat_entries.foo", "entries.0.id"),
+					resource.TestCheckResourceAttrSet("data.alicloud_snat_entries.foo", "entries.0.snat_ip"),
+					resource.TestCheckResourceAttr("data.alicloud_snat_entries.foo", "entries.0.status", "Available"),
+					resource.TestCheckResourceAttr("data.alicloud_snat_entries.foo", "entries.0.source_cidr", "172.16.0.0/21"),
+				),
+			},
+			{
+				Config: testAccCheckAlicloudSnatEntriesDataSourceConfig_mismatch,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAlicloudDataSourceID("data.alicloud_snat_entries.foo"),
+					resource.TestCheckResourceAttr("data.alicloud_snat_entries.foo", "entries.#", "0"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAlicloudSnatEntriesDataSourceCidr(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+		},
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCheckAlicloudSnatEntriesDataSourceCidr,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAlicloudDataSourceID("data.alicloud_snat_entries.foo"),
+					resource.TestCheckResourceAttr("data.alicloud_snat_entries.foo", "entries.#", "1"),
+					resource.TestCheckResourceAttrSet("data.alicloud_snat_entries.foo", "entries.0.id"),
+					resource.TestCheckResourceAttrSet("data.alicloud_snat_entries.foo", "entries.0.snat_ip"),
+					resource.TestCheckResourceAttr("data.alicloud_snat_entries.foo", "entries.0.status", "Available"),
+					resource.TestCheckResourceAttr("data.alicloud_snat_entries.foo", "entries.0.source_cidr", "172.16.0.0/21"),
+				),
+			},
+			{
+				Config: testAccCheckAlicloudSnatEntriesDataSourceCidr_mismatch,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAlicloudDataSourceID("data.alicloud_snat_entries.foo"),
+					resource.TestCheckResourceAttr("data.alicloud_snat_entries.foo", "entries.#", "0"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAlicloudSnatEntriesDataSourceIp(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+		},
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCheckAlicloudSnatEntriesDataSourceIp,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAlicloudDataSourceID("data.alicloud_snat_entries.foo"),
+					resource.TestCheckResourceAttr("data.alicloud_snat_entries.foo", "entries.#", "1"),
+					resource.TestCheckResourceAttrSet("data.alicloud_snat_entries.foo", "entries.0.id"),
+					resource.TestCheckResourceAttrSet("data.alicloud_snat_entries.foo", "entries.0.snat_ip"),
+					resource.TestCheckResourceAttr("data.alicloud_snat_entries.foo", "entries.0.status", "Available"),
+					resource.TestCheckResourceAttr("data.alicloud_snat_entries.foo", "entries.0.source_cidr", "172.16.0.0/21"),
+				),
+			},
+			{
+				Config: testAccCheckAlicloudSnatEntriesDataSourceIp_mismatch,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAlicloudDataSourceID("data.alicloud_snat_entries.foo"),
+					resource.TestCheckResourceAttr("data.alicloud_snat_entries.foo", "entries.#", "0"),
+				),
+			},
+		},
+	})
+}
+
+const testAccCheckAlicloudSnatEntriesDataSourceConfig = `
+variable "name" {
+	default = "tf-testAcc-for-snat-entries-datasource"
+}
+
+data "alicloud_zones" "default" {
+	"available_resource_creation"= "VSwitch"
+}
+
+resource "alicloud_vpc" "foo" {
+	name = "${var.name}"
+	cidr_block = "172.16.0.0/12"
+}
+
+resource "alicloud_vswitch" "foo" {
+	vpc_id = "${alicloud_vpc.foo.id}"
+	cidr_block = "172.16.0.0/21"
+	availability_zone = "${data.alicloud_zones.default.zones.0.id}"
+	name = "${var.name}"
+}
+
+resource "alicloud_nat_gateway" "foo" {
+	vpc_id = "${alicloud_vpc.foo.id}"
+	specification = "Small"
+	name = "${var.name}"
+}
+
+resource "alicloud_eip" "foo" {
+	name = "${var.name}"
+}
+
+resource "alicloud_eip_association" "foo" {
+	allocation_id = "${alicloud_eip.foo.id}"
+	instance_id = "${alicloud_nat_gateway.foo.id}"
+}
+
+resource "alicloud_snat_entry" "foo" {
+	snat_table_id = "${alicloud_nat_gateway.foo.snat_table_ids}"
+	source_vswitch_id = "${alicloud_vswitch.foo.id}"
+	snat_ip = "${alicloud_eip.foo.ip_address}"
+}
+
+data "alicloud_snat_entries" "foo" {
+    source_cidr = "${alicloud_vswitch.foo.cidr_block}"
+    snat_ip = "${alicloud_snat_entry.foo.snat_ip}"
+    snat_table_id = "${alicloud_snat_entry.foo.snat_table_id}"
+}
+`
+const testAccCheckAlicloudSnatEntriesDataSourceConfig_mismatch = `
+variable "name" {
+	default = "tf-testAcc-for-snat-entries-datasource"
+}
+
+data "alicloud_zones" "default" {
+	"available_resource_creation"= "VSwitch"
+}
+
+resource "alicloud_vpc" "foo" {
+	name = "${var.name}"
+	cidr_block = "172.16.0.0/12"
+}
+
+resource "alicloud_vswitch" "foo" {
+	vpc_id = "${alicloud_vpc.foo.id}"
+	cidr_block = "172.16.0.0/21"
+	availability_zone = "${data.alicloud_zones.default.zones.0.id}"
+	name = "${var.name}"
+}
+
+resource "alicloud_nat_gateway" "foo" {
+	vpc_id = "${alicloud_vpc.foo.id}"
+	specification = "Small"
+	name = "${var.name}"
+}
+
+resource "alicloud_eip" "foo" {
+	name = "${var.name}"
+}
+
+resource "alicloud_eip_association" "foo" {
+	allocation_id = "${alicloud_eip.foo.id}"
+	instance_id = "${alicloud_nat_gateway.foo.id}"
+}
+
+resource "alicloud_snat_entry" "foo" {
+	snat_table_id = "${alicloud_nat_gateway.foo.snat_table_ids}"
+	source_vswitch_id = "${alicloud_vswitch.foo.id}"
+	snat_ip = "${alicloud_eip.foo.ip_address}"
+}
+
+data "alicloud_snat_entries" "foo" {
+    source_cidr = "${alicloud_vswitch.foo.cidr_block}-fake"
+    snat_ip = "${alicloud_snat_entry.foo.snat_ip}-fake"
+    snat_table_id = "${alicloud_snat_entry.foo.snat_table_id}-fake"
+}
+`
+
+const testAccCheckAlicloudSnatEntriesDataSourceCidr = `
+variable "name" {
+	default = "tf-testAcc-for-snat-entries-datasource"
+}
+
+data "alicloud_zones" "default" {
+	"available_resource_creation"= "VSwitch"
+}
+
+resource "alicloud_vpc" "foo" {
+	name = "${var.name}"
+	cidr_block = "172.16.0.0/12"
+}
+
+resource "alicloud_vswitch" "foo" {
+	vpc_id = "${alicloud_vpc.foo.id}"
+	cidr_block = "172.16.0.0/21"
+	availability_zone = "${data.alicloud_zones.default.zones.0.id}"
+	name = "${var.name}"
+}
+
+resource "alicloud_nat_gateway" "foo" {
+	vpc_id = "${alicloud_vpc.foo.id}"
+	specification = "Small"
+	name = "${var.name}"
+}
+
+resource "alicloud_eip" "foo" {
+	name = "${var.name}"
+}
+
+resource "alicloud_eip_association" "foo" {
+	allocation_id = "${alicloud_eip.foo.id}"
+	instance_id = "${alicloud_nat_gateway.foo.id}"
+}
+
+resource "alicloud_snat_entry" "foo" {
+	snat_table_id = "${alicloud_nat_gateway.foo.snat_table_ids}"
+	source_vswitch_id = "${alicloud_vswitch.foo.id}"
+	snat_ip = "${alicloud_eip.foo.ip_address}"
+}
+
+data "alicloud_snat_entries" "foo" {
+    source_cidr = "${alicloud_vswitch.foo.cidr_block}"
+    snat_table_id = "${alicloud_snat_entry.foo.snat_table_id}"
+}
+`
+const testAccCheckAlicloudSnatEntriesDataSourceCidr_mismatch = `
+variable "name" {
+	default = "tf-testAcc-for-snat-entries-datasource"
+}
+
+data "alicloud_zones" "default" {
+	"available_resource_creation"= "VSwitch"
+}
+
+resource "alicloud_vpc" "foo" {
+	name = "${var.name}"
+	cidr_block = "172.16.0.0/12"
+}
+
+resource "alicloud_vswitch" "foo" {
+	vpc_id = "${alicloud_vpc.foo.id}"
+	cidr_block = "172.16.0.0/21"
+	availability_zone = "${data.alicloud_zones.default.zones.0.id}"
+	name = "${var.name}"
+}
+
+resource "alicloud_nat_gateway" "foo" {
+	vpc_id = "${alicloud_vpc.foo.id}"
+	specification = "Small"
+	name = "${var.name}"
+}
+
+resource "alicloud_eip" "foo" {
+	name = "${var.name}"
+}
+
+resource "alicloud_eip_association" "foo" {
+	allocation_id = "${alicloud_eip.foo.id}"
+	instance_id = "${alicloud_nat_gateway.foo.id}"
+}
+
+resource "alicloud_snat_entry" "foo" {
+	snat_table_id = "${alicloud_nat_gateway.foo.snat_table_ids}"
+	source_vswitch_id = "${alicloud_vswitch.foo.id}"
+	snat_ip = "${alicloud_eip.foo.ip_address}"
+}
+
+data "alicloud_snat_entries" "foo" {
+    source_cidr = "${alicloud_vswitch.foo.cidr_block}-fake"
+    snat_table_id = "${alicloud_snat_entry.foo.snat_table_id}"
+}
+`
+const testAccCheckAlicloudSnatEntriesDataSourceIp = `
+variable "name" {
+	default = "tf-testAcc-for-snat-entries-datasource"
+}
+
+data "alicloud_zones" "default" {
+	"available_resource_creation"= "VSwitch"
+}
+
+resource "alicloud_vpc" "foo" {
+	name = "${var.name}"
+	cidr_block = "172.16.0.0/12"
+}
+
+resource "alicloud_vswitch" "foo" {
+	vpc_id = "${alicloud_vpc.foo.id}"
+	cidr_block = "172.16.0.0/21"
+	availability_zone = "${data.alicloud_zones.default.zones.0.id}"
+	name = "${var.name}"
+}
+
+resource "alicloud_nat_gateway" "foo" {
+	vpc_id = "${alicloud_vpc.foo.id}"
+	specification = "Small"
+	name = "${var.name}"
+}
+
+resource "alicloud_eip" "foo" {
+	name = "${var.name}"
+}
+
+resource "alicloud_eip_association" "foo" {
+	allocation_id = "${alicloud_eip.foo.id}"
+	instance_id = "${alicloud_nat_gateway.foo.id}"
+}
+
+resource "alicloud_snat_entry" "foo" {
+	snat_table_id = "${alicloud_nat_gateway.foo.snat_table_ids}"
+	source_vswitch_id = "${alicloud_vswitch.foo.id}"
+	snat_ip = "${alicloud_eip.foo.ip_address}"
+}
+
+data "alicloud_snat_entries" "foo" {
+    snat_ip = "${alicloud_snat_entry.foo.snat_ip}"
+    snat_table_id = "${alicloud_snat_entry.foo.snat_table_id}"
+}
+`
+const testAccCheckAlicloudSnatEntriesDataSourceIp_mismatch = `
+variable "name" {
+	default = "tf-testAcc-for-snat-entries-datasource"
+}
+
+data "alicloud_zones" "default" {
+	"available_resource_creation"= "VSwitch"
+}
+
+resource "alicloud_vpc" "foo" {
+	name = "${var.name}"
+	cidr_block = "172.16.0.0/12"
+}
+
+resource "alicloud_vswitch" "foo" {
+	vpc_id = "${alicloud_vpc.foo.id}"
+	cidr_block = "172.16.0.0/21"
+	availability_zone = "${data.alicloud_zones.default.zones.0.id}"
+	name = "${var.name}"
+}
+
+resource "alicloud_nat_gateway" "foo" {
+	vpc_id = "${alicloud_vpc.foo.id}"
+	specification = "Small"
+	name = "${var.name}"
+}
+
+resource "alicloud_eip" "foo" {
+	name = "${var.name}"
+}
+
+resource "alicloud_eip_association" "foo" {
+	allocation_id = "${alicloud_eip.foo.id}"
+	instance_id = "${alicloud_nat_gateway.foo.id}"
+}
+
+resource "alicloud_snat_entry" "foo" {
+	snat_table_id = "${alicloud_nat_gateway.foo.snat_table_ids}"
+	source_vswitch_id = "${alicloud_vswitch.foo.id}"
+	snat_ip = "${alicloud_eip.foo.ip_address}"
+}
+
+data "alicloud_snat_entries" "foo" {
+    snat_ip = "${alicloud_snat_entry.foo.snat_ip}-fake"
+    snat_table_id = "${alicloud_snat_entry.foo.snat_table_id}"
+}
+`

--- a/alicloud/provider.go
+++ b/alicloud/provider.go
@@ -155,6 +155,7 @@ func Provider() terraform.ResourceProvider {
 			"alicloud_route_tables":                   dataSourceAlicloudRouteTables(),
 			"alicloud_route_entries":                  dataSourceAlicloudRouteEntries(),
 			"alicloud_nat_gateways":                   dataSourceAlicloudNatGateways(),
+			"alicloud_snat_entries":                   dataSourceAlicloudSnatEntries(),
 		},
 		ResourcesMap: map[string]*schema.Resource{
 			"alicloud_instance":                           resourceAliyunInstance(),

--- a/website/alicloud.erb
+++ b/website/alicloud.erb
@@ -244,6 +244,9 @@
                         <li<%= sidebar_current("docs-alicloud-datasource-nat-gateways") %>>
                             <a href="/docs/providers/alicloud/d/nat_gateways.html">alicloud_nat_gateways</a>
                         </li>
+                        <li<%= sidebar_current("docs-alicloud-datasource-snat-entries") %>>
+                            <a href="/docs/providers/alicloud/d/snat_entries.html">alicloud_snat_entries</a>
+                        </li>
                     </ul>
                 </li>
 

--- a/website/docs/d/snat_entries.html.markdown
+++ b/website/docs/d/snat_entries.html.markdown
@@ -1,0 +1,81 @@
+---
+layout: "alicloud"
+page_title: "Alicloud: alicloud_snat_entries"
+sidebar_current: "docs-alicloud-datasource-snat-entries"
+description: |-
+    Provides a list of Snat Entries owned by an Alibaba Cloud account.
+---
+
+# alicloud\_snat\_entries
+
+This data source provides a list of Snat Entries owned by an Alibaba Cloud account.
+
+## Example Usage
+
+```
+variable "name" {
+	default = "tf-testAccSnatEntryConfig"
+}
+data "alicloud_zones" "default" {
+	"available_resource_creation"= "VSwitch"
+}
+
+resource "alicloud_vpc" "foo" {
+	name = "${var.name}"
+	cidr_block = "172.16.0.0/12"
+}
+
+resource "alicloud_vswitch" "foo" {
+	vpc_id = "${alicloud_vpc.foo.id}"
+	cidr_block = "172.16.0.0/21"
+	availability_zone = "${data.alicloud_zones.default.zones.0.id}"
+	name = "${var.name}"
+}
+
+resource "alicloud_nat_gateway" "foo" {
+	vpc_id = "${alicloud_vpc.foo.id}"
+	specification = "Small"
+	name = "${var.name}"
+}
+
+resource "alicloud_eip" "foo" {
+	name = "${var.name}"
+}
+
+resource "alicloud_eip_association" "foo" {
+	allocation_id = "${alicloud_eip.foo.id}"
+	instance_id = "${alicloud_nat_gateway.foo.id}"
+}
+
+resource "alicloud_snat_entry" "foo" {
+	snat_table_id = "${alicloud_nat_gateway.foo.snat_table_ids}"
+	source_vswitch_id = "${alicloud_vswitch.foo.id}"
+	snat_ip = "${alicloud_eip.foo.ip_address}"
+}
+
+data "alicloud_snat_entries" "foo" {
+    snat_table_id = "${alicloud_snat_entry.foo.snat_table_id}"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `ids` - (Optional) A list of Snat Entries IDs.
+* `snat_ip` - The public IP of the Snat Entry.
+* `source_cidr` - The source CIDR block of the Snat Entry.
+* `snat_table_id` - (Required, ForceNew) The ID of the Snat table.
+* `output_file` - (Optional) File name where to save data source results (after running `terraform plan`).
+
+## Attributes Reference
+
+The following attributes are exported in addition to the arguments listed above:
+
+* `ids` - (Optional) A list of Snat Entries IDs.
+* `entries` - A list of Snat Entries. Each element contains the following attributes:
+  * `id` - The ID of the Snat Entry.
+  * `snat_ip` - The public IP of the Snat Entry.
+  * `source_cidr` - The source CIDR block of the Snat Entry.
+  * `status` - The status of the Snat Entry.
+


### PR DESCRIPTION
MacBook-Pro-2:terraform-provider-alicloud jince$ TF_ACC=1 go test ./alicloud -v -run=TestAccAlicloudSnatEntriesDataSource -timeout=300m
=== RUN   TestAccAlicloudSnatEntriesDataSourceBasic
--- PASS: TestAccAlicloudSnatEntriesDataSourceBasic (51.74s)
PASS
ok  	github.com/terraform-providers/terraform-provider-alicloud/alicloud	51.808s