### PR TITLE
add child_instance_owner_id for resource_alicloud_cen_instance_attach…

### DIFF
--- a/alicloud/import_alicloud_cen_instance_grant_test.go
+++ b/alicloud/import_alicloud_cen_instance_grant_test.go
@@ -33,7 +33,7 @@ func SkipTestAccAlicloudCenInstanceGrant_importBasic(t *testing.T) {
 		CheckDestroy:      testAccCheckCenInstanceGrantDestroyWithProviders(&providers),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccCenInstanceGrantBasic(os.Getenv("ALICLOUD_ACCESS_KEY_2"), os.Getenv("ALICLOUD_SECRET_KEY_2"), os.Getenv("ALICLOUD_ACCOUNT_ID_2")),
+				Config: testAccCenInstanceGrantBasic(os.Getenv("ALICLOUD_ACCESS_KEY_2"), os.Getenv("ALICLOUD_SECRET_KEY_2"), os.Getenv("ALICLOUD_ACCOUNT_ID_1"), os.Getenv("ALICLOUD_ACCOUNT_ID_2")),
 			},
 
 			{

--- a/alicloud/resource_alicloud_cen_instance.go
+++ b/alicloud/resource_alicloud_cen_instance.go
@@ -68,7 +68,7 @@ func resourceAlicloudCenInstanceCreate(d *schema.ResourceData, meta interface{})
 	request.ClientToken = buildClientToken(request.GetActionName())
 
 	var cen *cbn.CreateCenResponse
-	err := resource.Retry(3*time.Minute, func() *resource.RetryError {
+	err := resource.Retry(5*time.Minute, func() *resource.RetryError {
 		req := *request
 		raw, err := client.WithCenClient(func(cbnClient *cbn.Client) (interface{}, error) {
 			return cbnClient.CreateCen(&req)

--- a/alicloud/resource_alicloud_cen_instance_attachment_test.go
+++ b/alicloud/resource_alicloud_cen_instance_attachment_test.go
@@ -38,6 +38,7 @@ func TestAccAlicloudCenInstanceAttachment_basic(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckCenInstanceAttachmentExistsWithProviders("alicloud_cen_instance_attachment.foo", &instance, &providers),
 					resource.TestCheckResourceAttr("alicloud_cen_instance_attachment.foo", "child_instance_region_id", defaultRegionToTest),
+					resource.TestCheckResourceAttrSet("alicloud_cen_instance_attachment.foo", "child_instance_owner_id"),
 				),
 			},
 		},
@@ -71,8 +72,10 @@ func TestAccAlicloudCenInstanceAttachment_multi_same_regions(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckCenInstanceAttachmentExistsWithProviders("alicloud_cen_instance_attachment.bar1", &instance, &providers),
 					resource.TestCheckResourceAttr("alicloud_cen_instance_attachment.bar1", "child_instance_region_id", defaultRegionToTest),
+					resource.TestCheckResourceAttrSet("alicloud_cen_instance_attachment.bar1", "child_instance_owner_id"),
 					testAccCheckCenInstanceAttachmentExistsWithProviders("alicloud_cen_instance_attachment.bar2", &instance, &providers),
 					resource.TestCheckResourceAttr("alicloud_cen_instance_attachment.bar2", "child_instance_region_id", defaultRegionToTest),
+					resource.TestCheckResourceAttrSet("alicloud_cen_instance_attachment.bar2", "child_instance_owner_id"),
 				),
 			},
 		},
@@ -106,8 +109,10 @@ func TestAccAlicloudCenInstanceAttachment_multi_different_regions(t *testing.T) 
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckCenInstanceAttachmentExistsWithProviders("alicloud_cen_instance_attachment.bar1", &instance, &providers),
 					resource.TestCheckResourceAttr("alicloud_cen_instance_attachment.bar1", "child_instance_region_id", "eu-central-1"),
+					resource.TestCheckResourceAttrSet("alicloud_cen_instance_attachment.bar1", "child_instance_owner_id"),
 					testAccCheckCenInstanceAttachmentExistsWithProviders("alicloud_cen_instance_attachment.bar2", &instance, &providers),
 					resource.TestCheckResourceAttr("alicloud_cen_instance_attachment.bar2", "child_instance_region_id", "cn-shanghai"),
+					resource.TestCheckResourceAttrSet("alicloud_cen_instance_attachment.bar2", "child_instance_owner_id"),
 				),
 			},
 		},

