### PR TITLE
Deprecate bucket  logging_isenabled and fix referer_config diff bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ IMPROVEMENTS:
 
 BUG FIXES:
 
+- Deprecate bucket `logging_isenable` and fix referer_config diff bug [GH-937]
 - modify ram user sweep [GH-929]
 - Fix the parameter bug when actiontrail is created [GH-921]
 - fix default pod_cidr in k8s docs [GH-919]

--- a/website/docs/r/oss_bucket.html.markdown
+++ b/website/docs/r/oss_bucket.html.markdown
@@ -52,8 +52,6 @@ resource "alicloud_oss_bucket" "bucket-logging" {
     target_bucket = "${alicloud_oss_bucket.bucket-target.id}"
     target_prefix = "log/"
   }
-
-  logging_isenable = true
 }
 ```
 
@@ -107,7 +105,7 @@ The following arguments are supported:
 * `cors_rule` - (Optional) A list rules of [Cross-Origin Resource Sharing](https://www.alibabacloud.com/help/doc-detail/31903.htm) (documented below). The items of cors rule are no more than 10 for every OSS bucket.
 * `website` - (Optional) A list website objects(documented below). The items of website are no more than 1 for every OSS bucket.
 * `logging` - (Optional) A list settings of [bucket logging](https://www.alibabacloud.com/help/doc-detail/31900.htm) (documented below). The items of logging are no more than 1 for every OSS bucket.
-* `logging_isenable` - (Optional) The flag of using logging enable container. Defaults true.
+* `logging_isenable` - (Deprecated) It has been deprecated from 1.37.0. When `logging` is set, the bucket logging will be able.
 * `referer_config` - (Optional) A list configurations of [referer](https://www.alibabacloud.com/help/doc-detail/31901.htm) (documented below). The items of referer_config are no more than 1 for every OSS bucket.
 * `lifecycle_rule` - (Optional) A list configurations of [object lifecycle management](https://www.alibabacloud.com/help/doc-detail/31904.htm) (documented below). The items of rules are no more than 1000 for every OSS bucket.
 
@@ -159,6 +157,7 @@ The lifecycle_rule expiration object supports the following:
 * `days` - (Optional, Type: int) Specifies the number of days after object creation when the specific rule action takes effect.
 
 `NOTE`: One and only one of "date" and "days" can be specified in one expiration configuration.
+
 ## Attributes Reference
 
 The following attributes are exported:


### PR DESCRIPTION
```
TF_ACC=1 go test ./alicloud -v -run=TestAccAlicloudOss -timeout=240m
=== RUN   TestAccAlicloudOssBucketObjectsDataSource_basic
--- PASS: TestAccAlicloudOssBucketObjectsDataSource_basic (20.37s)
=== RUN   TestAccAlicloudOssBucketObjectsDataSource_filterByPrefix
--- PASS: TestAccAlicloudOssBucketObjectsDataSource_filterByPrefix (21.10s)
=== RUN   TestAccAlicloudOssBucketObjectsDataSource_empty
--- PASS: TestAccAlicloudOssBucketObjectsDataSource_empty (17.10s)
=== RUN   TestAccAlicloudOssBucketsDataSource_basic
--- PASS: TestAccAlicloudOssBucketsDataSource_basic (25.77s)
=== RUN   TestAccAlicloudOssBucketsDataSource_full
--- PASS: TestAccAlicloudOssBucketsDataSource_full (40.94s)
=== RUN   TestAccAlicloudOssBucketsDataSource_empty
--- PASS: TestAccAlicloudOssBucketsDataSource_empty (7.74s)
=== RUN   TestAccAlicloudOssBucket_importBasic
--- PASS: TestAccAlicloudOssBucket_importBasic (20.37s)
=== RUN   TestAccAlicloudOssBucket_importCors
--- PASS: TestAccAlicloudOssBucket_importCors (18.74s)
=== RUN   TestAccAlicloudOssBucket_importWebsite
--- PASS: TestAccAlicloudOssBucket_importWebsite (18.95s)
=== RUN   TestAccAlicloudOssBucket_importLogging
--- PASS: TestAccAlicloudOssBucket_importLogging (33.17s)
=== RUN   TestAccAlicloudOssBucket_importReferer
--- PASS: TestAccAlicloudOssBucket_importReferer (18.72s)
=== RUN   TestAccAlicloudOssBucket_importLifecycle
--- PASS: TestAccAlicloudOssBucket_importLifecycle (18.86s)
=== RUN   TestAccAlicloudOssBucketObject_source
--- PASS: TestAccAlicloudOssBucketObject_source (18.86s)
=== RUN   TestAccAlicloudOssBucketObject_content
--- PASS: TestAccAlicloudOssBucketObject_content (18.54s)
=== RUN   TestAccAlicloudOssBucketObject_acl
--- PASS: TestAccAlicloudOssBucketObject_acl (18.69s)
=== RUN   TestAccAlicloudOssBucketBasic
--- PASS: TestAccAlicloudOssBucketBasic (18.37s)
=== RUN   TestAccAlicloudOssBucketCors
--- PASS: TestAccAlicloudOssBucketCors (16.92s)
=== RUN   TestAccAlicloudOssBucketWebsite
--- PASS: TestAccAlicloudOssBucketWebsite (16.88s)
=== RUN   TestAccAlicloudOssBucketLogging
--- PASS: TestAccAlicloudOssBucketLogging (31.81s)
=== RUN   TestAccAlicloudOssBucketReferer
--- PASS: TestAccAlicloudOssBucketReferer (17.01s)
=== RUN   TestAccAlicloudOssBucketLifecycle
--- PASS: TestAccAlicloudOssBucketLifecycle (17.02s)
PASS
ok  	github.com/terraform-providers/terraform-provider-alicloud/alicloud	436.002s
```