### PR TITLE
Move ID creation logic for alicloud_api_gateway_api up

### DIFF
--- a/alicloud/resource_alicloud_api_gateway_api.go
+++ b/alicloud/resource_alicloud_api_gateway_api.go
@@ -306,6 +306,8 @@ func resourceAliyunApigatewayApiCreate(d *schema.ResourceData, meta interface{})
 	addDebug(request.GetActionName(), raw)
 	response, _ := raw.(*cloudapi.CreateApiResponse)
 
+	d.SetId(fmt.Sprintf("%s%s%s", request.GroupId, COLON_SEPARATED, response.ApiId))
+
 	if l, ok := d.GetOk("stage_names"); ok {
 		err = updateApiStages(d, l.(*schema.Set), meta)
 		if err != nil {
@@ -313,7 +315,6 @@ func resourceAliyunApigatewayApiCreate(d *schema.ResourceData, meta interface{})
 		}
 	}
 
-	d.SetId(fmt.Sprintf("%s%s%s", request.GroupId, COLON_SEPARATED, response.ApiId))
 	return resourceAliyunApigatewayApiRead(d, meta)
 }
 


### PR DESCRIPTION
If `stage_names` is defined, the `updateApiStages()` function will get called. This deploys or undeploys APIs depending on whether or not they are included in `stage_names`. For both cases, the ID needs to contain the API group and the API ID separated by colon. The ID creation was moved up to make sure it is present before performing the requests for deploying APIs.

Also, when an API is created, all the stages in `stage_names` are not deployed by default. The if/else logic included in `updateApiStages()` is not necessary when an API gets newly deployed, so I set up a `deployApiStages()` func that just deploys everything in the `stage_names` set.

This fixes the following error:
```
Error: [ERROR] terraform-provider-alicloud/alicloud/resource_alicloud_api_gateway_api.go:312:
[ERROR] terraform-provider-alicloud/alicloud/resource_alicloud_api_gateway_api.go:979:
[ERROR] terraform-provider-alicloud/alicloud/service_alicloud_api_gateway.go:324:
[ERROR] terraform-provider-alicloud/alicloud/common.go:597:
Invalid Resource Id . Expected parts' length 2, got 1

  on api-gateway.tf line 9, in resource "alicloud_api_gateway_api" "apigw-api-test":
   9: resource "alicloud_api_gateway_api" "apigw-api-test" {
```