### PR TITLE
added ErrorCodeMaximum as valid parameter

### DIFF
--- a/alicloud/data_source_alicloud_pvtz_zone_records.go
+++ b/alicloud/data_source_alicloud_pvtz_zone_records.go
@@ -122,12 +122,12 @@ func dataSourceAlicloudPvtzZoneRecordsRead(d *schema.ResourceData, meta interfac
 
 		for _, key := range response.Records.Record {
 			if len(idsMap) > 0 {
-				if _, ok := idsMap[strconv.Itoa(key.RecordId)]; !ok {
+				if _, ok := idsMap[strconv.Itoa(int(key.RecordId))]; !ok {
 					continue
 				}
 			}
 			pvtzZoneRecords = append(pvtzZoneRecords, key)
-			ids = append(ids, strconv.Itoa(key.RecordId))
+			ids = append(ids, strconv.Itoa(int(key.RecordId)))
 		}
 
 		if page, err := getNextpageNumber(request.PageNumber); err != nil {

--- a/alicloud/extension_cms.go
+++ b/alicloud/extension_cms.go
@@ -1,9 +1,10 @@
 package alicloud
 
 const (
-	Average = "Average"
-	Minimum = "Minimum"
-	Maximum = "Maximum"
+	Average          = "Average"
+	Minimum          = "Minimum"
+	Maximum          = "Maximum"
+	ErrorCodeMaximum = "ErrorCodeMaximum"
 )
 
 const (
@@ -13,4 +14,15 @@ const (
 	LessThanOrEqual = "<="
 	Equal           = "=="
 	NotEqual        = "!="
+)
+
+const (
+	SiteMonitorHTTP = "HTTP"
+	SiteMonitorPing = "Ping"
+	SiteMonitorTCP  = "TCP"
+	SiteMonitorUDP  = "UDP"
+	SiteMonitorDNS  = "DNS"
+	SiteMonitorSMTP = "SMTP"
+	SiteMonitorPOP3 = "POP3"
+	SiteMonitorFTP  = "FTP"
 )

--- a/alicloud/provider.go
+++ b/alicloud/provider.go
@@ -363,6 +363,7 @@ func Provider() terraform.ResourceProvider {
 			"alicloud_ots_instance":                        resourceAlicloudOtsInstance(),
 			"alicloud_ots_instance_attachment":             resourceAlicloudOtsInstanceAttachment(),
 			"alicloud_cms_alarm":                           resourceAlicloudCmsAlarm(),
+			"alicloud_cms_sitemonitor":                     resourceAlicloudCmsSiteMonitor(),
 			"alicloud_pvtz_zone":                           resourceAlicloudPvtzZone(),
 			"alicloud_pvtz_zone_attachment":                resourceAlicloudPvtzZoneAttachment(),
 			"alicloud_pvtz_zone_record":                    resourceAlicloudPvtzZoneRecord(),

--- a/alicloud/resource_alicloud_cen_instance_attachment.go
+++ b/alicloud/resource_alicloud_cen_instance_attachment.go
@@ -109,7 +109,7 @@ func resourceAlicloudCenInstanceAttachmentRead(d *schema.ResourceData, meta inte
 	d.Set("instance_id", object.CenId)
 	d.Set("child_instance_id", object.ChildInstanceId)
 	d.Set("child_instance_region_id", object.ChildInstanceRegionId)
-	d.Set("child_instance_owner_id", strconv.Itoa(object.ChildInstanceOwnerId))
+	d.Set("child_instance_owner_id", strconv.Itoa(int(object.ChildInstanceOwnerId)))
 
 	return nil
 }

--- a/alicloud/resource_alicloud_cms_sitemonitor.go
+++ b/alicloud/resource_alicloud_cms_sitemonitor.go
@@ -1,0 +1,193 @@
+package alicloud
+
+import (
+	"fmt"
+	"strconv"
+	"time"
+
+	"github.com/aliyun/alibaba-cloud-sdk-go/services/cms"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/validation"
+
+	"github.com/terraform-providers/terraform-provider-alicloud/alicloud/connectivity"
+)
+
+func resourceAlicloudCmsSiteMonitor() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceAlicloudCmsSiteMonitorCreate,
+		Read:   resourceAlicloudCmsSiteMonitorRead,
+		Update: resourceAlicloudCmsSiteMonitorUpdate,
+		Delete: resourceAlicloudCmsSiteMonitorDelete,
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
+
+		Schema: map[string]*schema.Schema{
+			"address": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"task_name": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"task_type": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+				ValidateFunc: validation.StringInSlice([]string{SiteMonitorHTTP, SiteMonitorDNS, SiteMonitorFTP, SiteMonitorPOP3,
+					SiteMonitorPing, SiteMonitorSMTP, SiteMonitorTCP, SiteMonitorUDP}, false),
+			},
+			"alert_ids": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"interval": {
+				Type:         schema.TypeInt,
+				Optional:     true,
+				Default:      1,
+				ValidateFunc: validation.IntInSlice([]int{1, 5, 15}),
+			},
+			"isp_cities": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"options_json": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"task_state": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"create_time": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"update_time": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func resourceAlicloudCmsSiteMonitorCreate(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*connectivity.AliyunClient)
+
+	request := cms.CreateCreateSiteMonitorRequest()
+	request.Address = d.Get("address").(string)
+	request.AlertIds = d.Get("alert_ids").(string)
+	request.TaskName = d.Get("task_name").(string)
+	request.TaskType = d.Get("task_type").(string)
+	request.Interval = strconv.Itoa(d.Get("interval").(int))
+	request.IspCities = d.Get("isp_cities").(string)
+	request.OptionsJson = d.Get("options_json").(string)
+
+	_, err := client.WithCmsClient(func(cmsClient *cms.Client) (interface{}, error) {
+		return cmsClient.CreateSiteMonitor(request)
+	})
+	if err != nil {
+		return fmt.Errorf("Creating site monitor got an error: %#v", err)
+	}
+
+	return resourceAlicloudCmsSiteMonitorRead(d, meta)
+}
+
+func resourceAlicloudCmsSiteMonitorRead(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*connectivity.AliyunClient)
+
+	request := cms.CreateDescribeSiteMonitorListRequest()
+	request.Keyword = d.Get("task_name").(string)
+	request.Scheme = "https"
+
+	raw, err := client.WithCmsClient(func(cmsClient *cms.Client) (interface{}, error) {
+		return cmsClient.DescribeSiteMonitorList(request)
+	})
+	if err != nil {
+		return fmt.Errorf("Error calling DescribeSiteMonitorList: %#v", err)
+	}
+	response, _ := raw.(*cms.DescribeSiteMonitorListResponse)
+	if len(response.SiteMonitors.SiteMonitor) == 0 {
+		return fmt.Errorf("Task '%s' does not exist: %#v", request.Keyword, err)
+	}
+	siteMonitor := response.SiteMonitors.SiteMonitor[0]
+
+	d.SetId(siteMonitor.TaskId)
+	d.Set("address", siteMonitor.Address)
+	d.Set("task_name", siteMonitor.TaskName)
+	d.Set("task_type", siteMonitor.TaskType)
+	d.Set("task_state", siteMonitor.TaskState)
+	d.Set("interval", siteMonitor.Interval)
+	d.Set("options_json", siteMonitor.OptionsJson)
+	d.Set("create_time", siteMonitor.CreateTime)
+	d.Set("update_time", siteMonitor.UpdateTime)
+
+	return nil
+}
+
+func resourceAlicloudCmsSiteMonitorUpdate(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*connectivity.AliyunClient)
+
+	d.Partial(true)
+
+	request := cms.CreateModifySiteMonitorRequest()
+	request.TaskId = d.Id()
+	request.Address = d.Get("address").(string)
+	request.AlertIds = d.Get("alert_ids").(string)
+	request.Interval = strconv.Itoa(d.Get("interval").(int))
+	request.IspCities = d.Get("isp_cities").(string)
+	request.OptionsJson = d.Get("options_json").(string)
+	request.TaskName = d.Get("task_name").(string)
+
+	_, err := client.WithCmsClient(func(cmsClient *cms.Client) (interface{}, error) {
+		return cmsClient.ModifySiteMonitor(request)
+	})
+	if err != nil {
+		return fmt.Errorf("ModifySiteMonitor got an error: %#v", err)
+	}
+
+	d.SetPartial("address")
+	d.SetPartial("alert_ids")
+	d.SetPartial("interval")
+	d.SetPartial("isp_cities")
+	d.SetPartial("options_json")
+
+	d.Partial(false)
+
+	return resourceAlicloudCmsSiteMonitorRead(d, meta)
+}
+
+func resourceAlicloudCmsSiteMonitorDelete(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*connectivity.AliyunClient)
+	request := cms.CreateDeleteSiteMonitorsRequest()
+
+	request.TaskIds = d.Id()
+	request.IsDeleteAlarms = "false"
+	taskName := d.Get("task_name").(string)
+
+	return resource.Retry(3*time.Minute, func() *resource.RetryError {
+		_, err := client.WithCmsClient(func(cmsClient *cms.Client) (interface{}, error) {
+			return cmsClient.DeleteSiteMonitors(request)
+		})
+
+		if err != nil {
+			return resource.NonRetryableError(fmt.Errorf("Deleting Site Monitor got an error: %#v", err))
+		}
+
+		listRequest := cms.CreateDescribeSiteMonitorListRequest()
+		listRequest.Keyword = taskName
+		raw, err := client.WithCmsClient(func(cmsClient *cms.Client) (interface{}, error) {
+			return cmsClient.DescribeSiteMonitorList(listRequest)
+		})
+		list := raw.(*cms.DescribeSiteMonitorListResponse)
+		if err != nil {
+			return resource.NonRetryableError(fmt.Errorf("Describe site monitor got an error: %#v", err))
+		}
+		if list.TotalCount == 0 {
+			return nil
+		}
+		return resource.RetryableError(fmt.Errorf("Deleting site monitor got an error: %#v", err))
+	})
+}

--- a/alicloud/resource_alicloud_cms_sitemonitor_test.go
+++ b/alicloud/resource_alicloud_cms_sitemonitor_test.go
@@ -1,0 +1,136 @@
+package alicloud
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/aliyun/alibaba-cloud-sdk-go/services/cms"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/terraform"
+
+	"github.com/terraform-providers/terraform-provider-alicloud/alicloud/connectivity"
+)
+
+func TestAccAlicloudCmsSiteMonitor_basic(t *testing.T) {
+	resourceName := "alicloud_cms_sitemonitor.basic"
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+		},
+
+		IDRefreshName: resourceName,
+
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckCmsSiteMonitorDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCmsSiteMonitor_basic(),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("alicloud_cms_sitemonitor.basic", "task_name", "tf-testAccCmsSiteMonitor_basic"),
+					resource.TestCheckResourceAttr("alicloud_cms_sitemonitor.basic", "interval", "5"),
+					resource.TestCheckResourceAttr("alicloud_cms_sitemonitor.basic", "address", "http://www.alibabacloud.com"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAlicloudCmsSiteMonitor_update(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+		},
+
+		IDRefreshName: "alicloud_cms_sitemonitor.update",
+
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckCmsSiteMonitorDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCmsSiteMonitor_update(),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("alicloud_cms_sitemonitor.update", "task_name", "tf-testAccCmsSiteMonitor_update"),
+					resource.TestCheckResourceAttr("alicloud_cms_sitemonitor.update", "interval", "5"),
+					resource.TestCheckResourceAttr("alicloud_cms_sitemonitor.update", "address", "http://www.alibabacloud.com"),
+				),
+			},
+
+			{
+				Config: testAccCmsSiteMonitor_updateAfter(),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("alicloud_cms_sitemonitor.update", "task_name", "tf-testAccCmsSiteMonitor_updateafter"),
+					resource.TestCheckResourceAttr("alicloud_cms_sitemonitor.update", "interval", "1"),
+					resource.TestCheckResourceAttr("alicloud_cms_sitemonitor.update", "address", "http://www.alibaba.com"),
+				),
+			},
+		},
+	})
+}
+
+func testAccCheckCmsSiteMonitorDestroy(s *terraform.State) error {
+	client := testAccProvider.Meta().(*connectivity.AliyunClient)
+
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "alicloud_cms_sitemonitor" {
+			continue
+		}
+
+		request := cms.CreateDescribeSiteMonitorListRequest()
+		request.TaskId = rs.Primary.ID
+
+		raw, err := client.WithCmsClient(func(cmsClient *cms.Client) (interface{}, error) {
+			return cmsClient.DescribeSiteMonitorList(request)
+		})
+		list := raw.(*cms.DescribeSiteMonitorListResponse)
+		if err != nil {
+			if NotFoundError(err) {
+				continue
+			}
+			return err
+		}
+		if list.TotalCount > 0 {
+			return fmt.Errorf("Site Monitor %s still exists", rs.Primary.ID)
+		}
+	}
+
+	return nil
+}
+
+func testAccCmsSiteMonitor_basic() string {
+	return fmt.Sprintf(`
+	resource "alicloud_cms_sitemonitor" "basic" {
+	  address = "http://www.alibabacloud.com"
+	  task_name = "tf-testAccCmsSiteMonitor_basic"
+	  task_type = "HTTP"
+	  interval = 5
+	}
+	`)
+}
+
+func testAccCmsSiteMonitor_update() string {
+	return fmt.Sprintf(`
+data "alicloud_account" "current"{
+}
+
+resource "alicloud_cms_sitemonitor" "update" {
+	address = "http://www.alibabacloud.com"
+	task_name = "tf-testAccCmsSiteMonitor_update"
+	task_type = "HTTP"
+	interval = 5
+}
+`)
+}
+
+func testAccCmsSiteMonitor_updateAfter() string {
+	return fmt.Sprintf(`
+	data "alicloud_account" "current"{
+	}
+	
+	resource "alicloud_cms_sitemonitor" "update" {
+		address = "http://www.alibaba.com"
+		task_name = "tf-testAccCmsSiteMonitor_updateafter"
+		task_type = "HTTP"
+		interval = 1
+	}
+	`)
+}

