### PR TITLE
docs(format): Convert inline HCL configs to canonical format.

### DIFF
--- a/website/docs/d/account.html.markdown
+++ b/website/docs/d/account.html.markdown
@@ -13,7 +13,7 @@ This data source provides information about the current account.
 ## Example Usage
 
 ```
-data "alicloud_account" "current"{
+data "alicloud_account" "current" {
 }
 
 output "current_account_id" {

--- a/website/docs/d/actiontrails.html.markdown
+++ b/website/docs/d/actiontrails.html.markdown
@@ -13,8 +13,8 @@ This data source provides a list of action trail of the current Alibaba Cloud us
 ## Example Usage
 
 ```
-data "alicloud_actiontrails" "trails"{
-   name_regex = "tf-testacc-actiontrail"
+data "alicloud_actiontrails" "trails" {
+  name_regex = "tf-testacc-actiontrail"
 }
 
 output "first_trail_name" {

--- a/website/docs/d/api_gateway_apps.html.markdown
+++ b/website/docs/d/api_gateway_apps.html.markdown
@@ -13,7 +13,7 @@ This data source provides the apps of the current Alibaba Cloud user.
 ## Example Usage
 
 ```
-data "alicloud_api_gateway_apps" "data_apigatway"{
+data "alicloud_api_gateway_apps" "data_apigatway" {
   output_file = "outapps"
 }
 

--- a/website/docs/d/api_gateway_groups.html.markdown
+++ b/website/docs/d/api_gateway_groups.html.markdown
@@ -13,7 +13,7 @@ This data source provides the api groups of the current Alibaba Cloud user.
 ## Example Usage
 
 ```
-data "alicloud_api_gateway_groups" "data_apigatway"{
+data "alicloud_api_gateway_groups" "data_apigatway" {
   output_file = "outgroups"
 }
 

--- a/website/docs/d/cas_certificates.html.markdown
+++ b/website/docs/d/cas_certificates.html.markdown
@@ -14,7 +14,7 @@ This data source provides a list of CAS Certificates in an Alibaba Cloud account
 
 ```
 data "alicloud_cas_certificates" "certs" {
-  name_regex = "^cas"
+  name_regex  = "^cas"
   output_file = "${path.module}/cas_certificates.json"
 }
 

--- a/website/docs/d/cen_bandwidth_limits.html.markdown
+++ b/website/docs/d/cen_bandwidth_limits.html.markdown
@@ -13,8 +13,8 @@ This data source provides CEN Bandwidth Limits available to the user.
 ## Example Usage
 
 ```
-data "alicloud_cen_bandwidth_limits" "bwl"{
-	instance_ids = ["cen-id1"]
+data "alicloud_cen_bandwidth_limits" "bwl" {
+  instance_ids = ["cen-id1"]
 }
 
 output "first_cen_bandwidth_limits_local_region_id" {

--- a/website/docs/d/cen_bandwidth_packages.html.markdown
+++ b/website/docs/d/cen_bandwidth_packages.html.markdown
@@ -14,8 +14,8 @@ This data source provides CEN Bandwidth Packages available to the user.
 
 ```
 data "alicloud_cen_bandwidth_packages" "bwp" {
-	instance_id = "cen-id1"
-	name_regex="^foo"
+  instance_id = "cen-id1"
+  name_regex  = "^foo"
 }
 
 output "first_cen_bandwidth_package_id" {

--- a/website/docs/d/cen_instances.html.markdown
+++ b/website/docs/d/cen_instances.html.markdown
@@ -13,8 +13,8 @@ This data source provides CEN instances available to the user.
 ## Example Usage
 
 ```
-data "alicloud_cen_instances" "cen_instances_ds"{
-  ids = ["cen-id1"]
+data "alicloud_cen_instances" "cen_instances_ds" {
+  ids        = ["cen-id1"]
   name_regex = "^foo"
 }
 

--- a/website/docs/d/cen_region_route_entries.html.markdown
+++ b/website/docs/d/cen_region_route_entries.html.markdown
@@ -13,9 +13,9 @@ This data source provides CEN Regional Route Entries available to the user.
 ## Example Usage
 
 ```
-data "alicloud_cen_region_route_entries" "entry"{
-	instance_id = "cen-id1"
-	region_id = "cn-beijing"
+data "alicloud_cen_region_route_entries" "entry" {
+  instance_id = "cen-id1"
+  region_id   = "cn-beijing"
 }
 
 output "first_region_route_entries_route_entry_cidr_block" {

--- a/website/docs/d/cen_route_entries.html.markdown
+++ b/website/docs/d/cen_route_entries.html.markdown
@@ -13,9 +13,9 @@ This data source provides CEN Route Entries available to the user.
 ## Example Usage
 
 ```
-data "alicloud_cen_route_entries" "entry"{
-	instance_id = "cen-id1"
-	route_table_id = "vtb-id1"
+data "alicloud_cen_route_entries" "entry" {
+  instance_id    = "cen-id1"
+  route_table_id = "vtb-id1"
 }
 
 output "first_route_entries_route_entry_cidr_block" {

--- a/website/docs/d/common_bandwidth_packages.html.markdown
+++ b/website/docs/d/common_bandwidth_packages.html.markdown
@@ -15,14 +15,14 @@ This data source provides a list of Common Bandwidth Packages owned by an Alibab
 ## Example Usage
 
 ```
-data "alicloud_common_bandwidth_packages" "foo"  {
+data "alicloud_common_bandwidth_packages" "foo" {
   name_regex = "^tf-testAcc.*"
-  ids = ["${alicloud_common_bandwidth_package.foo.id}"]
+  ids        = ["${alicloud_common_bandwidth_package.foo.id}"]
 }
 
 resource "alicloud_common_bandwidth_package" "foo" {
-  bandwidth = "2"
-  name = "tf-testAccCommonBandwidthPackage"
+  bandwidth   = "2"
+  name        = "tf-testAccCommonBandwidthPackage"
   description = "tf-testAcc-CommonBandwidthPackage"
 }
 ```

--- a/website/docs/d/cr_namespaces.html.markdown
+++ b/website/docs/d/cr_namespaces.html.markdown
@@ -17,8 +17,8 @@ This data source provides a list Container Registry namespaces on Alibaba Cloud.
 ```
 # Declare the data source
 data "alicloud_cr_namespaces" "my_namespaces" {
-    name_regex = "my-namespace"
-    output_file = "my-namespace-json"
+  name_regex  = "my-namespace"
+  output_file = "my-namespace-json"
 }
 
 output "output" {

--- a/website/docs/d/cr_repos.html.markdown
+++ b/website/docs/d/cr_repos.html.markdown
@@ -17,8 +17,8 @@ This data source provides a list Container Registry repositories on Alibaba Clou
 ```
 # Declare the data source
 data "alicloud_cr_repos" "my_repos" {
-    name_regex = "my-repos"
-    output_file = "my-repo-json"
+  name_regex  = "my-repos"
+  output_file = "my-repo-json"
 }
 
 output "output" {

--- a/website/docs/d/cs_kubernetes_clusters.html.markdown
+++ b/website/docs/d/cs_kubernetes_clusters.html.markdown
@@ -17,7 +17,7 @@ This data source provides a list Container Service Kubernetes Clusters on Alibab
 ```
 # Declare the data source
 data "alicloud_cs_kubernetes_clusters" "k8s_clusters" {
-  name_regex = "my-first-k8s"
+  name_regex  = "my-first-k8s"
   output_file = "my-first-k8s-json"
 }
 

--- a/website/docs/d/cs_managed_kubernetes_clusters.html.markdown
+++ b/website/docs/d/cs_managed_kubernetes_clusters.html.markdown
@@ -17,7 +17,7 @@ This data source provides a list Container Service Managed Kubernetes Clusters o
 ```
 # Declare the data source
 data "alicloud_cs_managed_kubernetes_clusters" "k8s_clusters" {
-  name_regex = "my-first-k8s"
+  name_regex  = "my-first-k8s"
   output_file = "my-first-k8s-json"
 }
 

--- a/website/docs/d/dns_domains.html.markdown
+++ b/website/docs/d/dns_domains.html.markdown
@@ -15,7 +15,7 @@ This data source provides a list of DNS Domains in an Alibaba Cloud account acco
 ```
 data "alicloud_dns_domains" "domains_ds" {
   domain_name_regex = "^hegu"
-  output_file = "domains.txt"
+  output_file       = "domains.txt"
 }
 
 output "first_domain_id" {

--- a/website/docs/d/dns_groups.html.markdown
+++ b/website/docs/d/dns_groups.html.markdown
@@ -14,7 +14,7 @@ This data source provides a list of DNS Domain Groups in an Alibaba Cloud accoun
 
 ```
 data "alicloud_dns_groups" "groups_ds" {
-  name_regex = "^y[A-Za-z]+"
+  name_regex  = "^y[A-Za-z]+"
   output_file = "groups.txt"
 }
 

--- a/website/docs/d/dns_records.html.markdown
+++ b/website/docs/d/dns_records.html.markdown
@@ -14,11 +14,11 @@ This data source provides a list of DNS Domain Records in an Alibaba Cloud accou
 
 ```
 data "alicloud_dns_records" "records_ds" {
-  domain_name = "xiaozhu.top"
-  is_locked = false
-  type = "A"
+  domain_name       = "xiaozhu.top"
+  is_locked         = false
+  type              = "A"
   host_record_regex = "^@"
-  output_file = "records.txt"
+  output_file       = "records.txt"
 }
 
 output "first_record_id" {

--- a/website/docs/d/drds_instances.html.markdown
+++ b/website/docs/d/drds_instances.html.markdown
@@ -18,9 +18,9 @@ Filters support regular expression for the instance name, searches by tags, and 
  ```
 data "alicloud_drds_instances" "drds_instances_ds" {
   name_regex = "drds-\\d+"
-  ids     = "drdsfacbz68g3299test"
+  ids        = "drdsfacbz68g3299test"
 }
- output "first_db_instance_id" {
+output "first_db_instance_id" {
   value = "${data.alicloud_drds_instances.drds_instances_ds.instances.0.drdsInstanceId}"
 }
 ```

--- a/website/docs/d/ess_scaling_configurations.html.markdown
+++ b/website/docs/d/ess_scaling_configurations.html.markdown
@@ -14,9 +14,9 @@ This data source provides available scaling configuration resources.
 
 ```
 data "alicloud_ess_scaling_configurations" "scalingconfigurations_ds" {
-    scaling_group_id = "scaling_group_id"
-    ids = ["scaling_configuration_id1","scaling_configuration_id2"]
-    name_regex = "scaling_configuration_name"
+  scaling_group_id = "scaling_group_id"
+  ids              = ["scaling_configuration_id1", "scaling_configuration_id2"]
+  name_regex       = "scaling_configuration_name"
 }
 
 output "first_scaling_rule" {

--- a/website/docs/d/ess_scaling_groups.html.markdown
+++ b/website/docs/d/ess_scaling_groups.html.markdown
@@ -14,8 +14,8 @@ This data source provides available scaling group resources.
 
 ```
 data "alicloud_ess_scaling_groups" "scalinggroups_ds" {
-	ids = ["scaling_group_id1","scaling_group_id2"]
-	name_regex = "scaling_group_name"
+  ids        = ["scaling_group_id1", "scaling_group_id2"]
+  name_regex = "scaling_group_name"
 }
 
 output "first_scaling_group" {

--- a/website/docs/d/ess_scaling_rules.html.markdown
+++ b/website/docs/d/ess_scaling_rules.html.markdown
@@ -14,9 +14,9 @@ This data source provides available scaling rule resources.
 
 ```
 data "alicloud_ess_scaling_rules" "scalingrules_ds" {
-    scaling_group_id = "scaling_group_id"
-	ids = ["scaling_rule_id1","scaling_rule_id2"]
-	name_regex = "scaling_rule_name"
+  scaling_group_id = "scaling_group_id"
+  ids              = ["scaling_rule_id1", "scaling_rule_id2"]
+  name_regex       = "scaling_rule_name"
 }
 
 output "first_scaling_rule" {

--- a/website/docs/d/fc_functions.html.markdown
+++ b/website/docs/d/fc_functions.html.markdown
@@ -15,7 +15,7 @@ This data source provides the Function Compute functions of the current Alibaba 
 ```
 data "alicloud_fc_functions" "functions_ds" {
   service_name = "sample_service"
-  name_regex = "sample_fc_function"
+  name_regex   = "sample_fc_function"
 }
 
 output "first_fc_function_name" {

--- a/website/docs/d/fc_triggers.html.markdown
+++ b/website/docs/d/fc_triggers.html.markdown
@@ -14,9 +14,9 @@ This data source provides the Function Compute triggers of the current Alibaba C
 
 ```
 data "alicloud_fc_triggers" "fc_triggers_ds" {
-  service_name = "sample_service"
+  service_name  = "sample_service"
   function_name = "sample_function"
-  name_regex = "sample_fc_trigger"
+  name_regex    = "sample_fc_trigger"
 }
 
 output "first_fc_trigger_name" {

--- a/website/docs/d/forward_entries.html.markdown
+++ b/website/docs/d/forward_entries.html.markdown
@@ -16,51 +16,51 @@ This data source provides a list of Forward Entries owned by an Alibaba Cloud ac
 
 ```
 variable "name" {
-	default = "forward-entry-config-example-name"
+  default = "forward-entry-config-example-name"
 }
 
 data "alicloud_zones" "default" {
-	available_resource_creation = "VSwitch"
+  available_resource_creation = "VSwitch"
 }
 
 resource "alicloud_vpc" "default" {
-	name = "${var.name}"
-	cidr_block = "172.16.0.0/12"
+  name       = "${var.name}"
+  cidr_block = "172.16.0.0/12"
 }
 
 resource "alicloud_vswitch" "default" {
-	vpc_id = "${alicloud_vpc.default.id}"
-	cidr_block = "172.16.0.0/21"
-	availability_zone = "${data.alicloud_zones.default.zones.0.id}"
-	name = "${var.name}"
+  vpc_id            = "${alicloud_vpc.default.id}"
+  cidr_block        = "172.16.0.0/21"
+  availability_zone = "${data.alicloud_zones.default.zones.0.id}"
+  name              = "${var.name}"
 }
 
 resource "alicloud_nat_gateway" "default" {
-	vpc_id = "${alicloud_vpc.default.id}"
-	specification = "Small"
-	name = "${var.name}"
+  vpc_id        = "${alicloud_vpc.default.id}"
+  specification = "Small"
+  name          = "${var.name}"
 }
 
 resource "alicloud_eip" "default" {
-	name = "${var.name}"
+  name = "${var.name}"
 }
 
 resource "alicloud_eip_association" "default" {
-	allocation_id = "${alicloud_eip.default.id}"
-	instance_id = "${alicloud_nat_gateway.default.id}"
+  allocation_id = "${alicloud_eip.default.id}"
+  instance_id   = "${alicloud_nat_gateway.default.id}"
 }
 
-resource "alicloud_forward_entry" "default"{
-	forward_table_id = "${alicloud_nat_gateway.default.forward_table_ids}"
-	external_ip = "${alicloud_eip.default.ip_address}"
-	external_port = "80"
-	ip_protocol = "tcp"
-	internal_ip = "172.16.0.3"
-	internal_port = "8080"
+resource "alicloud_forward_entry" "default" {
+  forward_table_id = "${alicloud_nat_gateway.default.forward_table_ids}"
+  external_ip      = "${alicloud_eip.default.ip_address}"
+  external_port    = "80"
+  ip_protocol      = "tcp"
+  internal_ip      = "172.16.0.3"
+  internal_port    = "8080"
 }
 
 data "alicloud_forward_entries" "default" {
-    forward_table_id = "${alicloud_forward_entry.default.forward_table_id}"
+  forward_table_id = "${alicloud_forward_entry.default.forward_table_id}"
 }
 ```
 

--- a/website/docs/d/images.html.markdown
+++ b/website/docs/d/images.html.markdown
@@ -15,7 +15,7 @@ other public images and the ones available on the image market.
 
 ```
 data "alicloud_images" "images_ds" {
-  owners = "system"
+  owners     = "system"
   name_regex = "^centos_6"
 }
 

--- a/website/docs/d/instance_types.html.markdown
+++ b/website/docs/d/instance_types.html.markdown
@@ -20,7 +20,7 @@ This data source provides the ECS instance types of Alibaba Cloud.
 # Declare the data source
 data "alicloud_instance_types" "types_ds" {
   cpu_core_count = 1
-  memory_size = 2
+  memory_size    = 2
 }
 
 # Create ECS instance with the first matched instance_type

--- a/website/docs/d/instances.html.markdown
+++ b/website/docs/d/instances.html.markdown
@@ -14,8 +14,8 @@ The Instances data source list ECS instance resources according to their ID, nam
 
 ```
 data "alicloud_instances" "instances_ds" {
-	name_regex = "web_server"
-	status = "Running"
+  name_regex = "web_server"
+  status     = "Running"
 }
 
 output "first_instance_id" {

--- a/website/docs/d/kms_keys.html.markdown
+++ b/website/docs/d/kms_keys.html.markdown
@@ -15,8 +15,8 @@ This data source provides a list of KMS keys in an Alibaba Cloud account accordi
 ```
 # Declare the data source
 data "alicloud_kms_keys" "kms_keys_ds" {
-	description_regex = "Hello KMS"
-	output_file = "kms_keys.json"
+  description_regex = "Hello KMS"
+  output_file       = "kms_keys.json"
 }
 
 output "first_key_id" {

--- a/website/docs/d/kvstore_instance_classes.html.markdown
+++ b/website/docs/d/kvstore_instance_classes.html.markdown
@@ -16,7 +16,7 @@ This data source provides the KVStore instance classes resource available info o
 
 ```tf
 data "alicloud_zones" "resources" {
-	available_resource_creation= "KVStore"
+  available_resource_creation = "KVStore"
 }
 
 data "alicloud_kvstore_instance_classes" "resources" {

--- a/website/docs/d/kvstore_instance_engines.html.markdown
+++ b/website/docs/d/kvstore_instance_engines.html.markdown
@@ -16,7 +16,7 @@ This data source provides the KVStore instance engines resource available info o
 
 ```tf
 data "alicloud_zones" "resources" {
-	available_resource_creation= "KVStore"
+  available_resource_creation = "KVStore"
 }
 
 data "alicloud_kvstore_instance_engines" "resources" {

--- a/website/docs/d/mns_topic_subscriptions.html.markdown
+++ b/website/docs/d/mns_topic_subscriptions.html.markdown
@@ -14,7 +14,7 @@ This data source provides a list of MNS topic subscriptions in an Alibaba Cloud 
 
 ```
 data "alicloud_mns_topic_subscriptions" "subscriptions" {
-  topic_name="topic_name"
+  topic_name  = "topic_name"
   name_prefix = "tf-"
 }
 

--- a/website/docs/d/nas_access_groups.html.markdown
+++ b/website/docs/d/nas_access_groups.html.markdown
@@ -16,8 +16,8 @@ This data source provides user-available access groups. Use when you can create 
 
 ```
 data "alicloud_nas_access_groups" "ag" {
-  name_regex = "^foo"
-  type = "Classic"
+  name_regex  = "^foo"
+  type        = "Classic"
   description = "tf-testAccAccessGroupsdatasource"
 }
 

--- a/website/docs/d/nas_access_rules.html.markdown
+++ b/website/docs/d/nas_access_rules.html.markdown
@@ -17,9 +17,9 @@ This data source provides AccessRule available to the user.
 ```
 data "alicloud_nas_access_rules" "foo" {
   access_group_name = "tf-testAccAccessGroupsdatasource"
-  source_cidr_ip = "168.1.1.0/16"
-  rw_access = "RDWR"
-  user_access = "no_squash"
+  source_cidr_ip    = "168.1.1.0/16"
+  rw_access         = "RDWR"
+  user_access       = "no_squash"
 }
 
 output "alicloud_nas_access_rules_id" {

--- a/website/docs/d/nas_file_systems.html.markdown
+++ b/website/docs/d/nas_file_systems.html.markdown
@@ -16,8 +16,8 @@ This data source provides FileSystems available to the user.
 
 ```
 data "alicloud_nas_file_systems" "fs" {
-   protocol_type = "NFS"
-   description = "${alicloud_nas_file_system.foo.description}"
+  protocol_type = "NFS"
+  description   = "${alicloud_nas_file_system.foo.description}"
 }
 
 output "alicloud_nas_file_systems_id" {

--- a/website/docs/d/nas_protocols.html.markdown
+++ b/website/docs/d/nas_protocols.html.markdown
@@ -16,8 +16,8 @@ Provide  a data source to retrieve the type of protocol used to create NAS file 
 
 ```
 data "alicloud_nas_protocols" "default" {
-  type = "Performance"
-  zone_id = "cn-beijing-e"
+  type        = "Performance"
+  zone_id     = "cn-beijing-e"
   output_file = "protocols.txt"
 }
 

--- a/website/docs/d/nat_gateways.html.markdown
+++ b/website/docs/d/nat_gateways.html.markdown
@@ -20,24 +20,24 @@ variable "name" {
 }
 
 data "alicloud_zones" "default" {
-	available_resource_creation = "VSwitch"
+  available_resource_creation = "VSwitch"
 }
 
 resource "alicloud_vpc" "foo" {
-	name = "${var.name}"
-	cidr_block = "172.16.0.0/12"
+  name       = "${var.name}"
+  cidr_block = "172.16.0.0/12"
 }
 
 resource "alicloud_nat_gateway" "foo" {
-	vpc_id = "${alicloud_vpc.foo.id}"
-	specification = "Small"
-	name = "${var.name}"
+  vpc_id        = "${alicloud_vpc.foo.id}"
+  specification = "Small"
+  name          = "${var.name}"
 }
 
 data "alicloud_nat_gateways" "foo" {
-	vpc_id = "${alicloud_vpc.foo.id}"
-    name_regex = "${alicloud_nat_gateway.foo.name}"
-    ids = ["${alicloud_nat_gateway.foo.id}"]
+  vpc_id     = "${alicloud_vpc.foo.id}"
+  name_regex = "${alicloud_nat_gateway.foo.name}"
+  ids        = ["${alicloud_nat_gateway.foo.id}"]
 }
 ```
 

--- a/website/docs/d/oss_bucket_objects.html.markdown
+++ b/website/docs/d/oss_bucket_objects.html.markdown
@@ -15,7 +15,7 @@ This data source provides the objects of an OSS bucket.
 ```
 data "alicloud_oss_bucket_objects" "bucket_objects_ds" {
   bucket_name = "sample_bucket"
-  key_regex = "sample/sample_object.txt"
+  key_regex   = "sample/sample_object.txt"
 }
 
 output "first_object_key" {

--- a/website/docs/d/ots_instance_attachments.html.markdown
+++ b/website/docs/d/ots_instance_attachments.html.markdown
@@ -15,8 +15,8 @@ This data source provides the ots instance attachments of the current Alibaba Cl
 ```
 data "alicloud_ots_instance_attachments" "attachments_ds" {
   instance_name = "sample-instance"
-  name_regex = "testvpc"
-  output_file = "attachments.txt"
+  name_regex    = "testvpc"
+  output_file   = "attachments.txt"
 }
 
 output "first_ots_attachment_id" {

--- a/website/docs/d/ots_instances.html.markdown
+++ b/website/docs/d/ots_instances.html.markdown
@@ -14,7 +14,7 @@ This data source provides the ots instances of the current Alibaba Cloud user.
 
 ```
 data "alicloud_ots_instances" "instances_ds" {
-  name_regex = "sample-instance"
+  name_regex  = "sample-instance"
   output_file = "instances.txt"
 }
 

--- a/website/docs/d/ots_tables.html.markdown
+++ b/website/docs/d/ots_tables.html.markdown
@@ -17,8 +17,8 @@ This data source provides the ots tables of the current Alibaba Cloud user.
 ```
 data "alicloud_ots_tables" "tables_ds" {
   instance_name = "sample-instance"
-  name_regex = "sample-table"
-  output_file = "tables.txt"
+  name_regex    = "sample-table"
+  output_file   = "tables.txt"
 }
 
 output "first_table_id" {

--- a/website/docs/d/pvtz_zone_records.html.markdown
+++ b/website/docs/d/pvtz_zone_records.html.markdown
@@ -14,8 +14,8 @@ This data source provides Private Zone Records resource information owned by an 
 
 ```
 data "alicloud_pvtz_zone_records" "records_ds" {
-	zone_id = "${alicloud_pvtz_zone.basic.id}"
-	keyword = "${alicloud_pvtz_zone_record.foo.value}"
+  zone_id = "${alicloud_pvtz_zone.basic.id}"
+  keyword = "${alicloud_pvtz_zone_record.foo.value}"
 }
 
 output "first_record_id" {

--- a/website/docs/d/pvtz_zones.html.markdown
+++ b/website/docs/d/pvtz_zones.html.markdown
@@ -14,7 +14,7 @@ This data source lists a number of Private Zones resource information owned by a
 
 ```
 data "alicloud_pvtz_zones" "pvtz_zones_ds" {
-	keyword = "${alicloud_pvtz_zone.basic.zone_name}"
+  keyword = "${alicloud_pvtz_zone.basic.zone_name}"
 }
 
 output "first_zone_id" {

--- a/website/docs/d/ram_groups.html.markdown
+++ b/website/docs/d/ram_groups.html.markdown
@@ -15,8 +15,8 @@ This data source provides a list of RAM Groups in an Alibaba Cloud account accor
 ```
 data "alicloud_ram_groups" "groups_ds" {
   output_file = "groups.txt"
-  user_name = "user1"
-  name_regex = "^group[0-9]*"
+  user_name   = "user1"
+  name_regex  = "^group[0-9]*"
 }
 
 output "first_group_name" {

--- a/website/docs/d/ram_policies.html.markdown
+++ b/website/docs/d/ram_policies.html.markdown
@@ -15,9 +15,9 @@ This data source provides a list of RAM policies in an Alibaba Cloud account acc
 ```
 data "alicloud_ram_policies" "policies_ds" {
   output_file = "policies.txt"
-  user_name = "user1"
-  group_name = "group1"
-  type = "System"
+  user_name   = "user1"
+  group_name  = "group1"
+  type        = "System"
 }
 
 output "first_policy_name" {

--- a/website/docs/d/ram_roles.html.markdown
+++ b/website/docs/d/ram_roles.html.markdown
@@ -15,7 +15,7 @@ This data source provides a list of RAM Roles in an Alibaba Cloud account accord
 ```
 data "alicloud_ram_roles" "roles_ds" {
   output_file = "roles.txt"
-  name_regex = ".*test.*"
+  name_regex  = ".*test.*"
   policy_name = "AliyunACSDefaultAccess"
   policy_type = "Custom"
 }

--- a/website/docs/d/ram_users.html.markdown
+++ b/website/docs/d/ram_users.html.markdown
@@ -15,10 +15,10 @@ This data source provides a list of RAM users in an Alibaba Cloud account accord
 ```
 data "alicloud_ram_users" "users_ds" {
   output_file = "users.txt"
-  group_name = "group1"
+  group_name  = "group1"
   policy_name = "AliyunACSDefaultAccess"
   policy_type = "Custom"
-  name_regex = "^user"
+  name_regex  = "^user"
 }
 
 output "first_user_id" {

--- a/website/docs/d/route_entries.html.markdown
+++ b/website/docs/d/route_entries.html.markdown
@@ -16,74 +16,74 @@ This data source provides a list of Route Entries owned by an Alibaba Cloud acco
 
 ```
 data "alicloud_zones" "default" {
-	available_resource_creation = "VSwitch"
+  available_resource_creation = "VSwitch"
 }
 data "alicloud_instance_types" "default" {
- 	availability_zone = "${data.alicloud_zones.default.zones.0.id}"
-	cpu_core_count = 1
-	memory_size = 2
+  availability_zone = "${data.alicloud_zones.default.zones.0.id}"
+  cpu_core_count    = 1
+  memory_size       = 2
 }
 data "alicloud_images" "default" {
-        name_regex = "^ubuntu_14.*_64"
-	most_recent = true
-	owners = "system"
+  name_regex  = "^ubuntu_14.*_64"
+  most_recent = true
+  owners      = "system"
 }
 
 variable "name" {
-	default = "tf-testAccRouteEntryConfig"
+  default = "tf-testAccRouteEntryConfig"
 }
 resource "alicloud_vpc" "foo" {
-	name = "${var.name}"
-	cidr_block = "10.1.0.0/21"
+  name       = "${var.name}"
+  cidr_block = "10.1.0.0/21"
 }
 
 resource "alicloud_vswitch" "foo" {
-	vpc_id = "${alicloud_vpc.foo.id}"
-	cidr_block = "10.1.1.0/24"
-	availability_zone = "${data.alicloud_zones.default.zones.0.id}"
-	name = "${var.name}"
+  vpc_id            = "${alicloud_vpc.foo.id}"
+  cidr_block        = "10.1.1.0/24"
+  availability_zone = "${data.alicloud_zones.default.zones.0.id}"
+  name              = "${var.name}"
 }
 
 resource "alicloud_route_entry" "foo" {
-	route_table_id = "${alicloud_vpc.foo.route_table_id}"
-	destination_cidrblock = "172.11.1.1/32"
-	nexthop_type = "Instance"
-	nexthop_id = "${alicloud_instance.foo.id}"
+  route_table_id        = "${alicloud_vpc.foo.route_table_id}"
+  destination_cidrblock = "172.11.1.1/32"
+  nexthop_type          = "Instance"
+  nexthop_id            = "${alicloud_instance.foo.id}"
 }
 
 resource "alicloud_security_group" "tf_test_foo" {
-	name = "${var.name}"
-	description = "foo"
-	vpc_id = "${alicloud_vpc.foo.id}"
+  name        = "${var.name}"
+  description = "foo"
+  vpc_id      = "${alicloud_vpc.foo.id}"
 }
 
 resource "alicloud_security_group_rule" "ingress" {
-	type = "ingress"
-	ip_protocol = "tcp"
-	nic_type = "intranet"
-	policy = "accept"
-	port_range = "22/22"
-	priority = 1
-	security_group_id = "${alicloud_security_group.tf_test_foo.id}"
-	cidr_ip = "0.0.0.0/0"
+  type              = "ingress"
+  ip_protocol       = "tcp"
+  nic_type          = "intranet"
+  policy            = "accept"
+  port_range        = "22/22"
+  priority          = 1
+  security_group_id = "${alicloud_security_group.tf_test_foo.id}"
+  cidr_ip           = "0.0.0.0/0"
 }
 
 resource "alicloud_instance" "foo" {
-	# cn-beijing
-	security_groups = ["${alicloud_security_group.tf_test_foo.id}"]
+  # cn-beijing
+  security_groups = ["${alicloud_security_group.tf_test_foo.id}"]
 
-	vswitch_id = "${alicloud_vswitch.foo.id}"
-	allocate_public_ip = true
+  vswitch_id         = "${alicloud_vswitch.foo.id}"
+  allocate_public_ip = true
 
-	# series III
-	instance_charge_type = "PostPaid"
-	instance_type = "${data.alicloud_instance_types.default.instance_types.0.id}"
-	internet_charge_type = "PayByTraffic"
-	internet_max_bandwidth_out = 5
+  # series III
+  instance_charge_type       = "PostPaid"
+  instance_type              = "${data.alicloud_instance_types.default.instance_types.0.id}"
+  internet_charge_type       = "PayByTraffic"
+  internet_max_bandwidth_out = 5
 
-	system_disk_category = "cloud_efficiency"
-	image_id = "${data.alicloud_images.default.images.0.id}"
-	instance_name = "${var.name}"
+  system_disk_category = "cloud_efficiency"
+  image_id             = "${data.alicloud_images.default.images.0.id}"
+  instance_name        = "${var.name}"
 }
 
 data "alicloud_route_entries" "foo" {

--- a/website/docs/d/route_tables.html.markdown
+++ b/website/docs/d/route_tables.html.markdown
@@ -16,26 +16,26 @@ This data source provides a list of Route Tables owned by an Alibaba Cloud accou
 
 ```
 variable "name" {
-    default = "route-tables-datasource-example-name"
+  default = "route-tables-datasource-example-name"
 }
 
 resource "alicloud_vpc" "foo" {
-    cidr_block = "172.16.0.0/12"
-    name = "${var.name}"
+  cidr_block = "172.16.0.0/12"
+  name       = "${var.name}"
 }
 
 resource "alicloud_route_table" "foo" {
-    vpc_id = "${alicloud_vpc.foo.id}"
-    name = "${var.name}"
-    description = "${var.name}"
+  vpc_id      = "${alicloud_vpc.foo.id}"
+  name        = "${var.name}"
+  description = "${var.name}"
 }
 
 data "alicloud_route_tables" "foo" {
-    ids = ["${alicloud_route_table.foo.id}"]
+  ids = ["${alicloud_route_table.foo.id}"]
 }
 
 output "route_table_ids" {
-    value = "${data.alicloud_route_tables.foo.ids}"
+  value = "${data.alicloud_route_tables.foo.ids}"
 }
 ```
 

--- a/website/docs/d/router_interfaces.html.markdown
+++ b/website/docs/d/router_interfaces.html.markdown
@@ -15,8 +15,8 @@ that connect VPCs together.
 
 ```
 data "alicloud_router_interfaces" "router_interfaces_ds" {
-	name_regex = "^testenv"
-	status = "Active"
+  name_regex = "^testenv"
+  status     = "Active"
 }
 
 output "first_router_interface_id" {

--- a/website/docs/d/security_group_rules.html.markdown
+++ b/website/docs/d/security_group_rules.html.markdown
@@ -28,9 +28,9 @@ data "alicloud_security_groups" "groups_ds" {
 
 # Filter the security group rule by group
 data "alicloud_security_group_rules" "ingress_rules_ds" {
-  group_id = "${data.alicloud_security_groups.groups_ds.groups.0.id}" # or ${var.security_group_id}
-  nic_type = "internet"
-  direction = "ingress"
+  group_id    = "${data.alicloud_security_groups.groups_ds.groups.0.id}" # or ${var.security_group_id}
+  nic_type    = "internet"
+  direction   = "ingress"
   ip_protocol = "TCP"
 }
 

--- a/website/docs/d/slb_rules.html.markdown
+++ b/website/docs/d/slb_rules.html.markdown
@@ -15,7 +15,7 @@ This data source provides the rules associated with a server load balancer liste
 ```
 data "alicloud_slb_rules" "sample_ds" {
   load_balancer_id = "${alicloud_slb.sample_slb.id}"
-  frontend_port = 80
+  frontend_port    = 80
 }
 
 output "first_slb_rule_id" {

--- a/website/docs/d/snapshots.html.markdown
+++ b/website/docs/d/snapshots.html.markdown
@@ -18,7 +18,7 @@ For information about snapshot and how to use it, see [Snapshot](https://www.ali
 
 ```
 data "alicloud_snapshots" "snapshots" {
-  ids = ["s-123456890abcdef"]
+  ids        = ["s-123456890abcdef"]
   name_regex = "tf-testAcc-snapshot"
 }
 ```

--- a/website/docs/d/snat_entries.html.markdown
+++ b/website/docs/d/snat_entries.html.markdown
@@ -16,47 +16,47 @@ This data source provides a list of Snat Entries owned by an Alibaba Cloud accou
 
 ```
 variable "name" {
-	default = "snat-entry-example-name"
+  default = "snat-entry-example-name"
 }
 data "alicloud_zones" "default" {
-	available_resource_creation = "VSwitch"
+  available_resource_creation = "VSwitch"
 }
 
 resource "alicloud_vpc" "foo" {
-	name = "${var.name}"
-	cidr_block = "172.16.0.0/12"
+  name       = "${var.name}"
+  cidr_block = "172.16.0.0/12"
 }
 
 resource "alicloud_vswitch" "foo" {
-	vpc_id = "${alicloud_vpc.foo.id}"
-	cidr_block = "172.16.0.0/21"
-	availability_zone = "${data.alicloud_zones.default.zones.0.id}"
-	name = "${var.name}"
+  vpc_id            = "${alicloud_vpc.foo.id}"
+  cidr_block        = "172.16.0.0/21"
+  availability_zone = "${data.alicloud_zones.default.zones.0.id}"
+  name              = "${var.name}"
 }
 
 resource "alicloud_nat_gateway" "foo" {
-	vpc_id = "${alicloud_vpc.foo.id}"
-	specification = "Small"
-	name = "${var.name}"
+  vpc_id        = "${alicloud_vpc.foo.id}"
+  specification = "Small"
+  name          = "${var.name}"
 }
 
 resource "alicloud_eip" "foo" {
-	name = "${var.name}"
+  name = "${var.name}"
 }
 
 resource "alicloud_eip_association" "foo" {
-	allocation_id = "${alicloud_eip.foo.id}"
-	instance_id = "${alicloud_nat_gateway.foo.id}"
+  allocation_id = "${alicloud_eip.foo.id}"
+  instance_id   = "${alicloud_nat_gateway.foo.id}"
 }
 
 resource "alicloud_snat_entry" "foo" {
-	snat_table_id = "${alicloud_nat_gateway.foo.snat_table_ids}"
-	source_vswitch_id = "${alicloud_vswitch.foo.id}"
-	snat_ip = "${alicloud_eip.foo.ip_address}"
+  snat_table_id     = "${alicloud_nat_gateway.foo.snat_table_ids}"
+  source_vswitch_id = "${alicloud_vswitch.foo.id}"
+  snat_ip           = "${alicloud_eip.foo.ip_address}"
 }
 
 data "alicloud_snat_entries" "foo" {
-    snat_table_id = "${alicloud_snat_entry.foo.snat_table_id}"
+  snat_table_id = "${alicloud_snat_entry.foo.snat_table_id}"
 }
 ```
 

--- a/website/docs/d/ssl_vpn_client_certs.html.markdown
+++ b/website/docs/d/ssl_vpn_client_certs.html.markdown
@@ -14,10 +14,10 @@ The SSL-VPN client certificates data source lists lots of SSL-VPN client certifi
 
 ```
 data "alicloud_ssl_vpn_client_certs" "foo" {
-	ids = ["fake-cert-id"]
-	ssl_vpn_server_id = "fake-server-id"
-	output_file = "/tmp/clientcert"
-	name_regex = "^foo"
+  ids               = ["fake-cert-id"]
+  ssl_vpn_server_id = "fake-server-id"
+  output_file       = "/tmp/clientcert"
+  name_regex        = "^foo"
 }
 ```
 

--- a/website/docs/d/ssl_vpn_servers.html.markdown
+++ b/website/docs/d/ssl_vpn_servers.html.markdown
@@ -14,10 +14,10 @@ The SSL-VPN servers data source lists lots of SSL-VPN servers resource informati
 
 ```
 data "alicloud_ssl_vpn_servers" "foo" {
-	ids = ["fake-server-id"]
-	vpn_gateway_id = "fake-vpn-id"
-	output_file = "/tmp/sslserver"
-	name_regex = "^foo"
+  ids            = ["fake-server-id"]
+  vpn_gateway_id = "fake-vpn-id"
+  output_file    = "/tmp/sslserver"
+  name_regex     = "^foo"
 }
 ```
 

--- a/website/docs/d/vpcs.html.markdown
+++ b/website/docs/d/vpcs.html.markdown
@@ -13,9 +13,9 @@ This data source provides VPCs available to the user.
 ## Example Usage
 
 ```
-data "alicloud_vpcs" "vpcs_ds"{
+data "alicloud_vpcs" "vpcs_ds" {
   cidr_block = "172.16.0.0/12"
-  status = "Available"
+  status     = "Available"
   name_regex = "^foo"
 }
 

--- a/website/docs/d/vpn_connections.html.markdown
+++ b/website/docs/d/vpn_connections.html.markdown
@@ -14,10 +14,10 @@ The VPN connections data source lists lots of VPN connections resource informati
 
 ```
 data "alicloud_vpn_connections" "foo" {
-	ids = ["fake-conn-id"]
-	vpn_gateway_id = "fake-vpn-id"
-	customer_gateway_id = "fake-cgw-id"
-	output_file = "/tmp/vpnconn"
+  ids                 = ["fake-conn-id"]
+  vpn_gateway_id      = "fake-vpn-id"
+  customer_gateway_id = "fake-cgw-id"
+  output_file         = "/tmp/vpnconn"
 }
 
 ```

--- a/website/docs/d/vpn_customer_gateways.html.markdown
+++ b/website/docs/d/vpn_customer_gateways.html.markdown
@@ -14,9 +14,9 @@ The VPN customers gateways data source lists a number of VPN customer gateways r
 
 ```
 data "alicloud_vpn_customer_gateways" "foo" {
-	name_regex = "testAcc*"
-	customer_gateway_id = "fake-id*"
-	output_file = "/tmp/cgws"
+  name_regex          = "testAcc*"
+  customer_gateway_id = "fake-id*"
+  output_file         = "/tmp/cgws"
 }
 
 ```

--- a/website/docs/d/vpn_gateways.html.markdown
+++ b/website/docs/d/vpn_gateways.html.markdown
@@ -14,12 +14,12 @@ The VPNs data source lists a number of VPNs resource information owned by an Ali
 
 ```
 data "alicloud_vpn_gateways" "vpn_gateways" {
-	vpc_id = "fake-vpc-id"
-	vpn_gateway_id = "fake-vpn-id"
-	status = "active"
-	business_status = "Normal"
-	name_regex = "testAcc*"
-	output_file = "/tmp/vpns"
+  vpc_id          = "fake-vpc-id"
+  vpn_gateway_id  = "fake-vpn-id"
+  status          = "active"
+  business_status = "Normal"
+  name_regex      = "testAcc*"
+  output_file     = "/tmp/vpns"
 }
 
 ```

--- a/website/docs/d/vswitches.html.markdown
+++ b/website/docs/d/vswitches.html.markdown
@@ -20,13 +20,13 @@ data "alicloud_zones" "default" {}
 
 resource "alicloud_vpc" "vpc" {
   cidr_block = "172.16.0.0/16"
-  name = "${var.name}"
+  name       = "${var.name}"
 }
 
 resource "alicloud_vswitch" "vswitch" {
-  name = "${var.name}"
-  cidr_block = "172.16.0.0/24"
-  vpc_id = "${alicloud_vpc.vpc.id}"
+  name              = "${var.name}"
+  cidr_block        = "172.16.0.0/24"
+  vpc_id            = "${alicloud_vpc.vpc.id}"
   availability_zone = "${data.alicloud_zones.default.zones.0.id}"
 }
 

--- a/website/docs/d/zones.html.markdown
+++ b/website/docs/d/zones.html.markdown
@@ -19,7 +19,7 @@ This data source provides availability zones that can be accessed by an Alibaba 
 # Declare the data source
 data "alicloud_zones" "zones_ds" {
   available_instance_type = "ecs.n4.large"
-  available_disk_category  = "cloud_ssd"
+  available_disk_category = "cloud_ssd"
 }
 
 # Create an ECS instance with the first matched zone

--- a/website/docs/index.html.markdown
+++ b/website/docs/index.html.markdown
@@ -124,7 +124,7 @@ Usage:
 ```hcl
 provider "alicloud" {
   ecs_role_name = "terraform-provider-alicloud"
-  region     = "${var.region}"
+  region        = "${var.region}"
 }
 ```
 

--- a/website/docs/r/actiontrail.html.markdown
+++ b/website/docs/r/actiontrail.html.markdown
@@ -17,11 +17,11 @@ Provides a new resource to manage [Action Trail](https://www.alibabacloud.com/he
 ```
 # Create a new action trail.
 resource "alicloud_actiontrail" "foo" {
-	name = "action-trail"
-	event_rw = "Write-test"
-	oss_bucket_name = "${alicloud_oss_bucket.bucket.id}"
-	role_name = "${alicloud_ram_role_policy_attachment.attach.role_name}"
-	oss_key_prefix = "at-product-account-audit-B"
+  name            = "action-trail"
+  event_rw        = "Write-test"
+  oss_bucket_name = "${alicloud_oss_bucket.bucket.id}"
+  role_name       = "${alicloud_ram_role_policy_attachment.attach.role_name}"
+  oss_key_prefix  = "at-product-account-audit-B"
 }
 ```
 

--- a/website/docs/r/api_gateway_app.html.markdown
+++ b/website/docs/r/api_gateway_app.html.markdown
@@ -20,7 +20,7 @@ Basic Usage
 
 ```
 resource "alicloud_api_gateway_app" "apiTest" {
-  name = "ApiGatewayAPp"
+  name        = "ApiGatewayAPp"
   description = "description of the app"
 }
 ```

--- a/website/docs/r/api_gateway_app_attachment.html.markdown
+++ b/website/docs/r/api_gateway_app_attachment.html.markdown
@@ -20,9 +20,9 @@ Basic Usage
 
 ```
 resource "alicloud_api_gateway_app_attachment" "foo" {
-  api_id = "d29d25b9cfdf4742b1a3f6537299a749"
-  group_id = "aaef8cdbb404420f9398a74ed1db7fff"
-  app_id = "20898181"
+  api_id     = "d29d25b9cfdf4742b1a3f6537299a749"
+  group_id   = "aaef8cdbb404420f9398a74ed1db7fff"
+  app_id     = "20898181"
   stage_name = "PRE"
 }
 ```

--- a/website/docs/r/api_gateway_group.html.markdown
+++ b/website/docs/r/api_gateway_group.html.markdown
@@ -20,7 +20,7 @@ Basic Usage
 
 ```
 resource "alicloud_api_gateway_group" "apiGroup" {
-  name = "ApiGatewayGroup"
+  name        = "ApiGatewayGroup"
   description = "description of the api group"
 }
 ```

--- a/website/docs/r/api_gateway_vpc_access.html.markdown
+++ b/website/docs/r/api_gateway_vpc_access.html.markdown
@@ -20,10 +20,10 @@ Basic Usage
 
 ```
 resource "alicloud_api_gateway_vpc_access" "foo" {
-  name = "ApiGatewayVpc"
-  vpc_id = "vpc-awkcj192ka9zalz"
-  instance_id= "i-kai2ks92kzkw92ka"
-  port = 8080
+  name        = "ApiGatewayVpc"
+  vpc_id      = "vpc-awkcj192ka9zalz"
+  instance_id = "i-kai2ks92kzkw92ka"
+  port        = 8080
 }
 ```
 ## Argument Reference

--- a/website/docs/r/cas_certificate.html.markdown
+++ b/website/docs/r/cas_certificate.html.markdown
@@ -21,9 +21,9 @@ Provides a CAS Certificate resource.
 ```
 # Add a new Certificate.
 resource "alicloud_cas_certificate" "cert" {
-   name = "test"
-   cert = "${file("${path.module}/test.crt")}"
-   key = "${file("${path.module}/test.key")}"
+  name = "test"
+  cert = "${file("${path.module}/test.crt")}"
+  key  = "${file("${path.module}/test.key")}"
 }
 ```
 ## Argument Reference

--- a/website/docs/r/cdn_domain.html.markdown
+++ b/website/docs/r/cdn_domain.html.markdown
@@ -20,63 +20,63 @@ Provides a CDN Accelerated Domain resource.
 # Add a CDN Accelerated Domain with configs.
 resource "alicloud_cdn_domain" "domain" {
   domain_name = "${your_cdn_domain_name}"
-  cdn_type = "web"
+  cdn_type    = "web"
   source_type = "domain"
-  sources = ["${your_cdn_domain_source1}", "${your_cdn_domain_source2}"]
+  sources     = ["${your_cdn_domain_source1}", "${your_cdn_domain_source2}"]
 
   // configs
-  optimize_enable = "off"
+  optimize_enable      = "off"
   page_compress_enable = "off"
-  range_enable = "off"
-  video_seek_enable = "off"
-  block_ips = ["1.2.3.4", "111.222.111.111"]
+  range_enable         = "off"
+  video_seek_enable    = "off"
+  block_ips            = ["1.2.3.4", "111.222.111.111"]
   parameter_filter_config = [
     {
-      enable = "on"
+      enable        = "on"
       hash_key_args = ["hello", "youyouyou"]
-    }]
+  }]
   page_404_config = [
     {
-      page_type = "other"
+      page_type       = "other"
       custom_page_url = "http://${your_cdn_domain_name}/notfound/"
-    }]
+  }]
   refer_config = [
     {
-      refer_type = "block"
-      refer_list = ["www.xxxx.com", "www.xxxx.cn"]
+      refer_type  = "block"
+      refer_list  = ["www.xxxx.com", "www.xxxx.cn"]
       allow_empty = "off"
-    }]
+  }]
   auth_config = [
     {
-      auth_type = "type_a"
+      auth_type  = "type_a"
       master_key = "helloworld1"
-      slave_key = "helloworld2"
-    }]
+      slave_key  = "helloworld2"
+  }]
   http_header_config = [
     {
-      header_key = "Content-Type",
+      header_key   = "Content-Type",
       header_value = "text/plain"
     },
     {
-      header_key = "Access-Control-Allow-Origin",
+      header_key   = "Access-Control-Allow-Origin",
       header_value = "*"
-    }]
+  }]
   cache_config = [
     {
       cache_content = "/hello/world",
-      ttl = 1000
-      cache_type = "path"
+      ttl           = 1000
+      cache_type    = "path"
     },
     {
       cache_content = "/hello/world/youyou",
-      ttl = 1000
-      cache_type = "path"
+      ttl           = 1000
+      cache_type    = "path"
     },
     {
       cache_content = "txt,jpg,png",
-      ttl = 2000
-      cache_type = "suffix"
-    }]
+      ttl           = 2000
+      cache_type    = "suffix"
+  }]
 }
 ```
 ## Argument Reference

--- a/website/docs/r/cdn_domain_config.html.markdown
+++ b/website/docs/r/cdn_domain_config.html.markdown
@@ -21,24 +21,24 @@ Basic Usage
 ```
 # Create a new Domain config.
 resource "alicloud_cdn_domain_new" "domain" {
-	  domain_name = "tf-testacc%d.xiaozhu.com"
-	  cdn_type = "web"
-      scope="overseas"
-      sources {
-         content = "1.1.1.1"
-         type = "ipaddr"
-         priority = "20"
-         port = 80
-         weight = "15"
-      }
+  domain_name = "tf-testacc%d.xiaozhu.com"
+  cdn_type    = "web"
+  scope       = "overseas"
+  sources {
+    content  = "1.1.1.1"
+    type     = "ipaddr"
+    priority = "20"
+    port     = 80
+    weight   = "15"
+  }
 }
 resource "alicloud_cdn_domain_config" "config" {
-	  domain_name = "${alicloud_cdn_domain_new.domain.domain_name}"
-	  function_name = "ip_allow_list_set"
-      function_args {
-            arg_name = "ip_list"
-            arg_value = "110.110.110.110"
-      }
+  domain_name   = "${alicloud_cdn_domain_new.domain.domain_name}"
+  function_name = "ip_allow_list_set"
+  function_args {
+    arg_name  = "ip_list"
+    arg_value = "110.110.110.110"
+  }
 }
 
 ```

--- a/website/docs/r/cdn_domain_new.html.markdown
+++ b/website/docs/r/cdn_domain_new.html.markdown
@@ -21,16 +21,16 @@ Basic Usage
 ```
 # Create a new Domain.
 resource "alicloud_cdn_domain_new" "domain" {
-	  domain_name = "terraform.test.com"
-	  cdn_type = "web"
-	  scope="overseas"
-	  sources {
-         content = "1.1.1.1"
-         type = "ipaddr"
-         priority = 20
-         port = 80
-         weight = 10
-      }
+  domain_name = "terraform.test.com"
+  cdn_type    = "web"
+  scope       = "overseas"
+  sources {
+    content  = "1.1.1.1"
+    type     = "ipaddr"
+    priority = 20
+    port     = 80
+    weight   = 10
+  }
 }
 
 ```

--- a/website/docs/r/cen_bandwidth_limit.html.markdown
+++ b/website/docs/r/cen_bandwidth_limit.html.markdown
@@ -19,71 +19,71 @@ For information about CEN and how to use it, see [Cross-region interconnection b
 Basic Usage
 
 ```
-variable "name"{
-    default = "tf-testAccCenBandwidthLimitConfig"
+variable "name" {
+  default = "tf-testAccCenBandwidthLimitConfig"
 }
 
 provider "alicloud" {
-    alias = "fra"
-    region = "eu-central-1"
+  alias  = "fra"
+  region = "eu-central-1"
 }
 
 provider "alicloud" {
-    alias = "sh"
-    region = "cn-shanghai"
+  alias  = "sh"
+  region = "cn-shanghai"
 }
 
 resource "alicloud_vpc" "vpc1" {
-  provider = "alicloud.fra"
-  name = "${var.name}"
+  provider   = "alicloud.fra"
+  name       = "${var.name}"
   cidr_block = "192.168.0.0/16"
 }
 
 resource "alicloud_vpc" "vpc2" {
-  provider = "alicloud.sh"
-  name = "${var.name}"
+  provider   = "alicloud.sh"
+  name       = "${var.name}"
   cidr_block = "172.16.0.0/12"
 }
 
 resource "alicloud_cen_instance" "cen" {
-     name = "${var.name}"
-     description = "tf-testAccCenBandwidthLimitConfigDescription"
+  name        = "${var.name}"
+  description = "tf-testAccCenBandwidthLimitConfigDescription"
 }
 
 resource "alicloud_cen_bandwidth_package" "bwp" {
-    bandwidth = 5
-    geographic_region_ids = [
-		"Europe",
-		"China"]
+  bandwidth = 5
+  geographic_region_ids = [
+    "Europe",
+  "China"]
 }
 
 resource "alicloud_cen_bandwidth_package_attachment" "bwp_attach" {
-    instance_id = "${alicloud_cen_instance.cen.id}"
-    bandwidth_package_id = "${alicloud_cen_bandwidth_package.bwp.id}"
+  instance_id          = "${alicloud_cen_instance.cen.id}"
+  bandwidth_package_id = "${alicloud_cen_bandwidth_package.bwp.id}"
 }
 
 resource "alicloud_cen_instance_attachment" "vpc_attach_1" {
-    instance_id = "${alicloud_cen_instance.cen.id}"
-    child_instance_id = "${alicloud_vpc.vpc1.id}"
-    child_instance_region_id = "eu-central-1"
+  instance_id              = "${alicloud_cen_instance.cen.id}"
+  child_instance_id        = "${alicloud_vpc.vpc1.id}"
+  child_instance_region_id = "eu-central-1"
 }
 
 resource "alicloud_cen_instance_attachment" "vpc_attach_2" {
-    instance_id = "${alicloud_cen_instance.cen.id}"
-    child_instance_id = "${alicloud_vpc.vpc2.id}"
-    child_instance_region_id = "cn-shanghai"
+  instance_id              = "${alicloud_cen_instance.cen.id}"
+  child_instance_id        = "${alicloud_vpc.vpc2.id}"
+  child_instance_region_id = "cn-shanghai"
 }
 
 resource "alicloud_cen_bandwidth_limit" "foo" {
-    instance_id = "${alicloud_cen_instance.cen.id}"
-    region_ids = [
-        "eu-central-1",
-        "cn-shanghai"]
-     bandwidth_limit = 4
-     depends_on = [
-        "alicloud_cen_bandwidth_package_attachment.bwp_attach",
-        "alicloud_cen_instance_attachment.vpc_attach_1",
-        "alicloud_cen_instance_attachment.vpc_attach_2"]
+  instance_id = "${alicloud_cen_instance.cen.id}"
+  region_ids = [
+    "eu-central-1",
+  "cn-shanghai"]
+  bandwidth_limit = 4
+  depends_on = [
+    "alicloud_cen_bandwidth_package_attachment.bwp_attach",
+    "alicloud_cen_instance_attachment.vpc_attach_1",
+  "alicloud_cen_instance_attachment.vpc_attach_2"]
 }
 ```
 ## Argument Reference

--- a/website/docs/r/cen_bandwidth_package.html.markdown
+++ b/website/docs/r/cen_bandwidth_package.html.markdown
@@ -18,11 +18,11 @@ Basic Usage
 
 ```
 resource "alicloud_cen_bandwidth_package" "foo" {
-    name = "tf-testAccCenBandwidthPackageConfig"
-    bandwidth = 5
-    geographic_region_ids = [
-		"China",
-		"Asia-Pacific"]
+  name      = "tf-testAccCenBandwidthPackageConfig"
+  bandwidth = 5
+  geographic_region_ids = [
+    "China",
+  "Asia-Pacific"]
 }
 ```
 ## Argument Reference

--- a/website/docs/r/cen_bandwidth_package_attachment.html.markdown
+++ b/website/docs/r/cen_bandwidth_package_attachment.html.markdown
@@ -17,20 +17,20 @@ Basic Usage
 ```
 # Create a new bandwidth package attachment and use it to attach a bandwidth package to a new CEN
 resource "alicloud_cen_instance" "cen" {
-     name = "tf-testAccCenBandwidthPackageAttachmentConfig"
-     description = "tf-testAccCenBandwidthPackageAttachmentDescription"
+  name        = "tf-testAccCenBandwidthPackageAttachmentConfig"
+  description = "tf-testAccCenBandwidthPackageAttachmentDescription"
 }
 
 resource "alicloud_cen_bandwidth_package" "bwp" {
-    bandwidth = 20
-    geographic_region_ids = [
-		"China",
-		"Asia-Pacific"]
+  bandwidth = 20
+  geographic_region_ids = [
+    "China",
+  "Asia-Pacific"]
 }
 
 resource "alicloud_cen_bandwidth_package_attachment" "foo" {
-    instance_id = "${alicloud_cen_instance.cen.id}"
-    bandwidth_package_id = "${alicloud_cen_bandwidth_package.bwp.id}"
+  instance_id          = "${alicloud_cen_instance.cen.id}"
+  bandwidth_package_id = "${alicloud_cen_bandwidth_package.bwp.id}"
 }
 ```
 ## Argument Reference

--- a/website/docs/r/cen_instance.html.markdown
+++ b/website/docs/r/cen_instance.html.markdown
@@ -18,8 +18,8 @@ Basic Usage
 
 ```
 resource "alicloud_cen_instance" "cen" {
-	name = "tf_test_foo"
-	description = "an example for cen"
+  name        = "tf_test_foo"
+  description = "an example for cen"
 }
 ```
 ## Argument Reference

--- a/website/docs/r/cen_instance_attachment.html.markdown
+++ b/website/docs/r/cen_instance_attachment.html.markdown
@@ -16,24 +16,24 @@ Basic Usage
 
 ```
 # Create a new instance-attachment and use it to attach one child instance to a new CEN
-variable "name"{
-	default = "tf-testAccCenInstanceAttachmentBasic"
+variable "name" {
+  default = "tf-testAccCenInstanceAttachmentBasic"
 }
 
 resource "alicloud_cen_instance" "cen" {
-	name = "${var.name}"
-	description = "terraform01"
+  name        = "${var.name}"
+  description = "terraform01"
 }
 
 resource "alicloud_vpc" "vpc" {
-	name = "${var.name}"
-	cidr_block = "192.168.0.0/16"
+  name       = "${var.name}"
+  cidr_block = "192.168.0.0/16"
 }
 
 resource "alicloud_cen_instance_attachment" "foo" {
-    instance_id = "${alicloud_cen_instance.cen.id}"
-	child_instance_id = "${alicloud_vpc.vpc.id}"
-	child_instance_region_id = "cn-beijing"
+  instance_id              = "${alicloud_cen_instance.cen.id}"
+  child_instance_id        = "${alicloud_vpc.vpc.id}"
+  child_instance_region_id = "cn-beijing"
 }
 ```
 ## Argument Reference

--- a/website/docs/r/cen_instance_grant.html.markdown
+++ b/website/docs/r/cen_instance_grant.html.markdown
@@ -18,49 +18,49 @@ Basic Usage
 
 ```
 # Create a new instance-grant and use it to grant one child instance of account1 to a new CEN of account 2.
-	provider "alicloud" {
-		access_key = "access123"
-		secret_key = "secret123"
-		alias = "account1"
-	}
+provider "alicloud" {
+  access_key = "access123"
+  secret_key = "secret123"
+  alias      = "account1"
+}
 
-	provider "alicloud" {
-		access_key = "access456"
-		secret_key = "secret456"
-		alias = "account2"
-	}
+provider "alicloud" {
+  access_key = "access456"
+  secret_key = "secret456"
+  alias      = "account2"
+}
 
-	variable "name" {
-		default = "tf-testAccCenInstanceGrantBasic"
-	}
+variable "name" {
+  default = "tf-testAccCenInstanceGrantBasic"
+}
 
-	resource "alicloud_cen_instance" "cen" {
-		provider = "alicloud.account2"
-		name = "${var.name}"
-	}
+resource "alicloud_cen_instance" "cen" {
+  provider = "alicloud.account2"
+  name     = "${var.name}"
+}
 
-	resource "alicloud_vpc" "vpc" {
-		provider = "alicloud.account1"
-		name = "${var.name}"
-		cidr_block = "192.168.0.0/16"
-	}
-	
-	resource "alicloud_cen_instance_grant" "example" {
-		provider = "alicloud.account1"
-		cen_id = "${alicloud_cen_instance.cen.id}"
-		child_instance_id = "${alicloud_vpc.vpc.id}"
-		cen_owner_id = "uid2"
-	}
-	
-  resource "alicloud_cen_instance_attachment" "foo" {
-  	provider = "alicloud.account2"
-  	instance_id = "${alicloud_cen_instance.cen.id}"
-  	child_instance_id = "${alicloud_vpc.vpc.id}"
-  	child_instance_region_id = "cn-qingdao"
-  	child_instance_owner_id = "uid1"
-  	depends_on = [
-  		"alicloud_cen_instance_grant.foo"]
-  }
+resource "alicloud_vpc" "vpc" {
+  provider   = "alicloud.account1"
+  name       = "${var.name}"
+  cidr_block = "192.168.0.0/16"
+}
+
+resource "alicloud_cen_instance_grant" "example" {
+  provider          = "alicloud.account1"
+  cen_id            = "${alicloud_cen_instance.cen.id}"
+  child_instance_id = "${alicloud_vpc.vpc.id}"
+  cen_owner_id      = "uid2"
+}
+
+resource "alicloud_cen_instance_attachment" "foo" {
+  provider                 = "alicloud.account2"
+  instance_id              = "${alicloud_cen_instance.cen.id}"
+  child_instance_id        = "${alicloud_vpc.vpc.id}"
+  child_instance_region_id = "cn-qingdao"
+  child_instance_owner_id  = "uid1"
+  depends_on = [
+  "alicloud_cen_instance_grant.foo"]
+}
 ```
 ## Argument Reference
 

--- a/website/docs/r/cen_route_entry.html.markdown
+++ b/website/docs/r/cen_route_entry.html.markdown
@@ -20,94 +20,94 @@ Basic Usage
 # Create a cen_route_entry resource and use it to publish a route entry pointing to an ECS.
 
 provider "alicloud" {
-    alias = "hz"
-    region = "cn-hangzhou"
+  alias  = "hz"
+  region = "cn-hangzhou"
 }
 
 variable "name" {
-    default = "tf-testAccCenRouteEntryConfig"
+  default = "tf-testAccCenRouteEntryConfig"
 }
 
 data "alicloud_zones" "default" {
-    provider = "alicloud.hz"
-    available_disk_category = "cloud_efficiency"
-    available_resource_creation = "VSwitch"
+  provider                    = "alicloud.hz"
+  available_disk_category     = "cloud_efficiency"
+  available_resource_creation = "VSwitch"
 }
 
 data "alicloud_instance_types" "default" {
-    provider = "alicloud.hz"
-    availability_zone = "${data.alicloud_zones.default.zones.0.id}"
-    cpu_core_count = 1
-    memory_size = 2
+  provider          = "alicloud.hz"
+  availability_zone = "${data.alicloud_zones.default.zones.0.id}"
+  cpu_core_count    = 1
+  memory_size       = 2
 }
 
 data "alicloud_images" "default" {
-    provider = "alicloud.hz"
-    name_regex = "^ubuntu_14.*_64"
-    most_recent = true
-    owners = "system"
+  provider    = "alicloud.hz"
+  name_regex  = "^ubuntu_14.*_64"
+  most_recent = true
+  owners      = "system"
 }
 
 resource "alicloud_vpc" "vpc" {
-    provider = "alicloud.hz"
-    name = "${var.name}"
-    cidr_block = "172.16.0.0/12"
+  provider   = "alicloud.hz"
+  name       = "${var.name}"
+  cidr_block = "172.16.0.0/12"
 }
 
 resource "alicloud_vswitch" "default" {
-    provider = "alicloud.hz"
-    vpc_id = "${alicloud_vpc.vpc.id}"
-    cidr_block = "172.16.0.0/21"
-    availability_zone = "${data.alicloud_zones.default.zones.0.id}"
-    name = "${var.name}"
+  provider          = "alicloud.hz"
+  vpc_id            = "${alicloud_vpc.vpc.id}"
+  cidr_block        = "172.16.0.0/21"
+  availability_zone = "${data.alicloud_zones.default.zones.0.id}"
+  name              = "${var.name}"
 }
 
 resource "alicloud_security_group" "default" {
-    provider = "alicloud.hz"
-    name = "${var.name}"
-    description = "foo"
-    vpc_id = "${alicloud_vpc.vpc.id}"
+  provider    = "alicloud.hz"
+  name        = "${var.name}"
+  description = "foo"
+  vpc_id      = "${alicloud_vpc.vpc.id}"
 }
 
 resource "alicloud_instance" "default" {
-    provider = "alicloud.hz"
-    vswitch_id = "${alicloud_vswitch.default.id}"
-    image_id = "${data.alicloud_images.default.images.0.id}"
-    instance_type = "${data.alicloud_instance_types.default.instance_types.0.id}"
-    system_disk_category = "cloud_efficiency"
-    internet_charge_type = "PayByTraffic"
-    internet_max_bandwidth_out = 5
-    security_groups = ["${alicloud_security_group.default.id}"]
-    instance_name = "${var.name}"
+  provider                   = "alicloud.hz"
+  vswitch_id                 = "${alicloud_vswitch.default.id}"
+  image_id                   = "${data.alicloud_images.default.images.0.id}"
+  instance_type              = "${data.alicloud_instance_types.default.instance_types.0.id}"
+  system_disk_category       = "cloud_efficiency"
+  internet_charge_type       = "PayByTraffic"
+  internet_max_bandwidth_out = 5
+  security_groups            = ["${alicloud_security_group.default.id}"]
+  instance_name              = "${var.name}"
 }
 
 resource "alicloud_cen_instance" "cen" {
-    name = "${var.name}"
+  name = "${var.name}"
 }
 
 resource "alicloud_cen_instance_attachment" "attach" {
-    instance_id = "${alicloud_cen_instance.cen.id}"
-    child_instance_id = "${alicloud_vpc.vpc.id}"
-    child_instance_region_id = "cn-hangzhou"
-    depends_on = [
-      "alicloud_vswitch.default"]
+  instance_id              = "${alicloud_cen_instance.cen.id}"
+  child_instance_id        = "${alicloud_vpc.vpc.id}"
+  child_instance_region_id = "cn-hangzhou"
+  depends_on = [
+  "alicloud_vswitch.default"]
 }
 
 resource "alicloud_route_entry" "route" {
-    provider = "alicloud.hz"
-    route_table_id = "${alicloud_vpc.vpc.route_table_id}"
-    destination_cidrblock = "11.0.0.0/16"
-    nexthop_type = "Instance"
-    nexthop_id = "${alicloud_instance.default.id}"
+  provider              = "alicloud.hz"
+  route_table_id        = "${alicloud_vpc.vpc.route_table_id}"
+  destination_cidrblock = "11.0.0.0/16"
+  nexthop_type          = "Instance"
+  nexthop_id            = "${alicloud_instance.default.id}"
 }
 
 resource "alicloud_cen_route_entry" "foo" {
-    provider = "alicloud.hz"
-    instance_id = "${alicloud_cen_instance.cen.id}"
-    route_table_id = "${alicloud_vpc.vpc.route_table_id}"
-    cidr_block = "${alicloud_route_entry.route.destination_cidrblock}"
-    depends_on = [
-        "alicloud_cen_instance_attachment.attach"]
+  provider       = "alicloud.hz"
+  instance_id    = "${alicloud_cen_instance.cen.id}"
+  route_table_id = "${alicloud_vpc.vpc.route_table_id}"
+  cidr_block     = "${alicloud_route_entry.route.destination_cidrblock}"
+  depends_on = [
+  "alicloud_cen_instance_attachment.attach"]
 }
 ```
 ## Argument Reference

--- a/website/docs/r/cms_alarm.html.markdown
+++ b/website/docs/r/cms_alarm.html.markdown
@@ -17,23 +17,23 @@ Basic Usage
 
 ```
 resource "alicloud_cms_alarm" "basic" {
-  name = "tf-testAccCmsAlarm_basic"
+  name    = "tf-testAccCmsAlarm_basic"
   project = "acs_ecs_dashboard"
-  metric = "disk_writebytes"
+  metric  = "disk_writebytes"
   dimensions = {
     instanceId = "i-bp1247,i-bp11gd"
-    device = "/dev/vda1,/dev/vdb1"
+    device     = "/dev/vda1,/dev/vdb1"
   }
-  statistics ="Average"
-  period = 900
-  operator = "<="
-  threshold = 35
+  statistics      = "Average"
+  period          = 900
+  operator        = "<="
+  threshold       = 35
   triggered_count = 2
-  contact_groups = ["test-group"]
-  end_time = 20
-  start_time = 6
-  notify_type = 1
-  webhook = "https://${data.alicloud_account.current.id}.eu-central-1.fc.aliyuncs.com/2016-08-15/proxy/Terraform/AlarmEndpointMock/"
+  contact_groups  = ["test-group"]
+  end_time        = 20
+  start_time      = 6
+  notify_type     = 1
+  webhook         = "https://${data.alicloud_account.current.id}.eu-central-1.fc.aliyuncs.com/2016-08-15/proxy/Terraform/AlarmEndpointMock/"
 }
 ```
 

--- a/website/docs/r/common_bandwidth_package.html.markdown
+++ b/website/docs/r/common_bandwidth_package.html.markdown
@@ -22,10 +22,10 @@ Basic Usage
 
 ```
 resource "alicloud_common_bandwidth_package" "foo" {
-  bandwidth = "200"
+  bandwidth            = "200"
   internet_charge_type = "PayByBandwidth"
-  name = "test-common-bandwidth-package"
-  description = "test-common-bandwidth-package"
+  name                 = "test-common-bandwidth-package"
+  description          = "test-common-bandwidth-package"
 }
 ```
 ## Argument Reference

--- a/website/docs/r/common_bandwidth_package_attachment.html.markdown
+++ b/website/docs/r/common_bandwidth_package_attachment.html.markdown
@@ -20,8 +20,8 @@ Basic Usage
 
 ```
 resource "alicloud_common_bandwidth_package" "foo" {
-  bandwidth = "2"
-  name = "test_common_bandwidth_package"
+  bandwidth   = "2"
+  name        = "test_common_bandwidth_package"
   description = "test_common_bandwidth_package"
 }
 
@@ -32,7 +32,7 @@ resource "alicloud_eip" "foo" {
 
 resource "alicloud_common_bandwidth_package_attachment" "foo" {
   bandwidth_package_id = "${alicloud_common_bandwidth_package.foo.id}"
-  instance_id = "${alicloud_eip.foo.id}"
+  instance_id          = "${alicloud_eip.foo.id}"
 }
 
 ```

--- a/website/docs/r/cr_namespace.html.markdown
+++ b/website/docs/r/cr_namespace.html.markdown
@@ -20,9 +20,9 @@ Basic Usage
 
 ```
 resource "alicloud_cr_namespace" "my-namespace" {
-    name = "my-namespace"
-    auto_create = false
-    default_visibility = "PUBLIC"
+  name               = "my-namespace"
+  auto_create        = false
+  default_visibility = "PUBLIC"
 }
 ```
 

--- a/website/docs/r/cr_repo.html.markdown
+++ b/website/docs/r/cr_repo.html.markdown
@@ -20,17 +20,17 @@ Basic Usage
 
 ```
 resource "alicloud_cr_namespace" "my-namespace" {
-    name = "my-namespace"
-    auto_create = false
-    default_visibility = "PUBLIC"
+  name               = "my-namespace"
+  auto_create        = false
+  default_visibility = "PUBLIC"
 }
 
 resource "alicloud_cr_repo" "my-repo" {
-    namespace = "${alicloud_cr_namespace.my-namespace.name}"
-    name = "my-repo"
-    summary = "this is summary of my new repo"
-    repo_type = "PUBLIC"
-    detail  = "this is a public repo"
+  namespace = "${alicloud_cr_namespace.my-namespace.name}"
+  name      = "my-repo"
+  summary   = "this is summary of my new repo"
+  repo_type = "PUBLIC"
+  detail    = "this is a public repo"
 }
 ```
 

--- a/website/docs/r/cs_application.html.markdown
+++ b/website/docs/r/cs_application.html.markdown
@@ -24,9 +24,9 @@ Basic Usage
 ```
 resource "alicloud_cs_application" "app" {
   cluster_name = "my-first-swarm"
-  name = "wordpress"
-  version = "1.2"
-  template = "${file("wordpress.yml")}"
+  name         = "wordpress"
+  version      = "1.2"
+  template     = "${file("wordpress.yml")}"
   latest_image = true
   environment = {
     EXTERNAL_URL = "123.123.123.123:8080"

--- a/website/docs/r/cs_kubernetes.html.markdown
+++ b/website/docs/r/cs_kubernetes.html.markdown
@@ -46,16 +46,16 @@ data "alicloud_zones" "default" {
 }
 
 resource "alicloud_cs_kubernetes" "main" {
-  name_prefix = "my-first-k8s"
-  availability_zone = "${data.alicloud_zones.default.zones.0.id}"
-  new_nat_gateway = true
+  name_prefix           = "my-first-k8s"
+  availability_zone     = "${data.alicloud_zones.default.zones.0.id}"
+  new_nat_gateway       = true
   master_instance_types = ["ecs.n4.small"]
   worker_instance_types = ["ecs.n4.small"]
-  worker_numbers = [3]
-  password = "Yourpassword1234"
-  pod_cidr = "192.168.1.0/16"
-  service_cidr = "192.168.2.0/24"
-  enable_ssh = true
+  worker_numbers        = [3]
+  password              = "Yourpassword1234"
+  pod_cidr              = "192.168.1.0/16"
+  service_cidr          = "192.168.2.0/24"
+  enable_ssh            = true
   install_cloud_monitor = true
 }
 ```
@@ -64,7 +64,7 @@ Three AZ Kubernetes Cluster
 
 ```
 variable "name" {
-	default = "my-first-3az-k8s"
+  default = "my-first-3az-k8s"
 }
 
 data "alicloud_zones" main {
@@ -72,71 +72,71 @@ data "alicloud_zones" main {
 }
 
 data "alicloud_instance_types" "instance_types_1_master" {
-	availability_zone = "${data.alicloud_zones.main.zones.0.id}"
-	cpu_core_count = 2
-	memory_size = 4
-	kubernetes_node_role = "Master"
+  availability_zone    = "${data.alicloud_zones.main.zones.0.id}"
+  cpu_core_count       = 2
+  memory_size          = 4
+  kubernetes_node_role = "Master"
 }
 data "alicloud_instance_types" "instance_types_2_master" {
-	availability_zone = "${lookup(data.alicloud_zones.main.zones[(length(data.alicloud_zones.main.zones)-1)%length(data.alicloud_zones.main.zones)], "id")}"
-	cpu_core_count = 2
-	memory_size = 4
-	kubernetes_node_role = "Master"
+  availability_zone    = "${lookup(data.alicloud_zones.main.zones[(length(data.alicloud_zones.main.zones) - 1) % length(data.alicloud_zones.main.zones)], "id")}"
+  cpu_core_count       = 2
+  memory_size          = 4
+  kubernetes_node_role = "Master"
 }
 data "alicloud_instance_types" "instance_types_3_master" {
-	availability_zone = "${lookup(data.alicloud_zones.main.zones[(length(data.alicloud_zones.main.zones)-2)%length(data.alicloud_zones.main.zones)], "id")}"
-	cpu_core_count = 2
-	memory_size = 4
-	kubernetes_node_role = "Master"
+  availability_zone    = "${lookup(data.alicloud_zones.main.zones[(length(data.alicloud_zones.main.zones) - 2) % length(data.alicloud_zones.main.zones)], "id")}"
+  cpu_core_count       = 2
+  memory_size          = 4
+  kubernetes_node_role = "Master"
 }
 
 data "alicloud_instance_types" "instance_types_1_worker" {
-	availability_zone = "${data.alicloud_zones.main.zones.0.id}"
-	cpu_core_count = 2
-	memory_size = 4
-	kubernetes_node_role = "Worker"
+  availability_zone    = "${data.alicloud_zones.main.zones.0.id}"
+  cpu_core_count       = 2
+  memory_size          = 4
+  kubernetes_node_role = "Worker"
 }
 data "alicloud_instance_types" "instance_types_2_worker" {
-	availability_zone = "${lookup(data.alicloud_zones.main.zones[(length(data.alicloud_zones.main.zones)-1)%length(data.alicloud_zones.main.zones)], "id")}"
-	cpu_core_count = 2
-	memory_size = 4
-	kubernetes_node_role = "Worker"
+  availability_zone    = "${lookup(data.alicloud_zones.main.zones[(length(data.alicloud_zones.main.zones) - 1) % length(data.alicloud_zones.main.zones)], "id")}"
+  cpu_core_count       = 2
+  memory_size          = 4
+  kubernetes_node_role = "Worker"
 }
 data "alicloud_instance_types" "instance_types_3_worker" {
-	availability_zone = "${lookup(data.alicloud_zones.main.zones[(length(data.alicloud_zones.main.zones)-2)%length(data.alicloud_zones.main.zones)], "id")}"
-	cpu_core_count = 2
-	memory_size = 4
-	kubernetes_node_role = "Worker"
+  availability_zone    = "${lookup(data.alicloud_zones.main.zones[(length(data.alicloud_zones.main.zones) - 2) % length(data.alicloud_zones.main.zones)], "id")}"
+  cpu_core_count       = 2
+  memory_size          = 4
+  kubernetes_node_role = "Worker"
 }
 resource "alicloud_vpc" "foo" {
-  name = "${var.name}"
+  name       = "${var.name}"
   cidr_block = "10.1.0.0/21"
 }
 
 resource "alicloud_vswitch" "vsw1" {
-  name = "${var.name}"
-  vpc_id = "${alicloud_vpc.foo.id}"
-  cidr_block = "10.1.1.0/24"
+  name              = "${var.name}"
+  vpc_id            = "${alicloud_vpc.foo.id}"
+  cidr_block        = "10.1.1.0/24"
   availability_zone = "${data.alicloud_zones.main.zones.0.id}"
 }
 
 resource "alicloud_vswitch" "vsw2" {
-  name = "${var.name}"
-  vpc_id = "${alicloud_vpc.foo.id}"
-  cidr_block = "10.1.2.0/24"
-  availability_zone = "${lookup(data.alicloud_zones.main.zones[(length(data.alicloud_zones.main.zones)-1)%length(data.alicloud_zones.main.zones)], "id")}"
+  name              = "${var.name}"
+  vpc_id            = "${alicloud_vpc.foo.id}"
+  cidr_block        = "10.1.2.0/24"
+  availability_zone = "${lookup(data.alicloud_zones.main.zones[(length(data.alicloud_zones.main.zones) - 1) % length(data.alicloud_zones.main.zones)], "id")}"
 }
 
 resource "alicloud_vswitch" "vsw3" {
-  name = "${var.name}"
-  vpc_id = "${alicloud_vpc.foo.id}"
-  cidr_block = "10.1.3.0/24"
-  availability_zone = "${lookup(data.alicloud_zones.main.zones[(length(data.alicloud_zones.main.zones)-2)%length(data.alicloud_zones.main.zones)], "id")}"
+  name              = "${var.name}"
+  vpc_id            = "${alicloud_vpc.foo.id}"
+  cidr_block        = "10.1.3.0/24"
+  availability_zone = "${lookup(data.alicloud_zones.main.zones[(length(data.alicloud_zones.main.zones) - 2) % length(data.alicloud_zones.main.zones)], "id")}"
 }
 
 resource "alicloud_nat_gateway" "nat_gateway" {
-  name = "${var.name}"
-  vpc_id = "${alicloud_vpc.foo.id}"
+  name          = "${var.name}"
+  vpc_id        = "${alicloud_vpc.foo.id}"
   specification = "Small"
 }
 
@@ -159,7 +159,7 @@ resource "alicloud_snat_entry" "snat_entry_3" {
 }
 
 resource "alicloud_eip" "eip" {
-  name = "${var.name}"
+  name      = "${var.name}"
   bandwidth = "100"
 }
 
@@ -169,23 +169,23 @@ resource "alicloud_eip_association" "eip_asso" {
 }
 
 resource "alicloud_cs_kubernetes" "k8s" {
-  name = "${var.name}"
-  vswitch_ids = ["${alicloud_vswitch.vsw1.id}", "${alicloud_vswitch.vsw2.id}", "${alicloud_vswitch.vsw3.id}"]
-  new_nat_gateway = true
-  master_instance_types = ["${data.alicloud_instance_types.instance_types_1_master.instance_types.0.id}", "${data.alicloud_instance_types.instance_types_2_master.instance_types.0.id}", "${data.alicloud_instance_types.instance_types_3_master.instance_types.0.id}"]
-  worker_instance_types = ["${data.alicloud_instance_types.instance_types_1_worker.instance_types.0.id}", "${data.alicloud_instance_types.instance_types_2_worker.instance_types.0.id}", "${data.alicloud_instance_types.instance_types_3_worker.instance_types.0.id}"]
-  worker_numbers = [1, 2, 3]
-  master_disk_category  = "cloud_ssd"
-  worker_disk_size = 50
-  worker_data_disk_category  = "cloud_ssd"
-  worker_data_disk_size = 50
-  password = "Yourpassword1234"
-  pod_cidr = "192.168.1.0/16"
-  service_cidr = "192.168.2.0/24"
-  enable_ssh = true
-  slb_internet_enabled = true
-  node_cidr_mask = 25
-  install_cloud_monitor = true
+  name                      = "${var.name}"
+  vswitch_ids               = ["${alicloud_vswitch.vsw1.id}", "${alicloud_vswitch.vsw2.id}", "${alicloud_vswitch.vsw3.id}"]
+  new_nat_gateway           = true
+  master_instance_types     = ["${data.alicloud_instance_types.instance_types_1_master.instance_types.0.id}", "${data.alicloud_instance_types.instance_types_2_master.instance_types.0.id}", "${data.alicloud_instance_types.instance_types_3_master.instance_types.0.id}"]
+  worker_instance_types     = ["${data.alicloud_instance_types.instance_types_1_worker.instance_types.0.id}", "${data.alicloud_instance_types.instance_types_2_worker.instance_types.0.id}", "${data.alicloud_instance_types.instance_types_3_worker.instance_types.0.id}"]
+  worker_numbers            = [1, 2, 3]
+  master_disk_category      = "cloud_ssd"
+  worker_disk_size          = 50
+  worker_data_disk_category = "cloud_ssd"
+  worker_data_disk_size     = 50
+  password                  = "Yourpassword1234"
+  pod_cidr                  = "192.168.1.0/16"
+  service_cidr              = "192.168.2.0/24"
+  enable_ssh                = true
+  slb_internet_enabled      = true
+  node_cidr_mask            = 25
+  install_cloud_monitor     = true
 }
 ```
 

--- a/website/docs/r/cs_managed_kubernetes.html.markdown
+++ b/website/docs/r/cs_managed_kubernetes.html.markdown
@@ -34,29 +34,29 @@ Basic Usage
 
 ```
 variable "name" {
-	default = "my-first-k8s"
+  default = "my-first-k8s"
 }
 data "alicloud_zones" main {
   available_resource_creation = "VSwitch"
 }
 
 data "alicloud_instance_types" "default" {
-	availability_zone = "${data.alicloud_zones.main.zones.0.id}"
-	cpu_core_count = 1
-	memory_size = 2
+  availability_zone = "${data.alicloud_zones.main.zones.0.id}"
+  cpu_core_count    = 1
+  memory_size       = 2
 }
 
 resource "alicloud_cs_managed_kubernetes" "k8s" {
-  name = "${var.name}"
-  availability_zone = "${data.alicloud_zones.main.zones.0.id}"
-  new_nat_gateway = true
+  name                  = "${var.name}"
+  availability_zone     = "${data.alicloud_zones.main.zones.0.id}"
+  new_nat_gateway       = true
   worker_instance_types = ["${data.alicloud_instance_types.default.instance_types.0.id}"]
-  worker_numbers = [2]
-  password = "Yourpassword1234"
-  pod_cidr = "172.20.0.0/16"
-  service_cidr = "172.21.0.0/20"
+  worker_numbers        = [2]
+  password              = "Yourpassword1234"
+  pod_cidr              = "172.20.0.0/16"
+  service_cidr          = "172.21.0.0/20"
   install_cloud_monitor = true
-  slb_internet_enabled = true
+  slb_internet_enabled  = true
   worker_disk_category  = "cloud_efficiency"
 }
 ```

--- a/website/docs/r/cs_swarm.html.markdown
+++ b/website/docs/r/cs_swarm.html.markdown
@@ -20,15 +20,15 @@ Basic Usage
 
 ```
 resource "alicloud_cs_swarm" "my_cluster" {
-  password = "Yourpassword1234"
+  password      = "Yourpassword1234"
   instance_type = "ecs.n4.small"
-  name = "ClusterFromAlicloud"
-  node_number = 2
+  name          = "ClusterFromAlicloud"
+  node_number   = 2
   disk_category = "cloud_efficiency"
-  disk_size = 20
-  cidr_block = "172.18.0.0/24"
-  image_id = "${var.image_id}"
-  vswitch_id = "${var.vswitch_id}"
+  disk_size     = 20
+  cidr_block    = "172.18.0.0/24"
+  image_id      = "${var.image_id}"
+  vswitch_id    = "${var.vswitch_id}"
 }
 ```
 ## Argument Reference

--- a/website/docs/r/datahub_project.html.markdown
+++ b/website/docs/r/datahub_project.html.markdown
@@ -18,7 +18,7 @@ Basic Usage
 
 ```
 resource "alicloud_datahub_project" "example" {
-  name = "tf_datahub_project"
+  name    = "tf_datahub_project"
   comment = "created by terraform"
 }
 ```

--- a/website/docs/r/datahub_subscription.html.markdown
+++ b/website/docs/r/datahub_subscription.html.markdown
@@ -17,8 +17,8 @@ Basic Usage
 ```
 resource "alicloud_datahub_subscription" "example" {
   project_name = "tf_datahub_project"
-  topic_name = "tf_datahub_topic"
-  comment = "created by terraform"
+  topic_name   = "tf_datahub_topic"
+  comment      = "created by terraform"
 }
 ```
 

--- a/website/docs/r/datahub_topic.html.markdown
+++ b/website/docs/r/datahub_topic.html.markdown
@@ -17,33 +17,33 @@ Basic Usage
 - BLob Topic
 
   ```
-  resource "alicloud_datahub_topic" "example" {
-    name = "tf_datahub_topic"
-    project_name = "tf_datahub_project"
-    record_type = "BLOB"
-    shard_count = 3
-    life_cycle = 7
-    comment = "created by terraform"
-  }
+resource "alicloud_datahub_topic" "example" {
+  name         = "tf_datahub_topic"
+  project_name = "tf_datahub_project"
+  record_type  = "BLOB"
+  shard_count  = 3
+  life_cycle   = 7
+  comment      = "created by terraform"
+}
   ```
 - Tuple Topic
 
   ```
-  resource "alicloud_datahub_topic" "example" {
-    name = "tf_datahub_topic"
-    project_name = "tf_datahub_project"
-    record_type = "TUPLE"
-    record_schema = {
-      bigint_field = "BIGINT"
-      timestamp_field = "TIMESTAMP"
-      string_field = "STRING"
-      double_field = "DOUBLE"
-      boolean_field = "BOOLEAN"
-    }
-    shard_count = 3
-    life_cycle = 7
-    comment = "created by terraform"
+resource "alicloud_datahub_topic" "example" {
+  name         = "tf_datahub_topic"
+  project_name = "tf_datahub_project"
+  record_type  = "TUPLE"
+  record_schema = {
+    bigint_field    = "BIGINT"
+    timestamp_field = "TIMESTAMP"
+    string_field    = "STRING"
+    double_field    = "DOUBLE"
+    boolean_field   = "BOOLEAN"
   }
+  shard_count = 3
+  life_cycle  = 7
+  comment     = "created by terraform"
+}
   ```
 
 ## Argument Reference

--- a/website/docs/r/db_account.html.markdown
+++ b/website/docs/r/db_account.html.markdown
@@ -16,44 +16,44 @@ Provides an RDS account resource and used to manage databases.
 ## Example Usage
 
 ```
-    variable "creation" {
-    		default = "Rds"
-    }
-    
-    variable "name" {
-    		default = "dbaccountmysql"
-    }
+variable "creation" {
+  default = "Rds"
+}
 
-    data "alicloud_zones" "default" {
-        available_resource_creation = "${var.creation}"
-    }
+variable "name" {
+  default = "dbaccountmysql"
+}
 
-    resource "alicloud_vpc" "default" {
-        name       = "${var.name}"
-        cidr_block = "172.16.0.0/16"
-    }
+data "alicloud_zones" "default" {
+  available_resource_creation = "${var.creation}"
+}
 
-    resource "alicloud_vswitch" "default" {
-        vpc_id            = "${alicloud_vpc.default.id}"
-        cidr_block        = "172.16.0.0/24"
-        availability_zone = "${data.alicloud_zones.default.zones.0.id}"
-        name              = "${var.name}"
-    }
-    
-	resource "alicloud_db_instance" "instance" {
-		engine = "MySQL"
-		engine_version = "5.6"
-		instance_type = "rds.mysql.s1.small"
-		instance_storage = "10"
-		vswitch_id = "${alicloud_vswitch.default.id}"
-	    instance_name = "${var.name}"
-	}
+resource "alicloud_vpc" "default" {
+  name       = "${var.name}"
+  cidr_block = "172.16.0.0/16"
+}
 
-	resource "alicloud_db_account" "account" {
-	  	instance_id = "${alicloud_db_instance.instance.id}"
-	  	name = "tftestnormal"
-	  	password = "Test12345"
-	}
+resource "alicloud_vswitch" "default" {
+  vpc_id            = "${alicloud_vpc.default.id}"
+  cidr_block        = "172.16.0.0/24"
+  availability_zone = "${data.alicloud_zones.default.zones.0.id}"
+  name              = "${var.name}"
+}
+
+resource "alicloud_db_instance" "instance" {
+  engine           = "MySQL"
+  engine_version   = "5.6"
+  instance_type    = "rds.mysql.s1.small"
+  instance_storage = "10"
+  vswitch_id       = "${alicloud_vswitch.default.id}"
+  instance_name    = "${var.name}"
+}
+
+resource "alicloud_db_account" "account" {
+  instance_id = "${alicloud_db_instance.instance.id}"
+  name        = "tftestnormal"
+  password    = "Test12345"
+}
 ```
 
 ## Argument Reference

--- a/website/docs/r/db_account_privilege.html.markdown
+++ b/website/docs/r/db_account_privilege.html.markdown
@@ -13,59 +13,59 @@ Provides an RDS account privilege resource and used to grant several database so
 ## Example Usage
 
 ```
-    variable "creation" {
-    		default = "Rds"
-    }
-    
-    variable "name" {
-    		default = "dbaccountprivilegebasic"
-    }
+variable "creation" {
+  default = "Rds"
+}
 
-    data "alicloud_zones" "default" {
-        available_resource_creation = "${var.creation}"
-    }
+variable "name" {
+  default = "dbaccountprivilegebasic"
+}
 
-    resource "alicloud_vpc" "default" {
-        name       = "${var.name}"
-        cidr_block = "172.16.0.0/16"
-    }   
+data "alicloud_zones" "default" {
+  available_resource_creation = "${var.creation}"
+}
 
-    resource "alicloud_vswitch" "default" {
-        vpc_id            = "${alicloud_vpc.default.id}"
-        cidr_block        = "172.16.0.0/24"
-        availability_zone = "${data.alicloud_zones.default.zones.0.id}"
-        name              = "${var.name}"
-    }
-   
-	resource "alicloud_db_instance" "instance" {
-		engine = "MySQL"
-		engine_version = "5.6"
-		instance_type = "rds.mysql.s1.small"
-		instance_storage = "10"
-		vswitch_id = "${alicloud_vswitch.default.id}"
-		instance_name = "${var.name}"
-	}
+resource "alicloud_vpc" "default" {
+  name       = "${var.name}"
+  cidr_block = "172.16.0.0/16"
+}
 
-	resource "alicloud_db_database" "db" {
-	  count = 2
-	  instance_id = "${alicloud_db_instance.instance.id}"
-	  name = "tfaccountpri_${count.index}"
-	  description = "from terraform"
-	}
+resource "alicloud_vswitch" "default" {
+  vpc_id            = "${alicloud_vpc.default.id}"
+  cidr_block        = "172.16.0.0/24"
+  availability_zone = "${data.alicloud_zones.default.zones.0.id}"
+  name              = "${var.name}"
+}
 
-	resource "alicloud_db_account" "account" {
-	  instance_id = "${alicloud_db_instance.instance.id}"
-	  name = "tftestprivilege"
-	  password = "Test12345"
-	  description = "from terraform"
-	}
+resource "alicloud_db_instance" "instance" {
+  engine           = "MySQL"
+  engine_version   = "5.6"
+  instance_type    = "rds.mysql.s1.small"
+  instance_storage = "10"
+  vswitch_id       = "${alicloud_vswitch.default.id}"
+  instance_name    = "${var.name}"
+}
 
-	resource "alicloud_db_account_privilege" "privilege" {
-	  instance_id = "${alicloud_db_instance.instance.id}"
-	  account_name = "${alicloud_db_account.account.name}"
-	  privilege = "ReadOnly"
-	  db_names = "${alicloud_db_database.db.*.name}"
-	}
+resource "alicloud_db_database" "db" {
+  count       = 2
+  instance_id = "${alicloud_db_instance.instance.id}"
+  name        = "tfaccountpri_${count.index}"
+  description = "from terraform"
+}
+
+resource "alicloud_db_account" "account" {
+  instance_id = "${alicloud_db_instance.instance.id}"
+  name        = "tftestprivilege"
+  password    = "Test12345"
+  description = "from terraform"
+}
+
+resource "alicloud_db_account_privilege" "privilege" {
+  instance_id  = "${alicloud_db_instance.instance.id}"
+  account_name = "${alicloud_db_account.account.name}"
+  privilege    = "ReadOnly"
+  db_names     = "${alicloud_db_database.db.*.name}"
+}
 ```
 
 ## Argument Reference

--- a/website/docs/r/db_backup_policy.html.markdown
+++ b/website/docs/r/db_backup_policy.html.markdown
@@ -15,42 +15,42 @@ Provides an RDS instance backup policy resource and used to configure instance b
 ## Example Usage
 
 ```
-    variable "creation" {
-		default = "Rds"
-	}
+variable "creation" {
+  default = "Rds"
+}
 
-	variable "name" {
-		default = "dbbackuppolicybasic"
-	}
+variable "name" {
+  default = "dbbackuppolicybasic"
+}
 
-    data "alicloud_zones" "default" {
-        available_resource_creation = "${var.creation}"
-    }
+data "alicloud_zones" "default" {
+  available_resource_creation = "${var.creation}"
+}
 
-    resource "alicloud_vpc" "default" {
-        name       = "${var.name}"
-        cidr_block = "172.16.0.0/16"
-    }
+resource "alicloud_vpc" "default" {
+  name       = "${var.name}"
+  cidr_block = "172.16.0.0/16"
+}
 
-    resource "alicloud_vswitch" "default" {
-        vpc_id            = "${alicloud_vpc.default.id}"
-        cidr_block        = "172.16.0.0/24"
-        availability_zone = "${data.alicloud_zones.default.zones.0.id}"
-        name              = "${var.name}"
-    }
-    
-	resource "alicloud_db_instance" "instance" {
-		engine = "MySQL"
-		engine_version = "5.6"
-		instance_type = "rds.mysql.s1.small"
-		instance_storage = "10"
-		vswitch_id = "${alicloud_vswitch.default.id}"
-		instance_name = "${var.name}"
-	}
+resource "alicloud_vswitch" "default" {
+  vpc_id            = "${alicloud_vpc.default.id}"
+  cidr_block        = "172.16.0.0/24"
+  availability_zone = "${data.alicloud_zones.default.zones.0.id}"
+  name              = "${var.name}"
+}
 
-	resource "alicloud_db_backup_policy" "policy" {
-		  instance_id = "${alicloud_db_instance.instance.id}"
-	}
+resource "alicloud_db_instance" "instance" {
+  engine           = "MySQL"
+  engine_version   = "5.6"
+  instance_type    = "rds.mysql.s1.small"
+  instance_storage = "10"
+  vswitch_id       = "${alicloud_vswitch.default.id}"
+  instance_name    = "${var.name}"
+}
+
+resource "alicloud_db_backup_policy" "policy" {
+  instance_id = "${alicloud_db_instance.instance.id}"
+}
 ```
 
 ## Argument Reference

--- a/website/docs/r/db_connection.html.markdown
+++ b/website/docs/r/db_connection.html.markdown
@@ -16,43 +16,43 @@ Provides an RDS connection resource to allocate an Internet connection string fo
 ## Example Usage
 
 ```
-    variable "creation" {
-		default = "Rds"
-	}
+variable "creation" {
+  default = "Rds"
+}
 
-	variable "name" {
-		default = "dbconnectionbasic"
-	}
+variable "name" {
+  default = "dbconnectionbasic"
+}
 
-    data "alicloud_zones" "default" {
-        available_resource_creation = "${var.creation}"
-    }
+data "alicloud_zones" "default" {
+  available_resource_creation = "${var.creation}"
+}
 
-    resource "alicloud_vpc" "default" {
-        name       = "${var.name}"
-        cidr_block = "172.16.0.0/16"
-    }
+resource "alicloud_vpc" "default" {
+  name       = "${var.name}"
+  cidr_block = "172.16.0.0/16"
+}
 
-    resource "alicloud_vswitch" "default" {
-        vpc_id            = "${alicloud_vpc.default.id}"
-        cidr_block        = "172.16.0.0/24"
-        availability_zone = "${data.alicloud_zones.default.zones.0.id}"
-        name              = "${var.name}"
-    }
-    
-	resource "alicloud_db_instance" "instance" {
-		engine = "MySQL"
-		engine_version = "5.6"
-		instance_type = "rds.mysql.t1.small"
-		instance_storage = "10"
-		  vswitch_id = "${alicloud_vswitch.default.id}"
-		instance_name = "${var.name}"
-	}
+resource "alicloud_vswitch" "default" {
+  vpc_id            = "${alicloud_vpc.default.id}"
+  cidr_block        = "172.16.0.0/24"
+  availability_zone = "${data.alicloud_zones.default.zones.0.id}"
+  name              = "${var.name}"
+}
 
-	resource "alicloud_db_connection" "foo" {
-	  instance_id = "${alicloud_db_instance.instance.id}"
-	  connection_prefix = "testabc"
-	}
+resource "alicloud_db_instance" "instance" {
+  engine           = "MySQL"
+  engine_version   = "5.6"
+  instance_type    = "rds.mysql.t1.small"
+  instance_storage = "10"
+  vswitch_id       = "${alicloud_vswitch.default.id}"
+  instance_name    = "${var.name}"
+}
+
+resource "alicloud_db_connection" "foo" {
+  instance_id       = "${alicloud_db_instance.instance.id}"
+  connection_prefix = "testabc"
+}
 ```
 
 ## Argument Reference

--- a/website/docs/r/db_database.html.markdown
+++ b/website/docs/r/db_database.html.markdown
@@ -18,43 +18,43 @@ you can use [Postgresql Provider](https://www.terraform.io/docs/providers/postgr
 ## Example Usage
 
 ```
-    variable "creation" {
-		default = "Rds"
-	}
+variable "creation" {
+  default = "Rds"
+}
 
-	variable "name" {
-		default = "dbdatabasebasic"
-	}
+variable "name" {
+  default = "dbdatabasebasic"
+}
 
-    data "alicloud_zones" "default" {
-        available_resource_creation = "${var.creation}"
-    }
+data "alicloud_zones" "default" {
+  available_resource_creation = "${var.creation}"
+}
 
-    resource "alicloud_vpc" "default" {
-        name       = "${var.name}"
-        cidr_block = "172.16.0.0/16"
-    }
+resource "alicloud_vpc" "default" {
+  name       = "${var.name}"
+  cidr_block = "172.16.0.0/16"
+}
 
-    resource "alicloud_vswitch" "default" {
-        vpc_id            = "${alicloud_vpc.default.id}"
-        cidr_block        = "172.16.0.0/24"
-        availability_zone = "${data.alicloud_zones.default.zones.0.id}"
-        name              = "${var.name}"
-    }
-    
-	resource "alicloud_db_instance" "instance" {
-		engine = "MySQL"
-		engine_version = "5.6"
-		instance_type = "rds.mysql.s1.small"
-		instance_storage = "10"
-		vswitch_id = "${alicloud_vswitch.default.id}"
-		instance_name = "${var.name}"
-	}
+resource "alicloud_vswitch" "default" {
+  vpc_id            = "${alicloud_vpc.default.id}"
+  cidr_block        = "172.16.0.0/24"
+  availability_zone = "${data.alicloud_zones.default.zones.0.id}"
+  name              = "${var.name}"
+}
 
-	resource "alicloud_db_database" "default" {
-	  instance_id = "${alicloud_db_instance.instance.id}"
-	  name = "tftestdatabase"
-	}
+resource "alicloud_db_instance" "instance" {
+  engine           = "MySQL"
+  engine_version   = "5.6"
+  instance_type    = "rds.mysql.s1.small"
+  instance_storage = "10"
+  vswitch_id       = "${alicloud_vswitch.default.id}"
+  instance_name    = "${var.name}"
+}
+
+resource "alicloud_db_database" "default" {
+  instance_id = "${alicloud_db_instance.instance.id}"
+  name        = "tftestdatabase"
+}
 ```
 
 ## Argument Reference

--- a/website/docs/r/db_instance.html.markdown
+++ b/website/docs/r/db_instance.html.markdown
@@ -18,10 +18,10 @@ databases.
 
 ```
 variable "name" {
-	default = "dbInstanceconfig"
+  default = "dbInstanceconfig"
 }
 variable "creation" {
-		default = "Rds"
+  default = "Rds"
 }
 data "alicloud_zones" "default" {
   available_resource_creation = "${var.creation}"
@@ -37,14 +37,14 @@ resource "alicloud_vswitch" "default" {
   name              = "${var.name}"
 }
 resource "alicloud_db_instance" "default" {
-	engine = "MySQL"
-	engine_version = "5.6"
-	instance_type = "rds.mysql.s2.large"
-	instance_storage = "30"
-	instance_charge_type = "Postpaid"
-	instance_name = "${var.name}"
-	vswitch_id = "${alicloud_vswitch.default.id}"
-	monitoring_period = "60"
+  engine               = "MySQL"
+  engine_version       = "5.6"
+  instance_type        = "rds.mysql.s2.large"
+  instance_storage     = "30"
+  instance_charge_type = "Postpaid"
+  instance_name        = "${var.name}"
+  vswitch_id           = "${alicloud_vswitch.default.id}"
+  monitoring_period    = "60"
 }
 ```
 
@@ -52,38 +52,38 @@ resource "alicloud_db_instance" "default" {
 
 ```
 resource "alicloud_vpc" "default" {
-	name       = "vpc-123456"
-	cidr_block = "172.16.0.0/16"
+  name       = "vpc-123456"
+  cidr_block = "172.16.0.0/16"
 }
 
 resource "alicloud_vswitch" "default" {
-	vpc_id            = "${alicloud_vpc.default.id}"
-	cidr_block        = "172.16.0.0/24"
-	availability_zone = "${data.alicloud_zones.default.zones.0.id}"
-	name              = "vpc-123456"
+  vpc_id            = "${alicloud_vpc.default.id}"
+  cidr_block        = "172.16.0.0/24"
+  availability_zone = "${data.alicloud_zones.default.zones.0.id}"
+  name              = "vpc-123456"
 }
 
 resource "alicloud_db_instance" "default" {
-	engine = "MySQL"
-	engine_version = "5.6"
-	db_instance_class = "rds.mysql.t1.small"
-	db_instance_storage = "10"
-	vswitch_id = "${alicloud_vswitch.default.id}"
+  engine              = "MySQL"
+  engine_version      = "5.6"
+  db_instance_class   = "rds.mysql.t1.small"
+  db_instance_storage = "10"
+  vswitch_id          = "${alicloud_vswitch.default.id}"
 }
 
 resource "alicloud_db_instance" "default" {
-	engine = "MySQL"
-	engine_version = "5.6"
-	db_instance_class = "rds.mysql.t1.small"
-	db_instance_storage = "10"
-	parameters {
-		name = "innodb_large_prefix"
-		value = "ON"
-	}
-	parameters {
-		name = "connect_timeout"
-		value = "50"
-	}
+  engine              = "MySQL"
+  engine_version      = "5.6"
+  db_instance_class   = "rds.mysql.t1.small"
+  db_instance_storage = "10"
+  parameters {
+    name  = "innodb_large_prefix"
+    value = "ON"
+  }
+  parameters {
+    name  = "connect_timeout"
+    value = "50"
+  }
 }
 ```
 

--- a/website/docs/r/db_read_write_splitting_connection.html.markdown
+++ b/website/docs/r/db_read_write_splitting_connection.html.markdown
@@ -13,58 +13,58 @@ Provides an RDS read write splitting connection resource to allocate an Intranet
 ## Example Usage
 
 ```
-    variable "creation" {
-		default = "Rds"
-	}
-	
-	variable "name" {
-		default = "dbInstancevpc"
-	}
+variable "creation" {
+  default = "Rds"
+}
 
-    data "alicloud_zones" "default" {
-        available_resource_creation = "${var.creation}"
-    }
+variable "name" {
+  default = "dbInstancevpc"
+}
 
-    resource "alicloud_vpc" "default" {
-        name       = "${var.name}"
-        cidr_block = "172.16.0.0/16"
-    }
+data "alicloud_zones" "default" {
+  available_resource_creation = "${var.creation}"
+}
 
-    resource "alicloud_vswitch" "default" {
-        vpc_id            = "${alicloud_vpc.default.id}"
-        cidr_block        = "172.16.0.0/24"
-        availability_zone = "${data.alicloud_zones.default.zones.0.id}"
-        name              = "${var.name}"
-    }
+resource "alicloud_vpc" "default" {
+  name       = "${var.name}"
+  cidr_block = "172.16.0.0/16"
+}
 
-	resource "alicloud_db_instance" "default" {
-		engine = "MySQL"
-		engine_version = "5.6"
-		instance_type = "rds.mysql.t1.small"
-		instance_storage = "20"
-		instance_charge_type = "Postpaid"
-		instance_name = "${var.name}"
-		vswitch_id = "${alicloud_vswitch.default.id}"
-		security_ips = ["10.168.1.12", "100.69.7.112"]
-	}
+resource "alicloud_vswitch" "default" {
+  vpc_id            = "${alicloud_vpc.default.id}"
+  cidr_block        = "172.16.0.0/24"
+  availability_zone = "${data.alicloud_zones.default.zones.0.id}"
+  name              = "${var.name}"
+}
 
-    resource "alicloud_db_readonly_instance" "default" {
-		master_db_instance_id = "${alicloud_db_instance.default.id}"
-		zone_id = "${alicloud_db_instance.default.zone_id}"
-		engine_version = "${alicloud_db_instance.default.engine_version}"
-		instance_type = "${alicloud_db_instance.default.instance_type}"
-		instance_storage = "30"
-		instance_name = "${var.name}ro"
-		vswitch_id = "${alicloud_vswitch.default.id}"
-	}
+resource "alicloud_db_instance" "default" {
+  engine               = "MySQL"
+  engine_version       = "5.6"
+  instance_type        = "rds.mysql.t1.small"
+  instance_storage     = "20"
+  instance_charge_type = "Postpaid"
+  instance_name        = "${var.name}"
+  vswitch_id           = "${alicloud_vswitch.default.id}"
+  security_ips         = ["10.168.1.12", "100.69.7.112"]
+}
 
-    resource "alicloud_db_read_write_splitting_connection" "default" {
-	    instance_id = "${alicloud_db_instance.default.id}"
-		connection_prefix = "t-con-123"
-		distribution_type = "Standard"
-		
-		depends_on = ["alicloud_db_readonly_instance.default"]
-	}
+resource "alicloud_db_readonly_instance" "default" {
+  master_db_instance_id = "${alicloud_db_instance.default.id}"
+  zone_id               = "${alicloud_db_instance.default.zone_id}"
+  engine_version        = "${alicloud_db_instance.default.engine_version}"
+  instance_type         = "${alicloud_db_instance.default.instance_type}"
+  instance_storage      = "30"
+  instance_name         = "${var.name}ro"
+  vswitch_id            = "${alicloud_vswitch.default.id}"
+}
+
+resource "alicloud_db_read_write_splitting_connection" "default" {
+  instance_id       = "${alicloud_db_instance.default.id}"
+  connection_prefix = "t-con-123"
+  distribution_type = "Standard"
+
+  depends_on = ["alicloud_db_readonly_instance.default"]
+}
 ```
 
 -> **NOTE:** Resource `alicloud_db_read_write_splitting_connection` should be created after `alicloud_db_readonly_instance`, so the `depends_on` statement is necessary.

--- a/website/docs/r/db_readonly_instance.html.markdown
+++ b/website/docs/r/db_readonly_instance.html.markdown
@@ -13,50 +13,50 @@ Provides an RDS readonly instance resource.
 ## Example Usage
 
 ```
-    variable "creation" {
-		default = "Rds"
-	}
-	
-	variable "name" {
-		default = "dbInstancevpc"
-	}
+variable "creation" {
+  default = "Rds"
+}
 
-    data "alicloud_zones" "default" {
-        available_resource_creation = "${var.creation}"
-    }
+variable "name" {
+  default = "dbInstancevpc"
+}
 
-    resource "alicloud_vpc" "default" {
-        name       = "${var.name}"
-        cidr_block = "172.16.0.0/16"
-    }
+data "alicloud_zones" "default" {
+  available_resource_creation = "${var.creation}"
+}
 
-    resource "alicloud_vswitch" "default" {
-        vpc_id            = "${alicloud_vpc.default.id}"
-        cidr_block        = "172.16.0.0/24"
-        availability_zone = "${data.alicloud_zones.default.zones.0.id}"
-        name              = "${var.name}"
-    }
+resource "alicloud_vpc" "default" {
+  name       = "${var.name}"
+  cidr_block = "172.16.0.0/16"
+}
 
-	resource "alicloud_db_instance" "default" {
-		engine = "MySQL"
-		engine_version = "5.6"
-		instance_type = "rds.mysql.t1.small"
-		instance_storage = "20"
-		instance_charge_type = "Postpaid"
-		instance_name = "${var.name}"
-		vswitch_id = "${alicloud_vswitch.default.id}"
-		security_ips = ["10.168.1.12", "100.69.7.112"]
-	}
+resource "alicloud_vswitch" "default" {
+  vpc_id            = "${alicloud_vpc.default.id}"
+  cidr_block        = "172.16.0.0/24"
+  availability_zone = "${data.alicloud_zones.default.zones.0.id}"
+  name              = "${var.name}"
+}
 
-    resource "alicloud_db_readonly_instance" "default" {
-		master_db_instance_id = "${alicloud_db_instance.default.id}"
-		zone_id = "${alicloud_db_instance.default.zone_id}"
-		engine_version = "${alicloud_db_instance.default.engine_version}"
-		instance_type = "${alicloud_db_instance.default.instance_type}"
-		instance_storage = "30"
-		instance_name = "${var.name}ro"
-		vswitch_id = "${alicloud_vswitch.default.id}"
-	}
+resource "alicloud_db_instance" "default" {
+  engine               = "MySQL"
+  engine_version       = "5.6"
+  instance_type        = "rds.mysql.t1.small"
+  instance_storage     = "20"
+  instance_charge_type = "Postpaid"
+  instance_name        = "${var.name}"
+  vswitch_id           = "${alicloud_vswitch.default.id}"
+  security_ips         = ["10.168.1.12", "100.69.7.112"]
+}
+
+resource "alicloud_db_readonly_instance" "default" {
+  master_db_instance_id = "${alicloud_db_instance.default.id}"
+  zone_id               = "${alicloud_db_instance.default.zone_id}"
+  engine_version        = "${alicloud_db_instance.default.engine_version}"
+  instance_type         = "${alicloud_db_instance.default.instance_type}"
+  instance_storage      = "30"
+  instance_name         = "${var.name}ro"
+  vswitch_id            = "${alicloud_vswitch.default.id}"
+}
 
 ```
 

--- a/website/docs/r/ddoscoo_instance.html.markdown
+++ b/website/docs/r/ddoscoo_instance.html.markdown
@@ -28,13 +28,13 @@ provider "alicloud" {
 }
 
 resource "alicloud_ddoscoo_instance" "newInstance" {
-    name                   = "yourDdoscooInstanceName"
-    bandwidth              = "30"
-    base_bandwidth         = "30"
-    service_bandwidth      = "100"
-    port_count             = "50"
-    domain_count           = "50"
-    period                 = "1"
+  name              = "yourDdoscooInstanceName"
+  bandwidth         = "30"
+  base_bandwidth    = "30"
+  service_bandwidth = "100"
+  port_count        = "50"
+  domain_count      = "50"
+  period            = "1"
 }
 ```
 ## Argument Reference

--- a/website/docs/r/dns.html.markdown
+++ b/website/docs/r/dns.html.markdown
@@ -17,8 +17,8 @@ Provides a DNS resource.
 ```
 # Add a new Domain.
 resource "alicloud_dns" "dns" {
-  name = "starmove.com"                      
-  group_id = "85ab8713-4a30-4de4-9d20-155ff830f651" 
+  name     = "starmove.com"
+  group_id = "85ab8713-4a30-4de4-9d20-155ff830f651"
 }
 ```
 ## Argument Reference

--- a/website/docs/r/dns_record.html.markdown
+++ b/website/docs/r/dns_record.html.markdown
@@ -17,10 +17,10 @@ Provides a DNS Record resource.
 ```
 # Create a new Domain record
 resource "alicloud_dns_record" "record" {
-  name = "domainname"
+  name        = "domainname"
   host_record = "@"
-  type = "A"
-  value = "192.168.99.99"
+  type        = "A"
+  value       = "192.168.99.99"
 }
 ```
 

--- a/website/docs/r/drds_instance.html.markdown
+++ b/website/docs/r/drds_instance.html.markdown
@@ -21,13 +21,13 @@ For information about DRDS and how to use it, see [What is DRDS](https://www.ali
 ## Example Usage
 
 ```
- resource "alicloud_drds_instance" "default" {
-  description = "drds instance"
+resource "alicloud_drds_instance" "default" {
+  description          = "drds instance"
   instance_charge_type = "PostPaid"
-  zone_id = "cn-hangzhou-e"
-  vswitch_id = "vsw-bp1jlu3swk8rq2yoi40ey"
-  instance_series = "drds.sn1.4c8g"
-  specification = "drds.sn1.4c8g.8C16G"
+  zone_id              = "cn-hangzhou-e"
+  vswitch_id           = "vsw-bp1jlu3swk8rq2yoi40ey"
+  instance_series      = "drds.sn1.4c8g"
+  specification        = "drds.sn1.4c8g.8C16G"
 }
 ```
 

--- a/website/docs/r/eip_association.html.markdown
+++ b/website/docs/r/eip_association.html.markdown
@@ -44,18 +44,18 @@ data "alicloud_instance_types" "default" {
 }
 
 data "alicloud_images" "default" {
-  name_regex = "^ubuntu_14.*_64"
+  name_regex  = "^ubuntu_14.*_64"
   most_recent = true
-  owners = "system"
+  owners      = "system"
 }
 
 resource "alicloud_instance" "ecs_instance" {
-  image_id              = "${data.alicloud_images.default.images.0.id}"
-  instance_type         = "${data.alicloud_instance_types.default.instance_types.0.id}"
-  availability_zone     = "${data.alicloud_zones.default.zones.0.id}"
-  security_groups       = ["${alicloud_security_group.group.id}"]
-  vswitch_id            = "${alicloud_vswitch.vsw.id}"
-  instance_name         = "hello"
+  image_id          = "${data.alicloud_images.default.images.0.id}"
+  instance_type     = "${data.alicloud_instance_types.default.instance_types.0.id}"
+  availability_zone = "${data.alicloud_zones.default.zones.0.id}"
+  security_groups   = ["${alicloud_security_group.group.id}"]
+  vswitch_id        = "${alicloud_vswitch.vsw.id}"
+  instance_name     = "hello"
   tags = {
     Name = "TerraformTest-instance"
   }

--- a/website/docs/r/ess_alarm.html.markdown
+++ b/website/docs/r/ess_alarm.html.markdown
@@ -13,68 +13,68 @@ Provides a ESS alarm task resource.
 ## Example Usage
 ```
 data "alicloud_zones" "default" {
-	available_disk_category = "cloud_efficiency"
-	available_resource_creation = "VSwitch"
+  available_disk_category     = "cloud_efficiency"
+  available_resource_creation = "VSwitch"
 }
 
 data "alicloud_images" "ecs_image" {
   most_recent = true
-  name_regex =  "^centos_6\\w{1,5}[64].*"
+  name_regex  = "^centos_6\\w{1,5}[64].*"
 }
 
 data "alicloud_instance_types" "default" {
- 	availability_zone = "${data.alicloud_zones.default.zones.0.id}"
-	cpu_core_count = 1
-	memory_size = 2
+  availability_zone = "${data.alicloud_zones.default.zones.0.id}"
+  cpu_core_count    = 1
+  memory_size       = 2
 }
 
 resource "alicloud_vpc" "foo" {
-  	name = "tf-testAccEssAlarm_basic"
-  	cidr_block = "172.16.0.0/16"
+  name       = "tf-testAccEssAlarm_basic"
+  cidr_block = "172.16.0.0/16"
 }
 
 resource "alicloud_vswitch" "foo" {
-	name = "tf-testAccEssAlarm_basic_foo"
-  	vpc_id = "${alicloud_vpc.foo.id}"
-  	cidr_block = "172.16.0.0/24"
-	availability_zone = "${data.alicloud_zones.default.zones.0.id}"
+  name              = "tf-testAccEssAlarm_basic_foo"
+  vpc_id            = "${alicloud_vpc.foo.id}"
+  cidr_block        = "172.16.0.0/24"
+  availability_zone = "${data.alicloud_zones.default.zones.0.id}"
 }
 
 resource "alicloud_vswitch" "bar" {
-	name = "tf-testAccEssAlarm_basic_bar"
-  	vpc_id = "${alicloud_vpc.foo.id}"
-  	cidr_block = "172.16.1.0/24"
-  	availability_zone = "${data.alicloud_zones.default.zones.0.id}"
+  name              = "tf-testAccEssAlarm_basic_bar"
+  vpc_id            = "${alicloud_vpc.foo.id}"
+  cidr_block        = "172.16.1.0/24"
+  availability_zone = "${data.alicloud_zones.default.zones.0.id}"
 }
 
 resource "alicloud_ess_scaling_group" "foo" {
-	min_size = 1
-	max_size = 1
-	scaling_group_name = "tf-testAccEssAlarm_basic"
-	removal_policies = ["OldestInstance", "NewestInstance"]
-	vswitch_ids = ["${alicloud_vswitch.foo.id}","${alicloud_vswitch.bar.id}"]
+  min_size           = 1
+  max_size           = 1
+  scaling_group_name = "tf-testAccEssAlarm_basic"
+  removal_policies   = ["OldestInstance", "NewestInstance"]
+  vswitch_ids        = ["${alicloud_vswitch.foo.id}", "${alicloud_vswitch.bar.id}"]
 }
 
 resource "alicloud_ess_scaling_rule" "foo" {
-	scaling_rule_name = "tf-testAccEssAlarm_basic"
-	scaling_group_id = "${alicloud_ess_scaling_group.foo.id}"
-	adjustment_type = "TotalCapacity"
-	adjustment_value = 2
-	cooldown = 60
+  scaling_rule_name = "tf-testAccEssAlarm_basic"
+  scaling_group_id  = "${alicloud_ess_scaling_group.foo.id}"
+  adjustment_type   = "TotalCapacity"
+  adjustment_value  = 2
+  cooldown          = 60
 }
 
 resource "alicloud_ess_alarm" "foo" {
-	name = "tf-testAccEssAlarm_basic"
-    description = "Acc alarm test"
-    alarm_actions = ["${alicloud_ess_scaling_rule.foo.ari}"]
-    scaling_group_id = "${alicloud_ess_scaling_group.foo.id}"
-    metric_type = "system"
-    metric_name = "CpuUtilization"
-    period = 300
-    statistics = "Average"
-    threshold = 200.3
-    comparison_operator = ">="
-	evaluation_count = 2 
+  name                = "tf-testAccEssAlarm_basic"
+  description         = "Acc alarm test"
+  alarm_actions       = ["${alicloud_ess_scaling_rule.foo.ari}"]
+  scaling_group_id    = "${alicloud_ess_scaling_group.foo.id}"
+  metric_type         = "system"
+  metric_name         = "CpuUtilization"
+  period              = 300
+  statistics          = "Average"
+  threshold           = 200.3
+  comparison_operator = ">="
+  evaluation_count    = 2
 }
 ```
 

--- a/website/docs/r/ess_attachment.html.markdown
+++ b/website/docs/r/ess_attachment.html.markdown
@@ -18,89 +18,89 @@ Attaches several ECS instances to a specified scaling group or remove them from 
 
 ```
 variable "name" {
-    default = "essattachmentconfig"
+  default = "essattachmentconfig"
 }
 
 data "alicloud_zones" "default" {
-    available_disk_category     = "cloud_efficiency"
-    available_resource_creation = "VSwitch"
+  available_disk_category     = "cloud_efficiency"
+  available_resource_creation = "VSwitch"
 }
 
 data "alicloud_instance_types" "default" {
-    availability_zone = "${data.alicloud_zones.default.zones.0.id}"
-    cpu_core_count    = 2
-    memory_size       = 4
+  availability_zone = "${data.alicloud_zones.default.zones.0.id}"
+  cpu_core_count    = 2
+  memory_size       = 4
 }
 
 data "alicloud_images" "default" {
-    name_regex  = "^ubuntu_14.*_64"
-    most_recent = true
-    owners      = "system"
+  name_regex  = "^ubuntu_14.*_64"
+  most_recent = true
+  owners      = "system"
 }
 
 resource "alicloud_vpc" "default" {
-    name       = "${var.name}"
-    cidr_block = "172.16.0.0/16"
+  name       = "${var.name}"
+  cidr_block = "172.16.0.0/16"
 }
 
 resource "alicloud_vswitch" "default" {
-    vpc_id            = "${alicloud_vpc.default.id}"
-    cidr_block        = "172.16.0.0/24"
-    availability_zone = "${data.alicloud_zones.default.zones.0.id}"
-    name              = "${var.name}"
+  vpc_id            = "${alicloud_vpc.default.id}"
+  cidr_block        = "172.16.0.0/24"
+  availability_zone = "${data.alicloud_zones.default.zones.0.id}"
+  name              = "${var.name}"
 }
 
 resource "alicloud_security_group" "default" {
-    name   = "${var.name}"
-    vpc_id = "${alicloud_vpc.default.id}"
+  name   = "${var.name}"
+  vpc_id = "${alicloud_vpc.default.id}"
 }
 
 resource "alicloud_security_group_rule" "default" {
-    type = "ingress"
-    ip_protocol = "tcp"
-    nic_type = "intranet"
-    policy = "accept"
-    port_range = "22/22"
-    priority = 1
-    security_group_id = "${alicloud_security_group.default.id}"
-    cidr_ip = "172.16.0.0/24"
+  type              = "ingress"
+  ip_protocol       = "tcp"
+  nic_type          = "intranet"
+  policy            = "accept"
+  port_range        = "22/22"
+  priority          = 1
+  security_group_id = "${alicloud_security_group.default.id}"
+  cidr_ip           = "172.16.0.0/24"
 }
 
 resource "alicloud_ess_scaling_group" "default" {
-    min_size = 0
-    max_size = 2
-    scaling_group_name = "${var.name}"
-    removal_policies = ["OldestInstance", "NewestInstance"]
-    vswitch_ids = ["${alicloud_vswitch.default.id}"]
+  min_size           = 0
+  max_size           = 2
+  scaling_group_name = "${var.name}"
+  removal_policies   = ["OldestInstance", "NewestInstance"]
+  vswitch_ids        = ["${alicloud_vswitch.default.id}"]
 }
 
 resource "alicloud_ess_scaling_configuration" "default" {
-    scaling_group_id = "${alicloud_ess_scaling_group.default.id}"
-    image_id = "${data.alicloud_images.default.images.0.id}"
-    instance_type = "${data.alicloud_instance_types.default.instance_types.0.id}"
-    security_group_id = "${alicloud_security_group.default.id}"
-    force_delete = true
-    active = true
-    enable = true
+  scaling_group_id  = "${alicloud_ess_scaling_group.default.id}"
+  image_id          = "${data.alicloud_images.default.images.0.id}"
+  instance_type     = "${data.alicloud_instance_types.default.instance_types.0.id}"
+  security_group_id = "${alicloud_security_group.default.id}"
+  force_delete      = true
+  active            = true
+  enable            = true
 }
 
 resource "alicloud_instance" "default" {
-    image_id = "${data.alicloud_images.default.images.0.id}"
-    instance_type = "${data.alicloud_instance_types.default.instance_types.0.id}"
-    count = 2
-    security_groups = ["${alicloud_security_group.default.id}"]
-    internet_charge_type = "PayByTraffic"
-    internet_max_bandwidth_out = "10"
-    instance_charge_type = "PostPaid"
-    system_disk_category = "cloud_efficiency"
-    vswitch_id = "${alicloud_vswitch.default.id}"
-    instance_name = "${var.name}"
+  image_id                   = "${data.alicloud_images.default.images.0.id}"
+  instance_type              = "${data.alicloud_instance_types.default.instance_types.0.id}"
+  count                      = 2
+  security_groups            = ["${alicloud_security_group.default.id}"]
+  internet_charge_type       = "PayByTraffic"
+  internet_max_bandwidth_out = "10"
+  instance_charge_type       = "PostPaid"
+  system_disk_category       = "cloud_efficiency"
+  vswitch_id                 = "${alicloud_vswitch.default.id}"
+  instance_name              = "${var.name}"
 }
 
 resource "alicloud_ess_attachment" "default" {
-    scaling_group_id = "${alicloud_ess_scaling_group.default.id}"
-    instance_ids = ["${alicloud_instance.default.0.id}", "${alicloud_instance.default.1.id}"]
-    force = true
+  scaling_group_id = "${alicloud_ess_scaling_group.default.id}"
+  instance_ids     = ["${alicloud_instance.default.0.id}", "${alicloud_instance.default.1.id}"]
+  force            = true
 }
 
 ```

--- a/website/docs/r/ess_scaling_configuration.html.markdown
+++ b/website/docs/r/ess_scaling_configuration.html.markdown
@@ -16,68 +16,68 @@ Provides a ESS scaling configuration resource.
 
 ```
 variable "name" {
-    default = "essscalingconfiguration"
+  default = "essscalingconfiguration"
 }
-	
+
 data "alicloud_zones" "default" {
-    available_disk_category     = "cloud_efficiency"
-    available_resource_creation = "VSwitch"
+  available_disk_category     = "cloud_efficiency"
+  available_resource_creation = "VSwitch"
 }
-    
+
 data "alicloud_instance_types" "default" {
-    availability_zone = "${data.alicloud_zones.default.zones.0.id}"
-    cpu_core_count    = 2
-    memory_size       = 4
+  availability_zone = "${data.alicloud_zones.default.zones.0.id}"
+  cpu_core_count    = 2
+  memory_size       = 4
 }
-    
+
 data "alicloud_images" "default" {
-    name_regex  = "^ubuntu_14.*_64"
-    most_recent = true
-    owners      = "system"
+  name_regex  = "^ubuntu_14.*_64"
+  most_recent = true
+  owners      = "system"
 }
-    
+
 resource "alicloud_vpc" "default" {
-    name       = "${var.name}"
-    cidr_block = "172.16.0.0/16"
+  name       = "${var.name}"
+  cidr_block = "172.16.0.0/16"
 }
-    
+
 resource "alicloud_vswitch" "default" {
-    vpc_id            = "${alicloud_vpc.default.id}"
-    cidr_block        = "172.16.0.0/24"
-    availability_zone = "${data.alicloud_zones.default.zones.0.id}"
-    name              = "${var.name}"
+  vpc_id            = "${alicloud_vpc.default.id}"
+  cidr_block        = "172.16.0.0/24"
+  availability_zone = "${data.alicloud_zones.default.zones.0.id}"
+  name              = "${var.name}"
 }
-    
+
 resource "alicloud_security_group" "default" {
-    name   = "${var.name}"
-    vpc_id = "${alicloud_vpc.default.id}"
+  name   = "${var.name}"
+  vpc_id = "${alicloud_vpc.default.id}"
 }
-    
+
 resource "alicloud_security_group_rule" "default" {
-    type = "ingress"
-    ip_protocol = "tcp"
-    nic_type = "intranet"
-    policy = "accept"
-    port_range = "22/22"
-    priority = 1
-    security_group_id = "${alicloud_security_group.default.id}"
-    cidr_ip = "172.16.0.0/24"
+  type              = "ingress"
+  ip_protocol       = "tcp"
+  nic_type          = "intranet"
+  policy            = "accept"
+  port_range        = "22/22"
+  priority          = 1
+  security_group_id = "${alicloud_security_group.default.id}"
+  cidr_ip           = "172.16.0.0/24"
 }
 
 resource "alicloud_ess_scaling_group" "default" {
-    min_size = 1
-    max_size = 1
-    scaling_group_name = "${var.name}"
-    removal_policies = ["OldestInstance", "NewestInstance"]
-    vswitch_ids = ["${alicloud_vswitch.default.id}"]
+  min_size           = 1
+  max_size           = 1
+  scaling_group_name = "${var.name}"
+  removal_policies   = ["OldestInstance", "NewestInstance"]
+  vswitch_ids        = ["${alicloud_vswitch.default.id}"]
 }
-	
+
 resource "alicloud_ess_scaling_configuration" "default" {
-    scaling_group_id = "${alicloud_ess_scaling_group.default.id}"
-    image_id = "${data.alicloud_images.default.images.0.id}"
-    instance_type = "${data.alicloud_instance_types.default.instance_types.0.id}"
-    security_group_id = "${alicloud_security_group.default.id}"
-    force_delete = true
+  scaling_group_id  = "${alicloud_ess_scaling_group.default.id}"
+  image_id          = "${data.alicloud_images.default.images.0.id}"
+  instance_type     = "${data.alicloud_instance_types.default.instance_types.0.id}"
+  security_group_id = "${alicloud_security_group.default.id}"
+  force_delete      = true
 }
 
 ```

--- a/website/docs/r/ess_scaling_group.html.markdown
+++ b/website/docs/r/ess_scaling_group.html.markdown
@@ -18,68 +18,68 @@ It defines the maximum and minimum numbers of ECS instances in the group, and th
 
 ```
 variable "name" {
-    default = "essscalinggroupconfig"
+  default = "essscalinggroupconfig"
 }
-	
+
 data "alicloud_zones" "default" {
-    available_disk_category     = "cloud_efficiency"
-    available_resource_creation = "VSwitch"
+  available_disk_category     = "cloud_efficiency"
+  available_resource_creation = "VSwitch"
 }
-    
+
 data "alicloud_instance_types" "default" {
-    availability_zone = "${data.alicloud_zones.default.zones.0.id}"
-    cpu_core_count    = 2
-    memory_size       = 4
+  availability_zone = "${data.alicloud_zones.default.zones.0.id}"
+  cpu_core_count    = 2
+  memory_size       = 4
 }
-    
+
 data "alicloud_images" "default" {
-    name_regex  = "^ubuntu_14.*_64"
-    most_recent = true
-    owners      = "system"
+  name_regex  = "^ubuntu_14.*_64"
+  most_recent = true
+  owners      = "system"
 }
-    
+
 resource "alicloud_vpc" "default" {
-    name       = "${var.name}"
-    cidr_block = "172.16.0.0/16"
+  name       = "${var.name}"
+  cidr_block = "172.16.0.0/16"
 }
-    
+
 resource "alicloud_vswitch" "default" {
-    vpc_id            = "${alicloud_vpc.default.id}"
-    cidr_block        = "172.16.0.0/24"
-    availability_zone = "${data.alicloud_zones.default.zones.0.id}"
-    name              = "${var.name}"
+  vpc_id            = "${alicloud_vpc.default.id}"
+  cidr_block        = "172.16.0.0/24"
+  availability_zone = "${data.alicloud_zones.default.zones.0.id}"
+  name              = "${var.name}"
 }
-    
+
 resource "alicloud_security_group" "default" {
-    name   = "${var.name}"
-    vpc_id = "${alicloud_vpc.default.id}"
+  name   = "${var.name}"
+  vpc_id = "${alicloud_vpc.default.id}"
 }
-    
+
 resource "alicloud_security_group_rule" "default" {
-    type = "ingress"
-    ip_protocol = "tcp"
-    nic_type = "intranet"
-    policy = "accept"
-    port_range = "22/22"
-    priority = 1
-    security_group_id = "${alicloud_security_group.default.id}"
-    cidr_ip = "172.16.0.0/24"
+  type              = "ingress"
+  ip_protocol       = "tcp"
+  nic_type          = "intranet"
+  policy            = "accept"
+  port_range        = "22/22"
+  priority          = 1
+  security_group_id = "${alicloud_security_group.default.id}"
+  cidr_ip           = "172.16.0.0/24"
 }
-	
+
 resource "alicloud_vswitch" "default2" {
-    vpc_id = "${alicloud_vpc.default.id}"
-    cidr_block = "172.16.1.0/24"
-    availability_zone = "${data.alicloud_zones.default.zones.0.id}"
-    name = "${var.name}-bar"
+  vpc_id            = "${alicloud_vpc.default.id}"
+  cidr_block        = "172.16.1.0/24"
+  availability_zone = "${data.alicloud_zones.default.zones.0.id}"
+  name              = "${var.name}-bar"
 }
-	
+
 resource "alicloud_ess_scaling_group" "default" {
-    min_size = 1
-    max_size = 1
-    scaling_group_name = "${var.name}"
-    default_cooldown = 20
-    vswitch_ids = ["${alicloud_vswitch.default.id}", "${alicloud_vswitch.default2.id}"]
-    removal_policies = ["OldestInstance", "NewestInstance"]
+  min_size           = 1
+  max_size           = 1
+  scaling_group_name = "${var.name}"
+  default_cooldown   = 20
+  vswitch_ids        = ["${alicloud_vswitch.default.id}", "${alicloud_vswitch.default2.id}"]
+  removal_policies   = ["OldestInstance", "NewestInstance"]
 }
 ```
 

--- a/website/docs/r/ess_scaling_lifecycle_hook.html.markdown
+++ b/website/docs/r/ess_scaling_lifecycle_hook.html.markdown
@@ -13,41 +13,41 @@ Provides a ESS lifecycle hook resource. More about Ess lifecycle hook, see [Life
 ## Example Usage
 ```
 data "alicloud_zones" "default" {
-	available_disk_category = "cloud_efficiency"
-	available_resource_creation = "VSwitch"
+  available_disk_category     = "cloud_efficiency"
+  available_resource_creation = "VSwitch"
 }
 
 resource "alicloud_vpc" "foo" {
-  	name = "testAccEssScalingGroup_vpc"
-  	cidr_block = "172.16.0.0/16"
+  name       = "testAccEssScalingGroup_vpc"
+  cidr_block = "172.16.0.0/16"
 }
 
 resource "alicloud_vswitch" "foo" {
-  	vpc_id = "${alicloud_vpc.foo.id}"
-  	cidr_block = "172.16.0.0/24"
-	availability_zone = "${data.alicloud_zones.default.zones.0.id}"
+  vpc_id            = "${alicloud_vpc.foo.id}"
+  cidr_block        = "172.16.0.0/24"
+  availability_zone = "${data.alicloud_zones.default.zones.0.id}"
 }
 
 resource "alicloud_vswitch" "bar" {
-  	vpc_id = "${alicloud_vpc.foo.id}"
-  	cidr_block = "172.16.1.0/24"
-  	availability_zone = "${data.alicloud_zones.default.zones.0.id}"
+  vpc_id            = "${alicloud_vpc.foo.id}"
+  cidr_block        = "172.16.1.0/24"
+  availability_zone = "${data.alicloud_zones.default.zones.0.id}"
 }
 
 resource "alicloud_ess_scaling_group" "foo" {
-	min_size = 1
-	max_size = 1
-	scaling_group_name = "testAccEssScaling_group"
-	removal_policies = ["OldestInstance", "NewestInstance"]
-	vswitch_ids = ["${alicloud_vswitch.foo.id}","${alicloud_vswitch.bar.id}"]
+  min_size           = 1
+  max_size           = 1
+  scaling_group_name = "testAccEssScaling_group"
+  removal_policies   = ["OldestInstance", "NewestInstance"]
+  vswitch_ids        = ["${alicloud_vswitch.foo.id}", "${alicloud_vswitch.bar.id}"]
 }
 
-resource "alicloud_ess_lifecycle_hook" "foo"{
-	scaling_group_id = "${alicloud_ess_scaling_group.foo.id}"
-	name = "testAccEssLifecycle_hook"
-	lifecycle_transition = "SCALE_OUT"
-	heartbeat_timeout = 400
-	notification_metadata = "helloworld"
+resource "alicloud_ess_lifecycle_hook" "foo" {
+  scaling_group_id      = "${alicloud_ess_scaling_group.foo.id}"
+  name                  = "testAccEssLifecycle_hook"
+  lifecycle_transition  = "SCALE_OUT"
+  heartbeat_timeout     = 400
+  notification_metadata = "helloworld"
 }
 ```
 

--- a/website/docs/r/ess_scaling_rule.html.markdown
+++ b/website/docs/r/ess_scaling_rule.html.markdown
@@ -14,74 +14,74 @@ Provides a ESS scaling rule resource.
 
 ```
 variable "name" {
-    default = "essscalingruleconfig"
+  default = "essscalingruleconfig"
 }
 
 data "alicloud_zones" "default" {
-    available_disk_category     = "cloud_efficiency"
-    available_resource_creation = "VSwitch"
+  available_disk_category     = "cloud_efficiency"
+  available_resource_creation = "VSwitch"
 }
 
 data "alicloud_instance_types" "default" {
-    availability_zone = "${data.alicloud_zones.default.zones.0.id}"
-    cpu_core_count    = 2
-    memory_size       = 4
+  availability_zone = "${data.alicloud_zones.default.zones.0.id}"
+  cpu_core_count    = 2
+  memory_size       = 4
 }
 
 data "alicloud_images" "default" {
-    name_regex  = "^ubuntu_14.*_64"
-    most_recent = true
-    owners      = "system"
+  name_regex  = "^ubuntu_14.*_64"
+  most_recent = true
+  owners      = "system"
 }
 
 resource "alicloud_vpc" "default" {
-    name       = "${var.name}"
-    cidr_block = "172.16.0.0/16"
+  name       = "${var.name}"
+  cidr_block = "172.16.0.0/16"
 }
 
 resource "alicloud_vswitch" "default" {
-    vpc_id            = "${alicloud_vpc.default.id}"
-    cidr_block        = "172.16.0.0/24"
-    availability_zone = "${data.alicloud_zones.default.zones.0.id}"
-    name              = "${var.name}"
+  vpc_id            = "${alicloud_vpc.default.id}"
+  cidr_block        = "172.16.0.0/24"
+  availability_zone = "${data.alicloud_zones.default.zones.0.id}"
+  name              = "${var.name}"
 }
 
 resource "alicloud_security_group" "default" {
-    name   = "${var.name}"
-    vpc_id = "${alicloud_vpc.default.id}"
+  name   = "${var.name}"
+  vpc_id = "${alicloud_vpc.default.id}"
 }
 
 resource "alicloud_security_group_rule" "default" {
-    type = "ingress"
-    ip_protocol = "tcp"
-    nic_type = "intranet"
-    policy = "accept"
-    port_range = "22/22"
-    priority = 1
-    security_group_id = "${alicloud_security_group.default.id}"
-    cidr_ip = "172.16.0.0/24"
+  type              = "ingress"
+  ip_protocol       = "tcp"
+  nic_type          = "intranet"
+  policy            = "accept"
+  port_range        = "22/22"
+  priority          = 1
+  security_group_id = "${alicloud_security_group.default.id}"
+  cidr_ip           = "172.16.0.0/24"
 }
 
 resource "alicloud_ess_scaling_group" "default" {
-    min_size = 1
-    max_size = 1
-    scaling_group_name = "${var.name}"
-    vswitch_ids = ["${alicloud_vswitch.default.id}"]
-    removal_policies = ["OldestInstance", "NewestInstance"]
+  min_size           = 1
+  max_size           = 1
+  scaling_group_name = "${var.name}"
+  vswitch_ids        = ["${alicloud_vswitch.default.id}"]
+  removal_policies   = ["OldestInstance", "NewestInstance"]
 }
 
 resource "alicloud_ess_scaling_configuration" "default" {
-    scaling_group_id = "${alicloud_ess_scaling_group.default.id}"
-    image_id = "${data.alicloud_images.default.images.0.id}"
-    instance_type = "${data.alicloud_instance_types.default.instance_types.0.id}"
-    security_group_id = "${alicloud_security_group.default.id}"
-    force_delete = "true"
+  scaling_group_id  = "${alicloud_ess_scaling_group.default.id}"
+  image_id          = "${data.alicloud_images.default.images.0.id}"
+  instance_type     = "${data.alicloud_instance_types.default.instance_types.0.id}"
+  security_group_id = "${alicloud_security_group.default.id}"
+  force_delete      = "true"
 }
 
 resource "alicloud_ess_scaling_rule" "default" {
-    scaling_group_id = "${alicloud_ess_scaling_group.default.id}"
-    adjustment_type = "TotalCapacity"
-    adjustment_value = 1
+  scaling_group_id = "${alicloud_ess_scaling_group.default.id}"
+  adjustment_type  = "TotalCapacity"
+  adjustment_value = 1
 }
 ```
 

--- a/website/docs/r/ess_scheduled_task.html.markdown
+++ b/website/docs/r/ess_scheduled_task.html.markdown
@@ -14,81 +14,81 @@ Provides a ESS schedule resource.
 
 ```
 variable "name" {
-    default = "essscheduleconfig"
+  default = "essscheduleconfig"
 }
-	
+
 data "alicloud_zones" "default" {
-    available_disk_category     = "cloud_efficiency"
-    available_resource_creation = "VSwitch"
+  available_disk_category     = "cloud_efficiency"
+  available_resource_creation = "VSwitch"
 }
-    
+
 data "alicloud_instance_types" "default" {
-    availability_zone = "${data.alicloud_zones.default.zones.0.id}"
-    cpu_core_count    = 2
-    memory_size       = 4
+  availability_zone = "${data.alicloud_zones.default.zones.0.id}"
+  cpu_core_count    = 2
+  memory_size       = 4
 }
-    
+
 data "alicloud_images" "default" {
-    name_regex  = "^ubuntu_14.*_64"
-    most_recent = true
-    owners      = "system"
+  name_regex  = "^ubuntu_14.*_64"
+  most_recent = true
+  owners      = "system"
 }
-    
+
 resource "alicloud_vpc" "default" {
-    name       = "${var.name}"
-    cidr_block = "172.16.0.0/16"
+  name       = "${var.name}"
+  cidr_block = "172.16.0.0/16"
 }
-    
+
 resource "alicloud_vswitch" "default" {
-    vpc_id            = "${alicloud_vpc.default.id}"
-    cidr_block        = "172.16.0.0/24"
-    availability_zone = "${data.alicloud_zones.default.zones.0.id}"
-    name              = "${var.name}"
+  vpc_id            = "${alicloud_vpc.default.id}"
+  cidr_block        = "172.16.0.0/24"
+  availability_zone = "${data.alicloud_zones.default.zones.0.id}"
+  name              = "${var.name}"
 }
-    
+
 resource "alicloud_security_group" "default" {
-    name   = "${var.name}"
-    vpc_id = "${alicloud_vpc.default.id}"
+  name   = "${var.name}"
+  vpc_id = "${alicloud_vpc.default.id}"
 }
-    
+
 resource "alicloud_security_group_rule" "default" {
-    type = "ingress"
-    ip_protocol = "tcp"
-    nic_type = "intranet"
-    policy = "accept"
-    port_range = "22/22"
-    priority = 1
-    security_group_id = "${alicloud_security_group.default.id}"
-    cidr_ip = "172.16.0.0/24"
+  type              = "ingress"
+  ip_protocol       = "tcp"
+  nic_type          = "intranet"
+  policy            = "accept"
+  port_range        = "22/22"
+  priority          = 1
+  security_group_id = "${alicloud_security_group.default.id}"
+  cidr_ip           = "172.16.0.0/24"
 }
-	
+
 resource "alicloud_ess_scaling_group" "default" {
-    min_size = 1
-    max_size = 1
-    scaling_group_name = "${var.name}"
-    vswitch_ids = ["${alicloud_vswitch.default.id}"]
-    removal_policies = ["OldestInstance", "NewestInstance"]
+  min_size           = 1
+  max_size           = 1
+  scaling_group_name = "${var.name}"
+  vswitch_ids        = ["${alicloud_vswitch.default.id}"]
+  removal_policies   = ["OldestInstance", "NewestInstance"]
 }
-	
+
 resource "alicloud_ess_scaling_configuration" "default" {
-    scaling_group_id = "${alicloud_ess_scaling_group.default.id}"
-    image_id = "${data.alicloud_images.default.images.0.id}"
-    instance_type = "${data.alicloud_instance_types.default.instance_types.0.id}"
-    security_group_id = "${alicloud_security_group.default.id}"
-    force_delete = "true"
+  scaling_group_id  = "${alicloud_ess_scaling_group.default.id}"
+  image_id          = "${data.alicloud_images.default.images.0.id}"
+  instance_type     = "${data.alicloud_instance_types.default.instance_types.0.id}"
+  security_group_id = "${alicloud_security_group.default.id}"
+  force_delete      = "true"
 }
-	
+
 resource "alicloud_ess_scaling_rule" "default" {
-    scaling_group_id = "${alicloud_ess_scaling_group.default.id}"
-    adjustment_type = "TotalCapacity"
-    adjustment_value = 2
-    cooldown = 60
+  scaling_group_id = "${alicloud_ess_scaling_group.default.id}"
+  adjustment_type  = "TotalCapacity"
+  adjustment_value = 2
+  cooldown         = 60
 }
-	
+
 resource "alicloud_ess_scheduled_task" "default" {
-    scheduled_action = "${alicloud_ess_scaling_rule.default.ari}"
-    launch_time = "2019-05-21T11:37Z"
-    scheduled_task_name = "${var.name}"
+  scheduled_action    = "${alicloud_ess_scaling_rule.default.ari}"
+  launch_time         = "2019-05-21T11:37Z"
+  scheduled_task_name = "${var.name}"
 }
 ```
 

--- a/website/docs/r/fc_function.html.markdown
+++ b/website/docs/r/fc_function.html.markdown
@@ -19,37 +19,37 @@ Basic Usage
 
 ```
 variable "name" {
-    default = "alicloudfcfunctionconfig"
+  default = "alicloudfcfunctionconfig"
 }
 resource "alicloud_log_project" "default" {
-    name = "${var.name}"
-    description = "tf unit test"
+  name        = "${var.name}"
+  description = "tf unit test"
 }
 
 resource "alicloud_log_store" "default" {
-    project = "${alicloud_log_project.default.name}"
-    name = "${var.name}"
-    retention_period = "3000"
-    shard_count = 1
+  project          = "${alicloud_log_project.default.name}"
+  name             = "${var.name}"
+  retention_period = "3000"
+  shard_count      = 1
 }
 resource "alicloud_fc_service" "default" {
-    name = "${var.name}"
-    description = "tf unit test"
-    log_config {
-        project = "${alicloud_log_project.default.name}"
-        logstore = "${alicloud_log_store.default.name}"
-    }
-    role = "${alicloud_ram_role.default.arn}"
-    depends_on = ["alicloud_ram_role_policy_attachment.default"]
+  name        = "${var.name}"
+  description = "tf unit test"
+  log_config {
+    project  = "${alicloud_log_project.default.name}"
+    logstore = "${alicloud_log_store.default.name}"
+  }
+  role       = "${alicloud_ram_role.default.arn}"
+  depends_on = ["alicloud_ram_role_policy_attachment.default"]
 }
 resource "alicloud_oss_bucket" "default" {
-    bucket = "${var.name}"
+  bucket = "${var.name}"
 }
 
 resource "alicloud_oss_bucket_object" "default" {
-    bucket = "${alicloud_oss_bucket.default.id}"
-    key = "fc/hello.zip"
-    content = <<EOF
+  bucket  = "${alicloud_oss_bucket.default.id}"
+  key     = "fc/hello.zip"
+  content = <<EOF
         # -*- coding: utf-8 -*-
         def handler(event, context):
             print "hello world"
@@ -58,8 +58,8 @@ resource "alicloud_oss_bucket_object" "default" {
 }
 
 resource "alicloud_ram_role" "default" {
-    name = "${var.name}"
-    document = <<EOF
+  name = "${var.name}"
+  document = <<EOF
         {
           "Statement": [
             {
@@ -76,24 +76,24 @@ resource "alicloud_ram_role" "default" {
         }
     EOF
     description = "this is a test"
-    force = true
+    force       = true
 }
 
 resource "alicloud_ram_role_policy_attachment" "default" {
-    role_name = "${alicloud_ram_role.default.name}"
+    role_name   = "${alicloud_ram_role.default.name}"
     policy_name = "AliyunLogFullAccess"
     policy_type = "System"
 }
 
 resource "alicloud_fc_function" "foo" {
-    service = "${alicloud_fc_service.default.name}"
-    name = "${var.name}"
+    service     = "${alicloud_fc_service.default.name}"
+    name        = "${var.name}"
     description = "tf"
-    oss_bucket = "${alicloud_oss_bucket.default.id}"
-    oss_key = "${alicloud_oss_bucket_object.default.key}"
+    oss_bucket  = "${alicloud_oss_bucket.default.id}"
+    oss_key     = "${alicloud_oss_bucket_object.default.key}"
     memory_size = "512"
-    runtime = "python2.7"
-    handler = "hello.handler"
+    runtime     = "python2.7"
+    handler     = "hello.handler"
     environment_variables = {
         prefix = "terraform"
     }

--- a/website/docs/r/fc_service.html.markdown
+++ b/website/docs/r/fc_service.html.markdown
@@ -25,20 +25,20 @@ Basic Usage
 
 ```
 variable "name" {
-    default = "tf-testaccalicloudfcservice"
+  default = "tf-testaccalicloudfcservice"
 }
 
 resource "alicloud_log_project" "foo" {
-    name = "${var.name}"
+  name = "${var.name}"
 }
 
 resource "alicloud_log_store" "foo" {
-    project = "${alicloud_log_project.foo.name}"
-    name = "${var.name}"
+  project = "${alicloud_log_project.foo.name}"
+  name    = "${var.name}"
 }
 
 resource "alicloud_ram_role" "role" {
-  name = "${var.name}"
+  name     = "${var.name}"
   document = <<DEFINITION
   {
   "Statement": [
@@ -66,10 +66,10 @@ resource "alicloud_ram_role_policy_attachment" "attac" {
 }
 
 resource "alicloud_fc_service" "foo" {
-    name = "${var.name}"
-    description = "tf unit test"
-    role = "${alicloud_ram_role.role.arn}"
-    depends_on = ["alicloud_ram_role_policy_attachment.attac"]
+  name = "${var.name}"
+  description = "tf unit test"
+  role = "${alicloud_ram_role.role.arn}"
+  depends_on = ["alicloud_ram_role_policy_attachment.attac"]
 }
 ```
 ## Argument Reference

--- a/website/docs/r/fc_trigger.html.markdown
+++ b/website/docs/r/fc_trigger.html.markdown
@@ -27,17 +27,17 @@ variable "account" {
 
 provider "alicloud" {
   account_id = "${var.account}"
-  region = "${var.region}"
+  region     = "${var.region}"
 }
 
 resource "alicloud_fc_trigger" "foo" {
-  service = "my-fc-service"
-  function = "hello-world"
-  name = "hello-trigger"
-  role = "${alicloud_ram_role.foo.arn}"
+  service    = "my-fc-service"
+  function   = "hello-world"
+  name       = "hello-trigger"
+  role       = "${alicloud_ram_role.foo.arn}"
   source_arn = "acs:log:${var.region}:${var.account}:project/${alicloud_log_project.foo.name}"
-  type = "log"
-  config = <<EOF
+  type       = "log"
+  config     = <<EOF
     {
         "sourceConfig": {
             "project": "project-for-fc",
@@ -80,11 +80,11 @@ resource "alicloud_ram_role" "foo" {
   }
   EOF
   description = "this is a test"
-  force = true
+  force       = true
 }
 
 resource "alicloud_ram_role_policy_attachment" "foo" {
-  role_name = "${alicloud_ram_role.foo.name}"
+  role_name   = "${alicloud_ram_role.foo.name}"
   policy_name = "AliyunLogFullAccess"
   policy_type = "System"
 }
@@ -102,34 +102,34 @@ data "alicloud_regions" "current_region" {
 data "alicloud_account" "current" {
 }
 resource "alicloud_log_project" "foo" {
-  name = "${var.name}"
+  name        = "${var.name}"
   description = "tf unit test"
 }
 resource "alicloud_log_store" "bar" {
-  project = "${alicloud_log_project.foo.name}"
-  name = "${var.name}-source"
+  project          = "${alicloud_log_project.foo.name}"
+  name             = "${var.name}-source"
   retention_period = "3000"
-  shard_count = 1
+  shard_count      = 1
 }
 resource "alicloud_log_store" "foo" {
-  project = "${alicloud_log_project.foo.name}"
-  name = "${var.name}"
+  project          = "${alicloud_log_project.foo.name}"
+  name             = "${var.name}"
   retention_period = "3000"
-  shard_count = 1
+  shard_count      = 1
 }
 resource "alicloud_mns_topic" "foo" {
   name = "${var.name}"
 }
 resource "alicloud_fc_service" "foo" {
-  name = "${var.name}"
+  name            = "${var.name}"
   internet_access = false
 }
 resource "alicloud_oss_bucket" "foo" {
   bucket = "${var.name}"
 }
 resource "alicloud_oss_bucket_object" "foo" {
-  bucket = "${alicloud_oss_bucket.foo.id}"
-  key = "fc/hello.zip"
+  bucket  = "${alicloud_oss_bucket.foo.id}"
+  key     = "fc/hello.zip"
   content = <<EOF
   	# -*- coding: utf-8 -*-
 	def handler(event, context):
@@ -165,10 +165,10 @@ resource "alicloud_ram_role" "foo" {
   }
   EOF
   description = "this is a test"
-  force = true
+  force       = true
 }
 resource "alicloud_ram_policy" "foo" {
-  name = "${var.name}-trigger"
+  name     = "${var.name}-trigger"
   document = <<EOF
   {
     "Version": "1",

--- a/website/docs/r/forward_entry.html.markdown
+++ b/website/docs/r/forward_entry.html.markdown
@@ -16,47 +16,47 @@ Basic Usage
 
 ```
 variable "name" {
-	default = "forward-entry-example-name"
+  default = "forward-entry-example-name"
 }
 
 data "alicloud_zones" "default" {
-	available_resource_creation = "VSwitch"
+  available_resource_creation = "VSwitch"
 }
 
 resource "alicloud_vpc" "default" {
-	name = "${var.name}"
-	cidr_block = "172.16.0.0/12"
+  name       = "${var.name}"
+  cidr_block = "172.16.0.0/12"
 }
 
 resource "alicloud_vswitch" "default" {
-	vpc_id = "${alicloud_vpc.default.id}"
-	cidr_block = "172.16.0.0/21"
-	availability_zone = "${data.alicloud_zones.default.zones.0.id}"
-	name = "${var.name}"
+  vpc_id            = "${alicloud_vpc.default.id}"
+  cidr_block        = "172.16.0.0/21"
+  availability_zone = "${data.alicloud_zones.default.zones.0.id}"
+  name              = "${var.name}"
 }
 
 resource "alicloud_nat_gateway" "default" {
-	vpc_id = "${alicloud_vpc.default.id}"
-	specification = "Small"
-	name = "${var.name}"
+  vpc_id        = "${alicloud_vpc.default.id}"
+  specification = "Small"
+  name          = "${var.name}"
 }
 
 resource "alicloud_eip" "default" {
-	name = "${var.name}"
+  name = "${var.name}"
 }
 
 resource "alicloud_eip_association" "default" {
-	allocation_id = "${alicloud_eip.default.id}"
-	instance_id = "${alicloud_nat_gateway.default.id}"
+  allocation_id = "${alicloud_eip.default.id}"
+  instance_id   = "${alicloud_nat_gateway.default.id}"
 }
 
-resource "alicloud_forward_entry" "default"{
-	forward_table_id = "${alicloud_nat_gateway.default.forward_table_ids}"
-	external_ip = "${alicloud_eip.default.ip_address}"
-	external_port = "80"
-	ip_protocol = "tcp"
-	internal_ip = "172.16.0.3"
-	internal_port = "8080"
+resource "alicloud_forward_entry" "default" {
+  forward_table_id = "${alicloud_nat_gateway.default.forward_table_ids}"
+  external_ip      = "${alicloud_eip.default.ip_address}"
+  external_port    = "80"
+  ip_protocol      = "tcp"
+  internal_ip      = "172.16.0.3"
+  internal_port    = "8080"
 }
 
 ```

--- a/website/docs/r/gpdb_connection.html.markdown
+++ b/website/docs/r/gpdb_connection.html.markdown
@@ -18,43 +18,43 @@ Provides a connection resource to allocate an Internet connection string for ins
 ## Example Usage
 
 ```
-    variable "creation" {
-        default = "Gpdb"
-    }
+variable "creation" {
+  default = "Gpdb"
+}
 
-    variable "name" {
-        default = "gpdbConnectionBasic"
-    }
+variable "name" {
+  default = "gpdbConnectionBasic"
+}
 
-    data "alicloud_zones" "default" {
-        available_resource_creation = "${var.creation}"
-    }
+data "alicloud_zones" "default" {
+  available_resource_creation = "${var.creation}"
+}
 
-    resource "alicloud_vpc" "default" {
-        name       = "${var.name}"
-        cidr_block = "172.16.0.0/16"
-    }
+resource "alicloud_vpc" "default" {
+  name       = "${var.name}"
+  cidr_block = "172.16.0.0/16"
+}
 
-    resource "alicloud_vswitch" "default" {
-        vpc_id            = "${alicloud_vpc.default.id}"
-        cidr_block        = "172.16.0.0/24"
-        availability_zone = "${data.alicloud_zones.default.zones.0.id}"
-        name              = "${var.name}"
-    }
-    
-    resource "alicloud_gpdb_instance" "default" {
-        vswitch_id = "${alicloud_vswitch.default.id}"
-        engine = "gpdb"
-        engine_version = "4.3"
-        instance_class = "gpdb.group.segsdx2"
-        instance_group_count = "2"
-        description = "${var.name}"
-    }
-    
-    resource "alicloud_gpdb_connection" "default" {
-        instance_id = "${alicloud_gpdb_instance.default.id}"
-        connection_prefix = "testAbc"
-    }
+resource "alicloud_vswitch" "default" {
+  vpc_id            = "${alicloud_vpc.default.id}"
+  cidr_block        = "172.16.0.0/24"
+  availability_zone = "${data.alicloud_zones.default.zones.0.id}"
+  name              = "${var.name}"
+}
+
+resource "alicloud_gpdb_instance" "default" {
+  vswitch_id           = "${alicloud_vswitch.default.id}"
+  engine               = "gpdb"
+  engine_version       = "4.3"
+  instance_class       = "gpdb.group.segsdx2"
+  instance_group_count = "2"
+  description          = "${var.name}"
+}
+
+resource "alicloud_gpdb_connection" "default" {
+  instance_id       = "${alicloud_gpdb_instance.default.id}"
+  connection_prefix = "testAbc"
+}
 ```
 
 ## Argument Reference

--- a/website/docs/r/havip.html.markdown
+++ b/website/docs/r/havip.html.markdown
@@ -18,8 +18,8 @@ Basic Usage
 
 ```
 resource "alicloud_havip" "foo" {
-    vswitch_id = "vsw-fakeid"
-    description = "test_havip"
+  vswitch_id  = "vsw-fakeid"
+  description = "test_havip"
 }
 ```
 ## Argument Reference

--- a/website/docs/r/havip_attachment.html.markdown
+++ b/website/docs/r/havip_attachment.html.markdown
@@ -18,65 +18,65 @@ Basic Usage
 
 ```
 data "alicloud_zones" "default" {
-	available_resource_creation = "VSwitch"
+  available_resource_creation = "VSwitch"
 }
 
 data "alicloud_instance_types" "default" {
- 	availability_zone = "${data.alicloud_zones.default.zones.0.id}"
-	cpu_core_count = 1
-	memory_size = 2
+  availability_zone = "${data.alicloud_zones.default.zones.0.id}"
+  cpu_core_count    = 1
+  memory_size       = 2
 }
 
 data "alicloud_images" "default" {
-	name_regex = "^ubuntu_14.*_64"
-	most_recent = true
-	owners = "system"
+  name_regex  = "^ubuntu_14.*_64"
+  most_recent = true
+  owners      = "system"
 }
 
 variable "name" {
-	default = "test_havip_attachment"
+  default = "test_havip_attachment"
 }
 
 resource "alicloud_vpc" "foo" {
-	cidr_block = "172.16.0.0/12"
-	name = "${var.name}"
+  cidr_block = "172.16.0.0/12"
+  name       = "${var.name}"
 }
 
 resource "alicloud_vswitch" "foo" {
-	vpc_id = "${alicloud_vpc.foo.id}"
-	cidr_block = "172.16.0.0/21"
-	availability_zone = "${data.alicloud_zones.default.zones.0.id}"
-	name = "${var.name}"
+  vpc_id            = "${alicloud_vpc.foo.id}"
+  cidr_block        = "172.16.0.0/21"
+  availability_zone = "${data.alicloud_zones.default.zones.0.id}"
+  name              = "${var.name}"
 }
 
 resource "alicloud_havip" "foo" {
-	vswitch_id = "${alicloud_vswitch.foo.id}"
-	description = "${var.name}"
+  vswitch_id  = "${alicloud_vswitch.foo.id}"
+  description = "${var.name}"
 }
 
 resource "alicloud_havip_attachment" "foo" {
-	havip_id = "${alicloud_havip.foo.id}"
-	instance_id = "${alicloud_instance.foo.id}"
+  havip_id    = "${alicloud_havip.foo.id}"
+  instance_id = "${alicloud_instance.foo.id}"
 }
 
 resource "alicloud_security_group" "tf_test_foo" {
-	name = "${var.name}"
-	description = "foo"
-	vpc_id = "${alicloud_vpc.foo.id}"
+  name        = "${var.name}"
+  description = "foo"
+  vpc_id      = "${alicloud_vpc.foo.id}"
 }
 
 resource "alicloud_instance" "foo" {
-	availability_zone = "${data.alicloud_zones.default.zones.0.id}"
-	vswitch_id = "${alicloud_vswitch.foo.id}"
-	image_id = "${data.alicloud_images.default.images.0.id}"
-	# series III
-	instance_type = "${data.alicloud_instance_types.default.instance_types.0.id}"
-	system_disk_category = "cloud_efficiency"
-	internet_charge_type = "PayByTraffic"
-	internet_max_bandwidth_out = 5
-	security_groups = ["${alicloud_security_group.tf_test_foo.id}"]
-	instance_name = "${var.name}"
-	user_data = "echo 'net.ipv4.ip_forward=1'>> /etc/sysctl.conf"
+  availability_zone = "${data.alicloud_zones.default.zones.0.id}"
+  vswitch_id        = "${alicloud_vswitch.foo.id}"
+  image_id          = "${data.alicloud_images.default.images.0.id}"
+  # series III
+  instance_type              = "${data.alicloud_instance_types.default.instance_types.0.id}"
+  system_disk_category       = "cloud_efficiency"
+  internet_charge_type       = "PayByTraffic"
+  internet_max_bandwidth_out = 5
+  security_groups            = ["${alicloud_security_group.tf_test_foo.id}"]
+  instance_name              = "${var.name}"
+  user_data                  = "echo 'net.ipv4.ip_forward=1'>> /etc/sysctl.conf"
 }
 ```
 ## Argument Reference

--- a/website/docs/r/instance.html.markdown
+++ b/website/docs/r/instance.html.markdown
@@ -30,20 +30,20 @@ Provides a ECS instance resource.
 resource "alicloud_security_group" "group" {
   name        = "tf_test_foo"
   description = "foo"
-  vpc_id = "${alicloud_vpc.vpc.id}"
+  vpc_id      = "${alicloud_vpc.vpc.id}"
 }
 
 resource "alicloud_instance" "instance" {
   # cn-beijing
   availability_zone = "cn-beijing-b"
-  security_groups = "${alicloud_security_group.group.*.id}"
+  security_groups   = "${alicloud_security_group.group.*.id}"
 
   # series III
-  instance_type        = "ecs.n4.large"
-  system_disk_category = "cloud_efficiency"
-  image_id             = "ubuntu_140405_64_40G_cloudinit_20161115.vhd"
-  instance_name        = "test_foo"
-  vswitch_id = "${alicloud_vswitch.vswitch.id}"
+  instance_type              = "ecs.n4.large"
+  system_disk_category       = "cloud_efficiency"
+  image_id                   = "ubuntu_140405_64_40G_cloudinit_20161115.vhd"
+  instance_name              = "test_foo"
+  vswitch_id                 = "${alicloud_vswitch.vswitch.id}"
   internet_max_bandwidth_out = 10
 }
 

--- a/website/docs/r/key_pair.html.markdown
+++ b/website/docs/r/key_pair.html.markdown
@@ -16,18 +16,18 @@ Basic Usage
 
 ```
 resource "alicloud_key_pair" "basic" {
-	key_name = "terraform-test-key-pair"
+  key_name = "terraform-test-key-pair"
 }
 
 // Using name prefix to build key pair
 resource "alicloud_key_pair" "prefix" {
-	key_name_prefix = "terraform-test-key-pair-prefix"
+  key_name_prefix = "terraform-test-key-pair-prefix"
 }
 
 // Import an existing public key to build a alicloud key pair
 resource "alicloud_key_pair" "publickey" {
-    key_name = "my_public_key"
-  	public_key = "ssh-rsa AAAAB3Nza12345678qwertyuudsfsg"
+  key_name   = "my_public_key"
+  public_key = "ssh-rsa AAAAB3Nza12345678qwertyuudsfsg"
 }
 ```
 ## Argument Reference

--- a/website/docs/r/key_pair_attachment.html.markdown
+++ b/website/docs/r/key_pair_attachment.html.markdown
@@ -18,51 +18,51 @@ Basic Usage
 
 ```
 data "alicloud_zones" "default" {
-  available_disk_category = "cloud_ssd"
+  available_disk_category     = "cloud_ssd"
   available_resource_creation = "VSwitch"
 }
 data "alicloud_instance_types" "type" {
   availability_zone = "${data.alicloud_zones.default.zones.0.id}"
-  cpu_core_count = 1
-  memory_size = 2
+  cpu_core_count    = 1
+  memory_size       = 2
 }
 data "alicloud_images" "images" {
-  name_regex = "^ubuntu_14.*_64"
+  name_regex  = "^ubuntu_14.*_64"
   most_recent = true
-  owners = "system"
+  owners      = "system"
 }
 variable "name" {
   default = "keyPairAttachmentName"
 }
 
 resource "alicloud_vpc" "vpc" {
-  name = "${var.name}"
+  name       = "${var.name}"
   cidr_block = "10.1.0.0/21"
 }
 
 resource "alicloud_vswitch" "vswitch" {
-  vpc_id = "${alicloud_vpc.vpc.id}"
-  cidr_block = "10.1.1.0/24"
+  vpc_id            = "${alicloud_vpc.vpc.id}"
+  cidr_block        = "10.1.1.0/24"
   availability_zone = "${data.alicloud_zones.default.zones.0.id}"
-  name = "${var.name}"
+  name              = "${var.name}"
 }
 resource "alicloud_security_group" "group" {
-  name = "${var.name}"
+  name        = "${var.name}"
   description = "New security group"
-  vpc_id = "${alicloud_vpc.vpc.id}"
+  vpc_id      = "${alicloud_vpc.vpc.id}"
 }
 
 resource "alicloud_instance" "instancd" {
-  instance_name = "${var.name}-${count.index+1}"
-  image_id = "${data.alicloud_images.images.images.0.id}"
-  instance_type = "${data.alicloud_instance_types.type.instance_types.0.id}"
-  count = 2
+  instance_name   = "${var.name}-${count.index + 1}"
+  image_id        = "${data.alicloud_images.images.images.0.id}"
+  instance_type   = "${data.alicloud_instance_types.type.instance_types.0.id}"
+  count           = 2
   security_groups = ["${alicloud_security_group.group.id}"]
-  vswitch_id = "${alicloud_vswitch.vswitch.id}"
+  vswitch_id      = "${alicloud_vswitch.vswitch.id}"
 
-  internet_charge_type = "PayByTraffic"
+  internet_charge_type       = "PayByTraffic"
   internet_max_bandwidth_out = 5
-  password = "Test12345"
+  password                   = "Test12345"
 
   instance_charge_type = "PostPaid"
   system_disk_category = "cloud_ssd"
@@ -73,7 +73,7 @@ resource "alicloud_key_pair" "pair" {
 }
 
 resource "alicloud_key_pair_attachment" "attachment" {
-  key_name = "${alicloud_key_pair.pair.id}"
+  key_name     = "${alicloud_key_pair.pair.id}"
   instance_ids = ["${alicloud_instance.instancd.*.id}"]
 }
 ```

--- a/website/docs/r/kms_key.html.markdown
+++ b/website/docs/r/kms_key.html.markdown
@@ -16,9 +16,9 @@ Basic Usage
 
 ```
 resource "alicloud_kms_key" "key" {
-  description = "Hello KMS"
+  description             = "Hello KMS"
   deletion_window_in_days = "7"
-  is_enabled = true
+  is_enabled              = true
 }
 ```
 ## Argument Reference

--- a/website/docs/r/kvstore_backup_policy.html.markdown
+++ b/website/docs/r/kvstore_backup_policy.html.markdown
@@ -15,42 +15,42 @@ Provides a backup policy for ApsaraDB Redis / Memcache instance resource.
 Basic Usage
 
 ```
-    variable "creation" {
-        default = "KVStore"
-    }
-    variable "multi_az" {
-        default = "false"
-    }
-    variable "name" {
-        default = "kvstorebackuppolicyvpc"
-    }
-    data "alicloud_zones" "default" {
-        available_resource_creation = "${var.creation}"
-    }
-    resource "alicloud_vpc" "default" {
-        name       = "${var.name}"
-        cidr_block = "172.16.0.0/16"
-    }
-    resource "alicloud_vswitch" "default" {
-        vpc_id            = "${alicloud_vpc.default.id}"
-        cidr_block        = "172.16.0.0/24"
-        availability_zone = "${data.alicloud_zones.default.zones.0.id}"
-        name              = "${var.name}"
-    }
-    resource "alicloud_kvstore_instance" "default" {
-        instance_class = "Memcache"
-        instance_name  = "${var.name}"
-        vswitch_id     = "${alicloud_vswitch.default.id}"
-        private_ip     = "172.16.0.10"
-        security_ips = ["10.0.0.1"]
-        instance_type = "memcache.master.small.default"
-        engine_version = "2.8"
-    }
-    resource "alicloud_kvstore_backup_policy" "default" {
-        instance_id = "${alicloud_kvstore_instance.default.id}"
-        backup_period = ["Tuesday", "Wednesday"]
-        backup_time = "10:00Z-11:00Z"
-    }
+variable "creation" {
+  default = "KVStore"
+}
+variable "multi_az" {
+  default = "false"
+}
+variable "name" {
+  default = "kvstorebackuppolicyvpc"
+}
+data "alicloud_zones" "default" {
+  available_resource_creation = "${var.creation}"
+}
+resource "alicloud_vpc" "default" {
+  name       = "${var.name}"
+  cidr_block = "172.16.0.0/16"
+}
+resource "alicloud_vswitch" "default" {
+  vpc_id            = "${alicloud_vpc.default.id}"
+  cidr_block        = "172.16.0.0/24"
+  availability_zone = "${data.alicloud_zones.default.zones.0.id}"
+  name              = "${var.name}"
+}
+resource "alicloud_kvstore_instance" "default" {
+  instance_class = "Memcache"
+  instance_name  = "${var.name}"
+  vswitch_id     = "${alicloud_vswitch.default.id}"
+  private_ip     = "172.16.0.10"
+  security_ips   = ["10.0.0.1"]
+  instance_type  = "memcache.master.small.default"
+  engine_version = "2.8"
+}
+resource "alicloud_kvstore_backup_policy" "default" {
+  instance_id   = "${alicloud_kvstore_instance.default.id}"
+  backup_period = ["Tuesday", "Wednesday"]
+  backup_time   = "10:00Z-11:00Z"
+}
 ```
 
 ## Argument Reference

--- a/website/docs/r/kvstore_instance.html.markdown
+++ b/website/docs/r/kvstore_instance.html.markdown
@@ -15,34 +15,34 @@ Provides an ApsaraDB Redis / Memcache instance resource. A DB instance is an iso
 Basic Usage
 
 ```
-    variable "creation" {
-        default = "KVStore"
-    }
-    variable "name" {
-        default = "kvstoreinstancevpc"
-    }
-    data "alicloud_zones" "default" {
-        available_resource_creation = "${var.creation}"
-    }
-    resource "alicloud_vpc" "default" {
-        name       = "${var.name}"
-        cidr_block = "172.16.0.0/16"
-    }
-    resource "alicloud_vswitch" "default" {
-        vpc_id            = "${alicloud_vpc.default.id}"
-        cidr_block        = "172.16.0.0/24"
-        availability_zone = "${data.alicloud_zones.default.zones.0.id}"
-        name              = "${var.name}"
-    }
-    resource "alicloud_kvstore_instance" "default" {
-        instance_class = "redis.master.small.default"
-        instance_name  = "${var.name}"
-        vswitch_id     = "${alicloud_vswitch.default.id}"
-        private_ip     = "172.16.0.10"
-        security_ips = ["10.0.0.1"]
-        instance_type = "Redis"
-        engine_version = "4.0"
-    }
+variable "creation" {
+  default = "KVStore"
+}
+variable "name" {
+  default = "kvstoreinstancevpc"
+}
+data "alicloud_zones" "default" {
+  available_resource_creation = "${var.creation}"
+}
+resource "alicloud_vpc" "default" {
+  name       = "${var.name}"
+  cidr_block = "172.16.0.0/16"
+}
+resource "alicloud_vswitch" "default" {
+  vpc_id            = "${alicloud_vpc.default.id}"
+  cidr_block        = "172.16.0.0/24"
+  availability_zone = "${data.alicloud_zones.default.zones.0.id}"
+  name              = "${var.name}"
+}
+resource "alicloud_kvstore_instance" "default" {
+  instance_class = "redis.master.small.default"
+  instance_name  = "${var.name}"
+  vswitch_id     = "${alicloud_vswitch.default.id}"
+  private_ip     = "172.16.0.10"
+  security_ips   = ["10.0.0.1"]
+  instance_type  = "Redis"
+  engine_version = "4.0"
+}
 ```
 
 ## Argument Reference

--- a/website/docs/r/launch_template.html.markdown
+++ b/website/docs/r/launch_template.html.markdown
@@ -16,60 +16,60 @@ For information about Launch Template and how to use it, see [Launch Template](h
 
 ```
 data "alicloud_images" "images" {
-    owners = "system"
+  owners = "system"
 }
 
 data "alicloud_instances" "instances" {
 }
 
 resource "alicloud_launch_template" "template" {
-    name = "tf-test-template"
-    description = "test1"
-    image_id = "${data.alicloud_images.images.images.0.id}"
-    host_name = "tf-test-host"
-    instance_charge_type = "PrePaid"
-    instance_name = "tf-instance-name"
-    instance_type = "${data.alicloud_instances.instances.instances.0.instance_type}"
-    internet_charge_type = "PayByBandwidth"
-    internet_max_bandwidth_in = 5
-    internet_max_bandwidth_out = 0
-    io_optimized = "none"
-    key_pair_name = "test-key-pair"
-    ram_role_name = "xxxxx"
-    network_type = "vpc"
-    security_enhancement_strategy = "Active"
-    spot_price_limit = 5
-    spot_strategy = "SpotWithPriceLimit"
-    security_group_id = "sg-zxcvj0lasdf102350asdf9a"
-    system_disk_category = "cloud_ssd"
-    system_disk_description = "test disk"
-    system_disk_name = "hello"
-    system_disk_size = 40
-    resource_group_id = "rg-zkdfjahg9zxncv0"
-    userdata = "xxxxxxxxxxxxxx"
-    vswitch_id = "sw-ljkngaksdjfj0nnasdf"
-    vpc_id = "vpc-asdfnbg0as8dfk1nb2"
-    zone_id = "beijing-a"
+  name                          = "tf-test-template"
+  description                   = "test1"
+  image_id                      = "${data.alicloud_images.images.images.0.id}"
+  host_name                     = "tf-test-host"
+  instance_charge_type          = "PrePaid"
+  instance_name                 = "tf-instance-name"
+  instance_type                 = "${data.alicloud_instances.instances.instances.0.instance_type}"
+  internet_charge_type          = "PayByBandwidth"
+  internet_max_bandwidth_in     = 5
+  internet_max_bandwidth_out    = 0
+  io_optimized                  = "none"
+  key_pair_name                 = "test-key-pair"
+  ram_role_name                 = "xxxxx"
+  network_type                  = "vpc"
+  security_enhancement_strategy = "Active"
+  spot_price_limit              = 5
+  spot_strategy                 = "SpotWithPriceLimit"
+  security_group_id             = "sg-zxcvj0lasdf102350asdf9a"
+  system_disk_category          = "cloud_ssd"
+  system_disk_description       = "test disk"
+  system_disk_name              = "hello"
+  system_disk_size              = 40
+  resource_group_id             = "rg-zkdfjahg9zxncv0"
+  userdata                      = "xxxxxxxxxxxxxx"
+  vswitch_id                    = "sw-ljkngaksdjfj0nnasdf"
+  vpc_id                        = "vpc-asdfnbg0as8dfk1nb2"
+  zone_id                       = "beijing-a"
 
-    tags = {
-        tag1 = "hello"
-        tag2 = "world"
-    }
-    network_interfaces {
-            name = "eth0"
-            description = "hello1"
-            primary_ip = "10.0.0.2"
-            security_group_id = "xxxx"
-            vswitch_id = "xxxxxxx"
-        }
-    data_disks {
-            name = "disk1"
-            description = "test1"
-        }
-    data_disks {
-            name = "disk2"
-            description = "test2"
-        }
+  tags = {
+    tag1 = "hello"
+    tag2 = "world"
+  }
+  network_interfaces {
+    name              = "eth0"
+    description       = "hello1"
+    primary_ip        = "10.0.0.2"
+    security_group_id = "xxxx"
+    vswitch_id        = "xxxxxxx"
+  }
+  data_disks {
+    name        = "disk1"
+    description = "test1"
+  }
+  data_disks {
+    name        = "disk2"
+    description = "test2"
+  }
 }
 ```
 

--- a/website/docs/r/log_machine_group.html.markdown
+++ b/website/docs/r/log_machine_group.html.markdown
@@ -17,15 +17,15 @@ Basic Usage
 
 ```
 resource "alicloud_log_project" "example" {
-  name       = "tf-log"
+  name        = "tf-log"
   description = "created by terraform"
 }
 resource "alicloud_log_machine_group" "example" {
-    project = "${alicloud_log_project.example.name}"
-    name = "tf-machine-group"
-    identify_type = "ip"
-    topic = "terraform"
-    identify_list = ["10.0.0.1", "10.0.0.2"]
+  project       = "${alicloud_log_project.example.name}"
+  name          = "tf-machine-group"
+  identify_type = "ip"
+  topic         = "terraform"
+  identify_list = ["10.0.0.1", "10.0.0.2"]
 }
 ```
 ## Argument Reference

--- a/website/docs/r/log_project.html.markdown
+++ b/website/docs/r/log_project.html.markdown
@@ -17,7 +17,7 @@ Basic Usage
 
 ```
 resource "alicloud_log_project" "example" {
-  name       = "tf-log"
+  name        = "tf-log"
   description = "created by terraform"
 }
 ```

--- a/website/docs/r/log_store_index.html.markdown
+++ b/website/docs/r/log_store_index.html.markdown
@@ -17,25 +17,25 @@ Basic Usage
 
 ```
 resource "alicloud_log_project" "example" {
-  name       = "tf-log"
+  name        = "tf-log"
   description = "created by terraform"
 }
 resource "alicloud_log_store" "example" {
-  project = "${alicloud_log_project.example.name}"
-  name       = "tf-log-store"
+  project     = "${alicloud_log_project.example.name}"
+  name        = "tf-log-store"
   description = "created by terraform"
 }
 resource "alicloud_log_store_index" "example" {
-  project = "${alicloud_log_project.example.name}"
+  project  = "${alicloud_log_project.example.name}"
   logstore = "${alicloud_log_store.example.name}"
   full_text {
     case_sensitive = true
-    token = " #$%^*\r\n\t"
+    token          = " #$%^*\r\n\t"
   }
   field_search {
-      name = "terraform"
-      enable_analytics = true
-    }
+    name             = "terraform"
+    enable_analytics = true
+  }
 }
 ```
 ## Argument Reference

--- a/website/docs/r/logtail_attachment.html.markdown
+++ b/website/docs/r/logtail_attachment.html.markdown
@@ -21,33 +21,33 @@ This resource amis to attach one logtail configure to a machine group.
 Basic Usage
 
 ```
-resource "alicloud_log_project" "test"{
-	name = "test-tf2"
-	description = "create by terraform"
+resource "alicloud_log_project" "test" {
+  name        = "test-tf2"
+  description = "create by terraform"
 }
-resource "alicloud_log_store" "test"{
-  	project = "${alicloud_log_project.test.name}"
-  	name = "tf-test-logstore"
-  	retention_period = 3650
-  	shard_count = 3
-  	auto_split = true
-  	max_split_shard_count = 60
-  	append_meta = true
+resource "alicloud_log_store" "test" {
+  project               = "${alicloud_log_project.test.name}"
+  name                  = "tf-test-logstore"
+  retention_period      = 3650
+  shard_count           = 3
+  auto_split            = true
+  max_split_shard_count = 60
+  append_meta           = true
 }
 resource "alicloud_log_machine_group" "test" {
-	    project = "${alicloud_log_project.test.name}"
-	    name = "tf-log-machine-group"
-	    topic = "terraform"
-	    identify_list = ["10.0.0.1", "10.0.0.3", "10.0.0.2"]
+  project       = "${alicloud_log_project.test.name}"
+  name          = "tf-log-machine-group"
+  topic         = "terraform"
+  identify_list = ["10.0.0.1", "10.0.0.3", "10.0.0.2"]
 }
-resource "alicloud_logtail_config" "test"{
-	project = "${alicloud_log_project.test.name}"
-  	logstore = "${alicloud_log_store.test.name}"
-  	input_type = "file"
-  	log_sample = "test"
-  	name = "tf-log-config"
-	output_type = "LogService"
-  	input_detail = <<DEFINITION
+resource "alicloud_logtail_config" "test" {
+  project      = "${alicloud_log_project.test.name}"
+  logstore     = "${alicloud_log_store.test.name}"
+  input_type   = "file"
+  log_sample   = "test"
+  name         = "tf-log-config"
+  output_type  = "LogService"
+  input_detail = <<DEFINITION
   	{
 		"logPath": "/logPath",
 		"filePattern": "access.log",
@@ -61,9 +61,9 @@ resource "alicloud_logtail_config" "test"{
 	DEFINITION
 }
 resource "alicloud_logtail_attachment" "test" {
-	project = "${alicloud_log_project.test.name}"
-	logtail_config_name = "${alicloud_logtail_config.test.name}"
-	machine_group_name = "${alicloud_log_machine_group.test.name}"
+  project = "${alicloud_log_project.test.name}"
+  logtail_config_name = "${alicloud_logtail_config.test.name}"
+  machine_group_name = "${alicloud_log_machine_group.test.name}"
 }
 ```
 ## Argument Reference

--- a/website/docs/r/logtail_config.html.markdown
+++ b/website/docs/r/logtail_config.html.markdown
@@ -18,27 +18,27 @@ Compute Service (ECS) instances in real time in the Log Service console. [Refer 
 Basic Usage
 
 ```
-resource "alicloud_log_project" "example"{
-	name = "test-tf"
-	description = "create by terraform"
+resource "alicloud_log_project" "example" {
+  name        = "test-tf"
+  description = "create by terraform"
 }
-resource "alicloud_log_store" "example"{
-  	project = "${alicloud_log_project.example.name}"
-  	name = "tf-test-logstore"
-  	retention_period = 3650
-  	shard_count = 3
-  	auto_split = true
-  	max_split_shard_count = 60
-  	append_meta = true
+resource "alicloud_log_store" "example" {
+  project               = "${alicloud_log_project.example.name}"
+  name                  = "tf-test-logstore"
+  retention_period      = 3650
+  shard_count           = 3
+  auto_split            = true
+  max_split_shard_count = 60
+  append_meta           = true
 }
-resource "alicloud_logtail_config" "example"{
-	project = "${alicloud_log_project.example.name}"
-  	logstore = "${alicloud_log_store.example.name}"
-  	input_type = "file"
-  	log_sample = "test"
-  	name = "tf-log-config"
-	output_type = "LogService"
-  	input_detail = "${file("config.json")}"
+resource "alicloud_logtail_config" "example" {
+  project      = "${alicloud_log_project.example.name}"
+  logstore     = "${alicloud_log_store.example.name}"
+  input_type   = "file"
+  log_sample   = "test"
+  name         = "tf-log-config"
+  output_type  = "LogService"
+  input_detail = "${file("config.json")}"
 }
 ```
 ## Argument Reference

--- a/website/docs/r/mns_queue.html.markdown
+++ b/website/docs/r/mns_queue.html.markdown
@@ -17,13 +17,13 @@ Provides a MNS queue resource.
 Basic Usage
 
 ```
-resource "alicloud_mns_queue" "queue"{
-    name="tf-example-mnsqueue"
-    delay_seconds=0
-    maximum_message_size=65536
-    message_retention_period=345600
-    visibility_timeout=30
-    polling_wait_seconds=0
+resource "alicloud_mns_queue" "queue" {
+  name                     = "tf-example-mnsqueue"
+  delay_seconds            = 0
+  maximum_message_size     = 65536
+  message_retention_period = 345600
+  visibility_timeout       = 30
+  polling_wait_seconds     = 0
 }
 ```
 

--- a/website/docs/r/mns_topic.html.markdown
+++ b/website/docs/r/mns_topic.html.markdown
@@ -17,10 +17,10 @@ Provides a MNS topic resource.
 Basic Usage
 
 ```
-resource "alicloud_mns_topic" "topic"{
-    name="tf-example-mnstopic"
-    maximum_message_size=65536
-    logging_enabled=false
+resource "alicloud_mns_topic" "topic" {
+  name                 = "tf-example-mnstopic"
+  maximum_message_size = 65536
+  logging_enabled      = false
 }
 
 ```

--- a/website/docs/r/mns_topic_subscription.html.markdown
+++ b/website/docs/r/mns_topic_subscription.html.markdown
@@ -17,19 +17,19 @@ Provides a MNS topic subscription resource.
 Basic Usage
 
 ```
-resource "alicloud_mns_topic" "topic"{
-    name="tf-example-mnstopic"
-    maximum_message_size=65536
-    logging_enabled=false
+resource "alicloud_mns_topic" "topic" {
+  name                 = "tf-example-mnstopic"
+  maximum_message_size = 65536
+  logging_enabled      = false
 }
 
-resource "alicloud_mns_topic_subscription" "subscription"{
-    topic_name="tf-example-mnstopic"
-    name="tf-example-mnstopic-sub"
-    filter_tag="test"
-    endpoint="http://www.xxx.com/xxx"
-    notify_strategy="BACKOFF_RETRY"
-    notify_content_format="XML"
+resource "alicloud_mns_topic_subscription" "subscription" {
+  topic_name            = "tf-example-mnstopic"
+  name                  = "tf-example-mnstopic-sub"
+  filter_tag            = "test"
+  endpoint              = "http://www.xxx.com/xxx"
+  notify_strategy       = "BACKOFF_RETRY"
+  notify_content_format = "XML"
 }
 ```
 

--- a/website/docs/r/nas_access_group.html.markdown
+++ b/website/docs/r/nas_access_group.html.markdown
@@ -20,10 +20,10 @@ Basic Usage
 
 ```
 resource "alicloud_nas_access_group" "foo" {
-    name = "CreateAccessGroup"
- 	type = "Classic"
- 	description = "test_AccessG"
-  
+  name        = "CreateAccessGroup"
+  type        = "Classic"
+  description = "test_AccessG"
+
 }
 ```
 ## Argument Reference

--- a/website/docs/r/nas_access_rule.html.markdown
+++ b/website/docs/r/nas_access_rule.html.markdown
@@ -20,16 +20,16 @@ Basic Usage
 
 ```
 resource "alicloud_nas_access_group" "foo" {
-        name = "tf-NasConfigName-%d"
-        type = "Vpc"
-        description = "tf-testAccNasConfig"
+  name        = "tf-NasConfigName-%d"
+  type        = "Vpc"
+  description = "tf-testAccNasConfig"
 }
 resource "alicloud_nas_access_rule" "foo" {
-	access_group_name = "${alicloud_nas_access_group.foo.id}"
-        source_cidr_ip = "168.1.1.0/16"
-        rw_access_type = "RDWR"
-        user_access_type = "no_squash"
-        priority = 2
+  access_group_name = "${alicloud_nas_access_group.foo.id}"
+  source_cidr_ip    = "168.1.1.0/16"
+  rw_access_type    = "RDWR"
+  user_access_type  = "no_squash"
+  priority          = 2
 }
 ```
 

--- a/website/docs/r/nas_file_system.html.markdown
+++ b/website/docs/r/nas_file_system.html.markdown
@@ -23,9 +23,9 @@ Basic Usage
 ```
 resource "alicloud_nas_file_system" "foo" {
   protocol_type = "NFS"
-  storage_type = "Performance"
-  description = "tf-testAccNasConfig"
-  
+  storage_type  = "Performance"
+  description   = "tf-testAccNasConfig"
+
 }
 ```
 ## Argument Reference

--- a/website/docs/r/nas_mount_target.html.markdown
+++ b/website/docs/r/nas_mount_target.html.markdown
@@ -24,23 +24,23 @@ Basic Usage
 
 ```
 resource "alicloud_nas_file_system" "foo" {
-	protocol_type = "NFS"
-        storage_type = "Performance"
-        description = "tf-testAccNasConfigFs"
+  protocol_type = "NFS"
+  storage_type  = "Performance"
+  description   = "tf-testAccNasConfigFs"
 }
 resource "alicloud_nas_access_group" "foo" {
-        name = "tf-NasConfig-%d"
-        type = "Classic"
-        description = "tf-testAccNasConfig"
+  name        = "tf-NasConfig-%d"
+  type        = "Classic"
+  description = "tf-testAccNasConfig"
 }
 resource "alicloud_nas_access_group" "bar" {
-        name = "tf-cNasConfig-2-%d"
-        type = "Classic"
-        description = "tf-testAccNasConfig-2"
+  name        = "tf-cNasConfig-2-%d"
+  type        = "Classic"
+  description = "tf-testAccNasConfig-2"
 }
 resource "alicloud_nas_mount_target" "foo" {
-        file_system_id = "${alicloud_nas_file_system.foo.id}"
-        access_group_name = "${alicloud_nas_access_group.foo.id}"
+  file_system_id    = "${alicloud_nas_file_system.foo.id}"
+  access_group_name = "${alicloud_nas_access_group.foo.id}"
 }
 ```
 

--- a/website/docs/r/nat_gateway.html.markdown
+++ b/website/docs/r/nat_gateway.html.markdown
@@ -25,28 +25,28 @@ Basic usage
 
 ```
 variable "name" {
-	default = "natGatewayExampleName"
+  default = "natGatewayExampleName"
 }
 
 data "alicloud_zones" "default" {
-	available_resource_creation = "VSwitch"
+  available_resource_creation = "VSwitch"
 }
 
 resource "alicloud_vpc" "default" {
-	name = "${var.name}"
-	cidr_block = "172.16.0.0/12"
+  name       = "${var.name}"
+  cidr_block = "172.16.0.0/12"
 }
 
 resource "alicloud_vswitch" "default" {
-	vpc_id = "${alicloud_vpc.default.id}"
-	cidr_block = "172.16.0.0/21"
-	availability_zone = "${data.alicloud_zones.default.zones.0.id}"
-	name = "${var.name}"
+  vpc_id            = "${alicloud_vpc.default.id}"
+  cidr_block        = "172.16.0.0/21"
+  availability_zone = "${data.alicloud_zones.default.zones.0.id}"
+  name              = "${var.name}"
 }
 
 resource "alicloud_nat_gateway" "default" {
-	vpc_id = "${alicloud_vswitch.default.vpc_id}"
-	name = "${var.name}"
+  vpc_id = "${alicloud_vswitch.default.vpc_id}"
+  name   = "${var.name}"
 }
 ```
 

--- a/website/docs/r/network_acl.html.markdown
+++ b/website/docs/r/network_acl.html.markdown
@@ -19,12 +19,12 @@ Basic Usage
 ```
 resource "alicloud_vpc" "default" {
   cidr_block = "172.16.0.0/12"
-  name = "VpcConfig"
-}	
+  name       = "VpcConfig"
+}
 
 resource "alicloud_network_acl" "default" {
-  vpc_id = "${alicloud_vpc.default.id}"
-  name = "network_acl"
+  vpc_id      = "${alicloud_vpc.default.id}"
+  name        = "network_acl"
   description = "network_acl"
 }
 ```

--- a/website/docs/r/network_acl_attachment.html.markdown
+++ b/website/docs/r/network_acl_attachment.html.markdown
@@ -26,28 +26,28 @@ data "alicloud_zones" "default" {
 }
 
 resource "alicloud_vpc" "default" {
-  name = "${var.name}"
+  name       = "${var.name}"
   cidr_block = "172.16.0.0/12"
 }
 
 resource "alicloud_network_acl" "default" {
   vpc_id = "${alicloud_vpc.default.id}"
-  name = "${var.name}"
+  name   = "${var.name}"
 }
 
 
 resource "alicloud_vswitch" "default" {
-  vpc_id = "${alicloud_vpc.default.id}"
-  cidr_block = "172.16.0.0/21"
+  vpc_id            = "${alicloud_vpc.default.id}"
+  cidr_block        = "172.16.0.0/21"
   availability_zone = "${data.alicloud_zones.default.zones.0.id}"
-  name = "${var.name}"
+  name              = "${var.name}"
 }
 
 resource "alicloud_network_acl_attachment" "default" {
   network_acl_id = "${alicloud_network_acl.default.id}"
   resources = [
     {
-      resource_id = "${alicloud_vswitch.default.id}"
+      resource_id   = "${alicloud_vswitch.default.id}"
       resource_type = "VSwitch"
     }
   ]

--- a/website/docs/r/network_acl_entries.html.markdown
+++ b/website/docs/r/network_acl_entries.html.markdown
@@ -30,28 +30,28 @@ data "alicloud_zones" "default" {
 }
 
 resource "alicloud_vpc" "default" {
-  name = "${var.name}"
+  name       = "${var.name}"
   cidr_block = "172.16.0.0/12"
 }
 
 resource "alicloud_network_acl" "default" {
   vpc_id = "${alicloud_vpc.default.id}"
-  name = "${var.name}"
+  name   = "${var.name}"
 }
 
 
 resource "alicloud_vswitch" "default" {
-  vpc_id = "${alicloud_vpc.default.id}"
-  cidr_block = "172.16.0.0/21"
+  vpc_id            = "${alicloud_vpc.default.id}"
+  cidr_block        = "172.16.0.0/21"
   availability_zone = "${data.alicloud_zones.default.zones.0.id}"
-  name = "${var.name}"
+  name              = "${var.name}"
 }
 
 resource "alicloud_network_acl_attachment" "default" {
   network_acl_id = "${alicloud_network_acl.default.id}"
   resources = [
     {
-      resource_id = "${alicloud_vswitch.default.id}"
+      resource_id   = "${alicloud_vswitch.default.id}"
       resource_type = "VSwitch"
     }
   ]
@@ -61,24 +61,24 @@ resource "alicloud_network_acl_entries" "default" {
   network_acl_id = "${alicloud_network_acl.default.id}"
   ingress = [
     {
-      protocol = "all"
-      port = "-1/-1"
+      protocol       = "all"
+      port           = "-1/-1"
       source_cidr_ip = "0.0.0.0/32"
-      name = "${var.name}"
-      entry_type = "custom"
-      policy = "accept"
-      description = "${var.name}"
+      name           = "${var.name}"
+      entry_type     = "custom"
+      policy         = "accept"
+      description    = "${var.name}"
     }
   ]
   egress = [
     {
-      protocol = "all"
-      port = "-1/-1"
+      protocol            = "all"
+      port                = "-1/-1"
       destination_cidr_ip = "0.0.0.0/32"
-      name = "${var.name}"
-      entry_type = "custom"
-      policy = "accept"
-      description = "${var.name}"
+      name                = "${var.name}"
+      entry_type          = "custom"
+      policy              = "accept"
+      description         = "${var.name}"
     }
   ]
 }

--- a/website/docs/r/network_interface.html.markdown
+++ b/website/docs/r/network_interface.html.markdown
@@ -22,7 +22,7 @@ variable "name" {
 }
 
 resource "alicloud_vpc" "vpc" {
-  name = "${var.name}"
+  name       = "${var.name}"
   cidr_block = "192.168.0.0/24"
 }
 
@@ -31,22 +31,22 @@ data "alicloud_zones" "default" {
 }
 
 resource "alicloud_vswitch" "vswitch" {
-  name = "${var.name}"
-  cidr_block = "192.168.0.0/24"
+  name              = "${var.name}"
+  cidr_block        = "192.168.0.0/24"
   availability_zone = "${data.alicloud_zones.default.zones.0.id}"
-  vpc_id = "${alicloud_vpc.vpc.id}"
+  vpc_id            = "${alicloud_vpc.vpc.id}"
 }
 
 resource "alicloud_security_group" "group" {
-  name = "${var.name}"
+  name   = "${var.name}"
   vpc_id = "${alicloud_vpc.vpc.id}"
 }
 
 resource "alicloud_network_interface" "default" {
-  name = "${var.name}%d"
-  vswitch_id = "${alicloud_vswitch.vswitch.id}"
-  security_groups = [ "${alicloud_security_group.group.id}" ]
-  private_ip = "192.168.0.2"
+  name              = "${var.name}%d"
+  vswitch_id        = "${alicloud_vswitch.vswitch.id}"
+  security_groups   = ["${alicloud_security_group.group.id}"]
+  private_ip        = "192.168.0.2"
   private_ips_count = 3
 }
 ```

--- a/website/docs/r/ons_instance.html.markdown
+++ b/website/docs/r/ons_instance.html.markdown
@@ -21,9 +21,9 @@ For more information about how to use it, see [RocketMQ Instance Management API]
 Basic Usage
 
 ```
-resource "alicloud_ons_instance" "example"{
-    name="tf-example-ons-instance"
-    remark="tf-example-ons-instance-remark"
+resource "alicloud_ons_instance" "example" {
+  name   = "tf-example-ons-instance"
+  remark = "tf-example-ons-instance-remark"
 }
 ```
 

--- a/website/docs/r/oss_bucket_object.html.markdown
+++ b/website/docs/r/oss_bucket_object.html.markdown
@@ -27,12 +27,12 @@ resource "alicloud_oss_bucket_object" "object-source" {
 ```
 resource "alicloud_oss_bucket" "example" {
   bucket = "your_bucket_name"
-  acl = "public-read"
+  acl    = "public-read"
 }
 
 resource "alicloud_oss_bucket_object" "object-content" {
-  bucket = "${alicloud_oss_bucket.example.bucket}"
-  key    = "new_object_key"
+  bucket  = "${alicloud_oss_bucket.example.bucket}"
+  key     = "new_object_key"
   content = "the content that you want to upload."
 }
 ```

--- a/website/docs/r/ots_instance.html.markdown
+++ b/website/docs/r/ots_instance.html.markdown
@@ -16,12 +16,12 @@ It is foundation of creating data table.
 ```
 # Create an OTS instance
 resource "alicloud_ots_instance" "foo" {
-  name = "my-ots-instance"
+  name        = "my-ots-instance"
   description = "for table"
   accessed_by = "Vpc"
   tags = {
     Created = "TF"
-    For = "Building table"
+    For     = "Building table"
   }
 }
 ```

--- a/website/docs/r/ots_instance_attachment.html.markdown
+++ b/website/docs/r/ots_instance_attachment.html.markdown
@@ -15,12 +15,12 @@ This resource will help you to bind a VPC to an OTS instance.
 ```
 # Create an OTS instance
 resource "alicloud_ots_instance" "foo" {
-  name = "my-ots-instance"
+  name        = "my-ots-instance"
   description = "for table"
   accessed_by = "Vpc"
   tags = {
     Created = "TF"
-    For = "Building table"
+    For     = "Building table"
   }
 }
 
@@ -29,19 +29,19 @@ data "alicloud_zones" "foo" {
 }
 resource "alicloud_vpc" "foo" {
   cidr_block = "172.16.0.0/16"
-  name = "for-ots-instance"
+  name       = "for-ots-instance"
 }
 
 resource "alicloud_vswitch" "foo" {
-  vpc_id = "${alicloud_vpc.foo.id}"
-  name = "for-ots-instance"
-  cidr_block = "172.16.1.0/24"
+  vpc_id            = "${alicloud_vpc.foo.id}"
+  name              = "for-ots-instance"
+  cidr_block        = "172.16.1.0/24"
   availability_zone = "${data.alicloud_zones.foo.zones.0.id}"
 }
 resource "alicloud_ots_instance_attachment" "foo" {
   instance_name = "${alicloud_ots_instance.foo.name}"
-  vpc_name = "attachment1"
-  vswitch_id = "${alicloud_vswitch.foo.id}"
+  vpc_name      = "attachment1"
+  vswitch_id    = "${alicloud_vswitch.foo.id}"
 }
 ```
 

--- a/website/docs/r/ots_table.html.markdown
+++ b/website/docs/r/ots_table.html.markdown
@@ -20,35 +20,35 @@ variable "name" {
   default = "terraformtest"
 }
 resource "alicloud_ots_instance" "foo" {
-  name = "${var.name}"
+  name        = "${var.name}"
   description = "${var.name}"
   accessed_by = "Any"
   tags = {
     Created = "TF"
-    For = "acceptance test"
+    For     = "acceptance test"
   }
 }
 
 resource "alicloud_ots_table" "basic" {
   instance_name = "${alicloud_ots_instance.foo.name}"
-  table_name = "${var.name}"
+  table_name    = "${var.name}"
   primary_key = [
-  {
-    name = "pk1"
-    type = "Integer"
-  },
-  {
-    name = "pk2"
-    type = "String"
-  },
-  {
-    name = "pk3"
-    type = "Binary"
-  },
+    {
+      name = "pk1"
+      type = "Integer"
+    },
+    {
+      name = "pk2"
+      type = "String"
+    },
+    {
+      name = "pk3"
+      type = "Binary"
+    },
   ]
-  
-  time_to_live = -1
-  max_version = 1
+
+  time_to_live                  = -1
+  max_version                   = 1
   deviation_cell_version_in_sec = 1
 }
 ```

--- a/website/docs/r/pvtz_zone.html.markdown
+++ b/website/docs/r/pvtz_zone.html.markdown
@@ -18,7 +18,7 @@ Basic Usage
 
 ```
 resource "alicloud_pvtz_zone" "foo" {
-	name = "foo.test.com"
+  name = "foo.test.com"
 }
 ```
 ## Argument Reference

--- a/website/docs/r/pvtz_zone_attachment.html.markdown
+++ b/website/docs/r/pvtz_zone_attachment.html.markdown
@@ -18,17 +18,17 @@ Basic Usage
 
 ```
 resource "alicloud_pvtz_zone" "zone" {
-	name = "foo.test.com"
+  name = "foo.test.com"
 }
 
 resource "alicloud_vpc" "vpc" {
-	name = "tf_test_foo"
-	cidr_block = "172.16.0.0/12"
+  name       = "tf_test_foo"
+  cidr_block = "172.16.0.0/12"
 }
 
 resource "alicloud_pvtz_zone_attachment" "zone-attachment" {
-	zone_id = "${alicloud_pvtz_zone.zone.id}"
-	vpc_ids = ["${alicloud_vpc.vpc.id}"]
+  zone_id = "${alicloud_pvtz_zone.zone.id}"
+  vpc_ids = ["${alicloud_vpc.vpc.id}"]
 }
 ```
 ## Argument Reference

--- a/website/docs/r/ram_access_key.html.markdown
+++ b/website/docs/r/ram_access_key.html.markdown
@@ -17,16 +17,16 @@ Provides a RAM User access key resource.
 ```
 # Create a new RAM access key for user.
 resource "alicloud_ram_user" "user" {
-  name = "user_test"
+  name         = "user_test"
   display_name = "user_display_name"
-  mobile = "86-18688888888"
-  email = "hello.uuu@aaa.com"
-  comments = "yoyoyo"
-  force = true
+  mobile       = "86-18688888888"
+  email        = "hello.uuu@aaa.com"
+  comments     = "yoyoyo"
+  force        = true
 }
 
 resource "alicloud_ram_access_key" "ak" {
-  user_name = "${alicloud_ram_user.user.name}"
+  user_name   = "${alicloud_ram_user.user.name}"
   secret_file = "/xxx/xxx/xxx.txt"
 }
 ```

--- a/website/docs/r/ram_account_password_policy.html.markdown
+++ b/website/docs/r/ram_account_password_policy.html.markdown
@@ -26,15 +26,15 @@ resource "alicloud_ram_account_password_policy" "default" {
 
 ```hcl
 resource "alicloud_ram_account_password_policy" "corporate" {
-	minimum_password_length = 9
-	require_lowercase_characters = false
-	require_uppercase_characters = false
-	require_numbers = false
-	require_symbols = false
-	hard_expiry = true
-	max_password_age = 12
-	password_reuse_prevention = 5
-	max_login_attempts = 3
+  minimum_password_length      = 9
+  require_lowercase_characters = false
+  require_uppercase_characters = false
+  require_numbers              = false
+  require_symbols              = false
+  hard_expiry                  = true
+  max_password_age             = 12
+  password_reuse_prevention    = 5
+  max_login_attempts           = 3
 }
 ```
 For not specified values sets defaults.

--- a/website/docs/r/ram_group.html.markdown
+++ b/website/docs/r/ram_group.html.markdown
@@ -17,9 +17,9 @@ Provides a RAM Group resource.
 ```
 # Create a new RAM Group.
 resource "alicloud_ram_group" "group" {
-  name = "groupName"
+  name     = "groupName"
   comments = "this is a group comments."
-  force = true
+  force    = true
 }
 ```
 ## Argument Reference

--- a/website/docs/r/ram_group_policy_attachment.html.markdown
+++ b/website/docs/r/ram_group_policy_attachment.html.markdown
@@ -15,13 +15,13 @@ Provides a RAM Group Policy attachment resource.
 ```
 # Create a RAM Group Policy attachment.
 resource "alicloud_ram_group" "group" {
-  name = "groupName"
+  name     = "groupName"
   comments = "this is a group comments."
-  force = true
+  force    = true
 }
 
 resource "alicloud_ram_policy" "policy" {
-  name = "policyName"
+  name     = "policyName"
   document = <<EOF
     {
       "Statement": [

--- a/website/docs/r/ram_login_profile.html.markdown
+++ b/website/docs/r/ram_login_profile.html.markdown
@@ -16,17 +16,17 @@ Provides a RAM User Login Profile resource.
 ```
 # Create a RAM login profile.
 resource "alicloud_ram_user" "user" {
-  name = "user_test"
+  name         = "user_test"
   display_name = "user_display_name"
-  mobile = "86-18688888888"
-  email = "hello.uuu@aaa.com"
-  comments = "yoyoyo"
-  force = true
+  mobile       = "86-18688888888"
+  email        = "hello.uuu@aaa.com"
+  comments     = "yoyoyo"
+  force        = true
 }
 
 resource "alicloud_ram_login_profile" "profile" {
   user_name = "${alicloud_ram_user.user.name}"
-  password = "Yourpassword1234"
+  password  = "Yourpassword1234"
 }
 ```
 ## Argument Reference

--- a/website/docs/r/ram_policy.html.markdown
+++ b/website/docs/r/ram_policy.html.markdown
@@ -18,7 +18,7 @@ Provides a RAM Policy resource.
 ```
 # Create a new RAM Policy.
 resource "alicloud_ram_policy" "policy" {
-  name = "policyName"
+  name     = "policyName"
   document = <<EOF
   {
     "Statement": [

--- a/website/docs/r/ram_role.html.markdown
+++ b/website/docs/r/ram_role.html.markdown
@@ -17,7 +17,7 @@ Provides a RAM Role resource.
 ```
 # Create a new RAM Role.
 resource "alicloud_ram_role" "role" {
-  name = "testrole"
+  name     = "testrole"
   document = <<EOF
   {
     "Statement": [

--- a/website/docs/r/ram_role_attachment.html.markdown
+++ b/website/docs/r/ram_role_attachment.html.markdown
@@ -48,32 +48,32 @@ resource "alicloud_security_group" "default" {
 }
 
 resource "alicloud_security_group_rule" "default" {
-  type = "ingress"
-  ip_protocol = "tcp"
-  nic_type = "intranet"
-  policy = "accept"
-  port_range = "22/22"
-  priority = 1
+  type              = "ingress"
+  ip_protocol       = "tcp"
+  nic_type          = "intranet"
+  policy            = "accept"
+  port_range        = "22/22"
+  priority          = 1
   security_group_id = "${alicloud_security_group.default.id}"
-  cidr_ip = "172.16.0.0/24"
+  cidr_ip           = "172.16.0.0/24"
 }
 variable "name" {
   default = "ecsInstanceVPCExample"
 }
 resource "alicloud_instance" "foo" {
   vswitch_id = "${alicloud_vswitch.default.id}"
-  image_id = "${data.alicloud_images.default.images.0.id}"
+  image_id   = "${data.alicloud_images.default.images.0.id}"
 
-  instance_type = "${data.alicloud_instance_types.default.instance_types.0.id}"
+  instance_type        = "${data.alicloud_instance_types.default.instance_types.0.id}"
   system_disk_category = "cloud_efficiency"
 
-  internet_charge_type = "PayByTraffic"
+  internet_charge_type       = "PayByTraffic"
   internet_max_bandwidth_out = 5
-  security_groups = ["${alicloud_security_group.default.id}"]
-  instance_name = "${var.name}"
+  security_groups            = ["${alicloud_security_group.default.id}"]
+  instance_name              = "${var.name}"
 }
 resource "alicloud_ram_role" "role" {
-  name = "testrole"
+  name     = "testrole"
   document = <<EOF
   {
     "Statement": [

--- a/website/docs/r/ram_role_policy_attachment.html.markdown
+++ b/website/docs/r/ram_role_policy_attachment.html.markdown
@@ -15,7 +15,7 @@ Provides a RAM Role attachment resource.
 ```
 # Create a RAM Role Policy attachment.
 resource "alicloud_ram_role" "role" {
-  name = "roleName"
+  name     = "roleName"
   document = <<EOF
     {
       "Statement": [
@@ -58,13 +58,13 @@ resource "alicloud_ram_policy" "policy" {
   }
   EOF
   description = "this is a policy test"
-  force = true
+  force       = true
 }
 
 resource "alicloud_ram_role_policy_attachment" "attach" {
   policy_name = "${alicloud_ram_policy.policy.name}"
   policy_type = "${alicloud_ram_policy.policy.type}"
-  role_name = "${alicloud_ram_role.role.name}"
+  role_name   = "${alicloud_ram_role.role.name}"
 }
 ```
 ## Argument Reference

--- a/website/docs/r/ram_user.html.markdown
+++ b/website/docs/r/ram_user.html.markdown
@@ -17,12 +17,12 @@ Provides a RAM User resource.
 ```
 # Create a new RAM user.
 resource "alicloud_ram_user" "user" {
-  name = "user_test"
+  name         = "user_test"
   display_name = "user_display_name"
-  mobile = "86-18688888888"
-  email = "hello.uuu@aaa.com"
-  comments = "yoyoyo"
-  force = true
+  mobile       = "86-18688888888"
+  email        = "hello.uuu@aaa.com"
+  comments     = "yoyoyo"
+  force        = true
 }
 ```
 ## Argument Reference

--- a/website/docs/r/ram_user_policy_attachment.html.markdown
+++ b/website/docs/r/ram_user_policy_attachment.html.markdown
@@ -15,16 +15,16 @@ Provides a RAM User Policy attachment resource.
 ```
 # Create a RAM User Policy attachment.
 resource "alicloud_ram_user" "user" {
-  name = "userName"
+  name         = "userName"
   display_name = "user_display_name"
-  mobile = "86-18688888888"
-  email = "hello.uuu@aaa.com"
-  comments = "yoyoyo"
-  force = true
+  mobile       = "86-18688888888"
+  email        = "hello.uuu@aaa.com"
+  comments     = "yoyoyo"
+  force        = true
 }
 
 resource "alicloud_ram_policy" "policy" {
-  name = "policyName"
+  name     = "policyName"
   document = <<EOF
   {
     "Statement": [

--- a/website/docs/r/route_entry.html.markdown
+++ b/website/docs/r/route_entry.html.markdown
@@ -16,70 +16,70 @@ Basic Usage
 
 ```
 data "alicloud_zones" "default" {
-	available_resource_creation = "VSwitch"
+  available_resource_creation = "VSwitch"
 }
 data "alicloud_instance_types" "default" {
- 	availability_zone = "${data.alicloud_zones.default.zones.0.id}"
-	cpu_core_count = 1
-	memory_size = 2
+  availability_zone = "${data.alicloud_zones.default.zones.0.id}"
+  cpu_core_count    = 1
+  memory_size       = 2
 }
 data "alicloud_images" "default" {
-    name_regex = "^ubuntu_14.*_64"
-	most_recent = true
-	owners = "system"
+  name_regex  = "^ubuntu_14.*_64"
+  most_recent = true
+  owners      = "system"
 }
 
 variable "name" {
-	default = "RouteEntryConfig"
+  default = "RouteEntryConfig"
 }
 resource "alicloud_vpc" "foo" {
-	name = "${var.name}"
-	cidr_block = "10.1.0.0/21"
+  name       = "${var.name}"
+  cidr_block = "10.1.0.0/21"
 }
 
 resource "alicloud_vswitch" "foo" {
-	vpc_id = "${alicloud_vpc.foo.id}"
-	cidr_block = "10.1.1.0/24"
-	availability_zone = "${data.alicloud_zones.default.zones.0.id}"
-	name = "${var.name}"
+  vpc_id            = "${alicloud_vpc.foo.id}"
+  cidr_block        = "10.1.1.0/24"
+  availability_zone = "${data.alicloud_zones.default.zones.0.id}"
+  name              = "${var.name}"
 }
 
 resource "alicloud_security_group" "tf_test_foo" {
-	name = "${var.name}"
-	description = "foo"
-	vpc_id = "${alicloud_vpc.foo.id}"
+  name        = "${var.name}"
+  description = "foo"
+  vpc_id      = "${alicloud_vpc.foo.id}"
 }
 
 resource "alicloud_security_group_rule" "ingress" {
-	type = "ingress"
-	ip_protocol = "tcp"
-	nic_type = "intranet"
-	policy = "accept"
-	port_range = "22/22"
-	priority = 1
-	security_group_id = "${alicloud_security_group.tf_test_foo.id}"
-	cidr_ip = "0.0.0.0/0"
+  type              = "ingress"
+  ip_protocol       = "tcp"
+  nic_type          = "intranet"
+  policy            = "accept"
+  port_range        = "22/22"
+  priority          = 1
+  security_group_id = "${alicloud_security_group.tf_test_foo.id}"
+  cidr_ip           = "0.0.0.0/0"
 }
 
 resource "alicloud_instance" "foo" {
-	security_groups = ["${alicloud_security_group.tf_test_foo.id}"]
+  security_groups = ["${alicloud_security_group.tf_test_foo.id}"]
 
-	vswitch_id = "${alicloud_vswitch.foo.id}"
+  vswitch_id = "${alicloud_vswitch.foo.id}"
 
-	instance_charge_type = "PostPaid"
-	instance_type = "${data.alicloud_instance_types.default.instance_types.0.id}"
-	internet_charge_type = "PayByTraffic"
-	internet_max_bandwidth_out = 5
+  instance_charge_type       = "PostPaid"
+  instance_type              = "${data.alicloud_instance_types.default.instance_types.0.id}"
+  internet_charge_type       = "PayByTraffic"
+  internet_max_bandwidth_out = 5
 
-	system_disk_category = "cloud_efficiency"
-	image_id = "${data.alicloud_images.default.images.0.id}"
-	instance_name = "${var.name}"
+  system_disk_category = "cloud_efficiency"
+  image_id             = "${data.alicloud_images.default.images.0.id}"
+  instance_name        = "${var.name}"
 }
 resource "alicloud_route_entry" "foo" {
-	route_table_id = "${alicloud_vpc.foo.route_table_id}"
-	destination_cidrblock = "172.11.1.1/32"
-	nexthop_type = "Instance"
-	nexthop_id = "${alicloud_instance.foo.id}"
+  route_table_id        = "${alicloud_vpc.foo.route_table_id}"
+  destination_cidrblock = "172.11.1.1/32"
+  nexthop_type          = "Instance"
+  nexthop_id            = "${alicloud_instance.foo.id}"
 }
 ```
 ## Argument Reference

--- a/website/docs/r/route_table.html.markdown
+++ b/website/docs/r/route_table.html.markdown
@@ -21,14 +21,14 @@ Basic Usage
 
 ```
 resource "alicloud_vpc" "foo" {
-    cidr_block = "172.16.0.0/12"
-    name = "vpc-example-name"
+  cidr_block = "172.16.0.0/12"
+  name       = "vpc-example-name"
 }
 
 resource "alicloud_route_table" "foo" {
-    vpc_id = "${alicloud_vpc.foo.id}"
-    name = "route-table-example-name"
-    description = "route-table-example-description"
+  vpc_id      = "${alicloud_vpc.foo.id}"
+  name        = "route-table-example-name"
+  description = "route-table-example-description"
 }
 ```
 

--- a/website/docs/r/route_table_attachment.html.markdown
+++ b/website/docs/r/route_table_attachment.html.markdown
@@ -20,31 +20,31 @@ Basic Usage
 
 ```
 variable "name" {
-        default = "route-table-attachment-example-name"
+  default = "route-table-attachment-example-name"
 }
 resource "alicloud_vpc" "foo" {
-        cidr_block = "172.16.0.0/12"
-        name = "${var.name}"
+  cidr_block = "172.16.0.0/12"
+  name       = "${var.name}"
 }
 data "alicloud_zones" "default" {
-        available_resource_creation = "VSwitch"
+  available_resource_creation = "VSwitch"
 }
 resource "alicloud_vswitch" "foo" {
-        vpc_id = "${alicloud_vpc.foo.id}"
-        cidr_block = "172.16.0.0/21"
-        availability_zone = "${data.alicloud_zones.default.zones.0.id}"
-        name = "${var.name}"
+  vpc_id            = "${alicloud_vpc.foo.id}"
+  cidr_block        = "172.16.0.0/21"
+  availability_zone = "${data.alicloud_zones.default.zones.0.id}"
+  name              = "${var.name}"
 }
 
 resource "alicloud_route_table" "foo" {
-        vpc_id = "${alicloud_vpc.foo.id}"
-        name = "${var.name}"
-        description = "route_table_attachment"
+  vpc_id      = "${alicloud_vpc.foo.id}"
+  name        = "${var.name}"
+  description = "route_table_attachment"
 }
 
 resource "alicloud_route_table_attachment" "foo" {
-        vswitch_id = "${alicloud_vswitch.foo.id}"
-        route_table_id = "${alicloud_route_table.foo.id}"
+  vswitch_id     = "${alicloud_vswitch.foo.id}"
+  route_table_id = "${alicloud_route_table.foo.id}"
 }
 ```
 ## Argument Reference

--- a/website/docs/r/router_interface.html.markdown
+++ b/website/docs/r/router_interface.html.markdown
@@ -19,18 +19,18 @@ Provides a VPC router interface resource aim to build a connection between two V
 
 ```
 resource "alicloud_vpc" "foo" {
-  name = "tf_test_foo12345"
+  name       = "tf_test_foo12345"
   cidr_block = "172.16.0.0/12"
 }
 
 resource "alicloud_router_interface" "interface" {
   opposite_region = "cn-beijing"
-  router_type = "VRouter"
-  router_id = "${alicloud_vpc.foo.router_id}"
-  role = "InitiatingSide"
-  specification = "Large.2"
-  name = "test1"
-  description = "test1"
+  router_type     = "VRouter"
+  router_id       = "${alicloud_vpc.foo.router_id}"
+  role            = "InitiatingSide"
+  specification   = "Large.2"
+  name            = "test1"
+  description     = "test1"
 }
 ```
 ## Argument Reference

--- a/website/docs/r/router_interface_connection.html.markdown
+++ b/website/docs/r/router_interface_connection.html.markdown
@@ -33,44 +33,44 @@ variable "name" {
   default = "alicloudRouterInterfaceConnectionBasic"
 }
 resource "alicloud_vpc" "foo" {
-  name = "${var.name}"
+  name       = "${var.name}"
   cidr_block = "172.16.0.0/12"
 }
 resource "alicloud_vpc" "bar" {
-  provider = "alicloud"
-  name = "${var.name}"
+  provider   = "alicloud"
+  name       = "${var.name}"
   cidr_block = "192.168.0.0/16"
 }
 resource "alicloud_router_interface" "initiate" {
-  opposite_region = "${var.region}"
-  router_type = "VRouter"
-  router_id = "${alicloud_vpc.foo.router_id}"
-  role = "InitiatingSide"
-  specification = "Large.2"
-  name = "${var.name}"
-	description = "${var.name}"
-	instance_charge_type = "PostPaid"
+  opposite_region      = "${var.region}"
+  router_type          = "VRouter"
+  router_id            = "${alicloud_vpc.foo.router_id}"
+  role                 = "InitiatingSide"
+  specification        = "Large.2"
+  name                 = "${var.name}"
+  description          = "${var.name}"
+  instance_charge_type = "PostPaid"
 }
 resource "alicloud_router_interface" "opposite" {
-  provider = "alicloud"
+  provider        = "alicloud"
   opposite_region = "${var.region}"
-  router_type = "VRouter"
-  router_id = "${alicloud_vpc.bar.router_id}"
-  role = "AcceptingSide"
-  specification = "Large.1"
-  name = "${var.name}-opposite"
-  description = "${var.name}-opposite"
+  router_type     = "VRouter"
+  router_id       = "${alicloud_vpc.bar.router_id}"
+  role            = "AcceptingSide"
+  specification   = "Large.1"
+  name            = "${var.name}-opposite"
+  description     = "${var.name}-opposite"
 }
 
 // A integrated router interface connection tunnel requires both InitiatingSide and AcceptingSide configuring opposite router interface.
 resource "alicloud_router_interface_connection" "foo" {
-  interface_id = "${alicloud_router_interface.initiate.id}"
+  interface_id          = "${alicloud_router_interface.initiate.id}"
   opposite_interface_id = "${alicloud_router_interface.opposite.id}"
-  depends_on = ["alicloud_router_interface_connection.bar"] // The connection must start from the accepting side.
+  depends_on            = ["alicloud_router_interface_connection.bar"] // The connection must start from the accepting side.
 }
 resource "alicloud_router_interface_connection" "bar" {
-  provider = "alicloud"
-  interface_id = "${alicloud_router_interface.opposite.id}"
+  provider              = "alicloud"
+  interface_id          = "${alicloud_router_interface.opposite.id}"
   opposite_interface_id = "${alicloud_router_interface.initiate.id}"
 }
 

--- a/website/docs/r/slb.html.markdown
+++ b/website/docs/r/slb.html.markdown
@@ -25,25 +25,25 @@ variable "name" {
   default = "terraformtestslbconfig"
 }
 data "alicloud_zones" "default" {
-	available_resource_creation = "VSwitch"
+  available_resource_creation = "VSwitch"
 }
 
 resource "alicloud_vpc" "default" {
-  name = "${var.name}"
+  name       = "${var.name}"
   cidr_block = "172.16.0.0/12"
 }
 
 resource "alicloud_vswitch" "default" {
-  vpc_id = "${alicloud_vpc.default.id}"
-  cidr_block = "172.16.0.0/21"
+  vpc_id            = "${alicloud_vpc.default.id}"
+  cidr_block        = "172.16.0.0/21"
   availability_zone = "${data.alicloud_zones.default.zones.0.id}"
-  name = "${var.name}"
+  name              = "${var.name}"
 }
 
 resource "alicloud_slb" "default" {
-  name = "${var.name}"
+  name          = "${var.name}"
   specification = "slb.s2.small"
-  vswitch_id = "${alicloud_vswitch.default.id}"
+  vswitch_id    = "${alicloud_vswitch.default.id}"
   tags = {
     tag_a = 1
     tag_b = 2

--- a/website/docs/r/slb_attachment.html.markdown
+++ b/website/docs/r/slb_attachment.html.markdown
@@ -14,60 +14,60 @@ Add a group of backend servers (ECS instance) to the Server Load Balancer or rem
 
 ```
 variable "name" {
-    default = "slbattachmenttest"
+  default = "slbattachmenttest"
 }
 data "alicloud_zones" "default" {
-    available_disk_category = "cloud_efficiency"
-    available_resource_creation = "VSwitch"
+  available_disk_category     = "cloud_efficiency"
+  available_resource_creation = "VSwitch"
 }
 data "alicloud_instance_types" "default" {
-    availability_zone = "${data.alicloud_zones.default.zones.0.id}"
-    cpu_core_count = 1
-    memory_size = 2
+  availability_zone = "${data.alicloud_zones.default.zones.0.id}"
+  cpu_core_count    = 1
+  memory_size       = 2
 }
 data "alicloud_images" "default" {
-    name_regex = "^ubuntu_14.*_64"
-    most_recent = true
-    owners = "system"
+  name_regex  = "^ubuntu_14.*_64"
+  most_recent = true
+  owners      = "system"
 }
 
 resource "alicloud_vpc" "default" {
-    name = "${var.name}"
-    cidr_block = "172.16.0.0/16"
+  name       = "${var.name}"
+  cidr_block = "172.16.0.0/16"
 }
 
 resource "alicloud_vswitch" "default" {
-    vpc_id = "${alicloud_vpc.default.id}"
-    cidr_block = "172.16.0.0/16"
-    availability_zone = "${data.alicloud_zones.default.zones.0.id}"
-    name = "${var.name}"
+  vpc_id            = "${alicloud_vpc.default.id}"
+  cidr_block        = "172.16.0.0/16"
+  availability_zone = "${data.alicloud_zones.default.zones.0.id}"
+  name              = "${var.name}"
 }
 
 resource "alicloud_security_group" "default" {
-    name = "${var.name}"
-    vpc_id = "${alicloud_vpc.default.id}"
+  name   = "${var.name}"
+  vpc_id = "${alicloud_vpc.default.id}"
 }
 
 resource "alicloud_instance" "default" {
-    image_id = "${data.alicloud_images.default.images.0.id}"
-    instance_type = "${data.alicloud_instance_types.default.instance_types.0.id}"
-    internet_charge_type = "PayByTraffic"
-    internet_max_bandwidth_out = "5"
-    system_disk_category = "cloud_efficiency"
-    security_groups = ["${alicloud_security_group.default.id}"]
-    instance_name = "${var.name}"
-    vswitch_id = "${alicloud_vswitch.default.id}"
+  image_id                   = "${data.alicloud_images.default.images.0.id}"
+  instance_type              = "${data.alicloud_instance_types.default.instance_types.0.id}"
+  internet_charge_type       = "PayByTraffic"
+  internet_max_bandwidth_out = "5"
+  system_disk_category       = "cloud_efficiency"
+  security_groups            = ["${alicloud_security_group.default.id}"]
+  instance_name              = "${var.name}"
+  vswitch_id                 = "${alicloud_vswitch.default.id}"
 }
 
 resource "alicloud_slb" "default" {
-    name = "${var.name}"
-    vswitch_id = "${alicloud_vswitch.default.id}"
+  name       = "${var.name}"
+  vswitch_id = "${alicloud_vswitch.default.id}"
 }
 
 resource "alicloud_slb_attachment" "default" {
-    load_balancer_id = "${alicloud_slb.default.id}"
-    instance_ids = ["${alicloud_instance.default.id}"]
-    weight = 90
+  load_balancer_id = "${alicloud_slb.default.id}"
+  instance_ids     = ["${alicloud_instance.default.id}"]
+  weight           = 90
 }
 ```
 

--- a/website/docs/r/slb_ca_certificate.html.markdown
+++ b/website/docs/r/slb_ca_certificate.html.markdown
@@ -20,18 +20,18 @@ For information about CA Certificate and how to use it, see [Configure CA Certif
 * using CA certificate content
 
 ```
-  # create a CA certificate
-  resource "alicloud_slb_ca_certificate" "foo" {
-    name = "tf-testAccSlbCACertificate"
-    ca_certificate = "-----BEGIN CERTIFICATE-----\nMIIDRjCCAq+gAwIBAgIJAJnI******90EAxEG/bJJyOm5LqoiA=\n-----END CERTIFICATE-----"
-  }
+# create a CA certificate
+resource "alicloud_slb_ca_certificate" "foo" {
+  name           = "tf-testAccSlbCACertificate"
+  ca_certificate = "-----BEGIN CERTIFICATE-----\nMIIDRjCCAq+gAwIBAgIJAJnI******90EAxEG/bJJyOm5LqoiA=\n-----END CERTIFICATE-----"
+}
 ```
 
 * using CA certificate file
 
 ```
 resource "alicloud_slb_ca_certificate" "foo-file" {
-  name = "tf-testAccSlbCACertificate"
+  name           = "tf-testAccSlbCACertificate"
   ca_certificate = "${file("${path.module}/ca_certificate.pem")}"
 }
 ```

--- a/website/docs/r/slb_listener.html.markdown
+++ b/website/docs/r/slb_listener.html.markdown
@@ -27,52 +27,52 @@ variable "name" {
 }
 variable "ip_version" {
   default = "ipv4"
-}	
+}
 resource "alicloud_slb" "default" {
-  name = "tf-testAccSlbListenerHttp"
+  name                 = "tf-testAccSlbListenerHttp"
   internet_charge_type = "PayByTraffic"
-  internet = true
+  internet             = true
 }
 resource "alicloud_slb_listener" "default" {
-  load_balancer_id = "${alicloud_slb.default.id}"
-  backend_port = 80
-  frontend_port = 80
-  protocol = "http"
-  bandwidth = 10
-  sticky_session = "on"
-  sticky_session_type = "insert"
-  cookie_timeout = 86400
-  cookie = "testslblistenercookie"
-  health_check = "on"
-  health_check_domain = "ali.com"
-  health_check_uri = "/cons"
+  load_balancer_id          = "${alicloud_slb.default.id}"
+  backend_port              = 80
+  frontend_port             = 80
+  protocol                  = "http"
+  bandwidth                 = 10
+  sticky_session            = "on"
+  sticky_session_type       = "insert"
+  cookie_timeout            = 86400
+  cookie                    = "testslblistenercookie"
+  health_check              = "on"
+  health_check_domain       = "ali.com"
+  health_check_uri          = "/cons"
   health_check_connect_port = 20
-  healthy_threshold = 8
-  unhealthy_threshold = 8
-  health_check_timeout = 8
-  health_check_interval = 5
-  health_check_http_code = "http_2xx,http_3xx"
+  healthy_threshold         = 8
+  unhealthy_threshold       = 8
+  health_check_timeout      = 8
+  health_check_interval     = 5
+  health_check_http_code    = "http_2xx,http_3xx"
   x_forwarded_for {
     retrive_slb_ip = true
     retrive_slb_id = true
   }
-  acl_status = "on"
-  acl_type   = "white"
-  acl_id     = "${alicloud_slb_acl.default.id}"
-  request_timeout           = 80
-  idle_timeout              = 30
+  acl_status      = "on"
+  acl_type        = "white"
+  acl_id          = "${alicloud_slb_acl.default.id}"
+  request_timeout = 80
+  idle_timeout    = 30
 }
 resource "alicloud_slb_acl" "default" {
-  name = "${var.name}"
+  name       = "${var.name}"
   ip_version = "${var.ip_version}"
   entry_list {
-      entry="10.10.10.0/24"
-      comment="first"
+    entry   = "10.10.10.0/24"
+    comment = "first"
   }
-   entry_list {
-      entry="168.10.10.0/24"
-      comment="second"
-   }
+  entry_list {
+    entry   = "168.10.10.0/24"
+    comment = "second"
+  }
 }
 ```
 

--- a/website/docs/r/slb_rule.html.markdown
+++ b/website/docs/r/slb_rule.html.markdown
@@ -25,98 +25,98 @@ You can add forwarding rules to a listener to forward requests based on the doma
 
 ```
 variable "name" {
-    default = "slbrulebasicconfig"
+  default = "slbrulebasicconfig"
 }
 
 data "alicloud_zones" "default" {
-    available_disk_category = "cloud_efficiency"
-    available_resource_creation = "VSwitch"
+  available_disk_category     = "cloud_efficiency"
+  available_resource_creation = "VSwitch"
 }
 data "alicloud_instance_types" "default" {
-    availability_zone = "${data.alicloud_zones.default.zones.0.id}"
-    cpu_core_count = 1
-    memory_size = 2
+  availability_zone = "${data.alicloud_zones.default.zones.0.id}"
+  cpu_core_count    = 1
+  memory_size       = 2
 }
 data "alicloud_images" "default" {
-    name_regex = "^ubuntu_14.*_64"
-    most_recent = true
-    owners = "system"
+  name_regex  = "^ubuntu_14.*_64"
+  most_recent = true
+  owners      = "system"
 }
 
 resource "alicloud_vpc" "default" {
-    name = "${var.name}"
-    cidr_block = "172.16.0.0/16"
+  name       = "${var.name}"
+  cidr_block = "172.16.0.0/16"
 }
 
 resource "alicloud_vswitch" "default" {
-    vpc_id = "${alicloud_vpc.default.id}"
-    cidr_block = "172.16.0.0/16"
-    availability_zone = "${data.alicloud_zones.default.zones.0.id}"
-    name = "${var.name}"
+  vpc_id            = "${alicloud_vpc.default.id}"
+  cidr_block        = "172.16.0.0/16"
+  availability_zone = "${data.alicloud_zones.default.zones.0.id}"
+  name              = "${var.name}"
 }
 resource "alicloud_security_group" "default" {
-    name = "${var.name}"
-    vpc_id = "${alicloud_vpc.default.id}"
+  name   = "${var.name}"
+  vpc_id = "${alicloud_vpc.default.id}"
 }
 
 resource "alicloud_instance" "default" {
-    image_id = "${data.alicloud_images.default.images.0.id}"
-    instance_type = "${data.alicloud_instance_types.default.instance_types.0.id}"
-    security_groups = "${alicloud_security_group.default.*.id}"
-    internet_charge_type = "PayByTraffic"
-    internet_max_bandwidth_out = "10"
-    availability_zone = "${data.alicloud_zones.default.zones.0.id}"
-    instance_charge_type = "PostPaid"
-    system_disk_category = "cloud_efficiency"
-    vswitch_id = "${alicloud_vswitch.default.id}"
-    instance_name = "${var.name}"
+  image_id                   = "${data.alicloud_images.default.images.0.id}"
+  instance_type              = "${data.alicloud_instance_types.default.instance_types.0.id}"
+  security_groups            = "${alicloud_security_group.default.*.id}"
+  internet_charge_type       = "PayByTraffic"
+  internet_max_bandwidth_out = "10"
+  availability_zone          = "${data.alicloud_zones.default.zones.0.id}"
+  instance_charge_type       = "PostPaid"
+  system_disk_category       = "cloud_efficiency"
+  vswitch_id                 = "${alicloud_vswitch.default.id}"
+  instance_name              = "${var.name}"
 }
 
 resource "alicloud_slb" "default" {
-    name = "${var.name}"
-    vswitch_id = "${alicloud_vswitch.default.id}"
+  name       = "${var.name}"
+  vswitch_id = "${alicloud_vswitch.default.id}"
 }
 
 resource "alicloud_slb_listener" "default" {
-    load_balancer_id = "${alicloud_slb.default.id}"
-    backend_port = 22
-    frontend_port = 22
-    protocol = "http"
-    bandwidth = 5
-    health_check_connect_port = "20"
+  load_balancer_id          = "${alicloud_slb.default.id}"
+  backend_port              = 22
+  frontend_port             = 22
+  protocol                  = "http"
+  bandwidth                 = 5
+  health_check_connect_port = "20"
 }
 
 resource "alicloud_slb_server_group" "default" {
-    load_balancer_id = "${alicloud_slb.default.id}"
-    servers {
-            server_ids = "${alicloud_instance.default.*.id}"
-            port = 80
-            weight = 100
-    }
+  load_balancer_id = "${alicloud_slb.default.id}"
+  servers {
+    server_ids = "${alicloud_instance.default.*.id}"
+    port       = 80
+    weight     = 100
+  }
 }
 
 resource "alicloud_slb_rule" "default" {
-  load_balancer_id = "${alicloud_slb.default.id}"
-  frontend_port = "${alicloud_slb_listener.default.frontend_port}"
-  name = "${var.name}"
-  domain = "*.aliyun.com"
-  url = "/image"
-  server_group_id = "${alicloud_slb_server_group.default.id}"
-  cookie = "23ffsa"
-  cookie_timeout = 100
-  health_check_http_code = "http_2xx"
-  health_check_interval = 10
-  health_check_uri = "/test"
+  load_balancer_id          = "${alicloud_slb.default.id}"
+  frontend_port             = "${alicloud_slb_listener.default.frontend_port}"
+  name                      = "${var.name}"
+  domain                    = "*.aliyun.com"
+  url                       = "/image"
+  server_group_id           = "${alicloud_slb_server_group.default.id}"
+  cookie                    = "23ffsa"
+  cookie_timeout            = 100
+  health_check_http_code    = "http_2xx"
+  health_check_interval     = 10
+  health_check_uri          = "/test"
   health_check_connect_port = 80
-  health_check_timeout = 30
-  healthy_threshold = 3
-  unhealthy_threshold = 5
-  sticky_session = "on"
-  sticky_session_type = "server"
-  listener_sync = "off"
-  scheduler = "rr"
-  health_check_domain = "test"
-  health_check = "on"
+  health_check_timeout      = 30
+  healthy_threshold         = 3
+  unhealthy_threshold       = 5
+  sticky_session            = "on"
+  sticky_session_type       = "server"
+  listener_sync             = "off"
+  scheduler                 = "rr"
+  health_check_domain       = "test"
+  health_check              = "on"
 }
 ```
 

--- a/website/docs/r/slb_server_certificate.html.markdown
+++ b/website/docs/r/slb_server_certificate.html.markdown
@@ -20,23 +20,23 @@ For information about Server Certificate and how to use it, see [Configure Serve
 * using server_certificate/private content as string example
 
 ```
-  # create a server certificate
-  resource "alicloud_slb_server_certificate" "foo" {
-    name = "slbservercertificate"
-    server_certificate = "-----BEGIN CERTIFICATE-----\nMIIDRjCCAq+gAwIBAgI+OuMs******XTtI90EAxEG/bJJyOm5LqoiA=\n-----END CERTIFICATE-----"
-    private_key = "-----BEGIN RSA PRIVATE KEY-----\nMIICXAIBAAKBgQDO0knDrlNdiys******ErVpjsckAaOW/JDG5PCSwkaMxk=\n-----END RSA PRIVATE KEY-----"
-  }
+# create a server certificate
+resource "alicloud_slb_server_certificate" "foo" {
+  name               = "slbservercertificate"
+  server_certificate = "-----BEGIN CERTIFICATE-----\nMIIDRjCCAq+gAwIBAgI+OuMs******XTtI90EAxEG/bJJyOm5LqoiA=\n-----END CERTIFICATE-----"
+  private_key        = "-----BEGIN RSA PRIVATE KEY-----\nMIICXAIBAAKBgQDO0knDrlNdiys******ErVpjsckAaOW/JDG5PCSwkaMxk=\n-----END RSA PRIVATE KEY-----"
+}
 ```
 
 * using server_certificate/private file example
 
 ```
-  # create a server certificate
-  resource "alicloud_slb_server_certificate" "foo" {
-    name = "slbservercertificate"
-    server_certificate = "${file("${path.module}/server_certificate.pem")}"
-    private_key = "${file("${path.module}/private_key.pem")}"
-  }
+# create a server certificate
+resource "alicloud_slb_server_certificate" "foo" {
+  name               = "slbservercertificate"
+  server_certificate = "${file("${path.module}/server_certificate.pem")}"
+  private_key        = "${file("${path.module}/private_key.pem")}"
+}
 ```
 
 ## Argument Reference

--- a/website/docs/r/slb_server_group.html.markdown
+++ b/website/docs/r/slb_server_group.html.markdown
@@ -25,66 +25,66 @@ and to meet the personalized requirements of domain name and URL forwarding.
 
 ```
 variable "name" {
-    default = "slbservergroupvpc"
+  default = "slbservergroupvpc"
 }
 data "alicloud_zones" "default" {
-    available_disk_category = "cloud_efficiency"
-    available_resource_creation = "VSwitch"
+  available_disk_category     = "cloud_efficiency"
+  available_resource_creation = "VSwitch"
 }
 data "alicloud_instance_types" "default" {
-    availability_zone = "${data.alicloud_zones.default.zones.0.id}"
-    cpu_core_count = 1
-    memory_size = 2
+  availability_zone = "${data.alicloud_zones.default.zones.0.id}"
+  cpu_core_count    = 1
+  memory_size       = 2
 }
 data "alicloud_images" "default" {
-    name_regex = "^ubuntu_14.*_64"
-    most_recent = true
-    owners = "system"
+  name_regex  = "^ubuntu_14.*_64"
+  most_recent = true
+  owners      = "system"
 }
 resource "alicloud_vpc" "default" {
-    name = "${var.name}"
-    cidr_block = "172.16.0.0/16"
+  name       = "${var.name}"
+  cidr_block = "172.16.0.0/16"
 }
 resource "alicloud_vswitch" "default" {
-    vpc_id = "${alicloud_vpc.default.id}"
-    cidr_block = "172.16.0.0/16"
-    availability_zone = "${data.alicloud_zones.default.zones.0.id}"
-    name = "${var.name}"
+  vpc_id            = "${alicloud_vpc.default.id}"
+  cidr_block        = "172.16.0.0/16"
+  availability_zone = "${data.alicloud_zones.default.zones.0.id}"
+  name              = "${var.name}"
 }
 resource "alicloud_security_group" "default" {
-    name = "${var.name}"
-    vpc_id = "${alicloud_vpc.default.id}"
+  name   = "${var.name}"
+  vpc_id = "${alicloud_vpc.default.id}"
 }
 resource "alicloud_instance" "instance" {
-    image_id = "${data.alicloud_images.default.images.0.id}"
-    instance_type = "${data.alicloud_instance_types.default.instance_types.0.id}"
-    instance_name = "${var.name}"
-    count = "2"
-    security_groups = "${alicloud_security_group.default.*.id}"
-    internet_charge_type = "PayByTraffic"
-    internet_max_bandwidth_out = "10"
-    availability_zone = "${data.alicloud_zones.default.zones.0.id}"
-    instance_charge_type = "PostPaid"
-    system_disk_category = "cloud_efficiency"
-    vswitch_id = "${alicloud_vswitch.default.id}"
+  image_id                   = "${data.alicloud_images.default.images.0.id}"
+  instance_type              = "${data.alicloud_instance_types.default.instance_types.0.id}"
+  instance_name              = "${var.name}"
+  count                      = "2"
+  security_groups            = "${alicloud_security_group.default.*.id}"
+  internet_charge_type       = "PayByTraffic"
+  internet_max_bandwidth_out = "10"
+  availability_zone          = "${data.alicloud_zones.default.zones.0.id}"
+  instance_charge_type       = "PostPaid"
+  system_disk_category       = "cloud_efficiency"
+  vswitch_id                 = "${alicloud_vswitch.default.id}"
 }
 resource "alicloud_slb" "default" {
-    name = "${var.name}"
-    vswitch_id = "${alicloud_vswitch.default.id}"
+  name       = "${var.name}"
+  vswitch_id = "${alicloud_vswitch.default.id}"
 }
 resource "alicloud_slb_server_group" "default" {
-    load_balancer_id = "${alicloud_slb.default.id}"
-    name = "${var.name}"
-    servers {
-            server_ids = ["${alicloud_instance.instance.0.id}", "${alicloud_instance.instance.1.id}"]
-            port = 100
-            weight = 10
-    }
-    servers {
-            server_ids = ["${alicloud_instance.instance.*.id}"]
-            port = 80
-            weight = 100
-    }
+  load_balancer_id = "${alicloud_slb.default.id}"
+  name             = "${var.name}"
+  servers {
+    server_ids = ["${alicloud_instance.instance.0.id}", "${alicloud_instance.instance.1.id}"]
+    port       = 100
+    weight     = 10
+  }
+  servers {
+    server_ids = ["${alicloud_instance.instance.*.id}"]
+    port       = 80
+    weight     = 100
+  }
 }
 ```
 

--- a/website/docs/r/snapshot.html.markdown
+++ b/website/docs/r/snapshot.html.markdown
@@ -16,8 +16,8 @@ For information about snapshot and how to use it, see [Snapshot](https://www.ali
 
 ```
 resource "alicloud_snapshot" "snapshot" {
-  disk_id = "${alicloud_disk_attachment.instance-attachment.disk_id}"
-  name = "test-snapshot"
+  disk_id     = "${alicloud_disk_attachment.instance-attachment.disk_id}"
+  name        = "test-snapshot"
   description = "this snapshot is created for testing"
   tags = {
     version = "1.2"

--- a/website/docs/r/snapshot_policy.html.markdown
+++ b/website/docs/r/snapshot_policy.html.markdown
@@ -18,10 +18,10 @@ For information about snapshot policy and how to use it, see [Snapshot](https://
 
 ```
 resource "alicloud_snapshot_policy" "sp" {
-    name = "tf-testAcc-sp"
-    repeat_weekdays = [ "1", "2", "3" ]
-    retention_days = -1
-    time_points = ["1", "22", "23"]
+  name            = "tf-testAcc-sp"
+  repeat_weekdays = ["1", "2", "3"]
+  retention_days  = -1
+  time_points     = ["1", "22", "23"]
 }
 ```
 

--- a/website/docs/r/snat.html.markdown
+++ b/website/docs/r/snat.html.markdown
@@ -23,21 +23,21 @@ data "alicloud_zones" "default" {
 }
 
 resource "alicloud_vpc" "vpc" {
-  name = "${var.name}"
+  name       = "${var.name}"
   cidr_block = "172.16.0.0/12"
 }
 
 resource "alicloud_vswitch" "vswitch" {
-  vpc_id = "${alicloud_vpc.vpc.id}"
-  cidr_block = "172.16.0.0/21"
+  vpc_id            = "${alicloud_vpc.vpc.id}"
+  cidr_block        = "172.16.0.0/21"
   availability_zone = "${data.alicloud_zones.default.zones.0.id}"
-  name = "${var.name}"
+  name              = "${var.name}"
 }
 
 resource "alicloud_nat_gateway" "default" {
-  vpc_id = "${alicloud_vswitch.vswitch.vpc_id}"
+  vpc_id        = "${alicloud_vswitch.vswitch.vpc_id}"
   specification = "Small"
-  name = "${var.name}"
+  name          = "${var.name}"
 }
 
 resource "alicloud_eip" "eip" {
@@ -46,13 +46,13 @@ resource "alicloud_eip" "eip" {
 
 resource "alicloud_eip_association" "default" {
   allocation_id = "${alicloud_eip.eip.id}"
-  instance_id = "${alicloud_nat_gateway.default.id}"
+  instance_id   = "${alicloud_nat_gateway.default.id}"
 }
 
-resource "alicloud_snat_entry" "default"{
-  snat_table_id = "${alicloud_nat_gateway.default.snat_table_ids}"
+resource "alicloud_snat_entry" "default" {
+  snat_table_id     = "${alicloud_nat_gateway.default.snat_table_ids}"
   source_vswitch_id = "${alicloud_vswitch.vswitch.id}"
-  snat_ip = "${alicloud_eip.eip.ip_address}"
+  snat_ip           = "${alicloud_eip.eip.ip_address}"
 }
 ```
 

--- a/website/docs/r/ssl_vpn_client_cert.html.markdown
+++ b/website/docs/r/ssl_vpn_client_cert.html.markdown
@@ -18,8 +18,8 @@ Basic Usage
 
 ```
 resource "alicloud_ssl_vpn_client_cert" "foo" {
-	ssl_vpn_server_id = "ssl_vpn_server_fake_id"
-	name = "sslVpnClientCertExample"
+  ssl_vpn_server_id = "ssl_vpn_server_fake_id"
+  name              = "sslVpnClientCertExample"
 }
 ```
 ## Argument Reference

--- a/website/docs/r/ssl_vpn_server.html.markdown
+++ b/website/docs/r/ssl_vpn_server.html.markdown
@@ -18,23 +18,23 @@ Basic Usage
 
 ```
 resource "alicloud_vpn_gateway" "foo" {
-	name = "testAccVpnConfig_create"
-	vpc_id = "vpc-fake-id"
-	bandwidth = "10"
-	enable_ssl = true
-	instance_charge_type = "PostPaid"
-	description = "test_create_description"
+  name                 = "testAccVpnConfig_create"
+  vpc_id               = "vpc-fake-id"
+  bandwidth            = "10"
+  enable_ssl           = true
+  instance_charge_type = "PostPaid"
+  description          = "test_create_description"
 }
 
 resource "alicloud_ssl_vpn_server" "foo" {
-	name = "sslVpnServerNameExample"
-	vpn_gateway_id = "${alicloud_vpn_gateway.foo.id}"
-	client_ip_pool = "192.168.0.0/16"
-	local_subnet = "172.16.0.0/21"
-	protocol = "UDP"
-	cipher = "AES-128-CBC"
-	port = 1194
-	compress = "false"
+  name           = "sslVpnServerNameExample"
+  vpn_gateway_id = "${alicloud_vpn_gateway.foo.id}"
+  client_ip_pool = "192.168.0.0/16"
+  local_subnet   = "172.16.0.0/21"
+  protocol       = "UDP"
+  cipher         = "AES-128-CBC"
+  port           = 1194
+  compress       = "false"
 }
 ```
 ## Argument Reference

--- a/website/docs/r/vpn_connection.html.markdown
+++ b/website/docs/r/vpn_connection.html.markdown
@@ -19,45 +19,45 @@ Basic Usage
 
 ```
 resource "alicloud_vpn_gateway" "foo" {
-	name = "testAccVpnConfig_create"
-	vpc_id = "vpc-fake-id"
-	bandwidth = "10"
-	enable_ssl = true
-	instance_charge_type = "PostPaid"
-	description = "test_create_description"
+  name                 = "testAccVpnConfig_create"
+  vpc_id               = "vpc-fake-id"
+  bandwidth            = "10"
+  enable_ssl           = true
+  instance_charge_type = "PostPaid"
+  description          = "test_create_description"
 }
 
 resource "alicloud_vpn_customer_gateway" "foo" {
-	name = "testAccVpnCgwName"
-	ip_address = "42.104.22.228"
-	description = "testAccVpnCgwDesc"
+  name        = "testAccVpnCgwName"
+  ip_address  = "42.104.22.228"
+  description = "testAccVpnCgwDesc"
 }
 
 resource "alicloud_vpn_connection" "foo" {
-	name = "tf-vco_test1"
-	vpn_gateway_id = "${alicloud_vpn_gateway.foo.id}"
-	customer_gateway_id = "${alicloud_vpn_customer_gateway.foo.id}"
-	local_subnet = ["172.16.0.0/24", "172.16.1.0/24"]
-	remote_subnet = ["10.0.0.0/24", "10.0.1.0/24"]
-	effect_immediately = true
-	ike_config = [{
-        ike_auth_alg = "md5"
-        ike_enc_alg = "des"
-        ike_version = "ikev1"
-        ike_mode = "main"
-        ike_lifetime = 86400
-        psk = "tf-testvpn2"
-        ike_pfs = "group1"
-        ike_remote_id = "testbob2"
-        ike_local_id = "testalice2"
-        }
-    ]
-	ipsec_config = [{
-        ipsec_pfs = "group5"
-        ipsec_enc_alg = "des"
-        ipsec_auth_alg = "md5"
-        ipsec_lifetime = 8640
-    }]
+  name                = "tf-vco_test1"
+  vpn_gateway_id      = "${alicloud_vpn_gateway.foo.id}"
+  customer_gateway_id = "${alicloud_vpn_customer_gateway.foo.id}"
+  local_subnet        = ["172.16.0.0/24", "172.16.1.0/24"]
+  remote_subnet       = ["10.0.0.0/24", "10.0.1.0/24"]
+  effect_immediately  = true
+  ike_config = [{
+    ike_auth_alg  = "md5"
+    ike_enc_alg   = "des"
+    ike_version   = "ikev1"
+    ike_mode      = "main"
+    ike_lifetime  = 86400
+    psk           = "tf-testvpn2"
+    ike_pfs       = "group1"
+    ike_remote_id = "testbob2"
+    ike_local_id  = "testalice2"
+    }
+  ]
+  ipsec_config = [{
+    ipsec_pfs      = "group5"
+    ipsec_enc_alg  = "des"
+    ipsec_auth_alg = "md5"
+    ipsec_lifetime = 8640
+  }]
 }
 ```
 ## Argument Reference

--- a/website/docs/r/vpn_customer_gateway.html.markdown
+++ b/website/docs/r/vpn_customer_gateway.html.markdown
@@ -18,9 +18,9 @@ Basic Usage
 
 ```
 resource "alicloud_vpn_customer_gateway" "foo" {
-    name = "vpnCgwNameExample"
-    ip_address = "43.104.22.228"
-    description = "vpnCgwDescriptionExample"
+  name        = "vpnCgwNameExample"
+  ip_address  = "43.104.22.228"
+  description = "vpnCgwDescriptionExample"
 }
 ```
 ## Argument Reference

--- a/website/docs/r/vpn_gateway.html.markdown
+++ b/website/docs/r/vpn_gateway.html.markdown
@@ -20,12 +20,12 @@ Basic Usage
 
 ```
 resource "alicloud_vpn_gateway" "foo" {
-    name = "vpnGatewayConfig"
-    vpc_id = "vpc-fakeid"
-    bandwidth = "10"
-    enable_ssl = true
-    instance_charge_type = "PostPaid"
-    description = "test_create_description"
+  name                 = "vpnGatewayConfig"
+  vpc_id               = "vpc-fakeid"
+  bandwidth            = "10"
+  enable_ssl           = true
+  instance_charge_type = "PostPaid"
+  description          = "test_create_description"
 }
 ```
 ## Argument Reference


### PR DESCRIPTION
Along with the new Terraform v0.12, Terraform also introduces the recommended [Idiomatic Style Conventions](https://www.terraform.io/docs/configuration/style.html) for HCL languages. Besides the HCL explicitly defined in `.tf` and . `.tfvars`, the inline HCLs in docs should also follow that rule. This PR is trying to convert all the existing inline HCL codes into the canonical format. The overall formatting process is done by a tool I just developed, I've reviewed the changes twice. Still sorry for the heavy workload on reviewing this PR for me. Thanks.

Signed-off-by: imjoey <majunjiev@gmail.com>