--- a/alicloud/resource_alicloud_cen_instance_grant_test.go
+++ b/alicloud/resource_alicloud_cen_instance_grant_test.go
@@ -36,7 +36,7 @@ func TestAccAlicloudCenInstanceGrant_basic(t *testing.T) {
 		CheckDestroy:      testAccCheckCenInstanceGrantDestroyWithProviders(&providers),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccCenInstanceGrantBasic(os.Getenv("ALICLOUD_ACCESS_KEY_2"), os.Getenv("ALICLOUD_SECRET_KEY_2"), os.Getenv("ALICLOUD_ACCOUNT_ID_2")),
+				Config: testAccCenInstanceGrantBasic(os.Getenv("ALICLOUD_ACCESS_KEY_2"), os.Getenv("ALICLOUD_SECRET_KEY_2"), os.Getenv("ALICLOUD_ACCOUNT_ID_1"), os.Getenv("ALICLOUD_ACCOUNT_ID_2")),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckCenInstanceGrantExistsWithProviders("alicloud_cen_instance_grant.foo", &rule, &providers),
 					resource.TestCheckResourceAttr("alicloud_cen_instance_grant.foo", "cen_owner_id", os.Getenv("ALICLOUD_ACCOUNT_ID_2")),
@@ -130,7 +130,7 @@ func testAccCheckCenInstanceGrantDestroyWithProvider(s *terraform.State, provide
 	return nil
 }
 
-func testAccCenInstanceGrantBasic(access, secret, uid string) string {
+func testAccCenInstanceGrantBasic(access, secret, uid1, uid2 string) string {
 	return fmt.Sprintf(`
 	provider "alicloud" {
 		alias = "account1"
@@ -163,5 +163,15 @@ func testAccCenInstanceGrantBasic(access, secret, uid string) string {
 		child_instance_id = "${alicloud_vpc.vpc.id}"
 		cen_owner_id = "%s"
 	}
-	`, access, secret, uid)
+
+    resource "alicloud_cen_instance_attachment" "foo" {
+        provider = "alicloud.account2"
+        instance_id = "${alicloud_cen_instance.cen.id}"
+        child_instance_id = "${alicloud_vpc.vpc.id}"
+        child_instance_region_id = "cn-qingdao"
+        child_instance_owner_id = "%s"
+        depends_on = [
+            "alicloud_cen_instance_grant.foo"]
+    }
+	`, access, secret, uid2, uid1)
 }

--- a/website/docs/r/cen_instance_attachment.html.markdown
+++ b/website/docs/r/cen_instance_attachment.html.markdown
@@ -43,6 +43,7 @@ The following arguments are supported:
 * `instance_id` - (Required, ForceNew) The ID of the CEN.
 * `child_instance_id` - (Required, ForceNew) The ID of the child instance to attach.
 * `child_instance_region_id` - (Required, ForceNew) The region ID of the child instance to attach.
+* `child_instance_owner_id` - (Optional, Available in 1.42.0+) The uid of the child instance. Only used when attach a child instance of other account.
 
 ->**NOTE:** Ensure that the child instance is not used in Express Connect.
 

--- a/website/docs/r/cen_instance_grant.html.markdown
+++ b/website/docs/r/cen_instance_grant.html.markdown
@@ -17,7 +17,7 @@ For more information about how to use it, see [Attach a network in a different a
 Basic Usage
 
 ```
-# Create a new instance-grant and use it to grant one child instance of account1 to a new CEN of account 2
+# Create a new instance-grant and use it to grant one child instance of account1 to a new CEN of account 2.
 	provider "alicloud" {
 		access_key = "access123"
 		secret_key = "secret123"
@@ -49,8 +49,18 @@ Basic Usage
 		provider = "alicloud.account1"
 		cen_id = "${alicloud_cen_instance.cen.id}"
 		child_instance_id = "${alicloud_vpc.vpc.id}"
-		cen_owner_id = "%s"
+		cen_owner_id = "uid2"
 	}
+	
+  resource "alicloud_cen_instance_attachment" "foo" {
+  	provider = "alicloud.account2"
+  	instance_id = "${alicloud_cen_instance.cen.id}"
+  	child_instance_id = "${alicloud_vpc.vpc.id}"
+  	child_instance_region_id = "cn-qingdao"
+  	child_instance_owner_id = "uid1"
+  	depends_on = [
+  		"alicloud_cen_instance_grant.foo"]
+  }
 ```
 ## Argument Reference
 


### PR DESCRIPTION
$TF_ACC=1 go test ./alicloud -v -run=TestAccAlicloudCenInstanceAttachment
=== RUN   TestAccAlicloudCenInstanceAttachment_importBasic
--- PASS: TestAccAlicloudCenInstanceAttachment_importBasic (39.94s)
=== RUN   TestAccAlicloudCenInstanceAttachment_basic
--- PASS: TestAccAlicloudCenInstanceAttachment_basic (39.11s)
=== RUN   TestAccAlicloudCenInstanceAttachment_multi_same_regions
--- PASS: TestAccAlicloudCenInstanceAttachment_multi_same_regions (42.61s)
=== RUN   TestAccAlicloudCenInstanceAttachment_multi_different_regions
--- PASS: TestAccAlicloudCenInstanceAttachment_multi_different_regions (75.32s)
PASS
ok      github.com/terraform-providers/terraform-provider-alicloud/alicloud     197.037s

$TF_ACC=1 go test ./alicloud -v -run=TestAccAlicloudCenInstanceGrant
=== RUN   TestAccAlicloudCenInstanceGrant_basic
--- PASS: TestAccAlicloudCenInstanceGrant_basic (41.46s)
PASS
ok      github.com/terraform-providers/terraform-provider-alicloud/alicloud     41.522s