### PR TITLE
add mongodb sharding instance support

### DIFF
--- a/alicloud/extension_mongodb.go
+++ b/alicloud/extension_mongodb.go
@@ -6,3 +6,17 @@ const (
 	WiredTiger = MongoDBStorageEngine("WiredTiger")
 	RocksDB    = MongoDBStorageEngine("RocksDB")
 )
+
+type MongoDBShardingNodeType string
+
+const (
+	MongoDBShardingNodeMongos = MongoDBShardingNodeType("mongos")
+	MongoDBShardingNodeShard  = MongoDBShardingNodeType("shard")
+)
+
+type MongoDBInstanceType string
+
+const (
+	MongoDBSharding  = MongoDBInstanceType("sharding")
+	MongoDBReplicate = MongoDBInstanceType("replicate")
+)

--- a/alicloud/import_alicloud_mongodb_sharding_instance_test.go
+++ b/alicloud/import_alicloud_mongodb_sharding_instance_test.go
@@ -1,0 +1,26 @@
+package alicloud
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform/helper/resource"
+)
+
+func TestAccAlicloudMongoDBShardingInstance_import(t *testing.T) {
+	resourceName := "alicloud_mongodb_sharding_instance.default"
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckMongoDBInstanceDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testMongoDBShardingInstance_vpc_base,
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}

--- a/alicloud/provider.go
+++ b/alicloud/provider.go
@@ -186,6 +186,7 @@ func Provider() terraform.ResourceProvider {
 			"alicloud_db_read_write_splitting_connection": resourceAlicloudDBReadWriteSplittingConnection(),
 			"alicloud_db_instance":                        resourceAlicloudDBInstance(),
 			"alicloud_mongodb_instance":                   resourceAlicloudMongoDBInstance(),
+			"alicloud_mongodb_sharding_instance":          resourceAlicloudMongoDBShardingInstance(),
 			"alicloud_db_readonly_instance":               resourceAlicloudDBReadonlyInstance(),
 			"alicloud_ess_scaling_group":                  resourceAlicloudEssScalingGroup(),
 			"alicloud_ess_scaling_configuration":          resourceAlicloudEssScalingConfiguration(),

--- a/alicloud/resource_alicloud_mongodb_instance_test.go
+++ b/alicloud/resource_alicloud_mongodb_instance_test.go
@@ -641,7 +641,7 @@ func testAccCheckMongoDBInstanceExists(n string, d *dds.DBInstance) resource.Tes
 			return WrapError(err)
 		}
 
-		*d = *attr
+		*d = attr
 		return nil
 	}
 }

