### PR TITLE
修复scalingConfiguration传入base64的user_data时，和describe返回的信息不一致

### DIFF
--- a/alicloud/resource_alicloud_ess_scalingconfiguration.go
+++ b/alicloud/resource_alicloud_ess_scalingconfiguration.go
@@ -511,7 +511,6 @@ func resourceAliyunEssScalingConfigurationRead(d *schema.ResourceData, meta inte
 	d.Set("data_disk", essService.flattenDataDiskMappings(c.DataDisks.DataDisk))
 	d.Set("role_name", c.RamRoleName)
 	d.Set("key_name", c.KeyPairName)
-	d.Set("user_data", userDataHashSum(c.UserData))
 	d.Set("force_delete", d.Get("force_delete").(bool))
 	d.Set("tags", essTagsToMap(c.Tags.Tag))
 	d.Set("instance_name", c.InstanceName)
@@ -527,6 +526,17 @@ func resourceAliyunEssScalingConfigurationRead(d *schema.ResourceData, meta inte
 	}
 	if instanceTypes, ok := d.GetOk("instance_types"); ok && len(instanceTypes.([]interface{})) > 0 {
 		d.Set("instance_types", c.InstanceTypes.InstanceType)
+	}
+	userData := d.Get("user_data")
+	if userData.(string) != "" {
+		_, base64DecodeError := base64.StdEncoding.DecodeString(userData.(string))
+		if base64DecodeError == nil {
+			d.Set("user_data", c.UserData)
+		} else {
+			d.Set("user_data", userDataHashSum(c.UserData))
+		}
+	} else {
+		d.Set("user_data", userDataHashSum(c.UserData))
 	}
 	return nil
 }


### PR DESCRIPTION
=== RUN   TestAccAlicloudEssScalingConfiguration_basic
--- PASS: TestAccAlicloudEssScalingConfiguration_basic (82.71s)
=== RUN   TestAccAlicloudEssScalingConfiguration_SystemDisk
--- PASS: TestAccAlicloudEssScalingConfiguration_SystemDisk (75.33s)
=== RUN   TestAccAlicloudEssScalingConfiguration_multiConfig
--- PASS: TestAccAlicloudEssScalingConfiguration_multiConfig (86.38s)
=== RUN   TestAccAlicloudEssScalingConfiguration_active
--- PASS: TestAccAlicloudEssScalingConfiguration_active (77.38s)
=== RUN   TestAccAlicloudEssScalingConfiguration_disable
--- PASS: TestAccAlicloudEssScalingConfiguration_disable (74.96s)
=== RUN   TestAccAlicloudEssScalingConfiguration_modify
--- PASS: TestAccAlicloudEssScalingConfiguration_modify (127.61s)
=== RUN   TestAccAlicloudEssScalingConfiguration_multi_sgs
--- PASS: TestAccAlicloudEssScalingConfiguration_multi_sgs (77.85s)
=== RUN   TestAccAlicloudEssScalingConfiguration_modify_single_2_multi_sg
--- PASS: TestAccAlicloudEssScalingConfiguration_modify_single_2_multi_sg (104.97s)
=== RUN   TestAccAlicloudEssScalingConfiguration_multi_instance_types
--- PASS: TestAccAlicloudEssScalingConfiguration_multi_instance_types (74.47s)
=== RUN   TestAccAlicloudEssScalingConfiguration_modify_single_2_multi_instance_types
--- PASS: TestAccAlicloudEssScalingConfiguration_modify_single_2_multi_instance_types (100.41s)
=== RUN   TestAccAlicloudEssScalingConfiguration_user_data
--- PASS: TestAccAlicloudEssScalingConfiguration_user_data ( 994.298s)
PASS
ok      github.com/terraform-providers/terraform-provider-alicloud/alicloud     102.409s

