### PR TITLE
Add Forward Entries Datasource

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 FEATURES:
 
+- **New Data Source:** `alicloud_forward_entries` [GH-922]
 - **New Data Source:** `alicloud_snat_entries` [GH-920]
 - **New Data Source:** `alicloud_nat_gateways` [GH-918]
 - **New Data Source:** `alicloud_route_entries` [GH-915]

--- a/alicloud/data_source_alicloud_forward_entries.go
+++ b/alicloud/data_source_alicloud_forward_entries.go
@@ -1,0 +1,172 @@
+package alicloud
+
+import (
+	"github.com/aliyun/alibaba-cloud-sdk-go/sdk/requests"
+	"github.com/aliyun/alibaba-cloud-sdk-go/services/vpc"
+	"github.com/hashicorp/terraform/helper/schema"
+	"github.com/terraform-providers/terraform-provider-alicloud/alicloud/connectivity"
+)
+
+func dataSourceAlicloudForwardEntries() *schema.Resource {
+	return &schema.Resource{
+		Read: dataSourceAlicloudForwardEntriesRead,
+
+		Schema: map[string]*schema.Schema{
+			"forward_table_id": {
+				Type:     schema.TypeString,
+				ForceNew: true,
+				Required: true,
+			},
+			"output_file": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"external_ip": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"internal_ip": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"ids": {
+				Type:     schema.TypeList,
+				Optional: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+				ForceNew: true,
+				Computed: true,
+			},
+
+			// Computed values
+			"entries": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"external_ip": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"internal_ip": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"external_port": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"internal_port": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"ip_protocol": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"status": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+					},
+				},
+			},
+		},
+	}
+}
+func dataSourceAlicloudForwardEntriesRead(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*connectivity.AliyunClient)
+
+	request := vpc.CreateDescribeForwardTableEntriesRequest()
+	request.RegionId = string(client.Region)
+	request.PageSize = requests.NewInteger(PageSizeLarge)
+	request.PageNumber = requests.NewInteger(1)
+	request.ForwardTableId = d.Get("forward_table_id").(string)
+	idsMap := make(map[string]string)
+	if v, ok := d.GetOk("ids"); ok {
+		for _, vv := range v.([]interface{}) {
+			idsMap[Trim(vv.(string))] = Trim(vv.(string))
+		}
+	}
+
+	var allForwardEntries []vpc.ForwardTableEntry
+	invoker := NewInvoker()
+	for {
+		var raw interface{}
+		if err := invoker.Run(func() error {
+			response, err := client.WithVpcClient(func(vpcClient *vpc.Client) (interface{}, error) {
+				return vpcClient.DescribeForwardTableEntries(request)
+			})
+			raw = response
+			return err
+		}); err != nil {
+			return WrapErrorf(err, DataDefaultErrorMsg, "alicloud_forward_entries", request.GetActionName(), AlibabaCloudSdkGoERROR)
+		}
+		resp, _ := raw.(*vpc.DescribeForwardTableEntriesResponse)
+		if resp == nil || len(resp.ForwardTableEntries.ForwardTableEntry) < 1 {
+			break
+		}
+
+		for _, entries := range resp.ForwardTableEntries.ForwardTableEntry {
+			if external_ip, ok := d.GetOk("external_ip"); ok && entries.ExternalIp != external_ip.(string) {
+				continue
+			}
+			if internal_ip, ok := d.GetOk("internal_ip"); ok && entries.InternalIp != internal_ip.(string) {
+				continue
+			}
+			if len(idsMap) > 0 {
+				if _, ok := idsMap[entries.ForwardEntryId]; !ok {
+					continue
+				}
+			}
+			allForwardEntries = append(allForwardEntries, entries)
+		}
+
+		if len(resp.ForwardTableEntries.ForwardTableEntry) < PageSizeLarge {
+			break
+		}
+
+		if page, err := getNextpageNumber(request.PageNumber); err != nil {
+			return WrapError(err)
+		} else {
+			request.PageNumber = page
+		}
+	}
+
+	return ForwardEntriesDecriptionAttributes(d, allForwardEntries, meta)
+}
+
+func ForwardEntriesDecriptionAttributes(d *schema.ResourceData, entries []vpc.ForwardTableEntry, meta interface{}) error {
+	var ids []string
+	var s []map[string]interface{}
+	for _, entry := range entries {
+		mapping := map[string]interface{}{
+			"id":            entry.ForwardEntryId,
+			"external_ip":   entry.ExternalIp,
+			"internal_ip":   entry.InternalIp,
+			"external_port": entry.ExternalPort,
+			"internal_port": entry.InternalPort,
+			"ip_protocol":   entry.IpProtocol,
+			"status":        entry.Status,
+		}
+		ids = append(ids, entry.ForwardEntryId)
+		s = append(s, mapping)
+	}
+	d.SetId(dataResourceIdHash(ids))
+	if err := d.Set("entries", s); err != nil {
+		return WrapError(err)
+	}
+	if err := d.Set("ids", ids); err != nil {
+		return WrapError(err)
+	}
+
+	// create a json file in current directory and write data source to it.
+	if output, ok := d.GetOk("output_file"); ok && output.(string) != "" {
+		writeToFile(output.(string), s)
+	}
+	return nil
+
+}

