### PR TITLE
fixed DB log backup policy bug when the log_retention_period does not input.

### DIFF
--- a/alicloud/resource_alicloud_db_backup_policy.go
+++ b/alicloud/resource_alicloud_db_backup_policy.go
@@ -56,14 +56,14 @@ func resourceAlicloudDBBackupPolicy() *schema.Resource {
 			"log_backup": {
 				Type:     schema.TypeBool,
 				Optional: true,
-				Default:  true,
+				Computed: true,
 			},
 
 			"log_retention_period": {
 				Type:             schema.TypeInt,
 				ValidateFunc:     validateIntegerInRange(7, 730),
 				Optional:         true,
-				Default:          7,
+				Computed:         true,
 				DiffSuppressFunc: logRetentionPeriodDiffSuppressFunc,
 			},
 		},
@@ -108,9 +108,17 @@ func resourceAlicloudDBBackupPolicyUpdate(d *schema.ResourceData, meta interface
 	periodList := expandStringList(d.Get("backup_period").(*schema.Set).List())
 	backupPeriod := fmt.Sprintf("%s", strings.Join(periodList[:], COMMA_SEPARATED))
 	backupTime := d.Get("backup_time").(string)
-	retentionPeriod := strconv.Itoa(d.Get("retention_period").(int))
 	backupLog := "Enable"
-	logBackupRetentionPeriod := strconv.Itoa(d.Get("log_retention_period").(int))
+
+	retentionPeriod := ""
+	if temp, ok := d.GetOk("retention_period"); ok {
+		retentionPeriod = strconv.Itoa(temp.(int))
+	}
+
+	logBackupRetentionPeriod := ""
+	if temp, ok := d.GetOk("log_retention_period"); ok {
+		logBackupRetentionPeriod = strconv.Itoa(temp.(int))
+	}
 
 	if d.HasChange("backup_period") {
 		update = true

--- a/website/docs/r/db_backup_policy.html.markdown
+++ b/website/docs/r/db_backup_policy.html.markdown
@@ -61,8 +61,10 @@ The following arguments are supported:
 * `backup_period` - (Optional) DB Instance backup period. Valid values: [Monday, Tuesday, Wednesday, Thursday, Friday, Saturday, Sunday]. Default to ["Tuesday", "Thursday", "Saturday"].
 * `backup_time` - (Optional) DB instance backup time, in the format of HH:mmZ- HH:mmZ. Time setting interval is one hour. Default to "02:00Z-03:00Z". China time is 8 hours behind it.
 * `retention_period` - (Optional) Instance backup retention days. Valid values: [7-730]. Default to 7.
-* `log_backup` - (Optional) Whether to backup instance log. Default to true. Basic Edition DB Instance does not support [Refer to details](https://www.alibabacloud.com/help/doc-detail/55665.htm).
-* `log_retention_period` - (Optional) Instance log backup retention days. Valid values: [7-730]. Default to 7. It can be larger than 'retention_period'.
+* `log_backup` - (Optional) Whether to backup instance log. 
+    - defalut `false` to Basic Edition DB Instance with the Basic Edition DB Instance can not setting it. [Refer to details](https://www.alibabacloud.com/help/doc-detail/55665.htm).
+    - defalut `true` to other DB instance edition exclude Basic Edition.
+* `log_retention_period` - (Optional) Instance log backup retention days. Valid when the `log_backup` is `true`. Valid values: [7-730]. Default to 7. It cannot be larger than `retention_period`.
 
 ## Attributes Reference
 


### PR DESCRIPTION
1. if log_retention_period doesn't input, it defaults to 0. To string will be "0", that will get error code `InvalidLogBackupRetentionPeriod.Malformed`.
2. when log_backup doesn't input and PGDB instance is a single node instance, (basic edition instance doesn't support log_backup ), there will still have diff after terraform apply operation.

the test case run result :
--- PASS: TestAccAlicloudDBBackupPolicy_update (137.89s)
PASS