### PR TITLE
added DB instance monitor provider

### DIFF
--- a/alicloud/service_alicloud_rds.go
+++ b/alicloud/service_alicloud_rds.go
@@ -509,6 +509,24 @@ func (s *RdsService) DescribeBackupPolicy(instanceId string) (policy *rds.Descri
 	return raw.(*rds.DescribeBackupPolicyResponse), err
 }
 
+func (s *RdsService) DescribeDBInstanceMonitor(instanceId string) (monitoringPeriod int, err error) {
+	raw, err := s.client.WithRdsClient(func(client *rds.Client) (interface{}, error) {
+		request := rds.CreateDescribeDBInstanceMonitorRequest()
+		request.DBInstanceId = instanceId
+		return client.DescribeDBInstanceMonitor(request)
+	})
+	if err != nil {
+		return 0, fmt.Errorf("Error reading monitoring period of db instance: %#v", err)
+	}
+
+	resp, _ := raw.(*rds.DescribeDBInstanceMonitorResponse)
+	monPeriod, err := strconv.Atoi(resp.Period)
+	if err != nil {
+		return 0, fmt.Errorf("Error converting (Atoi) monitoring period of db instance: %#v", err)
+	}
+	return monPeriod, nil
+}
+
 // WaitForInstance waits for instance to given status
 func (s *RdsService) WaitForDBInstance(instanceId string, status Status, timeout int) error {
 	if timeout <= 0 {

--- a/website/docs/r/db_instance.html.markdown
+++ b/website/docs/r/db_instance.html.markdown
@@ -95,6 +95,7 @@ The following arguments are supported:
 * `instance_name` - (Optional) The name of DB instance. It a string of 2 to 256 characters.
 * `instance_charge_type` - (Optional) Valid values are `Prepaid`, `Postpaid`, Default to `Postpaid`.
 * `period` - (Optional) The duration that you will buy DB instance (in month). It is valid when instance_charge_type is `PrePaid`. Valid values: [1~9], 12, 24, 36. Default to 1.
+* `monitoring_period` - (Optional) The monitoring frequency in seconds. Valid values are 5, 60, 300. Defaults to 300. 
 * `auto_renew` - (Optional, Available in 1.34.0+) Whether to renewal a DB instance automatically or not. It is valid when instance_charge_type is `PrePaid`. Default to `false`.
 * `auto_renew_period` - (Optional, Available in 1.34.0+) Auto-renewal period of an instance, in the unit of the month. It is valid when instance_charge_type is `PrePaid`. Valid value:[1~12], Default to 1.
 * `zone_id` - (Optional) The Zone to launch the DB instance. From version 1.8.1, it supports multiple zone.


### PR DESCRIPTION
Unit test:
go test -run TestAccAlicloudDBInstanceMonitor_vpc -v -timeout 9999s                                                                                                                                                     
=== RUN   TestAccAlicloudDBInstanceMonitor_vpc
--- PASS: TestAccAlicloudDBInstanceMonitor_vpc (116.99s)
PASS
ok  	github.com/terraform-providers/terraform-provider-alicloud/alicloud	117.058s
