### PR TITLE
improve(rds): db_instance resource supports timeouts setting.

### DIFF
--- a/website/docs/r/db_instance.html.markdown
+++ b/website/docs/r/db_instance.html.markdown
@@ -139,6 +139,16 @@ The following attributes are exported:
 * `port` - RDS database connection port.
 * `connection_string` - RDS database connection string.
 
+### Timeouts
+
+-> **NOTE:** Available in 1.53.0+.
+
+The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/docs/configuration-0-11/resources.html#timeouts) for certain actions:
+
+* `create` - (Defaults to 20 mins) Used when creating the db instance (until it reaches the initial `Running` status). 
+* `update` - (Defaults to 20 mins) Used when updating the db instance (until it reaches the initial `Running` status). 
+* `delete` - (Defaults to 20 mins) Used when terminating the db instance. 
+
 ## Import
 
 RDS instance can be imported using the id, e.g.


### PR DESCRIPTION
tf文件设置一秒时，超时
![image](https://user-images.githubusercontent.com/28719851/60961530-fbd74600-a33e-11e9-9f61-0a34bcc216e7.png)


tf文件设置正常时间，或者不设置，apply成功