### PR TITLE
update mongodb instance test case multiAZ

### DIFF
--- a/alicloud/connectivity/regions.go
+++ b/alicloud/connectivity/regions.go
@@ -67,4 +67,4 @@ var NasClassicSupportedRegions = []Region{Hangzhou, Qingdao, Beijing, Hongkong, 
 var CasClassicSupportedRegions = []Region{Hangzhou, APSouth1, MEEast1, EUCentral1, APNorthEast1, APSouthEast2}
 var CRNoSupportedRegions = []Region{Beijing, Hangzhou, Qingdao, Huhehaote, Zhangjiakou}
 var MongoDBClassicNoSupportedRegions = []Region{Huhehaote, Zhangjiakou, APSouthEast2, APSouthEast3, APSouthEast5, APSouth1, USEast1, USWest1, APNorthEast1}
-var MongoDBMultiAzNoSupportedRegions = []Region{Qingdao, APNorthEast1, APSouthEast5, MEEast1}
+var MongoDBMultiAzSupportedRegions = []Region{Hangzhou, Beijing, Shenzhen, EUCentral1}

--- a/alicloud/resource_alicloud_mongodb_instance_test.go
+++ b/alicloud/resource_alicloud_mongodb_instance_test.go
@@ -23,8 +23,15 @@ func init() {
 
 func TestAccAlicloudMongoDBInstance_classic(t *testing.T) {
 	const res_format = `
+data "alicloud_zones" "default" {
+  available_resource_creation = "${var.creation}" 
+}
+variable "creation" {
+  default = "MongoDB"
+}
 resource "alicloud_mongodb_instance" "foo" {
 	%s
+	zone_id    = "${data.alicloud_zones.default.zones.0.id}"
 }
 `
 	const res_name = "alicloud_mongodb_instance.foo"
@@ -152,7 +159,7 @@ resource "alicloud_mongodb_instance" "foo" {
 	var args testMongoDBArgs
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
-			testAccPreCheckWithRegions(t, false, connectivity.MongoDBMultiAzNoSupportedRegions)
+			testAccPreCheckWithRegions(t, true, connectivity.MongoDBMultiAzSupportedRegions)
 		},
 		IDRefreshName: res_name,
 		Providers:     testAccProviders,


### PR DESCRIPTION
update mongodb instance test case multiAZ
test in "cn-beijing" region result :
=== RUN   TestAccAlicloudMongoDBInstance_import
--- PASS: TestAccAlicloudMongoDBInstance_import (364.96s)
=== RUN   TestAccAlicloudMongoDBInstance_classic
--- PASS: TestAccAlicloudMongoDBInstance_classic (1150.53s)
=== RUN   TestAccAlicloudMongoDBInstance_vpc
--- PASS: TestAccAlicloudMongoDBInstance_vpc (894.80s)
=== RUN   TestAccAlicloudMongoDBInstance_multiAZ
--- PASS: TestAccAlicloudMongoDBInstance_multiAZ (1291.16s)
=== RUN   TestAccAlicloudMongoDBInstance_multi_instance
--- PASS: TestAccAlicloudMongoDBInstance_multi_instance (614.82s)
PASS
ok      github.com/terraform-providers/terraform-provider-alicloud/alicloud     4316.311s