--- a/alicloud/resource_alicloud_mongodb_sharding_instance.go
+++ b/alicloud/resource_alicloud_mongodb_sharding_instance.go
@@ -1,0 +1,380 @@
+package alicloud
+
+import (
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/aliyun/alibaba-cloud-sdk-go/sdk/requests"
+	"github.com/aliyun/alibaba-cloud-sdk-go/services/dds"
+	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/helper/schema"
+	"github.com/terraform-providers/terraform-provider-alicloud/alicloud/connectivity"
+)
+
+func resourceAlicloudMongoDBShardingInstance() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceAlicloudMongoDBShardingInstanceCreate,
+		Read:   resourceAlicloudMongoDBShardingInstanceRead,
+		Update: resourceAlicloudMongoDBShardingInstanceUpdate,
+		Delete: resourceAlicloudMongoDBShardingInstanceDelete,
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
+
+		Schema: map[string]*schema.Schema{
+			"engine_version": {
+				Type:     schema.TypeString,
+				ForceNew: true,
+				Required: true,
+			},
+			"storage_engine": {
+				Type:         schema.TypeString,
+				ValidateFunc: validateAllowedStringValue([]string{string(WiredTiger), string(RocksDB)}),
+				Optional:     true,
+				Computed:     true,
+				ForceNew:     true,
+			},
+			"instance_charge_type": {
+				Type:         schema.TypeString,
+				ValidateFunc: validateAllowedStringValue([]string{string(PrePaid), string(PostPaid)}),
+				Optional:     true,
+				ForceNew:     true,
+				Computed:     true,
+			},
+			"period": {
+				Type:             schema.TypeInt,
+				ValidateFunc:     validateAllowedIntValue([]int{1, 2, 3, 4, 5, 6, 7, 8, 9, 12, 24, 36}),
+				Optional:         true,
+				Computed:         true,
+				DiffSuppressFunc: mongoDBPeriodDiffSuppressFunc,
+			},
+			"zone_id": {
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: true,
+			},
+			"vswitch_id": {
+				Type:     schema.TypeString,
+				ForceNew: true,
+				Optional: true,
+			},
+			"name": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ValidateFunc: validateDBInstanceName,
+			},
+			"security_ip_list": {
+				Type:     schema.TypeSet,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+				Computed: true,
+				Optional: true,
+			},
+			"account_password": {
+				Type:      schema.TypeString,
+				Optional:  true,
+				Sensitive: true,
+			},
+			"shard_list": {
+				Type: schema.TypeList,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"node_class": {
+							Type:     schema.TypeString,
+							Required: true,
+						},
+						"node_storage": {
+							Type:         schema.TypeInt,
+							Required:     true,
+							ValidateFunc: validateIntegerInRange(10, 1000),
+						},
+						//Computed
+						"node_id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+					},
+				},
+				Required: true,
+				MinItems: 2,
+				MaxItems: 32,
+			},
+
+			"mongo_list": {
+				Type: schema.TypeList,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"node_class": {
+							Type:     schema.TypeString,
+							Required: true,
+						},
+						//Computed
+						"node_id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"connect_string": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"port": {
+							Type:     schema.TypeInt,
+							Computed: true,
+						},
+					},
+				},
+				Required: true,
+				MinItems: 2,
+				MaxItems: 32,
+			},
+		},
+	}
+}
+
+func buildMongoDBShardingCreateRequest(d *schema.ResourceData, meta interface{}) (*dds.CreateShardingDBInstanceRequest, error) {
+	client := meta.(*connectivity.AliyunClient)
+	request := dds.CreateCreateShardingDBInstanceRequest()
+
+	request.RegionId = string(client.Region)
+	request.EngineVersion = Trim(d.Get("engine_version").(string))
+	request.Engine = "MongoDB"
+	request.DBInstanceDescription = d.Get("name").(string)
+	request.AccountPassword = d.Get("account_password").(string)
+	request.ZoneId = d.Get("zone_id").(string)
+
+	shardList, ok := d.GetOk("shard_list")
+	if ok {
+		replicaSets := []dds.CreateShardingDBInstanceReplicaSet{}
+		for _, rew := range shardList.([]interface{}) {
+			item := rew.(map[string]interface{})
+			class := item["node_class"].(string)
+			nodeStorage := item["node_storage"].(int)
+			replicaSets = append(replicaSets, dds.CreateShardingDBInstanceReplicaSet{strconv.Itoa(nodeStorage), class})
+		}
+		request.ReplicaSet = &replicaSets
+	}
+
+	mongoList, ok := d.GetOk("mongo_list")
+	if ok {
+		mongos := []dds.CreateShardingDBInstanceMongos{}
+		for _, rew := range mongoList.([]interface{}) {
+			item := rew.(map[string]interface{})
+			class := item["node_class"].(string)
+			mongos = append(mongos, dds.CreateShardingDBInstanceMongos{class})
+		}
+		request.Mongos = &mongos
+	}
+
+	request.ConfigServer = &[]dds.CreateShardingDBInstanceConfigServer{{"20", "dds.cs.mid"}}
+
+	request.NetworkType = string(Classic)
+	vswitchId := Trim(d.Get("vswitch_id").(string))
+	if vswitchId != "" {
+		// check vswitchId in zone
+		vpcService := VpcService{client}
+		vsw, err := vpcService.DescribeVswitch(vswitchId)
+		if err != nil {
+			return nil, WrapError(err)
+		}
+
+		if request.ZoneId == "" {
+			request.ZoneId = vsw.ZoneId
+		} else if strings.Contains(request.ZoneId, MULTI_IZ_SYMBOL) {
+			zonestr := strings.Split(strings.SplitAfter(request.ZoneId, "(")[1], ")")[0]
+			if !strings.Contains(zonestr, string([]byte(vsw.ZoneId)[len(vsw.ZoneId)-1])) {
+				return nil, WrapError(Error("The specified vswitch " + vsw.VSwitchId + " isn't in multi the zone " + request.ZoneId))
+			}
+		} else if request.ZoneId != vsw.ZoneId {
+			return nil, WrapError(Error("The specified vswitch " + vsw.VSwitchId + " isn't in the zone " + request.ZoneId))
+		}
+		request.VSwitchId = vswitchId
+		request.NetworkType = strings.ToUpper(string(Vpc))
+		request.VpcId = vsw.VpcId
+	}
+
+	request.ChargeType = d.Get("instance_charge_type").(string)
+	period, ok := d.GetOk("period")
+	if ok && PayType(request.ChargeType) == PrePaid {
+		request.Period = requests.NewInteger(period.(int))
+	}
+
+	request.SecurityIPList = LOCAL_HOST_IP
+	if len(d.Get("security_ip_list").(*schema.Set).List()) > 0 {
+		request.SecurityIPList = strings.Join(expandStringList(d.Get("security_ip_list").(*schema.Set).List()), COMMA_SEPARATED)
+	}
+
+	request.ClientToken = buildClientToken(request.GetActionName())
+	return request, nil
+}
+
+func resourceAlicloudMongoDBShardingInstanceCreate(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*connectivity.AliyunClient)
+	ddsService := MongoDBService{client}
+
+	request, err := buildMongoDBShardingCreateRequest(d, meta)
+	if err != nil {
+		return WrapError(err)
+	}
+
+	raw, err := client.WithDdsClient(func(client *dds.Client) (interface{}, error) {
+		return client.CreateShardingDBInstance(request)
+	})
+
+	if err != nil {
+		return WrapErrorf(err, DefaultErrorMsg, "alicloud_mongodb_sharding_instance", request.GetActionName(), AlibabaCloudSdkGoERROR)
+	}
+
+	response, _ := raw.(*dds.CreateShardingDBInstanceResponse)
+	addDebug(request.GetActionName(), response)
+
+	d.SetId(response.DBInstanceId)
+
+	if err := ddsService.WaitForMongoDBInstance(d.Id(), Running, DefaultLongTimeout); err != nil {
+		return WrapError(err)
+	}
+
+	return resourceAlicloudMongoDBShardingInstanceRead(d, meta)
+}
+
+func resourceAlicloudMongoDBShardingInstanceRead(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*connectivity.AliyunClient)
+	ddsService := MongoDBService{client}
+
+	instance, err := ddsService.DescribeMongoDBInstance(d.Id())
+	if err != nil {
+		if NotFoundError(err) {
+			d.SetId("")
+			return nil
+		}
+		return WrapError(err)
+	}
+
+	d.Set("name", instance.DBInstanceDescription)
+	d.Set("engine_version", instance.EngineVersion)
+	d.Set("storage_engine", instance.StorageEngine)
+	d.Set("zone_id", instance.ZoneId)
+	d.Set("instance_charge_type", instance.ChargeType)
+	d.Set("vswitch_id", instance.VSwitchId)
+
+	mongosList := []map[string]interface{}{}
+	for _, item := range instance.MongosList.MongosAttribute {
+		mongo := map[string]interface{}{
+			"node_class":     item.NodeClass,
+			"node_id":        item.NodeId,
+			"port":           item.Port,
+			"connect_string": item.ConnectSting,
+		}
+		mongosList = append(mongosList, mongo)
+	}
+	err = d.Set("mongo_list", mongosList)
+	if err != nil {
+		return WrapError(err)
+	}
+
+	shardList := []map[string]interface{}{}
+	for _, item := range instance.ShardList.ShardAttribute {
+		shard := map[string]interface{}{
+			"node_id":      item.NodeId,
+			"node_storage": item.NodeStorage,
+			"node_class":   item.NodeClass,
+		}
+		shardList = append(shardList, shard)
+	}
+	err = d.Set("shard_list", shardList)
+	if err != nil {
+		return WrapError(err)
+	}
+
+	ips, err := ddsService.GetSecurityIps(d.Id())
+	if err != nil {
+		return WrapError(err)
+	}
+
+	d.Set("security_ip_list", ips)
+
+	return nil
+}
+
+func resourceAlicloudMongoDBShardingInstanceUpdate(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*connectivity.AliyunClient)
+	ddsService := MongoDBService{client}
+	d.Partial(true)
+
+	if d.HasChange("shard_list") {
+		state, diff := d.GetChange("shard_list")
+		err := ddsService.ModifyMongodbShardingInstanceNode(d.Id(), MongoDBShardingNodeShard, state.([]interface{}), diff.([]interface{}))
+		if err != nil {
+			return WrapError(err)
+		}
+		d.SetPartial("shard_list")
+	}
+
+	if d.HasChange("mongo_list") {
+		state, diff := d.GetChange("mongo_list")
+		err := ddsService.ModifyMongodbShardingInstanceNode(d.Id(), MongoDBShardingNodeMongos, state.([]interface{}), diff.([]interface{}))
+		if err != nil {
+			return WrapError(err)
+		}
+		d.SetPartial("mongo_list")
+	}
+
+	if d.HasChange("name") {
+		request := dds.CreateModifyDBInstanceDescriptionRequest()
+		request.DBInstanceId = d.Id()
+		request.DBInstanceDescription = d.Get("name").(string)
+
+		raw, err := client.WithDdsClient(func(ddsClient *dds.Client) (interface{}, error) {
+			return ddsClient.ModifyDBInstanceDescription(request)
+		})
+
+		if err != nil {
+			return WrapErrorf(err, DefaultErrorMsg, d.Id(), request.GetActionName(), AlibabaCloudSdkGoERROR)
+		}
+		addDebug(request.GetActionName(), raw)
+		d.SetPartial("name")
+	}
+
+	if d.HasChange("security_ip_list") {
+		ipList := expandStringList(d.Get("security_ip_list").(*schema.Set).List())
+		ipstr := strings.Join(ipList[:], COMMA_SEPARATED)
+		// default disable connect from outside
+		if ipstr == "" {
+			ipstr = LOCAL_HOST_IP
+		}
+
+		if err := ddsService.ModifyMongoDBSecurityIps(d.Id(), ipstr); err != nil {
+			return WrapError(err)
+		}
+		d.SetPartial("security_ip_list")
+	}
+	d.Partial(false)
+	return resourceAlicloudMongoDBShardingInstanceRead(d, meta)
+}
+
+func resourceAlicloudMongoDBShardingInstanceDelete(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*connectivity.AliyunClient)
+	ddsService := MongoDBService{client}
+
+	request := dds.CreateDeleteDBInstanceRequest()
+	request.DBInstanceId = d.Id()
+
+	err := resource.Retry(10*5*time.Minute, func() *resource.RetryError {
+		raw, err := client.WithDdsClient(func(ddsClient *dds.Client) (interface{}, error) {
+			return ddsClient.DeleteDBInstance(request)
+		})
+
+		if err != nil {
+			if ddsService.NotFoundMongoDBInstance(err) {
+				return resource.NonRetryableError(err)
+			}
+			return resource.RetryableError(err)
+		}
+		addDebug(request.GetActionName(), raw)
+		return nil
+	})
+
+	if err != nil {
+		return WrapErrorf(err, DefaultErrorMsg, d.Id(), request.GetActionName(), AlibabaCloudSdkGoERROR)
+	}
+	return WrapError(ddsService.WaitForMongoDBInstance(d.Id(), Deleted, DefaultTimeout))
+}

