### PR TITLE
change ecs instance instance_charge_type modifying position

### DIFF
--- a/alicloud/resource_alicloud_cs_swarm_test.go
+++ b/alicloud/resource_alicloud_cs_swarm_test.go
@@ -48,6 +48,10 @@ func testSweepCSSwarms(region string) error {
 	for _, v := range clusters {
 		name := v.Name
 		id := v.ClusterID
+		if string(v.RegionID) != region {
+			log.Printf("The current cluster is in the region %s. Skipped.", string(v.RegionID))
+			continue
+		}
 		skip := true
 		for _, prefix := range prefixes {
 			if strings.HasPrefix(strings.ToLower(name), strings.ToLower(prefix)) {

--- a/alicloud/resource_alicloud_instance_test.go
+++ b/alicloud/resource_alicloud_instance_test.go
@@ -1973,10 +1973,16 @@ func testAccCheckInstanceType(common string) string {
 		default = "tf-testAccCheckInstanceType"
 	}
 	data "alicloud_instance_types" "new" {
-		availability_zone = "${data.alicloud_zones.default.zones.0.id}"
+		availability_zone = "${alicloud_vswitch.new.availability_zone}"
 		cpu_core_count = 1
 		memory_size = 0.5
 		instance_type_family = "ecs.t5"
+	}
+	resource "alicloud_vswitch" "new" {
+	  vpc_id            = "${alicloud_vpc.default.id}"
+	  cidr_block        = "172.16.1.0/24"
+	  availability_zone = "${lookup(data.alicloud_zones.default.zones[(length(data.alicloud_zones.default.zones)-1)%%length(data.alicloud_zones.default.zones)], "id")}"
+	  name              = "${var.name}"
 	}
 	resource "alicloud_instance" "type" {
 		image_id = "${data.alicloud_images.default.images.0.id}"
@@ -1985,7 +1991,7 @@ func testAccCheckInstanceType(common string) string {
 		instance_type = "${data.alicloud_instance_types.new.instance_types.0.id}"
 		instance_name = "${var.name}"
 		security_groups = ["${alicloud_security_group.default.id}"]
-		vswitch_id = "${alicloud_vswitch.default.id}"
+		vswitch_id = "${alicloud_vswitch.new.id}"
 	}
 	`, common)
 }
@@ -1997,12 +2003,17 @@ func testAccCheckInstanceTypeUpdate(common string) string {
 		default = "tf-testAccCheckInstanceType"
 	}
 	data "alicloud_instance_types" "new" {
-		availability_zone = "${data.alicloud_zones.default.zones.0.id}"
+		availability_zone = "${alicloud_vswitch.new.availability_zone}"
 		cpu_core_count = 1
 		memory_size = 1
 		instance_type_family = "ecs.t5"
 	}
-
+	resource "alicloud_vswitch" "new" {
+	  vpc_id            = "${alicloud_vpc.default.id}"
+	  cidr_block        = "172.16.1.0/24"
+	  availability_zone = "${lookup(data.alicloud_zones.default.zones[(length(data.alicloud_zones.default.zones)-1)%%length(data.alicloud_zones.default.zones)], "id")}"
+	  name              = "${var.name}"
+	}
 	resource "alicloud_instance" "type" {
 		image_id = "${data.alicloud_images.default.images.0.id}"
 		system_disk_category = "cloud_efficiency"
@@ -2010,7 +2021,7 @@ func testAccCheckInstanceTypeUpdate(common string) string {
 		instance_type = "${data.alicloud_instance_types.new.instance_types.0.id}"
 		instance_name = "${var.name}"
 		security_groups = ["${alicloud_security_group.default.id}"]
-		vswitch_id = "${alicloud_vswitch.default.id}"
+		vswitch_id = "${alicloud_vswitch.new.id}"
 	}
 	`, common)
 }
@@ -2022,10 +2033,16 @@ func testAccCheckInstanceTypePrepaid(common string) string {
 		default = "tf-testAccCheckInstanceType"
 	}
 	data "alicloud_instance_types" "new" {
-		availability_zone = "${data.alicloud_zones.default.zones.0.id}"
+		availability_zone = "${alicloud_vswitch.new.availability_zone}"
 		cpu_core_count = 1
 		memory_size = 2
 		instance_type_family = "ecs.t5"
+	}
+	resource "alicloud_vswitch" "new" {
+	  vpc_id            = "${alicloud_vpc.default.id}"
+	  cidr_block        = "172.16.1.0/24"
+	  availability_zone = "${lookup(data.alicloud_zones.default.zones[(length(data.alicloud_zones.default.zones)-1)%%length(data.alicloud_zones.default.zones)], "id")}"
+	  name              = "${var.name}"
 	}
 	resource "alicloud_instance" "type" {
 		image_id = "${data.alicloud_images.default.images.0.id}"
@@ -2036,7 +2053,7 @@ func testAccCheckInstanceTypePrepaid(common string) string {
 		instance_charge_type = "PrePaid"
 		force_delete = true
 		security_groups = ["${alicloud_security_group.default.id}"]
-		vswitch_id = "${alicloud_vswitch.default.id}"
+		vswitch_id = "${alicloud_vswitch.new.id}"
 	}
 	`, common)
 }
@@ -2048,12 +2065,17 @@ func testAccCheckInstanceTypePrepaidUpdate(common string) string {
 		default = "tf-testAccCheckInstanceType"
 	}
 	data "alicloud_instance_types" "new" {
-		availability_zone = "${data.alicloud_zones.default.zones.0.id}"
+		availability_zone = "${alicloud_vswitch.new.availability_zone}"
 		cpu_core_count = 2
 		memory_size = 4
 		instance_type_family = "ecs.t5"
 	}
-
+	resource "alicloud_vswitch" "new" {
+	  vpc_id            = "${alicloud_vpc.default.id}"
+	  cidr_block        = "172.16.1.0/24"
+	  availability_zone = "${lookup(data.alicloud_zones.default.zones[(length(data.alicloud_zones.default.zones)-1)%%length(data.alicloud_zones.default.zones)], "id")}"
+	  name              = "${var.name}"
+	}
 	resource "alicloud_instance" "type" {
 		image_id = "${data.alicloud_images.default.images.0.id}"
 		system_disk_category = "cloud_efficiency"
@@ -2063,7 +2085,7 @@ func testAccCheckInstanceTypePrepaidUpdate(common string) string {
 		instance_charge_type = "PrePaid"
 		force_delete = true
 		security_groups = ["${alicloud_security_group.default.id}"]
-		vswitch_id = "${alicloud_vswitch.default.id}"
+		vswitch_id = "${alicloud_vswitch.new.id}"
 	}
 	`, common)
 }

--- a/alicloud/resource_alicloud_ots_table.go
+++ b/alicloud/resource_alicloud_ots_table.go
@@ -5,11 +5,12 @@ import (
 	"strings"
 	"time"
 
+	"strconv"
+
 	"github.com/aliyun/aliyun-tablestore-go-sdk/tablestore"
 	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/helper/schema"
 	"github.com/terraform-providers/terraform-provider-alicloud/alicloud/connectivity"
-	"strconv"
 )
 
 func resourceAlicloudOtsTable() *schema.Resource {


### PR DESCRIPTION
```
TF_ACC=1 go test ./alicloud -v -run=TestAccAlicloudInstance -timeout=240m
=== RUN   TestAccAlicloudInstanceTypesDataSource_basic
--- PASS: TestAccAlicloudInstanceTypesDataSource_basic (3.37s)
=== RUN   TestAccAlicloudInstanceTypesDataSource_gpu
--- PASS: TestAccAlicloudInstanceTypesDataSource_gpu (4.12s)
=== RUN   TestAccAlicloudInstanceTypesDataSource_empty
--- PASS: TestAccAlicloudInstanceTypesDataSource_empty (1.34s)
=== RUN   TestAccAlicloudInstanceTypesDataSource_k8sSpec
--- PASS: TestAccAlicloudInstanceTypesDataSource_k8sSpec (3.51s)
=== RUN   TestAccAlicloudInstanceTypesDataSource_k8sFamily
--- PASS: TestAccAlicloudInstanceTypesDataSource_k8sFamily (1.35s)
=== RUN   TestAccAlicloudInstancesDataSourceBasic
--- PASS: TestAccAlicloudInstancesDataSourceBasic (251.37s)
=== RUN   TestAccAlicloudInstance_import
--- PASS: TestAccAlicloudInstance_import (137.99s)
=== RUN   TestAccAlicloudInstance_basic
--- PASS: TestAccAlicloudInstance_basic (104.23s)
=== RUN   TestAccAlicloudInstance_vpc
--- PASS: TestAccAlicloudInstance_vpc (155.10s)
=== RUN   TestAccAlicloudInstance_userData
--- PASS: TestAccAlicloudInstance_userData (138.83s)
=== RUN   TestAccAlicloudInstance_multipleRegions
--- PASS: TestAccAlicloudInstance_multipleRegions (155.04s)
=== RUN   TestAccAlicloudInstance_multiSecurityGroup
--- PASS: TestAccAlicloudInstance_multiSecurityGroup (163.26s)
=== RUN   TestAccAlicloudInstance_multiSecurityGroupByCount
--- PASS: TestAccAlicloudInstance_multiSecurityGroupByCount (132.62s)
=== RUN   TestAccAlicloudInstance_NetworkInstanceSecurityGroups
--- PASS: TestAccAlicloudInstance_NetworkInstanceSecurityGroups (132.38s)
=== RUN   TestAccAlicloudInstance_tags
--- PASS: TestAccAlicloudInstance_tags (181.58s)
=== RUN   TestAccAlicloudInstance_update
--- PASS: TestAccAlicloudInstance_update (210.76s)
=== RUN   TestAccAlicloudInstanceImage_update
--- PASS: TestAccAlicloudInstanceImage_update (256.95s)
=== RUN   TestAccAlicloudInstance_associatePublicIP
--- PASS: TestAccAlicloudInstance_associatePublicIP (140.97s)
=== RUN   TestAccAlicloudInstancePrivateIp_update
--- PASS: TestAccAlicloudInstancePrivateIp_update (269.73s)
=== RUN   TestAccAlicloudInstanceSecurityEnhancementStrategy_update
--- PASS: TestAccAlicloudInstanceSecurityEnhancementStrategy_update (238.92s)
=== RUN   TestAccAlicloudInstanceChargeType_post2Pre
--- PASS: TestAccAlicloudInstanceChargeType_post2Pre (469.27s)
=== RUN   TestAccAlicloudInstanceChargeType_pre2Post
--- PASS: TestAccAlicloudInstanceChargeType_pre2Post (465.56s)
=== RUN   TestAccAlicloudInstance_spot
--- PASS: TestAccAlicloudInstance_spot (163.55s)
=== RUN   TestAccAlicloudInstanceType_update
--- PASS: TestAccAlicloudInstanceType_update (1433.51s)
```