--- a/alicloud/data_source_alicloud_forward_entries_test.go
+++ b/alicloud/data_source_alicloud_forward_entries_test.go
@@ -1,0 +1,467 @@
+package alicloud
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform/helper/resource"
+)
+
+func TestAccAlicloudForwardEntriesDataSourceBasic(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+		},
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCheckAlicloudForwardEntriesDataSourceConfig,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAlicloudDataSourceID("data.alicloud_forward_entries.foo"),
+					resource.TestCheckResourceAttr("data.alicloud_forward_entries.foo", "entries.#", "1"),
+					resource.TestCheckResourceAttrSet("data.alicloud_forward_entries.foo", "entries.0.id"),
+					resource.TestCheckResourceAttrSet("data.alicloud_forward_entries.foo", "entries.0.external_ip"),
+					resource.TestCheckResourceAttr("data.alicloud_forward_entries.foo", "entries.0.external_port", "80"),
+					resource.TestCheckResourceAttr("data.alicloud_forward_entries.foo", "entries.0.internal_ip", "172.16.0.3"),
+					resource.TestCheckResourceAttr("data.alicloud_forward_entries.foo", "entries.0.internal_port", "8080"),
+					resource.TestCheckResourceAttr("data.alicloud_forward_entries.foo", "entries.0.ip_protocol", "tcp"),
+					resource.TestCheckResourceAttr("data.alicloud_forward_entries.foo", "entries.0.status", "Available"),
+					resource.TestCheckResourceAttr("data.alicloud_forward_entries.foo", "ids.#", "1"),
+				),
+			},
+			{
+				Config: testAccCheckAlicloudForwardEntriesDataSourceConfig_mismatch,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAlicloudDataSourceID("data.alicloud_forward_entries.foo"),
+					resource.TestCheckResourceAttr("data.alicloud_forward_entries.foo", "entries.#", "0"),
+					resource.TestCheckResourceAttr("data.alicloud_forward_entries.foo", "ids.#", "0"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAlicloudForwardEntriesDataSourceIds(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+		},
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCheckAlicloudForwardEntriesDataSourceIds,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAlicloudDataSourceID("data.alicloud_forward_entries.foo"),
+					resource.TestCheckResourceAttr("data.alicloud_forward_entries.foo", "entries.#", "1"),
+					resource.TestCheckResourceAttrSet("data.alicloud_forward_entries.foo", "entries.0.id"),
+					resource.TestCheckResourceAttrSet("data.alicloud_forward_entries.foo", "entries.0.external_ip"),
+					resource.TestCheckResourceAttr("data.alicloud_forward_entries.foo", "entries.0.external_port", "80"),
+					resource.TestCheckResourceAttr("data.alicloud_forward_entries.foo", "entries.0.internal_ip", "172.16.0.3"),
+					resource.TestCheckResourceAttr("data.alicloud_forward_entries.foo", "entries.0.internal_port", "8080"),
+					resource.TestCheckResourceAttr("data.alicloud_forward_entries.foo", "entries.0.ip_protocol", "tcp"),
+					resource.TestCheckResourceAttr("data.alicloud_forward_entries.foo", "entries.0.status", "Available"),
+					resource.TestCheckResourceAttr("data.alicloud_forward_entries.foo", "ids.#", "1"),
+				),
+			},
+			{
+				Config: testAccCheckAlicloudForwardEntriesDataSourceIds_mismatch,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAlicloudDataSourceID("data.alicloud_forward_entries.foo"),
+					resource.TestCheckResourceAttr("data.alicloud_forward_entries.foo", "entries.#", "0"),
+					resource.TestCheckResourceAttr("data.alicloud_forward_entries.foo", "ids.#", "0"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAlicloudForwardEntriesDataSourceExternalIp(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+		},
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCheckAlicloudForwardEntriesDataSourceExternalIp,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAlicloudDataSourceID("data.alicloud_forward_entries.foo"),
+					resource.TestCheckResourceAttr("data.alicloud_forward_entries.foo", "entries.#", "1"),
+					resource.TestCheckResourceAttrSet("data.alicloud_forward_entries.foo", "entries.0.id"),
+					resource.TestCheckResourceAttrSet("data.alicloud_forward_entries.foo", "entries.0.external_ip"),
+					resource.TestCheckResourceAttr("data.alicloud_forward_entries.foo", "entries.0.external_port", "80"),
+					resource.TestCheckResourceAttr("data.alicloud_forward_entries.foo", "entries.0.internal_ip", "172.16.0.3"),
+					resource.TestCheckResourceAttr("data.alicloud_forward_entries.foo", "entries.0.internal_port", "8080"),
+					resource.TestCheckResourceAttr("data.alicloud_forward_entries.foo", "entries.0.ip_protocol", "tcp"),
+					resource.TestCheckResourceAttr("data.alicloud_forward_entries.foo", "entries.0.status", "Available"),
+					resource.TestCheckResourceAttr("data.alicloud_forward_entries.foo", "ids.#", "1"),
+				),
+			},
+			{
+				Config: testAccCheckAlicloudForwardEntriesDataSourceExternalIp_mismatch,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAlicloudDataSourceID("data.alicloud_forward_entries.foo"),
+					resource.TestCheckResourceAttr("data.alicloud_forward_entries.foo", "entries.#", "0"),
+					resource.TestCheckResourceAttr("data.alicloud_forward_entries.foo", "ids.#", "0"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAlicloudForwardEntriesDataSourceInternalIp(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+		},
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCheckAlicloudForwardEntriesDataSourceInternalIp,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAlicloudDataSourceID("data.alicloud_forward_entries.foo"),
+					resource.TestCheckResourceAttr("data.alicloud_forward_entries.foo", "entries.#", "1"),
+					resource.TestCheckResourceAttrSet("data.alicloud_forward_entries.foo", "entries.0.id"),
+					resource.TestCheckResourceAttrSet("data.alicloud_forward_entries.foo", "entries.0.external_ip"),
+					resource.TestCheckResourceAttr("data.alicloud_forward_entries.foo", "entries.0.external_port", "80"),
+					resource.TestCheckResourceAttr("data.alicloud_forward_entries.foo", "entries.0.internal_ip", "172.16.0.3"),
+					resource.TestCheckResourceAttr("data.alicloud_forward_entries.foo", "entries.0.internal_port", "8080"),
+					resource.TestCheckResourceAttr("data.alicloud_forward_entries.foo", "entries.0.ip_protocol", "tcp"),
+					resource.TestCheckResourceAttr("data.alicloud_forward_entries.foo", "entries.0.status", "Available"),
+					resource.TestCheckResourceAttr("data.alicloud_forward_entries.foo", "ids.#", "1"),
+				),
+			},
+			{
+				Config: testAccCheckAlicloudForwardEntriesDataSourceInternalIp_mismatch,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAlicloudDataSourceID("data.alicloud_forward_entries.foo"),
+					resource.TestCheckResourceAttr("data.alicloud_forward_entries.foo", "entries.#", "0"),
+					resource.TestCheckResourceAttr("data.alicloud_forward_entries.foo", "ids.#", "0"),
+				),
+			},
+		},
+	})
+}
+
+const testAccCheckAlicloudForwardEntriesDataSourceConfig = `
+variable "name" {
+	default = "tf-testAcc-for-forward-entries-datasource"
+}
+
+resource "alicloud_vpc" "foo" {
+	name = "${var.name}"
+	cidr_block = "172.16.0.0/12"
+}
+
+resource "alicloud_nat_gateway" "foo" {
+	vpc_id = "${alicloud_vpc.foo.id}"
+	specification = "Small"
+	name = "${var.name}"
+}
+
+resource "alicloud_eip" "foo" {
+	name = "${var.name}"
+}
+
+resource "alicloud_eip_association" "foo" {
+	allocation_id = "${alicloud_eip.foo.id}"
+	instance_id = "${alicloud_nat_gateway.foo.id}"
+}
+
+resource "alicloud_forward_entry" "foo" {
+	forward_table_id = "${alicloud_nat_gateway.foo.forward_table_ids}"
+	external_ip = "${alicloud_eip.foo.ip_address}"
+	external_port = "80"
+	ip_protocol = "tcp"
+	internal_ip = "172.16.0.3"
+	internal_port = "8080"
+}
+
+data "alicloud_forward_entries" "foo" {
+	internal_ip = "${alicloud_forward_entry.foo.internal_ip}"
+    external_ip = "${alicloud_forward_entry.foo.external_ip}"
+    ids = ["${alicloud_forward_entry.foo.id}"]
+    forward_table_id = "${alicloud_forward_entry.foo.forward_table_id}"
+}
+`
+
+const testAccCheckAlicloudForwardEntriesDataSourceConfig_mismatch = `
+variable "name" {
+	default = "tf-testAcc-for-forward-entries-datasource"
+}
+
+resource "alicloud_vpc" "foo" {
+	name = "${var.name}"
+	cidr_block = "172.16.0.0/12"
+}
+
+resource "alicloud_nat_gateway" "foo" {
+	vpc_id = "${alicloud_vpc.foo.id}"
+	specification = "Small"
+	name = "${var.name}"
+}
+
+resource "alicloud_eip" "foo" {
+	name = "${var.name}"
+}
+
+resource "alicloud_eip_association" "foo" {
+	allocation_id = "${alicloud_eip.foo.id}"
+	instance_id = "${alicloud_nat_gateway.foo.id}"
+}
+
+resource "alicloud_forward_entry" "foo" {
+	forward_table_id = "${alicloud_nat_gateway.foo.forward_table_ids}"
+	external_ip = "${alicloud_eip.foo.ip_address}"
+	external_port = "80"
+	ip_protocol = "tcp"
+	internal_ip = "172.16.0.3"
+	internal_port = "8080"
+}
+
+data "alicloud_forward_entries" "foo" {
+	internal_ip = "${alicloud_forward_entry.foo.internal_ip}-fake"
+    external_ip = "${alicloud_forward_entry.foo.external_ip}-fake"
+    ids = ["${alicloud_forward_entry.foo.id}-fake"]
+    forward_table_id = "${alicloud_forward_entry.foo.forward_table_id}"
+}
+`
+
+const testAccCheckAlicloudForwardEntriesDataSourceIds = `
+variable "name" {
+	default = "tf-testAcc-for-forward-entries-datasource"
+}
+
+resource "alicloud_vpc" "foo" {
+	name = "${var.name}"
+	cidr_block = "172.16.0.0/12"
+}
+
+resource "alicloud_nat_gateway" "foo" {
+	vpc_id = "${alicloud_vpc.foo.id}"
+	specification = "Small"
+	name = "${var.name}"
+}
+
+resource "alicloud_eip" "foo" {
+	name = "${var.name}"
+}
+
+resource "alicloud_eip_association" "foo" {
+	allocation_id = "${alicloud_eip.foo.id}"
+	instance_id = "${alicloud_nat_gateway.foo.id}"
+}
+
+resource "alicloud_forward_entry" "foo" {
+	forward_table_id = "${alicloud_nat_gateway.foo.forward_table_ids}"
+	external_ip = "${alicloud_eip.foo.ip_address}"
+	external_port = "80"
+	ip_protocol = "tcp"
+	internal_ip = "172.16.0.3"
+	internal_port = "8080"
+}
+
+data "alicloud_forward_entries" "foo" {
+    ids = ["${alicloud_forward_entry.foo.id}"]
+    forward_table_id = "${alicloud_forward_entry.foo.forward_table_id}"
+}
+`
+
+const testAccCheckAlicloudForwardEntriesDataSourceIds_mismatch = `
+variable "name" {
+	default = "tf-testAcc-for-forward-entries-datasource"
+}
+
+resource "alicloud_vpc" "foo" {
+	name = "${var.name}"
+	cidr_block = "172.16.0.0/12"
+}
+
+resource "alicloud_nat_gateway" "foo" {
+	vpc_id = "${alicloud_vpc.foo.id}"
+	specification = "Small"
+	name = "${var.name}"
+}
+
+resource "alicloud_eip" "foo" {
+	name = "${var.name}"
+}
+
+resource "alicloud_eip_association" "foo" {
+	allocation_id = "${alicloud_eip.foo.id}"
+	instance_id = "${alicloud_nat_gateway.foo.id}"
+}
+
+resource "alicloud_forward_entry" "foo" {
+	forward_table_id = "${alicloud_nat_gateway.foo.forward_table_ids}"
+	external_ip = "${alicloud_eip.foo.ip_address}"
+	external_port = "80"
+	ip_protocol = "tcp"
+	internal_ip = "172.16.0.3"
+	internal_port = "8080"
+}
+
+data "alicloud_forward_entries" "foo" {
+    ids = ["${alicloud_forward_entry.foo.id}-fake"]
+    forward_table_id = "${alicloud_forward_entry.foo.forward_table_id}"
+}
+`
+
+const testAccCheckAlicloudForwardEntriesDataSourceExternalIp = `
+variable "name" {
+	default = "tf-testAcc-for-forward-entries-datasource"
+}
+
+resource "alicloud_vpc" "foo" {
+	name = "${var.name}"
+	cidr_block = "172.16.0.0/12"
+}
+
+resource "alicloud_nat_gateway" "foo" {
+	vpc_id = "${alicloud_vpc.foo.id}"
+	specification = "Small"
+	name = "${var.name}"
+}
+
+resource "alicloud_eip" "foo" {
+	name = "${var.name}"
+}
+
+resource "alicloud_eip_association" "foo" {
+	allocation_id = "${alicloud_eip.foo.id}"
+	instance_id = "${alicloud_nat_gateway.foo.id}"
+}
+
+resource "alicloud_forward_entry" "foo" {
+	forward_table_id = "${alicloud_nat_gateway.foo.forward_table_ids}"
+	external_ip = "${alicloud_eip.foo.ip_address}"
+	external_port = "80"
+	ip_protocol = "tcp"
+	internal_ip = "172.16.0.3"
+	internal_port = "8080"
+}
+
+data "alicloud_forward_entries" "foo" {
+    external_ip = "${alicloud_forward_entry.foo.external_ip}"
+    forward_table_id = "${alicloud_forward_entry.foo.forward_table_id}"
+}
+`
+
+const testAccCheckAlicloudForwardEntriesDataSourceExternalIp_mismatch = `
+variable "name" {
+	default = "tf-testAcc-for-forward-entries-datasource"
+}
+
+resource "alicloud_vpc" "foo" {
+	name = "${var.name}"
+	cidr_block = "172.16.0.0/12"
+}
+
+resource "alicloud_nat_gateway" "foo" {
+	vpc_id = "${alicloud_vpc.foo.id}"
+	specification = "Small"
+	name = "${var.name}"
+}
+
+resource "alicloud_eip" "foo" {
+	name = "${var.name}"
+}
+
+resource "alicloud_eip_association" "foo" {
+	allocation_id = "${alicloud_eip.foo.id}"
+	instance_id = "${alicloud_nat_gateway.foo.id}"
+}
+
+resource "alicloud_forward_entry" "foo" {
+	forward_table_id = "${alicloud_nat_gateway.foo.forward_table_ids}"
+	external_ip = "${alicloud_eip.foo.ip_address}"
+	external_port = "80"
+	ip_protocol = "tcp"
+	internal_ip = "172.16.0.3"
+	internal_port = "8080"
+}
+
+data "alicloud_forward_entries" "foo" {
+    external_ip = "${alicloud_forward_entry.foo.external_ip}-fake"
+    forward_table_id = "${alicloud_forward_entry.foo.forward_table_id}"
+}
+`
+
+const testAccCheckAlicloudForwardEntriesDataSourceInternalIp = `
+variable "name" {
+	default = "tf-testAcc-for-forward-entries-datasource"
+}
+
+resource "alicloud_vpc" "foo" {
+	name = "${var.name}"
+	cidr_block = "172.16.0.0/12"
+}
+
+resource "alicloud_nat_gateway" "foo" {
+	vpc_id = "${alicloud_vpc.foo.id}"
+	specification = "Small"
+	name = "${var.name}"
+}
+
+resource "alicloud_eip" "foo" {
+	name = "${var.name}"
+}
+
+resource "alicloud_eip_association" "foo" {
+	allocation_id = "${alicloud_eip.foo.id}"
+	instance_id = "${alicloud_nat_gateway.foo.id}"
+}
+
+resource "alicloud_forward_entry" "foo" {
+	forward_table_id = "${alicloud_nat_gateway.foo.forward_table_ids}"
+	external_ip = "${alicloud_eip.foo.ip_address}"
+	external_port = "80"
+	ip_protocol = "tcp"
+	internal_ip = "172.16.0.3"
+	internal_port = "8080"
+}
+
+data "alicloud_forward_entries" "foo" {
+	internal_ip = "${alicloud_forward_entry.foo.internal_ip}"
+    forward_table_id = "${alicloud_forward_entry.foo.forward_table_id}"
+}
+`
+
+const testAccCheckAlicloudForwardEntriesDataSourceInternalIp_mismatch = `
+variable "name" {
+	default = "tf-testAcc-for-forward-entries-datasource"
+}
+
+resource "alicloud_vpc" "foo" {
+	name = "${var.name}"
+	cidr_block = "172.16.0.0/12"
+}
+
+resource "alicloud_nat_gateway" "foo" {
+	vpc_id = "${alicloud_vpc.foo.id}"
+	specification = "Small"
+	name = "${var.name}"
+}
+
+resource "alicloud_eip" "foo" {
+	name = "${var.name}"
+}
+
+resource "alicloud_eip_association" "foo" {
+	allocation_id = "${alicloud_eip.foo.id}"
+	instance_id = "${alicloud_nat_gateway.foo.id}"
+}
+
+resource "alicloud_forward_entry" "foo" {
+	forward_table_id = "${alicloud_nat_gateway.foo.forward_table_ids}"
+	external_ip = "${alicloud_eip.foo.ip_address}"
+	external_port = "80"
+	ip_protocol = "tcp"
+	internal_ip = "172.16.0.3"
+	internal_port = "8080"
+}
+
+data "alicloud_forward_entries" "foo" {
+	internal_ip = "${alicloud_forward_entry.foo.internal_ip}-fake"
+    forward_table_id = "${alicloud_forward_entry.foo.forward_table_id}"
+}
+`