--- a/alicloud/resource_alicloud_mongodb_sharding_instance_test.go
+++ b/alicloud/resource_alicloud_mongodb_sharding_instance_test.go
@@ -1,0 +1,952 @@
+package alicloud
+
+import (
+	"log"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/aliyun/alibaba-cloud-sdk-go/sdk/requests"
+	"github.com/aliyun/alibaba-cloud-sdk-go/services/dds"
+	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/terraform"
+	"github.com/terraform-providers/terraform-provider-alicloud/alicloud/connectivity"
+)
+
+func init() {
+	resource.AddTestSweepers("alicloud_mongodb_sharding_instance", &resource.Sweeper{
+		Name: "alicloud_mongodb_sharding_instance",
+		F:    testSweepMongoDBShardingInstances,
+	})
+}
+func testSweepMongoDBShardingInstances(region string) error {
+	rawClient, err := sharedClientForRegion(region)
+	if err != nil {
+		return WrapError(err)
+	}
+	client := rawClient.(*connectivity.AliyunClient)
+
+	prefixes := []string{
+		"tf-testAcc",
+		"tf_testAcc",
+	}
+
+	var insts []dds.DBInstance
+	request := dds.CreateDescribeDBInstancesRequest()
+	request.RegionId = client.RegionId
+	request.PageSize = requests.NewInteger(PageSizeLarge)
+	request.PageNumber = requests.NewInteger(1)
+	for {
+		raw, err := client.WithDdsClient(func(ddsClient *dds.Client) (interface{}, error) {
+			return ddsClient.DescribeDBInstances(request)
+		})
+		if err != nil {
+			return WrapErrorf(err, DefaultErrorMsg, "testSweepMongoDBShardingInstances", request.GetActionName(), AlibabaCloudSdkGoERROR)
+		}
+		response, _ := raw.(*dds.DescribeDBInstancesResponse)
+		addDebug(request.GetActionName(), response)
+
+		if response == nil || len(response.DBInstances.DBInstance) < 1 {
+			break
+		}
+		insts = append(insts, response.DBInstances.DBInstance...)
+
+		if len(response.DBInstances.DBInstance) < PageSizeLarge {
+			break
+		}
+
+		if page, err := getNextpageNumber(request.PageNumber); err != nil {
+			return WrapError(err)
+		} else {
+			request.PageNumber = page
+		}
+	}
+
+	sweeped := false
+	for _, v := range insts {
+		name := v.DBInstanceDescription
+		id := v.DBInstanceId
+		skip := true
+		for _, prefix := range prefixes {
+			if strings.HasPrefix(strings.ToLower(name), strings.ToLower(prefix)) {
+				skip = false
+				break
+			}
+		}
+		if skip {
+			log.Printf("[INFO] Skipping MongoDB instance: %s (%s)\n", name, id)
+			continue
+		}
+		log.Printf("[INFO] Deleting MongoDB instance: %s (%s)\n", name, id)
+
+		sweeped = true
+
+		request := dds.CreateDeleteDBInstanceRequest()
+		request.DBInstanceId = id
+		raw, err := client.WithDdsClient(func(ddsClient *dds.Client) (interface{}, error) {
+			return ddsClient.DeleteDBInstance(request)
+		})
+
+		if err != nil {
+			log.Printf("[error] Failed to delete MongoDB instance,ID:%v(%v)\n", id, request.GetActionName())
+		}
+		addDebug(request.GetActionName(), raw)
+	}
+	if sweeped {
+		// Waiting 30 seconds to eusure these DB instances have been deleted.
+		time.Sleep(30 * time.Second)
+	}
+	return nil
+}
+
+func testAccCheckMongoDBShardingInstanceDestroy(s *terraform.State) error {
+	client := testAccProvider.Meta().(*connectivity.AliyunClient)
+	ddsService := MongoDBService{client}
+
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "alicloud_mongodb_sharding_instance" {
+			continue
+		}
+		_, err := ddsService.DescribeMongoDBInstance(rs.Primary.ID)
+		if err != nil {
+			if ddsService.NotFoundMongoDBInstance(err) {
+				continue
+			}
+			return WrapError(err)
+		}
+		return err
+	}
+	return nil
+}
+
+const testMongoDBShardingInstance_classic_base = `
+data "alicloud_zones" "default" {
+  available_resource_creation = "MongoDB"
+}
+resource "alicloud_mongodb_sharding_instance" "default" {
+  zone_id        = "${data.alicloud_zones.default.zones.0.id}"
+  engine_version = "3.4"
+  shard_list = [{
+    node_class   = "dds.shard.mid"
+    node_storage = 10
+    }, {
+    node_class   = "dds.shard.standard"
+    node_storage = 20
+  }]
+  mongo_list = [{
+    node_class = "dds.mongos.mid"
+    }, {
+    node_class = "dds.mongos.mid"
+  }]
+}`
+
+const testMongoDBShardingInstance_classic_name = `
+data "alicloud_zones" "default" {
+  available_resource_creation = "MongoDB"
+}
+resource "alicloud_mongodb_sharding_instance" "default" {
+  zone_id        = "${data.alicloud_zones.default.zones.0.id}"
+  engine_version = "3.4"
+  shard_list = [{
+    node_class   = "dds.shard.mid"
+    node_storage = 10
+    }, {
+    node_class   = "dds.shard.standard"
+    node_storage = 20
+  }]
+  mongo_list = [{
+    node_class = "dds.mongos.mid"
+    }, {
+    node_class = "dds.mongos.mid"
+  }]
+  name = "tf-testAccMongoDBShardingInstance_test"
+}`
+
+const testMongoDBShardingInstance_classic_account_password = `
+data "alicloud_zones" "default" {
+  available_resource_creation = "MongoDB"
+}
+resource "alicloud_mongodb_sharding_instance" "default" {
+  zone_id        = "${data.alicloud_zones.default.zones.0.id}"
+  engine_version = "3.4"
+  shard_list = [{
+    node_class   = "dds.shard.mid"
+    node_storage = 10
+    }, {
+    node_class   = "dds.shard.standard"
+    node_storage = 20
+  }]
+  mongo_list = [{
+    node_class = "dds.mongos.mid"
+    }, {
+    node_class = "dds.mongos.mid"
+  }]
+  name             = "tf-testAccMongoDBShardingInstance_test"
+  account_password = "1234@test"
+}`
+
+const testMongoDBShardingInstance_classic_mongos = `
+data "alicloud_zones" "default" {
+  available_resource_creation = "MongoDB"
+}
+resource "alicloud_mongodb_sharding_instance" "default" {
+  zone_id        = "${data.alicloud_zones.default.zones.0.id}"
+  engine_version = "3.4"
+  shard_list = [{
+    node_class   = "dds.shard.mid"
+    node_storage = 10
+    }, {
+    node_class   = "dds.shard.standard"
+    node_storage = 20
+  }]
+  mongo_list = [{
+    node_class = "dds.mongos.mid"
+    }, {
+    node_class = "dds.mongos.mid"
+    }, {
+    node_class = "dds.mongos.mid"
+  }]
+  name             = "tf-testAccMongoDBShardingInstance_test"
+  account_password = "1234@test"
+}`
+
+const testMongoDBShardingInstance_classic_shard = `
+data "alicloud_zones" "default" {
+  available_resource_creation = "MongoDB"
+}
+resource "alicloud_mongodb_sharding_instance" "default" {
+  zone_id        = "${data.alicloud_zones.default.zones.0.id}"
+  engine_version = "3.4"
+  shard_list = [{
+    node_class   = "dds.shard.mid"
+    node_storage = 10
+    }, {
+    node_class   = "dds.shard.standard"
+    node_storage = 20
+    }, {
+    node_class   = "dds.shard.standard"
+    node_storage = 20
+  }]
+  mongo_list = [{
+    node_class = "dds.mongos.mid"
+    }, {
+    node_class = "dds.mongos.mid"
+    }, {
+    node_class = "dds.mongos.mid"
+  }]
+  name             = "tf-testAccMongoDBShardingInstance_test"
+  account_password = "1234@test"
+}`
+
+const testMongoDBShardingInstance_classic_together = `
+data "alicloud_zones" "default" {
+  available_resource_creation = "MongoDB"
+}
+resource "alicloud_mongodb_sharding_instance" "default" {
+  zone_id        = "${data.alicloud_zones.default.zones.0.id}"
+  engine_version = "3.4"
+  shard_list = [{
+    node_class   = "dds.shard.mid"
+    node_storage = 10
+    }, {
+    node_class   = "dds.shard.standard"
+    node_storage = 20
+    }, {
+    node_class   = "dds.shard.standard"
+    node_storage = 20
+  }]
+  mongo_list = [{
+    node_class = "dds.mongos.mid"
+    }, {
+    node_class = "dds.mongos.mid"
+    }, {
+    node_class = "dds.mongos.mid"
+  }]
+  name             = "tf-testAccMongoDBShardingInstance_test_together"
+  account_password = "1234@test"
+  security_ip_list = ["10.168.1.12", "10.168.1.13"]
+}`
+
+func TestAccAlicloudMongoDBShardingInstance_classic(t *testing.T) {
+	var v dds.DBInstance
+	resourceId := "alicloud_mongodb_sharding_instance.default"
+	serverFunc := func() interface{} {
+		return &MongoDBService{testAccProvider.Meta().(*connectivity.AliyunClient)}
+	}
+	rc := resourceCheckInitWithDescribeMethod(resourceId, &v, serverFunc, "DescribeMongoDBInstance")
+	ra := resourceAttrInit(resourceId, nil)
+	rac := resourceAttrCheckInit(rc, ra)
+	testAccCheck := rac.resourceAttrMapUpdateSet()
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheckWithRegions(t, false, connectivity.MongoDBClassicNoSupportedRegions)
+		},
+		IDRefreshName: "alicloud_mongodb_sharding_instance.default",
+		Providers:     testAccProviders,
+		CheckDestroy:  testAccCheckMongoDBShardingInstanceDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testMongoDBShardingInstance_classic_base,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"zone_id":                   CHECKSET,
+						"engine_version":            "3.4",
+						"shard_list.#":              "2",
+						"shard_list.0.node_class":   "dds.shard.mid",
+						"shard_list.0.node_storage": "10",
+						"shard_list.1.node_class":   "dds.shard.standard",
+						"shard_list.1.node_storage": "20",
+						"mongo_list.#":              "2",
+						"mongo_list.0.node_class":   "dds.mongos.mid",
+						"mongo_list.1.node_class":   "dds.mongos.mid",
+					}),
+				),
+			},
+			{
+				Config: testMongoDBShardingInstance_classic_name,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"name": "tf-testAccMongoDBShardingInstance_test",
+					}),
+				),
+			},
+			{
+				Config: testMongoDBShardingInstance_classic_account_password,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"account_password": "1234@test",
+					}),
+				),
+			},
+			{
+				Config: testMongoDBShardingInstance_classic_mongos,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"mongo_list.#":            "3",
+						"mongo_list.0.node_class": "dds.mongos.mid",
+						"mongo_list.1.node_class": "dds.mongos.mid",
+						"mongo_list.2.node_class": "dds.mongos.mid",
+					}),
+				),
+			},
+			{
+				Config: testMongoDBShardingInstance_classic_shard,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"shard_list.#":              "3",
+						"shard_list.0.node_class":   "dds.shard.mid",
+						"shard_list.0.node_storage": "10",
+						"shard_list.1.node_class":   "dds.shard.standard",
+						"shard_list.1.node_storage": "20",
+						"shard_list.2.node_class":   "dds.shard.standard",
+						"shard_list.2.node_storage": "20",
+					}),
+				),
+			},
+			{
+				Config: testMongoDBShardingInstance_classic_together,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"name":                        "tf-testAccMongoDBShardingInstance_test_together",
+						"account_password":            "1234@test",
+						"security_ip_list.#":          "2",
+						"security_ip_list.4095458986": "10.168.1.12",
+						"security_ip_list.3976237035": "10.168.1.13",
+					}),
+				),
+			}},
+	})
+}
+
+const testMongoDBShardingInstance_vpc_base = `
+data "alicloud_zones" "default" {
+  available_resource_creation = "MongoDB"
+}
+resource "alicloud_vpc" "default" {
+  name       = "${var.name}"
+  cidr_block = "172.16.0.0/16"
+}
+resource "alicloud_vswitch" "default" {
+  vpc_id            = "${alicloud_vpc.default.id}"
+  cidr_block        = "172.16.0.0/24"
+  availability_zone = "${data.alicloud_zones.default.zones.0.id}"
+  name              = "${var.name}"
+}
+variable "name" {
+  default = "tf-testAccMongoDBShardingInstance_vpc"
+}
+resource "alicloud_mongodb_sharding_instance" "default" {
+  vswitch_id     = "${alicloud_vswitch.default.id}"
+  zone_id        = "${data.alicloud_zones.default.zones.0.id}"
+  engine_version = "3.4"
+  shard_list = [{
+    node_class   = "dds.shard.mid"
+    node_storage = 10
+    }, {
+    node_class   = "dds.shard.standard"
+    node_storage = 20
+  }]
+  mongo_list = [{
+    node_class = "dds.mongos.mid"
+    }, {
+    node_class = "dds.mongos.mid"
+  }]
+}`
+
+const testMongoDBShardingInstance_vpc_name = `
+data "alicloud_zones" "default" {
+  available_resource_creation = "MongoDB"
+}
+resource "alicloud_vpc" "default" {
+  name       = "${var.name}"
+  cidr_block = "172.16.0.0/16"
+}
+resource "alicloud_vswitch" "default" {
+  vpc_id            = "${alicloud_vpc.default.id}"
+  cidr_block        = "172.16.0.0/24"
+  availability_zone = "${data.alicloud_zones.default.zones.0.id}"
+  name              = "${var.name}"
+}
+variable "name" {
+  default = "tf-testAccMongoDBShardingInstance_vpc"
+}
+resource "alicloud_mongodb_sharding_instance" "default" {
+  vswitch_id     = "${alicloud_vswitch.default.id}"
+  zone_id        = "${data.alicloud_zones.default.zones.0.id}"
+  engine_version = "3.4"
+  shard_list = [{
+    node_class   = "dds.shard.mid"
+    node_storage = 10
+    }, {
+    node_class   = "dds.shard.standard"
+    node_storage = 20
+  }]
+  mongo_list = [{
+    node_class = "dds.mongos.mid"
+    }, {
+    node_class = "dds.mongos.mid"
+  }]
+  name = "tf-testAccMongoDBShardingInstance_test"
+}`
+
+const testMongoDBShardingInstance_vpc_account_password = `
+data "alicloud_zones" "default" {
+  available_resource_creation = "MongoDB"
+}
+resource "alicloud_vpc" "default" {
+  name       = "${var.name}"
+  cidr_block = "172.16.0.0/16"
+}
+resource "alicloud_vswitch" "default" {
+  vpc_id            = "${alicloud_vpc.default.id}"
+  cidr_block        = "172.16.0.0/24"
+  availability_zone = "${data.alicloud_zones.default.zones.0.id}"
+  name              = "${var.name}"
+}
+variable "name" {
+  default = "tf-testAccMongoDBShardingInstance_vpc"
+}
+resource "alicloud_mongodb_sharding_instance" "default" {
+  vswitch_id     = "${alicloud_vswitch.default.id}"
+  zone_id        = "${data.alicloud_zones.default.zones.0.id}"
+  engine_version = "3.4"
+  shard_list = [{
+    node_class   = "dds.shard.mid"
+    node_storage = 10
+    }, {
+    node_class   = "dds.shard.standard"
+    node_storage = 20
+  }]
+  mongo_list = [{
+    node_class = "dds.mongos.mid"
+    }, {
+    node_class = "dds.mongos.mid"
+  }]
+  name             = "tf-testAccMongoDBShardingInstance_test"
+  account_password = "1234@test"
+}`
+
+const testMongoDBShardingInstance_vpc_mongos = `
+data "alicloud_zones" "default" {
+  available_resource_creation = "MongoDB"
+}
+resource "alicloud_vpc" "default" {
+  name       = "${var.name}"
+  cidr_block = "172.16.0.0/16"
+}
+resource "alicloud_vswitch" "default" {
+  vpc_id            = "${alicloud_vpc.default.id}"
+  cidr_block        = "172.16.0.0/24"
+  availability_zone = "${data.alicloud_zones.default.zones.0.id}"
+  name              = "${var.name}"
+}
+variable "name" {
+  default = "tf-testAccMongoDBShardingInstance_vpc"
+}
+resource "alicloud_mongodb_sharding_instance" "default" {
+  vswitch_id     = "${alicloud_vswitch.default.id}"
+  zone_id        = "${data.alicloud_zones.default.zones.0.id}"
+  engine_version = "3.4"
+  shard_list = [{
+    node_class   = "dds.shard.mid"
+    node_storage = 10
+    }, {
+    node_class   = "dds.shard.standard"
+    node_storage = 20
+  }]
+  mongo_list = [{
+    node_class = "dds.mongos.mid"
+    }, {
+    node_class = "dds.mongos.mid"
+    }, {
+    node_class = "dds.mongos.mid"
+  }]
+  name             = "tf-testAccMongoDBShardingInstance_test"
+  account_password = "1234@test"
+}`
+
+const testMongoDBShardingInstance_vpc_shard = `
+data "alicloud_zones" "default" {
+  available_resource_creation = "MongoDB"
+}
+resource "alicloud_vpc" "default" {
+  name       = "${var.name}"
+  cidr_block = "172.16.0.0/16"
+}
+resource "alicloud_vswitch" "default" {
+  vpc_id            = "${alicloud_vpc.default.id}"
+  cidr_block        = "172.16.0.0/24"
+  availability_zone = "${data.alicloud_zones.default.zones.0.id}"
+  name              = "${var.name}"
+}
+variable "name" {
+  default = "tf-testAccMongoDBShardingInstance_vpc"
+}
+resource "alicloud_mongodb_sharding_instance" "default" {
+  vswitch_id     = "${alicloud_vswitch.default.id}"
+  zone_id        = "${data.alicloud_zones.default.zones.0.id}"
+  engine_version = "3.4"
+  shard_list = [{
+    node_class   = "dds.shard.mid"
+    node_storage = 10
+    }, {
+    node_class   = "dds.shard.standard"
+    node_storage = 20
+    }, {
+    node_class   = "dds.shard.standard"
+    node_storage = 20
+  }]
+  mongo_list = [{
+    node_class = "dds.mongos.mid"
+    }, {
+    node_class = "dds.mongos.mid"
+    }, {
+    node_class = "dds.mongos.mid"
+  }]
+  name             = "tf-testAccMongoDBShardingInstance_test"
+  account_password = "1234@test"
+}`
+
+const testMongoDBShardingInstance_vpc_together = `
+data "alicloud_zones" "default" {
+  available_resource_creation = "MongoDB"
+}
+resource "alicloud_vpc" "default" {
+  name       = "${var.name}"
+  cidr_block = "172.16.0.0/16"
+}
+resource "alicloud_vswitch" "default" {
+  vpc_id            = "${alicloud_vpc.default.id}"
+  cidr_block        = "172.16.0.0/24"
+  availability_zone = "${data.alicloud_zones.default.zones.0.id}"
+  name              = "${var.name}"
+}
+variable "name" {
+  default = "tf-testAccMongoDBShardingInstance_vpc"
+}
+resource "alicloud_mongodb_sharding_instance" "default" {
+  vswitch_id     = "${alicloud_vswitch.default.id}"
+  zone_id        = "${data.alicloud_zones.default.zones.0.id}"
+  engine_version = "3.4"
+  shard_list = [{
+    node_class   = "dds.shard.mid"
+    node_storage = 10
+    }, {
+    node_class   = "dds.shard.standard"
+    node_storage = 20
+    }, {
+    node_class   = "dds.shard.standard"
+    node_storage = 20
+  }]
+  mongo_list = [{
+    node_class = "dds.mongos.mid"
+    }, {
+    node_class = "dds.mongos.mid"
+    }, {
+    node_class = "dds.mongos.mid"
+  }]
+  name             = "tf-testAccMongoDBShardingInstance_test_together"
+  account_password = "1234@test"
+  security_ip_list = ["10.168.1.12", "10.168.1.13"]
+}`
+
+func TestAccAlicloudMongoDBShardingInstance_vpc(t *testing.T) {
+	var v dds.DBInstance
+	resourceId := "alicloud_mongodb_sharding_instance.default"
+	serverFunc := func() interface{} {
+		return &MongoDBService{testAccProvider.Meta().(*connectivity.AliyunClient)}
+	}
+	rc := resourceCheckInitWithDescribeMethod(resourceId, &v, serverFunc, "DescribeMongoDBInstance")
+	ra := resourceAttrInit(resourceId, nil)
+	rac := resourceAttrCheckInit(rc, ra)
+	testAccCheck := rac.resourceAttrMapUpdateSet()
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+		},
+		IDRefreshName: "alicloud_mongodb_sharding_instance.default",
+		Providers:     testAccProviders,
+		CheckDestroy:  testAccCheckMongoDBShardingInstanceDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testMongoDBShardingInstance_vpc_base,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"vswitch_id":                CHECKSET,
+						"zone_id":                   CHECKSET,
+						"engine_version":            "3.4",
+						"shard_list.#":              "2",
+						"shard_list.0.node_class":   "dds.shard.mid",
+						"shard_list.0.node_storage": "10",
+						"shard_list.1.node_class":   "dds.shard.standard",
+						"shard_list.1.node_storage": "20",
+						"mongo_list.#":              "2",
+						"mongo_list.0.node_class":   "dds.mongos.mid",
+						"mongo_list.1.node_class":   "dds.mongos.mid",
+					}),
+				),
+			},
+			{
+				Config: testMongoDBShardingInstance_vpc_name,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"name": "tf-testAccMongoDBShardingInstance_test",
+					}),
+				),
+			},
+			{
+				Config: testMongoDBShardingInstance_vpc_account_password,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"account_password": "1234@test",
+					}),
+				),
+			},
+			{
+				Config: testMongoDBShardingInstance_vpc_mongos,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"mongo_list.#":            "3",
+						"mongo_list.0.node_class": "dds.mongos.mid",
+						"mongo_list.1.node_class": "dds.mongos.mid",
+						"mongo_list.2.node_class": "dds.mongos.mid",
+					}),
+				),
+			},
+			{
+				Config: testMongoDBShardingInstance_vpc_shard,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"shard_list.#":              "3",
+						"shard_list.0.node_class":   "dds.shard.mid",
+						"shard_list.0.node_storage": "10",
+						"shard_list.1.node_class":   "dds.shard.standard",
+						"shard_list.1.node_storage": "20",
+						"shard_list.2.node_class":   "dds.shard.standard",
+						"shard_list.2.node_storage": "20",
+					}),
+				),
+			},
+			{
+				Config: testMongoDBShardingInstance_vpc_together,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"name":                        "tf-testAccMongoDBShardingInstance_test_together",
+						"account_password":            "1234@test",
+						"security_ip_list.#":          "2",
+						"security_ip_list.4095458986": "10.168.1.12",
+						"security_ip_list.3976237035": "10.168.1.13",
+					}),
+				),
+			}},
+	})
+}
+
+const testMongoDBShardingInstance_multi_instance_base = `
+data "alicloud_zones" "default" {
+  available_resource_creation = "MongoDB"
+}
+variable "name" {
+  default = "tf-testAccMongoDBShardingInstance_multi_instance"
+}
+
+resource "alicloud_mongodb_sharding_instance" "default" {
+  count          = 5
+  zone_id        = "${data.alicloud_zones.default.zones.0.id}"
+  engine_version = "3.4"
+  shard_list = [{
+    node_class   = "dds.shard.mid"
+    node_storage = 10
+    }, {
+    node_class   = "dds.shard.standard"
+    node_storage = 20
+  }]
+  mongo_list = [{
+    node_class = "dds.mongos.mid"
+    }, {
+    node_class = "dds.mongos.mid"
+  }]
+}`
+
+const testMongoDBShardingInstance_multi_instance_name = `
+data "alicloud_zones" "default" {
+  available_resource_creation = "MongoDB"
+}
+variable "name" {
+  default = "tf-testAccMongoDBShardingInstance_multi_instance"
+}
+
+resource "alicloud_mongodb_sharding_instance" "default" {
+  count          = 5
+  zone_id        = "${data.alicloud_zones.default.zones.0.id}"
+  engine_version = "3.4"
+  shard_list = [{
+    node_class   = "dds.shard.mid"
+    node_storage = 10
+    }, {
+    node_class   = "dds.shard.standard"
+    node_storage = 20
+  }]
+  mongo_list = [{
+    node_class = "dds.mongos.mid"
+    }, {
+    node_class = "dds.mongos.mid"
+  }]
+  name = "tf-testAccMongoDBShardingInstance_test"
+}`
+
+const testMongoDBShardingInstance_multi_instance_account_password = `
+data "alicloud_zones" "default" {
+  available_resource_creation = "MongoDB"
+}
+variable "name" {
+  default = "tf-testAccMongoDBShardingInstance_multi_instance"
+}
+
+resource "alicloud_mongodb_sharding_instance" "default" {
+  count          = 5
+  zone_id        = "${data.alicloud_zones.default.zones.0.id}"
+  engine_version = "3.4"
+  shard_list = [{
+    node_class   = "dds.shard.mid"
+    node_storage = 10
+    }, {
+    node_class   = "dds.shard.standard"
+    node_storage = 20
+  }]
+  mongo_list = [{
+    node_class = "dds.mongos.mid"
+    }, {
+    node_class = "dds.mongos.mid"
+  }]
+  name             = "tf-testAccMongoDBShardingInstance_test"
+  account_password = "1234@test"
+}`
+
+const testMongoDBShardingInstance_multi_instance_mongos = `
+data "alicloud_zones" "default" {
+  available_resource_creation = "MongoDB"
+}
+variable "name" {
+  default = "tf-testAccMongoDBShardingInstance_multi_instance"
+}
+
+resource "alicloud_mongodb_sharding_instance" "default" {
+  count          = 5
+  zone_id        = "${data.alicloud_zones.default.zones.0.id}"
+  engine_version = "3.4"
+  shard_list = [{
+    node_class   = "dds.shard.mid"
+    node_storage = 10
+    }, {
+    node_class   = "dds.shard.standard"
+    node_storage = 20
+  }]
+  mongo_list = [{
+    node_class = "dds.mongos.mid"
+    }, {
+    node_class = "dds.mongos.mid"
+    }, {
+    node_class = "dds.mongos.mid"
+  }]
+  name             = "tf-testAccMongoDBShardingInstance_test"
+  account_password = "1234@test"
+}`
+
+const testMongoDBShardingInstance_multi_instance_shard = `
+data "alicloud_zones" "default" {
+  available_resource_creation = "MongoDB"
+}
+variable "name" {
+  default = "tf-testAccMongoDBShardingInstance_multi_instance"
+}
+
+resource "alicloud_mongodb_sharding_instance" "default" {
+  count          = 5
+  zone_id        = "${data.alicloud_zones.default.zones.0.id}"
+  engine_version = "3.4"
+  shard_list = [{
+    node_class   = "dds.shard.mid"
+    node_storage = 10
+    }, {
+    node_class   = "dds.shard.standard"
+    node_storage = 20
+    }, {
+    node_class   = "dds.shard.standard"
+    node_storage = 20
+  }]
+  mongo_list = [{
+    node_class = "dds.mongos.mid"
+    }, {
+    node_class = "dds.mongos.mid"
+    }, {
+    node_class = "dds.mongos.mid"
+  }]
+  name             = "tf-testAccMongoDBShardingInstance_test"
+  account_password = "1234@test"
+}`
+
+const testMongoDBShardingInstance_multi_instance_together = `
+data "alicloud_zones" "default" {
+  available_resource_creation = "MongoDB"
+}
+variable "name" {
+  default = "tf-testAccMongoDBShardingInstance_multi_instance"
+}
+
+resource "alicloud_mongodb_sharding_instance" "default" {
+  count          = 5
+  zone_id        = "${data.alicloud_zones.default.zones.0.id}"
+  engine_version = "3.4"
+  shard_list = [{
+    node_class   = "dds.shard.mid"
+    node_storage = 10
+    }, {
+    node_class   = "dds.shard.standard"
+    node_storage = 20
+    }, {
+    node_class   = "dds.shard.standard"
+    node_storage = 20
+  }]
+  mongo_list = [{
+    node_class = "dds.mongos.mid"
+    }, {
+    node_class = "dds.mongos.mid"
+    }, {
+    node_class = "dds.mongos.mid"
+  }]
+  name             = "tf-testAccMongoDBShardingInstance_test_together"
+  account_password = "1234@test"
+  security_ip_list = ["10.168.1.12", "10.168.1.13"]
+}`
+
+func TestAccAlicloudMongoDBShardingInstance_multi_instance(t *testing.T) {
+	var v dds.DBInstance
+	resourceId := "alicloud_mongodb_sharding_instance.default.4"
+	serverFunc := func() interface{} {
+		return &MongoDBService{testAccProvider.Meta().(*connectivity.AliyunClient)}
+	}
+	rc := resourceCheckInitWithDescribeMethod(resourceId, &v, serverFunc, "DescribeMongoDBInstance")
+	ra := resourceAttrInit(resourceId, nil)
+	rac := resourceAttrCheckInit(rc, ra)
+	testAccCheck := rac.resourceAttrMapUpdateSet()
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+
+		},
+		IDRefreshName: "alicloud_mongodb_sharding_instance.default.4",
+		Providers:     testAccProviders,
+		CheckDestroy:  testAccCheckMongoDBShardingInstanceDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testMongoDBShardingInstance_multi_instance_base,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"zone_id":                   CHECKSET,
+						"engine_version":            "3.4",
+						"shard_list.#":              "2",
+						"shard_list.0.node_class":   "dds.shard.mid",
+						"shard_list.0.node_storage": "10",
+						"shard_list.1.node_class":   "dds.shard.standard",
+						"shard_list.1.node_storage": "20",
+						"mongo_list.#":              "2",
+						"mongo_list.0.node_class":   "dds.mongos.mid",
+						"mongo_list.1.node_class":   "dds.mongos.mid",
+					}),
+				),
+			},
+			{
+				Config: testMongoDBShardingInstance_multi_instance_name,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"name": "tf-testAccMongoDBShardingInstance_test",
+					}),
+				),
+			},
+			{
+				Config: testMongoDBShardingInstance_multi_instance_account_password,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"account_password": "1234@test",
+					}),
+				),
+			},
+			{
+				Config: testMongoDBShardingInstance_multi_instance_mongos,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"mongo_list.#":            "3",
+						"mongo_list.0.node_class": "dds.mongos.mid",
+						"mongo_list.1.node_class": "dds.mongos.mid",
+						"mongo_list.2.node_class": "dds.mongos.mid",
+					}),
+				),
+			},
+			{
+				Config: testMongoDBShardingInstance_multi_instance_shard,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"shard_list.#":              "3",
+						"shard_list.0.node_class":   "dds.shard.mid",
+						"shard_list.0.node_storage": "10",
+						"shard_list.1.node_class":   "dds.shard.standard",
+						"shard_list.1.node_storage": "20",
+						"shard_list.2.node_class":   "dds.shard.standard",
+						"shard_list.2.node_storage": "20",
+					}),
+				),
+			},
+			{
+				Config: testMongoDBShardingInstance_multi_instance_together,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"name":                        "tf-testAccMongoDBShardingInstance_test_together",
+						"account_password":            "1234@test",
+						"security_ip_list.#":          "2",
+						"security_ip_list.4095458986": "10.168.1.12",
+						"security_ip_list.3976237035": "10.168.1.13",
+					}),
+				),
+			}},
+	})
+}

