### PR TITLE
improve(docs): Reformat abnormal inline HCL code in docs

### DIFF
--- a/website/docs/d/nas_mount_targets.html.markdown
+++ b/website/docs/d/nas_mount_targets.html.markdown
@@ -16,7 +16,7 @@ This data source provides MountTargets available to the user.
 
 ```
 data "alicloud_nas_mount_targets" "mt" {
-  file_system_id = "1a2sc4d"
+  file_system_id    = "1a2sc4d"
   access_group_name = "tf-testAccNasConfig"
 }
 

--- a/website/docs/d/ons_instances.html.markdown
+++ b/website/docs/d/ons_instances.html.markdown
@@ -20,13 +20,13 @@ variable "name" {
 }
 
 resource "alicloud_ons_instance" "default" {
-  name = "${var.name}"
+  name   = "${var.name}"
   remark = "default_ons_instance_remark"
 }
 
 data "alicloud_ons_instances" "instances_ds" {
-  ids = ["${alicloud_ons_instance.default.id}"]
-  name_regex = "${alicloud_ons_instance.default.name}"
+  ids         = ["${alicloud_ons_instance.default.id}"]
+  name_regex  = "${alicloud_ons_instance.default.name}"
   output_file = "instances.txt"
 }
 

--- a/website/docs/r/network_interface_attachment.html.markdown
+++ b/website/docs/r/network_interface_attachment.html.markdown
@@ -17,7 +17,6 @@ For information about Elastic Network Interface and how to use it, see [Elastic 
 Bacis Usage
 
 ```
-...
 variable "name" {
   default = "networkInterfaceAttachment"
 }
@@ -27,7 +26,7 @@ variable "number" {
 }
 
 resource "alicloud_vpc" "vpc" {
-  name = "${var.name}"
+  name       = "${var.name}"
   cidr_block = "192.168.0.0/24"
 }
 
