### PR TITLE
Fix Eip And VSwitch Token

### DIFF
--- a/alicloud/errors.go
+++ b/alicloud/errors.go
@@ -36,6 +36,7 @@ const (
 	InstanceIncorrectStatus    = "IncorrectInstanceStatus"
 	HaVipIncorrectStatus       = "IncorrectHaVipStatus"
 	COMMODITYINVALID_COMPONENT = "COMMODITY.INVALID_COMPONENT"
+	AllocationIdNotFound       = "InvalidAllocationId.NotFound"
 	// slb
 	LoadBalancerNotFound        = "InvalidLoadBalancerId.NotFound"
 	UnsupportedProtocalPort     = "UnsupportedOperationonfixedprotocalport"
@@ -100,6 +101,7 @@ const (
 	// vswitch
 	VswitcInvalidRegionId    = "InvalidRegionId.NotFound"
 	InvalidVswitchIDNotFound = "InvalidVswitchID.NotFound"
+	TokenProcessing          = "OperationFailed.IdempotentTokenProcessing"
 	//route entry
 	IncorrectRouteEntryStatus            = "IncorrectRouteEntryStatus"
 	InvalidStatusRouteEntry              = "InvalidStatus.RouteEntry"

--- a/alicloud/resource_alicloud_eip.go
+++ b/alicloud/resource_alicloud_eip.go
@@ -202,6 +202,8 @@ func resourceAliyunEipDelete(d *schema.ResourceData, meta interface{}) error {
 		if err != nil {
 			if IsExceptedError(err, EipIncorrectStatus) {
 				return resource.RetryableError(WrapErrorf(err, DefaultErrorMsg, d.Id(), request.GetActionName(), AlibabaCloudSdkGoERROR))
+			} else if IsExceptedError(err, AllocationIdNotFound) {
+				return nil
 			}
 			return resource.NonRetryableError(WrapErrorf(err, DefaultErrorMsg, d.Id(), request.GetActionName(), AlibabaCloudSdkGoERROR))
 

--- a/alicloud/resource_alicloud_vswitch.go
+++ b/alicloud/resource_alicloud_vswitch.go
@@ -65,7 +65,7 @@ func resourceAliyunSwitchCreate(d *schema.ResourceData, meta interface{}) error 
 		})
 		if err != nil {
 			if IsExceptedErrors(err, []string{TaskConflict, UnknownError, InvalidStatusRouteEntry,
-				InvalidCidrBlockOverlapped, Throttling}) {
+				InvalidCidrBlockOverlapped, Throttling, TokenProcessing}) {
 				time.Sleep(5 * time.Second)
 				return resource.RetryableError(fmt.Errorf("Creating Vswitch is timeout and got an error: %#v", err))
 			}


### PR DESCRIPTION
MacBook-Pro-2:terraform-provider-alicloud jince$ TF_ACC=1 go test ./alicloud -v -run=TestAccAlicloudEIP -timeout=300m
=== RUN   TestAccAlicloudEIPsDataSource
--- PASS: TestAccAlicloudEIPsDataSource (4.11s)
=== RUN   TestAccAlicloudEIPsDataSourceIPAddresses
--- PASS: TestAccAlicloudEIPsDataSourceIPAddresses (3.64s)
=== RUN   TestAccAlicloudEIPsDataSourceBoth
--- PASS: TestAccAlicloudEIPsDataSourceBoth (3.92s)
=== RUN   TestAccAlicloudEIPsDataSourceEmpty
--- PASS: TestAccAlicloudEIPsDataSourceEmpty (0.50s)
=== RUN   TestAccAlicloudEIP_importBasic
--- PASS: TestAccAlicloudEIP_importBasic (1.96s)
=== RUN   TestAccAlicloudEIPAssociation
--- PASS: TestAccAlicloudEIPAssociation (182.12s)
=== RUN   TestAccAlicloudEIPAssociation_slb
--- PASS: TestAccAlicloudEIPAssociation_slb (36.05s)
=== RUN   TestAccAlicloudEIPAssociation_nat
--- PASS: TestAccAlicloudEIPAssociation_nat (39.44s)
=== RUN   TestAccAlicloudEIP_basic
--- PASS: TestAccAlicloudEIP_basic (3.33s)
=== RUN   TestAccAlicloudEIP_paybybandwidth
--- PASS: TestAccAlicloudEIP_paybybandwidth (1.97s)
PASS
ok  	github.com/terraform-providers/terraform-provider-alicloud/alicloud	277.111s
MacBook-Pro-2:terraform-provider-alicloud jince$ TF_ACC=1 go test ./alicloud -v -run=TestAccAlicloudVSwitch -timeout=300m
=== RUN   TestAccAlicloudVSwitchesDataSource_all
--- PASS: TestAccAlicloudVSwitchesDataSource_all (20.18s)
=== RUN   TestAccAlicloudVSwitchesDataSource_Name_Regex
--- PASS: TestAccAlicloudVSwitchesDataSource_Name_Regex (30.14s)
=== RUN   TestAccAlicloudVSwitchesDataSource_vpcid
--- PASS: TestAccAlicloudVSwitchesDataSource_vpcid (26.60s)
=== RUN   TestAccAlicloudVSwitchesDataSource_Zone_ID
--- PASS: TestAccAlicloudVSwitchesDataSource_Zone_ID (22.71s)
=== RUN   TestAccAlicloudVSwitch_Update
--- PASS: TestAccAlicloudVSwitch_Update (27.38s)
=== RUN   TestAccAlicloudVSwitch_multi
--- PASS: TestAccAlicloudVSwitch_multi (25.16s)
PASS
ok  	github.com/terraform-providers/terraform-provider-alicloud/alicloud	152.257s