--- a/alicloud/resource_alicloud_vswitch_test.go
+++ b/alicloud/resource_alicloud_vswitch_test.go
@@ -35,6 +35,7 @@ func init() {
 			"alicloud_elasticsearch_instance",
 			"alicloud_vpn_gateway",
 			"alicloud_mongodb_instance",
+			"alicloud_mongodb_sharding_instance",
 		},
 	})
 }

--- a/alicloud/service_alicloud_mongodb.go
+++ b/alicloud/service_alicloud_mongodb.go
@@ -4,6 +4,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/aliyun/alibaba-cloud-sdk-go/sdk/requests"
 	"github.com/aliyun/alibaba-cloud-sdk-go/services/dds"
 	"github.com/terraform-providers/terraform-provider-alicloud/alicloud/connectivity"
 )
@@ -19,7 +20,7 @@ func (s *MongoDBService) NotFoundMongoDBInstance(err error) bool {
 	return false
 }
 
-func (s *MongoDBService) DescribeMongoDBInstance(id string) (instance *dds.DBInstance, err error) {
+func (s *MongoDBService) DescribeMongoDBInstance(id string) (instance dds.DBInstance, err error) {
 	request := dds.CreateDescribeDBInstanceAttributeRequest()
 	request.DBInstanceId = id
 	raw, err := s.client.WithDdsClient(func(client *dds.Client) (interface{}, error) {
@@ -27,13 +28,13 @@ func (s *MongoDBService) DescribeMongoDBInstance(id string) (instance *dds.DBIns
 	})
 	response, _ := raw.(*dds.DescribeDBInstanceAttributeResponse)
 	if err != nil {
-		return nil, WrapErrorf(err, DefaultErrorMsg, id, request.GetActionName(), AlibabaCloudSdkGoERROR)
+		return instance, WrapErrorf(err, DefaultErrorMsg, id, request.GetActionName(), AlibabaCloudSdkGoERROR)
 	}
 	addDebug(request.GetActionName(), response)
 	if response == nil || len(response.DBInstances.DBInstance) == 0 {
-		return nil, WrapErrorf(Error(GetNotFoundMessage("MongoDB Instance", id)), NotFoundMsg, AlibabaCloudSdkGoERROR)
+		return instance, WrapErrorf(Error(GetNotFoundMessage("MongoDB Instance", id)), NotFoundMsg, AlibabaCloudSdkGoERROR)
 	}
-	return &response.DBInstances.DBInstance[0], nil
+	return response.DBInstances.DBInstance[0], nil
 }
 
 // WaitForInstance waits for instance to given statusid
@@ -131,6 +132,107 @@ func (s *MongoDBService) ModifyMongoDBSecurityIps(instanceId, ips string) error 
 
 	if err := s.WaitForMongoDBInstance(instanceId, Running, DefaultTimeoutMedium); err != nil {
 		return WrapError(err)
+	}
+	return nil
+}
+
+func (server *MongoDBService) ModifyMongodbShardingInstanceNode(
+	instanceID string, nodeType MongoDBShardingNodeType, stateList, diffList []interface{}) error {
+	client := server.client
+
+	//create node
+	if len(stateList) < len(diffList) {
+		createList := diffList[len(stateList):]
+		diffList = diffList[:len(stateList)]
+
+		for _, item := range createList {
+			node := item.(map[string]interface{})
+
+			request := dds.CreateCreateNodeRequest()
+			request.DBInstanceId = instanceID
+			request.NodeClass = node["node_class"].(string)
+			request.NodeType = string(nodeType)
+
+			if nodeType == MongoDBShardingNodeShard {
+				request.NodeStorage = requests.NewInteger(node["node_storage"].(int))
+			}
+
+			raw, err := client.WithDdsClient(func(ddsClient *dds.Client) (interface{}, error) {
+				return ddsClient.CreateNode(request)
+			})
+			if err != nil {
+				return WrapErrorf(err, DefaultErrorMsg, instanceID, request.GetActionName(), AlibabaCloudSdkGoERROR)
+			}
+			addDebug(request.GetActionName(), raw)
+
+			err = server.WaitForMongoDBInstance(instanceID, Updating, DefaultLongTimeout)
+			if err != nil {
+				return WrapError(err)
+			}
+
+			err = server.WaitForMongoDBInstance(instanceID, Running, DefaultLongTimeout)
+			if err != nil {
+				return WrapError(err)
+			}
+		}
+	} else if len(stateList) > len(diffList) {
+		deleteList := stateList[len(diffList):]
+		stateList = stateList[:len(diffList)]
+
+		for _, item := range deleteList {
+			node := item.(map[string]interface{})
+
+			request := dds.CreateDeleteNodeRequest()
+			request.DBInstanceId = instanceID
+			request.NodeId = node["node_id"].(string)
+
+			raw, err := client.WithDdsClient(func(ddsClient *dds.Client) (interface{}, error) {
+				return ddsClient.DeleteNode(request)
+			})
+			if err != nil {
+				return WrapErrorf(err, DefaultErrorMsg, instanceID, request.GetActionName(), AlibabaCloudSdkGoERROR)
+			}
+
+			addDebug(request.GetActionName(), raw)
+
+			err = server.WaitForMongoDBInstance(instanceID, Running, DefaultLongTimeout)
+			if err != nil {
+				return WrapError(err)
+			}
+		}
+	}
+
+	//motify node
+	for key := 0; key < len(stateList); key++ {
+		state := stateList[key].(map[string]interface{})
+		diff := diffList[key].(map[string]interface{})
+
+		if state["node_class"] != diff["node_class"] ||
+			state["node_storage"] != diff["node_storage"] {
+			request := dds.CreateModifyNodeSpecRequest()
+			request.DBInstanceId = instanceID
+			request.NodeClass = diff["node_class"].(string)
+			if nodeType == MongoDBShardingNodeShard {
+				request.NodeStorage = requests.NewInteger(diff["node_storage"].(int))
+			}
+			request.NodeId = state["node_id"].(string)
+
+			raw, err := client.WithDdsClient(func(ddsClient *dds.Client) (interface{}, error) {
+				return ddsClient.ModifyNodeSpec(request)
+			})
+			if err != nil {
+				return WrapErrorf(err, DefaultErrorMsg, instanceID, request.GetActionName(), AlibabaCloudSdkGoERROR)
+			}
+			addDebug(request.GetActionName(), raw)
+			err = server.WaitForMongoDBInstance(instanceID, Updating, DefaultLongTimeout)
+			if err != nil {
+				return WrapError(err)
+			}
+			err = server.WaitForMongoDBInstance(instanceID, Running, DefaultLongTimeout)
+			if err != nil {
+				return WrapError(err)
+			}
+		}
 	}
 	return nil
 }

--- a/website/alicloud.erb
+++ b/website/alicloud.erb
@@ -484,6 +484,11 @@
                             <a href="/docs/providers/alicloud/r/mongodb_instance.html">alicloud_mongodb_instance</a>
                         </li>
                     </ul>
+                    <ul class="nav nav-visible">
+                        <li<%= sidebar_current("docs-alicloud-resource-mongodb") %>>
+                            <a href="/docs/providers/alicloud/r/mongodb_sharding_instance.html">mongodb_sharding_instance</a>
+                        </li>
+                    </ul>
                 </li>
 
                 <li<%= sidebar_current("docs-alicloud-resource-kvstore") %>>

--- a/website/docs/r/mongodb_sharding_instance.html.markdown
+++ b/website/docs/r/mongodb_sharding_instance.html.markdown
@@ -1,0 +1,110 @@
+---
+layout: "alicloud"
+page_title: "Alicloud: alicloud_mongodb_sharding_instance"
+sidebar_current: "docs-alicloud-resource-mongodb-instance"
+description: |-
+  Provides a MongoDB sharding instance resource.
+---
+
+# alicloud\_mongodb\_sharding_instance
+
+Provides a MongoDB sharding instance resource supports replica set instances only. the MongoDB provides stable, reliable, and automatic scalable database services. 
+It offers a full range of database solutions, such as disaster recovery, backup, recovery, monitoring, and alarms.
+You can see detail product introduction [here](https://www.alibabacloud.com/help/doc-detail/26558.htm)
+
+-> **NOTE:**  Available in 1.40.0+
+
+-> **NOTE:**  The following regions don't support create Classic network MongoDB sharding instance.
+[`cn-zhangjiakou`,`cn-huhehaote`,`ap-southeast-2`,`ap-southeast-3`,`ap-southeast-5`,`ap-south-1`,`me-east-1`,`ap-northeast-1`,`eu-west-1`] 
+
+-> **NOTE:**  Create MongoDB Sharding instance or change instance type and storage would cost 10~20 minutes. Please make full preparation
+
+## Example Usage
+
+### Create a Mongodb Sharding instance
+
+```tf
+variable "name" {
+  default = "tf-example"
+}
+
+variable "shard" {
+  default = {
+    node_class   = "dds.shard.mid"
+    node_storage = 10
+  }
+}
+
+variable "mongo" {
+  default = {
+    node_class = "dds.mongos.mid"
+  }
+}
+
+data "alicloud_zones" "default" {
+  available_resource_creation = "MongoDB"
+}
+
+resource "alicloud_vpc" "default" {
+  name       = "${var.name}"
+  cidr_block = "172.16.0.0/16"
+}
+
+resource "alicloud_vswitch" "default" {
+  vpc_id            = "${alicloud_vpc.default.id}"
+  cidr_block        = "172.16.0.0/24"
+  availability_zone = "${data.alicloud_zones.default.zones.0.id}"
+  name              = "${var.name}"
+}
+
+resource "alicloud_mongodb_sharding_instance" "foo" {
+  zone_id        = "${data.alicloud_zones.default.zones.0.id}"
+  vswitch_id     = "${alicloud_vswitch.default.id}"
+  engine_version = "3.4"
+  name           = "${var.name}"
+  shard_list     = ["${var.shard}", "${var.shard}"]
+  mongo_list     = ["${var.mongo}", "${var.mongo}"]
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `engine_version` - (Required, ForceNew) Database version. Value options can refer to the latest docs [CreateDBInstance](https://www.alibabacloud.com/help/zh/doc-detail/61884.htm) `EngineVersion`. 
+* `storage_engine` (Optional, ForceNew) Storage engine: WiredTiger or RocksDB. System Default value: WiredTiger.
+* `name` - (Optional) The name of DB instance. It a string of 2 to 256 characters.
+* `instance_charge_type` - (Optional, ForceNew) Valid values are `PrePaid`, `PostPaid`,System default to `PostPaid`.
+* `period` - (Optional) The duration that you will buy DB instance (in month). It is valid when instance_charge_type is `PrePaid`. Valid values: [1~9], 12, 24, 36. System default to 1.
+* `zone_id` - (Optional, ForceNew) The Zone to launch the DB instance. MongoDB sharding instance does not support multiple-zone.
+If it is a multi-zone and `vswitch_id` is specified, the vswitch must in one of them.
+* `vswitch_id` - (Optional, ForceNew) The virtual switch ID to launch DB instances in one VPC.
+* `account_password` -  (Optional) Password of the root account. It is a string of 6 to 32 characters and is composed of letters, numbers, and underlines.
+* `security_ip_list` - (Optional) List of IP addresses allowed to access all databases of an instance. The list contains up to 1,000 IP addresses, separated by commas. Supported formats include 0.0.0.0/0, 10.23.12.24 (IP), and 10.23.12.24/24 (Classless Inter-Domain Routing (CIDR) mode. /24 represents the length of the prefix in an IP address. The range of the prefix length is [1,32]). System default to `["127.0.0.1"]`.
+* `mongo_list` - (Required) The mongo-node count can be purchased is in range of [2, 32].
+    * `node_class` -(Required) Node specification. see [Instance specifications](https://www.alibabacloud.com/help/doc-detail/57141.htm).
+* `shard_list` - (Required) the shard-node count can be purchased is in range of [2, 32].
+    * `node_class` -(Required) Node specification. see [Instance specifications](https://www.alibabacloud.com/help/doc-detail/57141.htm).
+    * `node_storage` - (Required)
+        - Custom storage space; value range: [10, 1,000]
+        - 10-GB increments. Unit: GB.
+
+## Attributes Reference
+
+The following attributes are exported:
+
+* `id` - The ID of the MongoDB.
+* `mongo_list`
+    * `node_id` - The ID of the mongo-node.
+    * `connect_string` - Mongo node connection string
+    * `port` - Mongo node port
+* `shard_list`
+    * `node_id` - The ID of the shard-node.
+
+## Import
+
+MongoDB can be imported using the id, e.g.
+
+```
+$ terraform import alicloud_mongodb_sharding_instance.example 
+```


### PR DESCRIPTION
add MongoDB sharding instance support
the test result:
=== RUN   TestAccAlicloudMongoDBShardingInstance_import
--- PASS: TestAccAlicloudMongoDBShardingInstance_import (781.59s)
=== RUN   TestAccAlicloudMongoDBShardingInstance_classic
--- PASS: TestAccAlicloudMongoDBShardingInstance_classic (1081.40s)
=== RUN   TestAccAlicloudMongoDBShardingInstance_vpc
--- PASS: TestAccAlicloudMongoDBShardingInstance_vpc (1115.70s)
=== RUN   TestAccAlicloudMongoDBShardingInstance_multi_instance
--- PASS: TestAccAlicloudMongoDBShardingInstance_multi_instance (1122.78s)
PASS
ok      github.com/terraform-providers/terraform-provider-alicloud/alicloud     4101.500s