@@ -36,20 +35,20 @@ data "alicloud_zones" "default" {
 }
 
 resource "alicloud_vswitch" "vswitch" {
-  name = "${var.name}"
-  cidr_block = "192.168.0.0/24"
+  name              = "${var.name}"
+  cidr_block        = "192.168.0.0/24"
   availability_zone = "${data.alicloud_zones.default.zones.0.id}"
-  vpc_id = "${alicloud_vpc.vpc.id}"
+  vpc_id            = "${alicloud_vpc.vpc.id}"
 }
 
 resource "alicloud_security_group" "group" {
-  name = "${var.name}"
+  name   = "${var.name}"
   vpc_id = "${alicloud_vpc.vpc.id}"
 }
 
 data "alicloud_instance_types" "instance_type" {
   availability_zone = "${data.alicloud_zones.default.zones.0.id}"
-  eni_amount = 2
+  eni_amount        = 2
 }
 
 data "alicloud_images" "default" {
@@ -59,31 +58,30 @@ data "alicloud_images" "default" {
 }
 
 resource "alicloud_instance" "instance" {
-  count = "${var.number}"
+  count             = "${var.number}"
   availability_zone = "${data.alicloud_zones.default.zones.0.id}"
-  security_groups = ["${alicloud_security_group.group.id}"]
+  security_groups   = ["${alicloud_security_group.group.id}"]
 
-  instance_type = "${data.alicloud_instance_types.instance_type.instance_types.0.id}"
-  system_disk_category = "cloud_efficiency"
-  image_id             = "${data.alicloud_images.default.images.0.id}"
-  instance_name        = "${var.name}"
-  vswitch_id = "${alicloud_vswitch.vswitch.id}"
+  instance_type              = "${data.alicloud_instance_types.instance_type.instance_types.0.id}"
+  system_disk_category       = "cloud_efficiency"
+  image_id                   = "${data.alicloud_images.default.images.0.id}"
+  instance_name              = "${var.name}"
+  vswitch_id                 = "${alicloud_vswitch.vswitch.id}"
   internet_max_bandwidth_out = 10
 }
 
 resource "alicloud_network_interface" "interface" {
-  count = "${var.number}"
-  name = "${var.name}"
-  vswitch_id = "${alicloud_vswitch.vswitch.id}"
-  security_groups = [ "${alicloud_security_group.group.id}" ]
+  count           = "${var.number}"
+  name            = "${var.name}"
+  vswitch_id      = "${alicloud_vswitch.vswitch.id}"
+  security_groups = ["${alicloud_security_group.group.id}"]
 }
 
 resource "alicloud_network_interface_attachment" "attachment" {
-  count = "${var.number}"
-  instance_id = "${element(alicloud_instance.instance.*.id, count.index)}"
+  count                = "${var.number}"
+  instance_id          = "${element(alicloud_instance.instance.*.id, count.index)}"
   network_interface_id = "${element(alicloud_network_interface.interface.*.id, count.index)}"
 }
-...
 ```
 
 ## Argument Reference

--- a/website/docs/r/oss_bucket.html.markdown
+++ b/website/docs/r/oss_bucket.html.markdown
@@ -18,9 +18,9 @@ Provides a resource to create a oss bucket and set its attribution.
 Private Bucket
 
 ```
-resource "alicloud_oss_bucket" "bucket-acl"{
+resource "alicloud_oss_bucket" "bucket-acl" {
   bucket = "bucket-170309-acl"
-  acl = "private"
+  acl    = "private"
 }
 ```
 
@@ -40,9 +40,9 @@ resource "alicloud_oss_bucket" "bucket-website" {
 Enable Logging
 
 ```
-resource "alicloud_oss_bucket" "bucket-target"{
+resource "alicloud_oss_bucket" "bucket-target" {
   bucket = "bucket-170309-acl"
-  acl = "public-read"
+  acl    = "public-read"
 }
 
 resource "alicloud_oss_bucket" "bucket-logging" {
@@ -60,11 +60,11 @@ Referer configuration
 ```
 resource "alicloud_oss_bucket" "bucket-referer" {
   bucket = "bucket-170309-referer"
-  acl = "private"
+  acl    = "private"
 
   referer_config {
-      allow_empty = false
-      referers = ["http://www.aliyun.com", "https://www.aliyun.com"]
+    allow_empty = false
+    referers    = ["http://www.aliyun.com", "https://www.aliyun.com"]
   }
 }
 ```
@@ -74,11 +74,11 @@ Set lifecycle rule
 ```
 resource "alicloud_oss_bucket" "bucket-lifecycle" {
   bucket = "bucket-170309-lifecycle"
-  acl = "public-read"
+  acl    = "public-read"
 
   lifecycle_rule {
-    id = "rule-days"
-    prefix = "path1/"
+    id      = "rule-days"
+    prefix  = "path1/"
     enabled = true
 
     expiration {
@@ -86,8 +86,8 @@ resource "alicloud_oss_bucket" "bucket-lifecycle" {
     }
   }
   lifecycle_rule {
-    id = "rule-date"
-    prefix = "path2/"
+    id      = "rule-date"
+    prefix  = "path2/"
     enabled = true
 
     expiration {
@@ -102,8 +102,8 @@ Set bucket policy
 ```
 resource "alicloud_oss_bucket" "bucket-policy" {
   bucket = "bucket-170309-policy"
-  acl = "private"
-  
+  acl    = "private"
+
   policy = <<POLICY
   {"Statement":
       [{"Action":
@@ -119,8 +119,8 @@ resource "alicloud_oss_bucket" "bucket-policy" {
 IA Bucket
 
 ```
-resource "alicloud_oss_bucket" "bucket-storageclass"{
-  bucket = "bucket-170309-storageclass"
+resource "alicloud_oss_bucket" "bucket-storageclass" {
+  bucket        = "bucket-170309-storageclass"
   storage_class = "IA"
 }
 ```
@@ -128,9 +128,9 @@ resource "alicloud_oss_bucket" "bucket-storageclass"{
 Set bucket server-side encryption rule 
 
 ```
-resource "alicloud_oss_bucket" "bucket-sserule"{
+resource "alicloud_oss_bucket" "bucket-sserule" {
   bucket = "bucket-170309-sserule"
-  acl = "private"
+  acl    = "private"
 
   server_side_encryption_rule {
     sse_algorithm = "AES256"
@@ -141,9 +141,9 @@ resource "alicloud_oss_bucket" "bucket-sserule"{
 Set bucket tags 
 
 ```
-resource "alicloud_oss_bucket" "bucket-tags"{
+resource "alicloud_oss_bucket" "bucket-tags" {
   bucket = "bucket-170309-tags"
-  acl = "private"
+  acl    = "private"
 
   tags = {
     key1 = "value1"
@@ -155,9 +155,9 @@ resource "alicloud_oss_bucket" "bucket-tags"{
 Enable bucket versioning 
 
 ```
-resource "alicloud_oss_bucket" "bucket-versioning"{
+resource "alicloud_oss_bucket" "bucket-versioning" {
   bucket = "bucket-170309-versioning"
-  acl = "private"
+  acl    = "private"
 
   versioning {
     status = "Enabled"

--- a/website/docs/r/pvtz_zone_record.html.markdown
+++ b/website/docs/r/pvtz_zone_record.html.markdown
@@ -18,15 +18,15 @@ Basic Usage
 
 ```
 resource "alicloud_pvtz_zone" "zone" {
-	name = "foo.test.com"
+  name = "foo.test.com"
 }
 
 resource "alicloud_pvtz_zone_record" "foo" {
-	zone_id = "${alicloud_pvtz_zone.zone.id}"
-	resource_record = "www"
-	type = "CNAME"
-	value = "bbb.test.com"
-	ttl="60
+  zone_id         = "${alicloud_pvtz_zone.zone.id}"
+  resource_record = "www"
+  type            = "CNAME"
+  value           = "bbb.test.com"
+  ttl             = 60
 }
 ```
 ## Argument Reference

--- a/website/docs/r/ram_group_membership.html.markdown
+++ b/website/docs/r/ram_group_membership.html.markdown
@@ -15,32 +15,32 @@ Provides a RAM Group membership resource.
 ```
 # Create a RAM Group membership.
 resource "alicloud_ram_group" "group" {
-  name = "groupName"
+  name     = "groupName"
   comments = "this is a group comments."
-  force = true
+  force    = true
 }
 
 resource "alicloud_ram_user" "user" {
-  name = "user_test"
+  name         = "user_test"
   display_name = "user_display_name"
-  mobile = "86-18688888888"
-  email = "hello.uuu@aaa.com"
-  comments = "yoyoyo"
-  force = true
+  mobile       = "86-18688888888"
+  email        = "hello.uuu@aaa.com"
+  comments     = "yoyoyo"
+  force        = true
 }
 
 resource "alicloud_ram_user" "user1" {
-  name = "user_test1"
+  name         = "user_test1"
   display_name = "user_display_name1"
-  mobile = "86-18688888889"
-  email = "hello.uuu@aaa.com"
-  comments = "yoyoyo"
-  force = true
+  mobile       = "86-18688888889"
+  email        = "hello.uuu@aaa.com"
+  comments     = "yoyoyo"
+  force        = true
 }
 
 resource "alicloud_ram_group_membership" "membership" {
   group_name = "${alicloud_ram_group.group.name}"
-  user_names = ["${alicloud_ram_user.user.name}"，"${alicloud_ram_user.user1.name}"]
+  user_names = ["${alicloud_ram_user.user.name}", "${alicloud_ram_user.user1.name}"]
 }
 ```
 ## Argument Reference

--- a/website/docs/r/slb_acl.html.markdown
+++ b/website/docs/r/slb_acl.html.markdown
@@ -37,25 +37,25 @@ For information about acl and how to use it, see [Configure an access control li
 
 ```
 variable "name" {
-    default = "terraformslbaclconfig"
+  default = "terraformslbaclconfig"
 }
 variable "ip_version" {
-    default = "ipv4"
+  default = "ipv4"
 }
 
 resource "alicloud_slb_acl" "default" {
-    name = "${var.name}"
-    ip_version = "${var.ip_version}"
-    entry_list {
-        entry="10.10.10.0/24"
-        comment="first"
-    }
-    entry_list {
-        entry="168.10.10.0/24"
-        comment="second"
-    }
+  name       = "${var.name}"
+  ip_version = "${var.ip_version}"
+  entry_list {
+    entry   = "10.10.10.0/24"
+    comment = "first"
+  }
+  entry_list {
+    entry   = "168.10.10.0/24"
+    comment = "second"
+  }
 }
-`
+
 ```
 
 ## Argument Reference


### PR DESCRIPTION
The previous PR-#1415 formatted plenty of HCL codes in docs. With the release of v1.52.0, I found that some of inline HCL codes were not formatted yet. 

After some digs on it, I figured it out that the tool I built has two limitations, which may cause the codes failed formatted:
1. It works only when the HCL code are valid; (This is a feature to avoid meaningless formatting.)
2. Due to a upstream issue https://github.com/russross/blackfriday/issues/423 , my tool cannot precisely parse the markdown file with CRLF line endings (mostly in Windows format);

Changes proposed in this PR to resolve the failures caused by the limitations above:

* Set `\n` as the line ending in `r/nas_mount_targets.html.markdown` and `r/oss_bucket.html.markdown` instead of `\r\n`
* Fix the code in `r/network_interface_attachment.html.markdown`, `r/pvtz_zone_record.html.markdown`, `r/ram_group_membership.html.markdown` and `r/slb_acl.html.markdown` to in valid HCL format
* Format the newly added `d/ons_instances.html.markdown` after last formatting

... And then format the inline HCL code as expected in the docs above.

Signed-off-by: imjoey <majunjiev@gmail.com>