--- a/alicloud/service_alicloud_cen.go
+++ b/alicloud/service_alicloud_cen.go
@@ -200,7 +200,7 @@ func (s *CenService) WaitForCenBandwidthPackage(id string, status Status, bandwi
 				return WrapError(err)
 			}
 		}
-		if object.Status == string(status) && object.Bandwidth == bandwidth {
+		if object.Status == string(status) && int(object.Bandwidth) == bandwidth {
 			return nil
 		}
 		if time.Now().After(deadline) {

--- a/alicloud/service_alicloud_pvtz.go
+++ b/alicloud/service_alicloud_pvtz.go
@@ -136,7 +136,7 @@ func (s *PvtzService) DescribePvtzZoneRecord(id string) (record pvtz.Record, err
 		}
 
 		for _, rec := range response.Records.Record {
-			if strconv.Itoa(rec.RecordId) == parts[0] {
+			if strconv.Itoa(int(rec.RecordId)) == parts[0] {
 				record = rec
 				return record, nil
 			}
@@ -222,11 +222,11 @@ func (s *PvtzService) WaitForPvtzZoneRecord(id string, status Status, timeout in
 				return WrapError(err)
 			}
 		}
-		if strconv.Itoa(object.RecordId) == parts[0] {
+		if strconv.Itoa(int(object.RecordId)) == parts[0] {
 			return nil
 		}
 		if time.Now().After(deadline) {
-			return WrapErrorf(err, WaitTimeoutMsg, id, GetFunc(1), timeout, strconv.Itoa(object.RecordId), id, ProviderERROR)
+			return WrapErrorf(err, WaitTimeoutMsg, id, GetFunc(1), timeout, strconv.Itoa(int(object.RecordId)), id, ProviderERROR)
 		}
 
 	}

--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module github.com/terraform-providers/terraform-provider-alicloud
 
 require (
 	github.com/Sirupsen/logrus v0.0.0-20181010200618-458213699411 // indirect
-	github.com/aliyun/alibaba-cloud-sdk-go v1.60.350
+	github.com/aliyun/alibaba-cloud-sdk-go v1.60.385
 	github.com/aliyun/aliyun-datahub-sdk-go v0.0.0-20180929121038-c1c85baca7c0
 	github.com/aliyun/aliyun-log-go-sdk v0.1.6-0.20191218073949-14a8ed32b27b
 	github.com/aliyun/aliyun-mns-go-sdk v0.0.0-20191115025756-088ba95470f4

--- a/go.sum
+++ b/go.sum
@@ -31,6 +31,10 @@ github.com/alecthomas/units v0.0.0-20151022065526-2efee857e7cf/go.mod h1:ybxpYRF
 github.com/aliyun/alibaba-cloud-sdk-go v0.0.0-20190329064014-6e358769c32a/go.mod h1:T9M45xf79ahXVelWoOBmH0y4aC1t5kXO5BxwyakgIGA=
 github.com/aliyun/alibaba-cloud-sdk-go v1.60.350 h1:pASTFTDZ8tYTRSEwpV/bA5xraGErpGW1gibXWgVRpbU=
 github.com/aliyun/alibaba-cloud-sdk-go v1.60.350/go.mod h1:mNZkuqaeM5UCiAdkV4r+lrheu8Q5fe/487bRFrGYZ8A=
+github.com/aliyun/alibaba-cloud-sdk-go v1.60.382 h1:60z5uBA2aSNgoXKu6g3ajPXNhBcC19kif90ZG8DX4Qg=
+github.com/aliyun/alibaba-cloud-sdk-go v1.60.382/go.mod h1:v8ESoHo4SyHmuB4b1tJqDHxfTGEciD+yhvOU/5s1Rfk=
+github.com/aliyun/alibaba-cloud-sdk-go v1.60.385 h1:WuQdQtjD+S9bC8GmqepLvHvk2hqhbCJ78whanptVcPE=
+github.com/aliyun/alibaba-cloud-sdk-go v1.60.385/go.mod h1:v8ESoHo4SyHmuB4b1tJqDHxfTGEciD+yhvOU/5s1Rfk=
 github.com/aliyun/aliyun-datahub-sdk-go v0.0.0-20180929121038-c1c85baca7c0 h1:nvOIS4LOMKF65MCDkJgAMZXNk5MdbbfFcA3Dk9WwsXM=
 github.com/aliyun/aliyun-datahub-sdk-go v0.0.0-20180929121038-c1c85baca7c0/go.mod h1:GwtZxKUD+aLBrtlkEcyPNAx+jRkBioEC7EKOlQ26lTc=
 github.com/aliyun/aliyun-log-go-sdk v0.1.6-0.20191218073949-14a8ed32b27b h1:cOuyfNLzDY0/fEc7HLKHIXHfJs4KMAMPVileOlJc7AI=

--- a/website/docs/r/cms_sitemonitor.markdown
+++ b/website/docs/r/cms_sitemonitor.markdown
@@ -1,0 +1,54 @@
+---
+subcategory: "Cloud Monitor"
+layout: "alicloud"
+page_title: "Alicloud: alicloud_cms_sitemonitor"
+sidebar_current: "docs-alicloud-resource-cms-sitemonitor"
+description: |-
+  Provides a resource to build a sitemonitor rule for cloud monitor.
+---
+
+# alicloud\_cms\_sitemonitor
+
+This resource provides a sitemonitor resource and it can be used to monitor public endpoints and websites.
+Details at https://www.alibabacloud.com/help/doc-detail/67907.htm
+
+## Example Usage
+
+Basic Usage
+
+```
+resource "alicloud_cms_sitemonitor" "basic" {
+	  address = "http://www.alibabacloud.com"
+	  task_name = "tf-testAccCmsSiteMonitor_basic"
+	  task_type = "HTTP"
+	  interval = 5
+	}   
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `address` - (Required) The URL or IP address monitored by the site monitoring task.
+* `task_name` - (Required) The name of the site monitoring task. The name must be 4 to 100 characters in length. The name can contain the following types of characters: letters, digits, and underscores.
+* `task_type` - (Required, ForceNew) The protocol of the site monitoring task. Currently, site monitoring supports the following protocols: HTTP, Ping, TCP, UDP, DNS, SMTP, POP3, and FTP.
+* `alert_ids` - The IDs of existing alert rules to be associated with the site monitoring task.
+* `interval` - The monitoring interval of the site monitoring task. Unit: minutes. Valid values: 1, 5, and 15. Default value: 1.
+* `isp_cities` - The detection points in a JSON array. For example, `[{"city":"546","isp":"465"},{"city":"572","isp":"465"},{"city":"738","isp":"465"}]` indicates the detection points in Beijing, Hangzhou, and Qingdao respectively. You can call the DescribeISPAreaCity operation to query detection point information. If this parameter is not specified, three detection points will be chosen randomly for monitoring.
+* `options_json` - The extended options of the protocol of the site monitoring task. The options vary according to the protocol.
+
+## Attributes Reference
+
+The following attributes are exported:
+
+* `id` - The ID of the site monitor rule.
+* `task_state` - The current sitemonitor status.
+
+## Import
+
+Alarm rule can be imported using the id, e.g.
+
+```
+$ terraform import alicloud_cms_sitemonitor.alarm abc12345
+```


### PR DESCRIPTION
This adds support for `ErrorCodeMaximum` as valid value for parameter for `statistics`.
This is needed for example when defining alarms for SiteMonitor.

Example:
```
resource "alicloud_cms_alarm" "testalarm" {
	  name = "tastalarmfromTF"
	  project = "acs_networkmonitor"
	  metric = "StatusCode"
	  dimensions = {
	    taskId = "ec7af3a6-4624-4f4c-9dd8-285ca45897e7"
	  }
	  statistics ="ErrorCodeMaximum"
	  period = 60
	  operator = ">="
	  threshold = 400
	  triggered_count = 3
	  contact_groups = ["testcg"]
	  effective_interval = "06:00-20:00"
	}
```