### PR TITLE
support filter invalid name for namespace

### DIFF
--- a/alicloud/data_source_alicloud_cr_namespaces.go
+++ b/alicloud/data_source_alicloud_cr_namespaces.go
@@ -17,7 +17,9 @@ func dataSourceAlicloudCRNamespaces() *schema.Resource {
 			"name_regex": {
 				Type:         schema.TypeString,
 				Optional:     true,
-				ValidateFunc: validateNameRegex,
+				ValidateFunc: validateNotAllowedStringValue([]string{
+					"private", "publish", "everyone","share","primary",
+				}),
 			},
 			"output_file": {
 				Type:     schema.TypeString,

--- a/alicloud/validators.go
+++ b/alicloud/validators.go
@@ -564,6 +564,26 @@ func validateAllowedStringValue(ss []string) schema.SchemaValidateFunc {
 	}
 }
 
+func validateNotAllowedStringValue(ss []string) schema.SchemaValidateFunc {
+	return func(v interface{}, k string) (ws []string, errors []error) {
+		value := Trim(v.(string))
+		existed := false
+		for _, s := range ss {
+			if s == value {
+				existed = true
+				break
+			}
+		}
+		if existed {
+			errors = append(errors, fmt.Errorf(
+				"%q must contain a valid string value should be in array %#v, got %q",
+				k, ss, value))
+		}
+		return
+
+	}
+}
+
 func validateAllowedSplitStringValue(ss []string, splitStr string) schema.SchemaValidateFunc {
 	return func(v interface{}, k string) (ws []string, errors []error) {
 		value := v.(string)

--- a/alicloud/validators_test.go
+++ b/alicloud/validators_test.go
@@ -415,6 +415,26 @@ func TestValidateAllowedStringValue(t *testing.T) {
 	}
 }
 
+func TestValidateNotAllowedStringValue(t *testing.T) {
+	exceptValues := []string{"aliyun", "alicloud", "alibaba"}
+	validValues := []string{"aliyun"}
+	for _, v := range validValues {
+		_, errors := validateNotAllowedStringValue(exceptValues)(v, "allowvalue")
+		if len(errors) != 0 {
+			t.Fatalf("%q should not be a valid value in %#v: %q", v, exceptValues, errors)
+		}
+	}
+
+	invalidValues := []string{"ali", "alidata", "terraform"}
+	for _, v := range invalidValues {
+		_, errors := validateNotAllowedStringValue(exceptValues)(v, "ali")
+		if len(errors) == 0 {
+			t.Fatalf("%q should be an invalid value", v)
+		}
+	}
+}
+
+
 func TestValidateAllowedStringSplitValue(t *testing.T) {
 	exceptValues := []string{"aliyun", "alicloud", "alibaba"}
 	validValues := "aliyun,alicloud"

--- a/website/docs/r/cr_namespace.html.markdown
+++ b/website/docs/r/cr_namespace.html.markdown
@@ -31,6 +31,7 @@ resource "alicloud_cr_namespace" "my-namespace" {
 The following arguments are supported:
 
 * `name` - (Required, ForceNew) Name of Container Registry namespace.
+   > Note: The name can't be one of them: public, share, primary, everyone, private. it will cause a duplicate error.
 * `auto_create` - (Required) Boolean, when it set to true, repositories are automatically created when pushing new images. If it set to false, you create repository for images before pushing.
 * `default_visibility` - (Required) `PUBLIC` or `PRIVATE`, default repository visibility in this namespace.
 


### PR DESCRIPTION
The aliyun docker registry service is not allowed the below value as namespace:
public, share, primary, everyone, private

I think we should limit it in terraform, instead return API errors.

PS: this is my first time to contribute a Go project, so please check it carefully. I am not familiar for Go.