### PR TITLE
temp fix no value returned by cs openapi

### DIFF
--- a/alicloud/diff_suppress_funcs.go
+++ b/alicloud/diff_suppress_funcs.go
@@ -203,6 +203,26 @@ func csKubernetesWorkerPostPaidDiffSuppressFunc(k, old, new string, d *schema.Re
 	return common.InstanceChargeType(d.Get("worker_instance_charge_type").(string)) == common.PostPaid
 }
 
+func csManagedKubernetesVswitchIdsSuppressFunc(k, old, new string, d *schema.ResourceData) bool {
+	if k == "vswitch_ids.0" {
+		// return from server is empty, failure due to OpenAPI
+		if old == "" {
+			return true
+		}
+	}
+	return false
+}
+
+func csManagedKubernetesWorkerInstanceTypesSuppressFunc(k, old, new string, d *schema.ResourceData) bool {
+	if k == "worker_instance_types.0" {
+		// return from server is empty, failure due to OpenAPI
+		if old == "" {
+			return true
+		}
+	}
+	return false
+}
+
 func zoneIdDiffSuppressFunc(k, old, new string, d *schema.ResourceData) bool {
 	if vsw, ok := d.GetOk("vswitch_id"); ok && vsw.(string) != "" {
 		return true

--- a/alicloud/resource_alicloud_cs_managed_kubernetes.go
+++ b/alicloud/resource_alicloud_cs_managed_kubernetes.go
@@ -60,7 +60,9 @@ func resourceAlicloudCSManagedKubernetes() *schema.Resource {
 					Type:         schema.TypeString,
 					ValidateFunc: validateContainerVswitchId,
 				},
-				MaxItems: 1,
+				MinItems:         1,
+				MaxItems:         5,
+				DiffSuppressFunc: csManagedKubernetesVswitchIdsSuppressFunc,
 			},
 			"new_nat_gateway": {
 				Type:     schema.TypeBool,
@@ -74,8 +76,9 @@ func resourceAlicloudCSManagedKubernetes() *schema.Resource {
 				Elem: &schema.Schema{
 					Type: schema.TypeString,
 				},
-				MinItems: 1,
-				MaxItems: 1,
+				MinItems:         1,
+				MaxItems:         5,
+				DiffSuppressFunc: csManagedKubernetesWorkerInstanceTypesSuppressFunc,
 			},
 			"worker_numbers": {
 				Type:     schema.TypeList,


### PR DESCRIPTION
This PR will fix the issue addressed in #1281 .

OpenAPI has changed two fields in newly-created managed kubernetes cluster's describe API
* VSwitchID -> WorkerVSwitchIds
* WorkerInstanceType -> WorkerInstanceTypes

Now the terraform plugin is unable to fetch a correct VSwitchID and WorkerInstanceType for newly-created managed kubernetes clusters. The container service team is now working on the new field to replace, for now, we suppress the diff if OpenAPI return empty values for these two fields.

Workaround before this pr is released:
* comment out `worker_instance_types` and `vswitch_ids` in users' terraform template.
* take care when applying any existing cluster's template.


##### Before
```bash
xh4n3@xh4n3:~/ops/terraform-managed% terraform apply
alicloud_cs_managed_kubernetes.k8s: Refreshing state... (ID: xxxx)

An execution plan has been generated and is shown below.
Resource actions are indicated with the following symbols:
-/+ destroy and then create replacement

Terraform will perform the following actions:

-/+ alicloud_cs_managed_kubernetes.k8s (new resource required)
      id:                          "xxxx" => <computed> (forces new resource)
      availability_zone:           "cn-shanghai-e" => "cn-shanghai-e"
      install_cloud_monitor:       "true" => "true"
      name:                        "test-managed-kubernetes" => "test-managed-kubernetes"
      name_prefix:                 "Terraform-Creation" => "Terraform-Creation"
      new_nat_gateway:             "true" => "true"
      password:                    <sensitive> => <sensitive> (attribute changed)
      pod_cidr:                    "172.20.0.0/16" => "172.20.0.0/16"
      security_group_id:           "sg-xxxx" => <computed>
      service_cidr:                "172.21.0.0/20" => "172.21.0.0/20"
      slb_internet_enabled:        "true" => "true"
      vpc_id:                      "vpc-xxxx" => <computed>
      vswitch_ids.#:               "1" => <computed>
      worker_disk_category:        "cloud_efficiency" => "cloud_efficiency"
      worker_disk_size:            "40" => "40"
      worker_instance_charge_type: "PostPaid" => "PostPaid"
      worker_instance_types.#:     "1" => "1"
      worker_instance_types.0:     "" => "ecs.c5.xlarge" (forces new resource)
      worker_nodes.#:              "2" => <computed>
      worker_numbers.#:            "1" => "1"
      worker_numbers.0:            "2" => "2"


Plan: 1 to add, 0 to change, 1 to destroy.

Do you want to perform these actions?
  Terraform will perform the actions described above.
  Only 'yes' will be accepted to approve.

  Enter a value:
```


##### After
``` bash
% terraform apply
alicloud_cs_managed_kubernetes.k8s: Refreshing state... (ID: xxxx)
Apply complete! Resources: 0 added, 0 changed, 0 destroyed.
```