### PR TITLE
fix(oss_bucket): fix oss bucket deleting timeout error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,8 @@ IMPROVEMENTS:
 
 BUG FIXES:
 
+- fix(oss_bucket): fix oss bucket deleting timeout error [GH-1399]
+- fix(route_entry):fix route_entry create bug [GH-1398]
 - fix(instance):fix testcase name too length bug [GH-1396]
 - fix(vswitch):fix vswitch describe method wrapErrorf bug [GH-1392]
 - fix(slb_rule): fix testcase bug [GH-1390]

--- a/alicloud/resource_alicloud_oss_bucket.go
+++ b/alicloud/resource_alicloud_oss_bucket.go
@@ -987,7 +987,7 @@ func resourceAlicloudOssBucketDelete(d *schema.ResourceData, meta interface{}) e
 		if err != nil {
 			if IsExceptedError(err, "BucketNotEmpty") {
 				if d.Get("force_destroy").(bool) {
-					raw, err := client.WithOssClient(func(ossClient *oss.Client) (interface{}, error) {
+					raw, er := client.WithOssClient(func(ossClient *oss.Client) (interface{}, error) {
 						bucket, _ := ossClient.Bucket(d.Get("bucket").(string))
 						lor, err := bucket.ListObjectVersions()
 						if err != nil {
@@ -1010,8 +1010,8 @@ func resourceAlicloudOssBucketDelete(d *schema.ResourceData, meta interface{}) e
 						}
 						return bucket.DeleteObjectVersions(objectsToDelete)
 					})
-					if err != nil {
-						return resource.NonRetryableError(err)
+					if er != nil {
+						return resource.NonRetryableError(er)
 					}
 					addDebug("DeleteObjectVersions", raw)
 					return resource.RetryableError(err)


### PR DESCRIPTION
```
TF_ACC=1 go test ./alicloud -v -run=TestAccAlicloudOss -timeout=240m
=== RUN   TestAccAlicloudOssBucketObjectsDataSource_basic
--- PASS: TestAccAlicloudOssBucketObjectsDataSource_basic (13.97s)
=== RUN   TestAccAlicloudOssBucketObjectsDataSource_versioning
--- SKIP: TestAccAlicloudOssBucketObjectsDataSource_versioning (0.00s)
    provider_test.go:90: Skipping unsupported region cn-beijing. Supported regions: [ap-south-1].
=== RUN   TestAccAlicloudOssBucketsDataSource_basic
--- PASS: TestAccAlicloudOssBucketsDataSource_basic (14.45s)
=== RUN   TestAccAlicloudOssBucketsDataSource_sserule
--- PASS: TestAccAlicloudOssBucketsDataSource_sserule (9.17s)
=== RUN   TestAccAlicloudOssBucketsDataSource_versioning
--- SKIP: TestAccAlicloudOssBucketsDataSource_versioning (0.00s)
    provider_test.go:90: Skipping unsupported region cn-beijing. Supported regions: [ap-south-1].
=== RUN   TestAccAlicloudOssBucketObject_basic
--- PASS: TestAccAlicloudOssBucketObject_basic (9.95s)
=== RUN   TestAccAlicloudOssBucketBasic
--- PASS: TestAccAlicloudOssBucketBasic (38.79s)
=== RUN   TestAccAlicloudOssBucketVersioning
--- SKIP: TestAccAlicloudOssBucketVersioning (0.00s)
    provider_test.go:90: Skipping unsupported region cn-beijing. Supported regions: [ap-south-1].
=== RUN   TestAccAlicloudOssBucketCheckSseRule
--- PASS: TestAccAlicloudOssBucketCheckSseRule (15.87s)
PASS
ok  	github.com/terraform-providers/terraform-provider-alicloud/alicloud	102.262s
```