### PR TITLE
Add support for assume_role in provider block

### DIFF
--- a/alicloud/connectivity/config.go
+++ b/alicloud/connectivity/config.go
@@ -2,6 +2,7 @@ package connectivity
 
 import (
 	"fmt"
+	"log"
 
 	"encoding/json"
 	"net/http"
@@ -26,6 +27,11 @@ type Config struct {
 	SecurityToken   string
 	OtsInstanceName string
 	AccountId       string
+
+	RamRoleArn               string
+	RamRoleSessionName       string
+	RamRolePolicy            string
+	RamRoleSessionExpiration int
 
 	EcsEndpoint           string
 	RdsEndpoint           string
@@ -82,10 +88,15 @@ func (c *Config) validateRegion() error {
 
 func (c *Config) getAuthCredential(stsSupported bool) auth.Credential {
 	if c.AccessKey != "" && c.SecretKey != "" {
+		if c.RamRoleArn != "" {
+			log.Printf("[INFO] Assume RAM Role specified in provider block assume_role { ... }")
+			return credentials.NewRamRoleArnWithPolicyCredential(
+				c.AccessKey, c.SecretKey, c.RamRoleArn,
+				c.RamRoleSessionName, c.RamRolePolicy, c.RamRoleSessionExpiration)
+		}
 		if stsSupported {
 			return credentials.NewStsTokenCredential(c.AccessKey, c.SecretKey, c.SecurityToken)
 		}
-
 		return credentials.NewAccessKeyCredential(c.AccessKey, c.SecretKey)
 	}
 	if c.EcsRoleName != "" {

--- a/alicloud/resource_alicloud_ram_account_password_policy.go
+++ b/alicloud/resource_alicloud_ram_account_password_policy.go
@@ -1,8 +1,6 @@
 package alicloud
 
 import (
-	"fmt"
-
 	"github.com/aliyun/alibaba-cloud-sdk-go/sdk/requests"
 	"github.com/aliyun/alibaba-cloud-sdk-go/services/ram"
 	"github.com/hashicorp/terraform/helper/schema"
@@ -156,26 +154,4 @@ func resourceAlicloudRamAccountPasswordPolicyDelete(d *schema.ResourceData, meta
 	}
 	addDebug(request.GetActionName(), raw)
 	return nil
-}
-
-// below copy/pasta from https://github.com/hashicorp/terraform/blob/master/helper/validation/validation.go
-// alicloud vendor contains very old version of Terraform which lacks this functions
-
-// IntBetween returns a SchemaValidateFunc which tests if the provided value
-// is of type int and is between min and max (inclusive)
-func intBetween(min, max int) schema.SchemaValidateFunc {
-	return func(i interface{}, k string) (s []string, es []error) {
-		v, ok := i.(int)
-		if !ok {
-			es = append(es, fmt.Errorf("expected type of %s to be int", k))
-			return
-		}
-
-		if v < min || v > max {
-			es = append(es, fmt.Errorf("expected %s to be in the range (%d - %d), got %d", k, min, max, v))
-			return
-		}
-
-		return
-	}
 }

--- a/alicloud/validators.go
+++ b/alicloud/validators.go
@@ -1580,3 +1580,46 @@ func validateActiontrailEventrw(v interface{}, k string) (ws []string, errors []
 	}
 	return
 }
+
+// below copy/pasta from https://github.com/hashicorp/terraform/blob/master/helper/validation/validation.go
+// alicloud vendor contains very old version of Terraform which lacks this functions
+
+// IntBetween returns a SchemaValidateFunc which tests if the provided value
+// is of type int and is between min and max (inclusive)
+func intBetween(min, max int) schema.SchemaValidateFunc {
+	return func(i interface{}, k string) (s []string, es []error) {
+		v, ok := i.(int)
+		if !ok {
+			es = append(es, fmt.Errorf("expected type of %s to be int", k))
+			return
+		}
+
+		if v < min || v > max {
+			es = append(es, fmt.Errorf("expected %s to be in the range (%d - %d), got %d", k, min, max, v))
+			return
+		}
+
+		return
+	}
+}
+
+// StringMatch returns a SchemaValidateFunc which tests if the provided value
+// matches a given regexp. Optionally an error message can be provided to
+// return something friendlier than "must match some globby regexp".
+func stringMatch(r *regexp.Regexp, message string) schema.SchemaValidateFunc {
+	return func(i interface{}, k string) ([]string, []error) {
+		v, ok := i.(string)
+		if !ok {
+			return nil, []error{fmt.Errorf("expected type of %s to be string", k)}
+		}
+
+		if ok := r.MatchString(v); !ok {
+			if message != "" {
+				return nil, []error{fmt.Errorf("invalid value for %s (%s)", k, message)}
+
+			}
+			return nil, []error{fmt.Errorf("expected value of %s to match regular expression %q", k, r)}
+		}
+		return nil, nil
+	}
+}

--- a/website/docs/index.html.markdown
+++ b/website/docs/index.html.markdown
@@ -127,6 +127,24 @@ provider "alicloud" {
 
 -> **NOTE:** At present, the [MNS Resources](https://www.terraform.io/docs/providers/alicloud/r/mns_queue.html) does not support ECS Role Credential.
 
+### Assume role
+
+If provided with a role ARN, Terraform will attempt to assume this role using the supplied credentials.
+
+Usage:
+
+```hcl
+provider "alicloud" {
+  assume_role {
+    role_arn           = "acs:ram::ACCOUNT_ID:role/ROLE_NAME"
+    policy             = "POLICY"
+    session_name       = "SESSION_NAME"
+    session_expiration = 999
+  }
+}
+```
+
+
 ## Argument Reference
 
 In addition to [generic `provider` arguments](https://www.terraform.io/docs/configuration/providers.html)
@@ -154,7 +172,21 @@ In addition to [generic `provider` arguments](https://www.terraform.io/docs/conf
   If not provided, the provider will attempt to retrieve it automatically with [STS GetCallerIdentity](https://www.alibabacloud.com/help/doc-detail/43767.htm).
   It can be sourced from the `ALICLOUD_ACCOUNT_ID` environment variable.
 
+* `assume_role` - (Optional) An `assume_role` block (documented below). Only one `assume_role` block may be in the configuration.
+
 * `endpoints` - (Optional) An `endpoints` block (documented below) to support custom endpoints.
+
+The nested `assume_role` block supports the following:
+
+* `role_arn` - (Required) The ARN of the role to assume. If ARN is set to an empty string, it does not perform role switching.
+  Terraform executes configuration on account with provided credentials.
+
+* `policy` - (Optional) A more restrictive policy to apply to the temporary credentials. This gives you a way to further restrict the permissions for the resulting temporary
+  security credentials. You cannot use the passed policy to grant permissions that are in excess of those allowed by the access policy of the role that is being assumed.
+
+* `session_name` - (Optional) The session name to use when assuming the role. If omitted, 'terraform' is passed to the AssumeRole call as session name.
+
+* `session_expiration` - (Optional) The time after which the established session for assuming role expires. Valid value range: [900-3600] seconds. Default to 0 (in this case Alicloud use own default value).
 
 Nested `endpoints` block supports the following:
 


### PR DESCRIPTION
This PR resolves issue #1068 
It adds `assume_role` inside provider block:
```hcl
provider "alicloud" {
    assume_role {
        role_arn = "acs:ram::ACCOUNT_ID:role/ROLE_NAME"
    }
}
```
If provided with a role ARN, Terraform will attempt to assume this role using the supplied credentials.