--- a/alicloud/provider.go
+++ b/alicloud/provider.go
@@ -156,6 +156,7 @@ func Provider() terraform.ResourceProvider {
 			"alicloud_route_entries":                  dataSourceAlicloudRouteEntries(),
 			"alicloud_nat_gateways":                   dataSourceAlicloudNatGateways(),
 			"alicloud_snat_entries":                   dataSourceAlicloudSnatEntries(),
+			"alicloud_forward_entries":                dataSourceAlicloudForwardEntries(),
 		},
 		ResourcesMap: map[string]*schema.Resource{
 			"alicloud_instance":                           resourceAliyunInstance(),

--- a/website/alicloud.erb
+++ b/website/alicloud.erb
@@ -247,6 +247,9 @@
                         <li<%= sidebar_current("docs-alicloud-datasource-snat-entries") %>>
                             <a href="/docs/providers/alicloud/d/snat_entries.html">alicloud_snat_entries</a>
                         </li>
+                        <li<%= sidebar_current("docs-alicloud-datasource-forward-entries") %>>
+                            <a href="/docs/providers/alicloud/d/forward_entries.html">alicloud_forward_entries</a>
+                        </li>
                     </ul>
                 </li>
 

--- a/website/docs/d/common_bandwidth_packages.html.markdown
+++ b/website/docs/d/common_bandwidth_packages.html.markdown
@@ -10,6 +10,8 @@ description: |-
 
 This data source provides a list of Common Bandwidth Packages owned by an Alibaba Cloud account.
 
+-> **NOTE:** Available in 1.36.0+.
+
 ## Example Usage
 
 ```

--- a/website/docs/d/forward_entries.html.markdown
+++ b/website/docs/d/forward_entries.html.markdown
@@ -1,0 +1,79 @@
+---
+layout: "alicloud"
+page_title: "Alicloud: alicloud_forward_entries"
+sidebar_current: "docs-alicloud-datasource-forward-entries"
+description: |-
+    Provides a list of Forward Entries owned by an Alibaba Cloud account.
+---
+
+# alicloud\_forward\_entries
+
+This data source provides a list of Forward Entries owned by an Alibaba Cloud account.
+
+-> **NOTE:** Available in 1.37.0+.
+
+## Example Usage
+
+```
+variable "name" {
+	default = "tf-testAccForwardEntryConfig"
+}
+
+resource "alicloud_vpc" "foo" {
+	name = "${var.name}"
+	cidr_block = "172.16.0.0/12"
+}
+
+resource "alicloud_nat_gateway" "foo" {
+	vpc_id = "${alicloud_vpc.foo.id}"
+	specification = "Small"
+	name = "${var.name}"
+}
+
+resource "alicloud_eip" "foo" {
+	name = "${var.name}"
+}
+
+resource "alicloud_eip_association" "foo" {
+	allocation_id = "${alicloud_eip.foo.id}"
+	instance_id = "${alicloud_nat_gateway.foo.id}"
+}
+
+resource "alicloud_forward_entry" "foo" {
+	forward_table_id = "${alicloud_nat_gateway.foo.forward_table_ids}"
+	external_ip = "${alicloud_eip.foo.ip_address}"
+	external_port = "80"
+	ip_protocol = "tcp"
+	internal_ip = "172.16.0.3"
+	internal_port = "8080"
+}
+
+data "alicloud_forward_entries" "foo" {
+    forward_table_id = "${alicloud_forward_entry.foo.forward_table_id}"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `ids` - (Optional) A list of Forward Entries IDs.
+* `external_ip` - (Optional) The public IP address.
+* `internal_ip` - (Optional) The private IP address.
+* `forward_table_id` - (Required, ForceNew) The ID of the Forward table.
+* `output_file` - (Optional) File name where to save data source results (after running `terraform plan`).
+
+## Attributes Reference
+
+The following attributes are exported in addition to the arguments listed above:
+
+* `ids` - A list of Forward Entries IDs.
+* `entries` - A list of Forward Entries. Each element contains the following attributes:
+  * `id` - The ID of the Forward Entry.
+  * `external_ip` - The public IP address.
+  * `external_port` - The public port.
+  * `ip_protocol` - The protocol type.
+  * `internal_ip` - The private IP address.
+  * `internal_port` - The private port.
+  * `status` - The status of the Forward Entry.
+

--- a/website/docs/d/nat_gateways.html.markdown
+++ b/website/docs/d/nat_gateways.html.markdown
@@ -10,6 +10,8 @@ description: |-
 
 This data source provides a list of Nat Gateways owned by an Alibaba Cloud account.
 
+-> **NOTE:** Available in 1.37.0+.
+
 ## Example Usage
 
 ```

--- a/website/docs/d/route_entries.html.markdown
+++ b/website/docs/d/route_entries.html.markdown
@@ -10,6 +10,8 @@ description: |-
 
 This data source provides a list of Route Entries owned by an Alibaba Cloud account.
 
+-> **NOTE:** Available in 1.37.0+.
+
 ## Example Usage
 
 ```

--- a/website/docs/d/route_tables.html.markdown
+++ b/website/docs/d/route_tables.html.markdown
@@ -10,6 +10,8 @@ description: |-
 
 This data source provides a list of Route Tables owned by an Alibaba Cloud account.
 
+-> **NOTE:** Available in 1.36.0+.
+
 ## Example Usage
 
 ```

--- a/website/docs/d/snat_entries.html.markdown
+++ b/website/docs/d/snat_entries.html.markdown
@@ -10,6 +10,8 @@ description: |-
 
 This data source provides a list of Snat Entries owned by an Alibaba Cloud account.
 
+-> **NOTE:** Available in 1.37.0+.
+
 ## Example Usage
 
 ```


### PR DESCRIPTION
MacBook-Pro-2:terraform-provider-alicloud jince$ TF_ACC=1 go test ./alicloud -v -run=TestAccAlicloudForwardEntriesDataSource -timeout=300m
=== RUN   TestAccAlicloudForwardEntriesDataSourceBasic
--- PASS: TestAccAlicloudForwardEntriesDataSourceBasic (53.35s)
=== RUN   TestAccAlicloudForwardEntriesDataSourceIds
--- PASS: TestAccAlicloudForwardEntriesDataSourceIds (52.97s)
=== RUN   TestAccAlicloudForwardEntriesDataSourceExternalIp
--- PASS: TestAccAlicloudForwardEntriesDataSourceExternalIp (65.96s)
=== RUN   TestAccAlicloudForwardEntriesDataSourceInternalIp
--- PASS: TestAccAlicloudForwardEntriesDataSourceInternalIp (54.25s)
PASS
ok  	github.com/terraform-providers/terraform-provider-alicloud/alicloud	226.581s