### PR TITLE
Remove govendor commands in CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,11 +12,9 @@ install:
 # packages that live there.
 # See: https://github.com/golang/go/issues/12933
 - bash scripts/gogetcookie.sh
-- go get github.com/kardianos/govendor
 
 script:
 - make test
-- make vendor-status
 - make vet
 - make website-test
 

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -34,9 +34,6 @@ fmtcheck:
 errcheck:
 	@sh -c "'$(CURDIR)/scripts/errcheck.sh'"
 
-vendor-status:
-	@govendor status
-
 test-compile:
 	@if [ "$(TEST)" = "./..." ]; then \
 		echo "ERROR: Set TEST to a specific package. For example,"; \
@@ -59,7 +56,7 @@ ifeq (,$(wildcard $(GOPATH)/src/$(WEBSITE_REPO)))
 endif
 	@$(MAKE) -C $(GOPATH)/src/$(WEBSITE_REPO) website-provider-test PROVIDER_PATH=$(shell pwd) PROVIDER_NAME=$(PKG_NAME)
 
-.PHONY: build test testacc vet fmt fmtcheck errcheck vendor-status test-compile website website-test
+.PHONY: build test testacc vet fmt fmtcheck errcheck test-compile website website-test
 
 all: mac windows linux
 


### PR DESCRIPTION
Since go module has been used, this PR is to propose to remove installing `govendor` packages and running `govendor status` command in CI.

Signed-off-by: imjoey <majunjiev@gmail.com>