### PR TITLE
Modified the error code returned when timeout of upgrading instance.

### DIFF
--- a/alicloud/errors.go
+++ b/alicloud/errors.go
@@ -324,9 +324,10 @@ const (
 	InvalidPrivateIpAddressDuplicated = "InvalidPrivateIpAddress.Duplicated"
 
 	// Elasticsearch
-	InstanceActivating      = "InstanceActivating"
-	ESInstanceNotFound      = "InstanceNotFound"
-	ESMustChangeOneResource = "MustChangeOneResource"
+	InstanceActivating         = "InstanceActivating"
+	ESInstanceNotFound         = "InstanceNotFound"
+	ESMustChangeOneResource    = "MustChangeOneResource"
+	ESCssCheckUpdowngradeError = "CssCheckUpdowngradeError"
 
 	// Ddoscoo
 	DdoscooInstanceNotFound = "InstanceNotFound"

--- a/alicloud/service_alicloud_elasticsearch.go
+++ b/alicloud/service_alicloud_elasticsearch.go
@@ -158,7 +158,7 @@ func updateDateNodeAmount(d *schema.ResourceData, meta interface{}) error {
 	if _, err = client.WithElasticsearchClient(func(elasticsearchClient *elasticsearch.Client) (resp interface{}, errs error) {
 		return elasticsearchClient.UpdateInstance(request)
 	}); err != nil {
-		if !IsExceptedErrors(err, []string{ESMustChangeOneResource}) {
+		if !IsExceptedErrors(err, []string{ESMustChangeOneResource, ESCssCheckUpdowngradeError}) {
 			return WrapErrorf(err, DefaultErrorMsg, d.Id(), request.GetActionName(), AlibabaCloudSdkGoERROR)
 		}
 	}
@@ -189,7 +189,7 @@ func updateDataNodeSpec(d *schema.ResourceData, meta interface{}) error {
 	if _, err = client.WithElasticsearchClient(func(elasticsearchClient *elasticsearch.Client) (interface{}, error) {
 		return elasticsearchClient.UpdateInstance(request)
 	}); err != nil {
-		if !IsExceptedErrors(err, []string{ESMustChangeOneResource}) {
+		if !IsExceptedErrors(err, []string{ESMustChangeOneResource, ESCssCheckUpdowngradeError}) {
 			return WrapErrorf(err, DefaultErrorMsg, d.Id(), request.GetActionName(), AlibabaCloudSdkGoERROR)
 		}
 	}
@@ -226,7 +226,7 @@ func updateMasterNode(d *schema.ResourceData, meta interface{}) error {
 	if _, err = client.WithElasticsearchClient(func(elasticsearchClient *elasticsearch.Client) (interface{}, error) {
 		return elasticsearchClient.UpdateInstance(request)
 	}); err != nil {
-		if !IsExceptedErrors(err, []string{ESMustChangeOneResource}) {
+		if !IsExceptedErrors(err, []string{ESMustChangeOneResource, ESCssCheckUpdowngradeError}) {
 			return WrapErrorf(err, DefaultErrorMsg, d.Id(), request.GetActionName(), AlibabaCloudSdkGoERROR)
 		}
 	}


### PR DESCRIPTION
Received the new error code "CssCheckUpdowngradeError" and ignored it when SDK retried to fetch api.

TF_ACC=1 go test ./alicloud -v -run=TestAccAlicloudElasticsearchInstance_upgrade -timeout=300m
=== RUN   TestAccAlicloudElasticsearchInstance_upgrade
--- PASS: TestAccAlicloudElasticsearchInstance_upgrade (6888.74s)
PASS
ok      github.com/terraform-providers/terraform-provider-alicloud/alicloud 6888.789s