### PR TITLE
bugfix: remove the 'ForceNew' attribute of 'vswitch_ids' from resourc…

### DIFF
--- a/alicloud/resource_alicloud_ess_scalinggroup.go
+++ b/alicloud/resource_alicloud_ess_scalinggroup.go
@@ -53,7 +53,6 @@ func resourceAlicloudEssScalingGroup() *schema.Resource {
 			"vswitch_ids": {
 				Type:     schema.TypeSet,
 				Optional: true,
-				ForceNew: true,
 				Elem:     &schema.Schema{Type: schema.TypeString},
 				MinItems: 1,
 			},
@@ -196,6 +195,11 @@ func resourceAliyunEssScalingGroupUpdate(d *schema.ResourceData, meta interface{
 
 	if d.HasChange("default_cooldown") {
 		request.DefaultCooldown = requests.NewInteger(d.Get("default_cooldown").(int))
+	}
+
+	if d.HasChange("vswitch_ids") {
+		vSwitchIds := expandStringList(d.Get("vswitch_ids").(*schema.Set).List())
+		request.VSwitchIds = &vSwitchIds
 	}
 
 	if d.HasChange("removal_policies") {

--- a/website/docs/r/ess_scaling_group.html.markdown
+++ b/website/docs/r/ess_scaling_group.html.markdown
@@ -92,7 +92,7 @@ The following arguments are supported:
 * `scaling_group_name` - (Optional) Name shown for the scaling group, which must contain 2-40 characters (English or Chinese). If this parameter is not specified, the default value is ScalingGroupId.
 * `default_cooldown` - (Optional) Default cool-down time (in seconds) of the scaling group. Value range: [0, 86400]. The default value is 300s.
 * `vswitch_id` - (Deprecated) It has been deprecated from version 1.7.1 and new field 'vswitch_ids' replaces it.
-* `vswitch_ids` - (Optional, ForceNew) List of virtual switch IDs in which the ecs instances to be launched.
+* `vswitch_ids` - (Optional) List of virtual switch IDs in which the ecs instances to be launched.
 * `removal_policies` - (Optional) RemovalPolicy is used to select the ECS instances you want to remove from the scaling group when multiple candidates for removal exist. Optional values:
     - OldestInstance: removes the first ECS instance attached to the scaling group.
     - NewestInstance: removes the first ECS instance attached to the scaling group.


### PR DESCRIPTION
TF_ACC=1 go test ./alicloud -v -run=TestAccAlicloudEssScalingGroup -timeout=300m 
=== RUN   TestAccAlicloudEssScalingGroup_importBasic
--- PASS: TestAccAlicloudEssScalingGroup_importBasic (38.63s)
=== RUN   TestAccAlicloudEssScalingGroup_basic
--- PASS: TestAccAlicloudEssScalingGroup_basic (66.13s)
=== RUN   TestAccAlicloudEssScalingGroup_vpc
--- PASS: TestAccAlicloudEssScalingGroup_vpc (77.53s)
=== RUN   TestAccAlicloudEssScalingGroup_slb
--- PASS: TestAccAlicloudEssScalingGroup_slb (104.04s)
=== RUN   TestAccAlicloudEssScalingGroup_modifyVsIds
--- PASS: TestAccAlicloudEssScalingGroup_modifyVsIds (37.92s)
PASS
ok      github.com/terraform-providers/terraform-provider-alicloud/alicloud     324.317s
