### PR TITLE
remove empty fields in managed k8s, add force_update, add multiple az support

### DIFF
--- a/alicloud/data_source_alicloud_cs_managed_kubernetes_clusters.go
+++ b/alicloud/data_source_alicloud_cs_managed_kubernetes_clusters.go
@@ -3,7 +3,6 @@ package alicloud
 import (
 	"fmt"
 	"regexp"
-	"strconv"
 	"strings"
 	"time"
 
@@ -69,6 +68,7 @@ func dataSourceAlicloudCSManagerKubernetesClusters() *schema.Resource {
 						"slb_internet_enabled": {
 							Type:     schema.TypeBool,
 							Computed: true,
+							Removed:  "Field 'slb_internet_enabled' has been removed from provider version 1.53.0.",
 						},
 						"security_group_id": {
 							Type:     schema.TypeString,
@@ -88,6 +88,7 @@ func dataSourceAlicloudCSManagerKubernetesClusters() *schema.Resource {
 							Elem: &schema.Schema{
 								Type: schema.TypeString,
 							},
+							Removed: "Field 'vswitch_ids' has been removed from provider version 1.53.0.",
 						},
 						"worker_instance_types": {
 							Type:     schema.TypeList,
@@ -95,6 +96,7 @@ func dataSourceAlicloudCSManagerKubernetesClusters() *schema.Resource {
 							Elem: &schema.Schema{
 								Type: schema.TypeString,
 							},
+							Removed: "Field 'worker_instance_types' has been removed from provider version 1.53.0.",
 						},
 						"worker_numbers": {
 							Type:     schema.TypeList,
@@ -102,22 +104,27 @@ func dataSourceAlicloudCSManagerKubernetesClusters() *schema.Resource {
 							Elem: &schema.Schema{
 								Type: schema.TypeInt,
 							},
+							Removed: "Field 'worker_numbers' has been removed from provider version 1.53.0.",
 						},
 						"key_name": {
 							Type:     schema.TypeString,
 							Computed: true,
+							Removed:  "Field 'key_name' has been removed from provider version 1.53.0.",
 						},
 						"pod_cidr": {
 							Type:     schema.TypeString,
 							Computed: true,
+							Removed:  "Field 'pod_cidr' has been removed from provider version 1.53.0.",
 						},
 						"service_cidr": {
 							Type:     schema.TypeString,
 							Computed: true,
+							Removed:  "Field 'service_cidr' has been removed from provider version 1.53.0.",
 						},
 						"cluster_network_type": {
 							Type:     schema.TypeString,
 							Computed: true,
+							Removed:  "Field 'cluster_network_type' has been removed from provider version 1.53.0.",
 						},
 						"log_config": {
 							Type:     schema.TypeList,
@@ -134,46 +141,57 @@ func dataSourceAlicloudCSManagerKubernetesClusters() *schema.Resource {
 									},
 								},
 							},
+							Removed: "Field 'log_config' has been removed from provider version 1.53.0.",
 						},
 						"image_id": {
 							Type:     schema.TypeString,
 							Computed: true,
+							Removed:  "Field 'image_id' has been removed from provider version 1.53.0.",
 						},
 						"worker_disk_size": {
 							Type:     schema.TypeInt,
 							Computed: true,
+							Removed:  "Field 'worker_disk_size' has been removed from provider version 1.53.0.",
 						},
 						"worker_disk_category": {
 							Type:     schema.TypeString,
 							Computed: true,
+							Removed:  "Field 'worker_disk_category' has been removed from provider version 1.53.0.",
 						},
 						"worker_data_disk_size": {
 							Type:     schema.TypeInt,
 							Computed: true,
+							Removed:  "Field 'worker_data_disk_size' has been removed from provider version 1.53.0.",
 						},
 						"worker_data_disk_category": {
 							Type:     schema.TypeString,
 							Computed: true,
+							Removed:  "Field 'worker_data_disk_category' has been removed from provider version 1.53.0.",
 						},
 						"worker_instance_charge_type": {
 							Type:     schema.TypeString,
 							Computed: true,
+							Removed:  "Field 'worker_instance_charge_type' has been removed from provider version 1.53.0.",
 						},
 						"worker_period_unit": {
 							Type:     schema.TypeString,
 							Computed: true,
+							Removed:  "Field 'worker_period_unit' has been removed from provider version 1.53.0.",
 						},
 						"worker_period": {
 							Type:     schema.TypeInt,
 							Computed: true,
+							Removed:  "Field 'worker_period' has been removed from provider version 1.53.0.",
 						},
 						"worker_auto_renew": {
 							Type:     schema.TypeBool,
 							Computed: true,
+							Removed:  "Field 'worker_auto_renew' has been removed from provider version 1.53.0.",
 						},
 						"worker_auto_renew_period": {
 							Type:     schema.TypeInt,
 							Computed: true,
+							Removed:  "Field 'worker_auto_renew_period' has been removed from provider version 1.53.0.",
 						},
 						"worker_nodes": {
 							Type:     schema.TypeList,
@@ -318,71 +336,6 @@ func csManagedKubernetesClusterDescriptionAttributes(d *schema.ResourceData, clu
 		mapping["vpc_id"] = ct.VPCID
 		mapping["security_group_id"] = ct.SecurityGroupID
 		mapping["availability_zone"] = ct.ZoneId
-		mapping["key_name"] = ct.Parameters.KeyPair
-		mapping["worker_disk_category"] = ct.Parameters.WorkerSystemDiskCategory
-		if ct.Parameters.PublicSLB != nil {
-			mapping["slb_internet_enabled"] = *ct.Parameters.PublicSLB
-		}
-
-		if ct.Parameters.ImageId != "" {
-			mapping["image_id"] = ct.Parameters.ImageId
-		} else {
-			mapping["image_id"] = ct.Parameters.MasterImageId
-		}
-
-		if size, err := strconv.Atoi(ct.Parameters.WorkerSystemDiskSize); err != nil {
-			return BuildWrapError("strconv.Atoi", d.Id(), ProviderERROR, err, "")
-		} else {
-			mapping["worker_disk_size"] = size
-		}
-
-		if ct.Parameters.WorkerInstanceChargeType == string(PrePaid) {
-			mapping["worker_instance_charge_type"] = string(PrePaid)
-			if period, err := strconv.Atoi(ct.Parameters.WorkerPeriod); err != nil {
-				return BuildWrapError("strconv.Atoi", d.Id(), ProviderERROR, err, "")
-			} else {
-				mapping["worker_period"] = period
-			}
-			mapping["worker_period_unit"] = ct.Parameters.WorkerPeriodUnit
-			if ct.Parameters.WorkerAutoRenew != nil {
-				mapping["worker_auto_renew"] = *ct.Parameters.WorkerAutoRenew
-			}
-			if period, err := strconv.Atoi(ct.Parameters.WorkerAutoRenewPeriod); err != nil {
-				return BuildWrapError("strconv.Atoi", d.Id(), ProviderERROR, err, "")
-			} else {
-				mapping["worker_auto_renew_period"] = period
-			}
-		} else {
-			mapping["worker_instance_charge_type"] = string(PostPaid)
-		}
-
-		if ct.Parameters.WorkerDataDisk != nil && *ct.Parameters.WorkerDataDisk {
-			if size, err := strconv.Atoi(ct.Parameters.WorkerDataDiskSize); err != nil {
-				return BuildWrapError("strconv.Atoi", d.Id(), ProviderERROR, err, "")
-			} else {
-				mapping["worker_data_disk_size"] = size
-			}
-			mapping["worker_data_disk_category"] = ct.Parameters.WorkerDataDiskCategory
-		}
-
-		if ct.Parameters.LoggingType != "None" {
-			logConfig := map[string]interface{}{}
-			logConfig["type"] = ct.Parameters.LoggingType
-			if ct.Parameters.SLSProjectName == "None" {
-				logConfig["project"] = ""
-			} else {
-				logConfig["project"] = ct.Parameters.SLSProjectName
-			}
-			mapping["log_config"] = []map[string]interface{}{logConfig}
-		}
-
-		if numOfNode, err := strconv.Atoi(ct.Parameters.NumOfNodes); err != nil {
-			return BuildWrapError("strconv.Atoi", d.Id(), ProviderERROR, err, "")
-		} else {
-			mapping["worker_numbers"] = []int{numOfNode}
-		}
-		mapping["vswitch_ids"] = []string{ct.Parameters.VSwitchID}
-		mapping["worker_instance_types"] = []string{ct.Parameters.WorkerInstanceType}
 
 		var workerNodes []map[string]interface{}
 

--- a/alicloud/data_source_alicloud_cs_managed_kubernetes_clusters_test.go
+++ b/alicloud/data_source_alicloud_cs_managed_kubernetes_clusters_test.go
@@ -20,10 +20,7 @@ func TestAccAlicloudCSManagedKubernetesClustersDataSource(t *testing.T) {
 					testAccCheckAlicloudDataSourceID("data.alicloud_cs_managed_kubernetes_clusters.default"),
 					resource.TestCheckResourceAttrSet("data.alicloud_cs_managed_kubernetes_clusters.default", "clusters.#"),
 					resource.TestMatchResourceAttr("data.alicloud_cs_managed_kubernetes_clusters.default", "clusters.0.name", regexp.MustCompile("^tf-testAccManagedK8s-datasource*")),
-					resource.TestCheckResourceAttr("data.alicloud_cs_managed_kubernetes_clusters.default", "clusters.0.worker_numbers.#", "1"),
-					resource.TestCheckResourceAttr("data.alicloud_cs_managed_kubernetes_clusters.default", "clusters.0.worker_numbers.0", "2"),
-					resource.TestCheckResourceAttr("data.alicloud_cs_managed_kubernetes_clusters.default", "clusters.0.worker_disk_category", "cloud_efficiency"),
-					resource.TestCheckResourceAttr("data.alicloud_cs_managed_kubernetes_clusters.default", "clusters.0.worker_disk_size", "40"),
+					resource.TestCheckResourceAttr("data.alicloud_cs_managed_kubernetes_clusters.default", "clusters.0.worker_nodes.#", "2"),
 					resource.TestCheckResourceAttr("data.alicloud_cs_managed_kubernetes_clusters.default", "clusters.0.connections.%", "4"),
 					resource.TestCheckResourceAttrSet("data.alicloud_cs_managed_kubernetes_clusters.default", "clusters.0.connections.master_public_ip"),
 					resource.TestCheckResourceAttrSet("data.alicloud_cs_managed_kubernetes_clusters.default", "clusters.0.connections.api_server_internet"),
@@ -69,7 +66,7 @@ resource "alicloud_cs_managed_kubernetes" "k8s" {
   vswitch_ids = ["${alicloud_vswitch.foo.id}"]
   new_nat_gateway = true
   worker_instance_types = ["${data.alicloud_instance_types.default.instance_types.0.id}"]
-  worker_numbers = [2]
+  worker_number = 2
   password = "Yourpassword1234"
   pod_cidr = "172.20.0.0/16"
   service_cidr = "172.21.0.0/20"

--- a/alicloud/diff_suppress_funcs.go
+++ b/alicloud/diff_suppress_funcs.go
@@ -204,30 +204,11 @@ func csKubernetesWorkerPostPaidDiffSuppressFunc(k, old, new string, d *schema.Re
 	return common.InstanceChargeType(d.Get("worker_instance_charge_type").(string)) == common.PostPaid || !(d.Id() == "") && !d.Get("force_update").(bool)
 }
 
-func csManagedKubernetesVswitchIdsSuppressFunc(k, old, new string, d *schema.ResourceData) bool {
+func csForceUpdate(k, old, new string, d *schema.ResourceData) bool {
 	if d.Id() == "" {
 		return false
 	}
-	if k == "vswitch_ids.0" {
-		// return from server is empty, failure due to OpenAPI
-		if old == "" {
-			return true
-		}
-	}
-	return false
-}
-
-func csManagedKubernetesWorkerInstanceTypesSuppressFunc(k, old, new string, d *schema.ResourceData) bool {
-	if d.Id() == "" {
-		return false
-	}
-	if k == "worker_instance_types.0" {
-		// return from server is empty, failure due to OpenAPI
-		if old == "" {
-			return true
-		}
-	}
-	return false
+	return !d.Get("force_update").(bool)
 }
 
 func csForceUpdateSuppressFunc(k, old, new string, d *schema.ResourceData) bool {

--- a/alicloud/resource_alicloud_cs_managed_kubernetes_test.go
+++ b/alicloud/resource_alicloud_cs_managed_kubernetes_test.go
@@ -30,15 +30,12 @@ func TestAccAlicloudCSManagedKubernetes_basic(t *testing.T) {
 					testAccCheckContainerClusterExists("alicloud_cs_managed_kubernetes.k8s", &k8s),
 					resource.TestMatchResourceAttr("alicloud_cs_managed_kubernetes.k8s", "name", regexp.MustCompile("^tf-testAccManagedKubernetes-basic*")),
 					resource.TestCheckResourceAttr("alicloud_cs_managed_kubernetes.k8s", "worker_instance_charge_type", "PostPaid"),
-					resource.TestCheckResourceAttr("alicloud_cs_managed_kubernetes.k8s", "worker_numbers.#", "1"),
-					resource.TestCheckResourceAttr("alicloud_cs_managed_kubernetes.k8s", "worker_numbers.0", "2"),
+					resource.TestCheckResourceAttr("alicloud_cs_managed_kubernetes.k8s", "worker_number", "2"),
 					resource.TestCheckResourceAttr("alicloud_cs_managed_kubernetes.k8s", "worker_disk_size", "50"),
 					resource.TestCheckResourceAttr("alicloud_cs_managed_kubernetes.k8s", "worker_disk_category", "cloud_ssd"),
 					resource.TestCheckResourceAttr("alicloud_cs_managed_kubernetes.k8s", "worker_instance_types.#", "1"),
 					resource.TestCheckResourceAttr("alicloud_cs_managed_kubernetes.k8s", "vswitch_ids.#", "1"),
-					resource.TestCheckResourceAttr("alicloud_cs_managed_kubernetes.k8s", "key_name", ""),
 
-					resource.TestCheckResourceAttrSet("alicloud_cs_managed_kubernetes.k8s", "image_id"),
 					resource.TestCheckResourceAttrSet("alicloud_cs_managed_kubernetes.k8s", "vpc_id"),
 					resource.TestCheckResourceAttrSet("alicloud_cs_managed_kubernetes.k8s", "security_group_id"),
 					resource.TestCheckResourceAttrSet("alicloud_cs_managed_kubernetes.k8s", "availability_zone"),
@@ -50,7 +47,37 @@ func TestAccAlicloudCSManagedKubernetes_basic(t *testing.T) {
 				ImportStateVerify: true,
 				ImportStateVerifyIgnore: []string{"name_prefix", "new_nat_gateway", "pod_cidr",
 					"service_cidr", "password", "install_cloud_monitor", "slb_internet_enabled",
-					"vswitch_ids", "worker_instance_types", "worker_numbers"},
+					"vswitch_ids", "worker_instance_types", "worker_numbers", "worker_disk_category", "worker_disk_size",
+					"worker_instance_charge_type", "worker_number", "force_update"},
+			},
+		},
+	})
+}
+
+func TestAccAlicloudCSManagedKubernetes_multiaz(t *testing.T) {
+	var k8s cs.ClusterType
+
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() { testAccPreCheckWithRegions(t, true, connectivity.ManagedKubernetesSupportedRegions) },
+
+		IDRefreshName: "alicloud_cs_managed_kubernetes.k8s",
+
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckManagedKubernetesClusterDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccManagedKubernetes_multiaz,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckContainerClusterExists("alicloud_cs_managed_kubernetes.k8s", &k8s),
+					resource.TestMatchResourceAttr("alicloud_cs_managed_kubernetes.k8s", "name", regexp.MustCompile("^tf-testAccManagedKubernetes-multiaz*")),
+					resource.TestCheckResourceAttr("alicloud_cs_managed_kubernetes.k8s", "worker_number", "2"),
+					resource.TestCheckResourceAttr("alicloud_cs_managed_kubernetes.k8s", "worker_disk_size", "40"),
+					resource.TestCheckResourceAttr("alicloud_cs_managed_kubernetes.k8s", "worker_disk_category", "cloud_efficiency"),
+					resource.TestCheckResourceAttr("alicloud_cs_managed_kubernetes.k8s", "worker_instance_charge_type", "PostPaid"),
+					resource.TestCheckResourceAttrSet("alicloud_cs_managed_kubernetes.k8s", "vpc_id"),
+					resource.TestCheckResourceAttrSet("alicloud_cs_managed_kubernetes.k8s", "security_group_id"),
+					resource.TestCheckResourceAttrSet("alicloud_cs_managed_kubernetes.k8s", "availability_zone"),
+				),
 			},
 		},
 	})
@@ -72,15 +99,12 @@ func TestAccAlicloudCSManagedKubernetes_update(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckContainerClusterExists("alicloud_cs_managed_kubernetes.k8s", &k8s),
 					resource.TestMatchResourceAttr("alicloud_cs_managed_kubernetes.k8s", "name", regexp.MustCompile("^tf-testAccManagedKubernetes-update*")),
-					resource.TestCheckResourceAttr("alicloud_cs_managed_kubernetes.k8s", "worker_numbers.#", "1"),
-					resource.TestCheckResourceAttr("alicloud_cs_managed_kubernetes.k8s", "worker_numbers.0", "2"),
+					resource.TestCheckResourceAttr("alicloud_cs_managed_kubernetes.k8s", "worker_number", "2"),
 					resource.TestCheckResourceAttr("alicloud_cs_managed_kubernetes.k8s", "worker_disk_size", "40"),
 					resource.TestCheckResourceAttr("alicloud_cs_managed_kubernetes.k8s", "worker_disk_category", "cloud_efficiency"),
 					resource.TestCheckResourceAttr("alicloud_cs_managed_kubernetes.k8s", "worker_instance_charge_type", "PostPaid"),
 					resource.TestCheckResourceAttr("alicloud_cs_managed_kubernetes.k8s", "worker_instance_types.#", "1"),
-					resource.TestCheckResourceAttr("alicloud_cs_managed_kubernetes.k8s", "key_name", ""),
 
-					resource.TestCheckResourceAttrSet("alicloud_cs_managed_kubernetes.k8s", "image_id"),
 					resource.TestCheckResourceAttrSet("alicloud_cs_managed_kubernetes.k8s", "vpc_id"),
 					resource.TestCheckResourceAttrSet("alicloud_cs_managed_kubernetes.k8s", "security_group_id"),
 					resource.TestCheckResourceAttrSet("alicloud_cs_managed_kubernetes.k8s", "availability_zone"),
@@ -91,15 +115,12 @@ func TestAccAlicloudCSManagedKubernetes_update(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckContainerClusterExists("alicloud_cs_managed_kubernetes.k8s", &k8s),
 					resource.TestMatchResourceAttr("alicloud_cs_managed_kubernetes.k8s", "name", regexp.MustCompile("^tf-testAccManagedKubernetes-update*")),
-					resource.TestCheckResourceAttr("alicloud_cs_managed_kubernetes.k8s", "worker_numbers.#", "1"),
-					resource.TestCheckResourceAttr("alicloud_cs_managed_kubernetes.k8s", "worker_numbers.0", "4"),
+					resource.TestCheckResourceAttr("alicloud_cs_managed_kubernetes.k8s", "worker_number", "4"),
 					resource.TestCheckResourceAttr("alicloud_cs_managed_kubernetes.k8s", "worker_disk_size", "40"),
 					resource.TestCheckResourceAttr("alicloud_cs_managed_kubernetes.k8s", "worker_disk_category", "cloud_efficiency"),
 					resource.TestCheckResourceAttr("alicloud_cs_managed_kubernetes.k8s", "worker_instance_charge_type", "PostPaid"),
 					resource.TestCheckResourceAttr("alicloud_cs_managed_kubernetes.k8s", "worker_instance_types.#", "1"),
-					resource.TestCheckResourceAttr("alicloud_cs_managed_kubernetes.k8s", "key_name", ""),
 
-					resource.TestCheckResourceAttrSet("alicloud_cs_managed_kubernetes.k8s", "image_id"),
 					resource.TestCheckResourceAttrSet("alicloud_cs_managed_kubernetes.k8s", "vpc_id"),
 					resource.TestCheckResourceAttrSet("alicloud_cs_managed_kubernetes.k8s", "security_group_id"),
 					resource.TestCheckResourceAttrSet("alicloud_cs_managed_kubernetes.k8s", "availability_zone"),
@@ -170,7 +191,7 @@ resource "alicloud_cs_managed_kubernetes" "k8s" {
   vswitch_ids = ["${alicloud_vswitch.foo.id}"]
   new_nat_gateway = true
   worker_instance_types = ["${data.alicloud_instance_types.default.instance_types.0.id}"]
-  worker_numbers = [2]
+  worker_number = 2
   password = "Test12345"
   pod_cidr = "172.20.0.0/16"
   service_cidr = "172.21.0.0/20"
@@ -195,12 +216,25 @@ data "alicloud_instance_types" "default" {
 	kubernetes_node_role = "Worker"
 }
 
+resource "alicloud_vpc" "foo" {
+  name = "${var.name}"
+  cidr_block = "10.1.0.0/21"
+}
+
+resource "alicloud_vswitch" "foo" {
+  name = "${var.name}"
+  vpc_id = "${alicloud_vpc.foo.id}"
+  cidr_block = "10.1.1.0/24"
+  availability_zone = "${data.alicloud_zones.main.zones.0.id}"
+}
+
 resource "alicloud_cs_managed_kubernetes" "k8s" {
   name_prefix = "${var.name}"
   availability_zone = "${data.alicloud_zones.main.zones.0.id}"
+  vswitch_ids = ["${alicloud_vswitch.foo.id}"]
   new_nat_gateway = true
   worker_instance_types = ["${data.alicloud_instance_types.default.instance_types.0.id}"]
-  worker_numbers = [2]
+  worker_number = 2
   password = "Test12345"
   pod_cidr = "172.20.0.0/16"
   service_cidr = "172.21.0.0/20"
@@ -224,16 +258,134 @@ data "alicloud_instance_types" "default" {
 	kubernetes_node_role = "Worker"
 }
 
+resource "alicloud_vpc" "foo" {
+  name = "${var.name}"
+  cidr_block = "10.1.0.0/21"
+}
+
+resource "alicloud_vswitch" "foo" {
+  name = "${var.name}"
+  vpc_id = "${alicloud_vpc.foo.id}"
+  cidr_block = "10.1.1.0/24"
+  availability_zone = "${data.alicloud_zones.main.zones.0.id}"
+}
+
 resource "alicloud_cs_managed_kubernetes" "k8s" {
   name_prefix = "${var.name}"
   availability_zone = "${data.alicloud_zones.main.zones.0.id}"
+  vswitch_ids = ["${alicloud_vswitch.foo.id}"]
   new_nat_gateway = true
   worker_instance_types = ["${data.alicloud_instance_types.default.instance_types.0.id}"]
-  worker_numbers = [4]
+  worker_number = 4
   password = "Test12345"
   pod_cidr = "172.20.0.0/16"
   service_cidr = "172.21.0.0/20"
   install_cloud_monitor = true
+  worker_disk_category  = "cloud_efficiency"
+}
+`
+
+const testAccManagedKubernetes_multiaz = `
+variable "name" {
+	default = "tf-testAccManagedKubernetes-multiaz"
+}
+
+data "alicloud_zones" main {
+  available_resource_creation = "VSwitch"
+}
+
+data "alicloud_instance_types" "instance_types_1_worker" {
+	availability_zone = "${data.alicloud_zones.main.zones.0.id}"
+	cpu_core_count = 2
+	memory_size = 4
+	kubernetes_node_role = "Worker"
+}
+
+data "alicloud_instance_types" "instance_types_2_worker" {
+	availability_zone = "${lookup(data.alicloud_zones.main.zones[(length(data.alicloud_zones.main.zones)-1)%length(data.alicloud_zones.main.zones)], "id")}"
+	cpu_core_count = 2
+	memory_size = 4
+	kubernetes_node_role = "Worker"
+}
+
+data "alicloud_instance_types" "instance_types_3_worker" {
+	availability_zone = "${lookup(data.alicloud_zones.main.zones[(length(data.alicloud_zones.main.zones)-2)%length(data.alicloud_zones.main.zones)], "id")}"
+	cpu_core_count = 2
+	memory_size = 4
+	kubernetes_node_role = "Worker"
+}
+
+resource "alicloud_vpc" "foo" {
+  name = "${var.name}"
+  cidr_block = "10.1.0.0/21"
+}
+
+resource "alicloud_vswitch" "vsw1" {
+  name = "${var.name}"
+  vpc_id = "${alicloud_vpc.foo.id}"
+  cidr_block = "10.1.1.0/24"
+  availability_zone = "${data.alicloud_zones.main.zones.0.id}"
+}
+
+resource "alicloud_vswitch" "vsw2" {
+  name = "${var.name}"
+  vpc_id = "${alicloud_vpc.foo.id}"
+  cidr_block = "10.1.2.0/24"
+  availability_zone = "${lookup(data.alicloud_zones.main.zones[(length(data.alicloud_zones.main.zones)-1)%length(data.alicloud_zones.main.zones)], "id")}"
+}
+
+resource "alicloud_vswitch" "vsw3" {
+  name = "${var.name}"
+  vpc_id = "${alicloud_vpc.foo.id}"
+  cidr_block = "10.1.3.0/24"
+  availability_zone = "${lookup(data.alicloud_zones.main.zones[(length(data.alicloud_zones.main.zones)-2)%length(data.alicloud_zones.main.zones)], "id")}"
+}
+
+resource "alicloud_nat_gateway" "nat_gateway" {
+  name = "${var.name}"
+  vpc_id = "${alicloud_vpc.foo.id}"
+  specification = "Small"
+}
+
+resource "alicloud_snat_entry" "snat_entry_1" {
+  snat_table_id     = "${alicloud_nat_gateway.nat_gateway.snat_table_ids}"
+  source_vswitch_id = "${alicloud_vswitch.vsw1.id}"
+  snat_ip           = "${alicloud_eip.eip.ip_address}"
+}
+
+resource "alicloud_snat_entry" "snat_entry_2" {
+  snat_table_id     = "${alicloud_nat_gateway.nat_gateway.snat_table_ids}"
+  source_vswitch_id = "${alicloud_vswitch.vsw2.id}"
+  snat_ip           = "${alicloud_eip.eip.ip_address}"
+}
+
+resource "alicloud_snat_entry" "snat_entry_3" {
+  snat_table_id     = "${alicloud_nat_gateway.nat_gateway.snat_table_ids}"
+  source_vswitch_id = "${alicloud_vswitch.vsw3.id}"
+  snat_ip           = "${alicloud_eip.eip.ip_address}"
+}
+
+resource "alicloud_eip" "eip" {
+  name = "${var.name}"
+  bandwidth = "100"
+}
+
+resource "alicloud_eip_association" "eip_asso" {
+  allocation_id = "${alicloud_eip.eip.id}"
+  instance_id   = "${alicloud_nat_gateway.nat_gateway.id}"
+}
+
+resource "alicloud_cs_managed_kubernetes" "k8s" {
+  name_prefix = "${var.name}"
+  vswitch_ids = ["${alicloud_vswitch.vsw1.id}", "${alicloud_vswitch.vsw2.id}", "${alicloud_vswitch.vsw3.id}"]
+  new_nat_gateway = true
+  worker_instance_types = ["${data.alicloud_instance_types.instance_types_1_worker.instance_types.0.id}", "${data.alicloud_instance_types.instance_types_2_worker.instance_types.0.id}", "${data.alicloud_instance_types.instance_types_3_worker.instance_types.0.id}"]
+  worker_number = 2
+  password = "Test12345"
+  pod_cidr = "172.20.0.0/16"
+  service_cidr = "172.21.0.0/20"
+  install_cloud_monitor = true
+  slb_internet_enabled = true
   worker_disk_category  = "cloud_efficiency"
 }
 `

--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,7 @@ require (
 	github.com/aws/aws-sdk-go v1.19.39 // indirect
 	github.com/cenkalti/backoff v2.1.1+incompatible // indirect
 	github.com/cloudflare/golz4 v0.0.0-20150217214814-ef862a3cdc58 // indirect
-	github.com/denverdino/aliyungo v0.0.0-20190308225517-f1fa5f5452ee
+	github.com/denverdino/aliyungo v0.0.0-20190730233141-daf435c01246
 	github.com/dxh031/ali_mns v0.0.0-20180927082505-3ae5346f8cf9
 	github.com/facebookgo/stack v0.0.0-20160209184415-751773369052 // indirect
 	github.com/go-test/deep v1.0.2-0.20181118220953-042da051cf31 // indirect

--- a/go.sum
+++ b/go.sum
@@ -96,6 +96,8 @@ github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/denverdino/aliyungo v0.0.0-20190308225517-f1fa5f5452ee h1:EEAfuL4IL6oi3sSAD20wdWDFu5dMJS6jVJsoJvuC+LU=
 github.com/denverdino/aliyungo v0.0.0-20190308225517-f1fa5f5452ee/go.mod h1:dV8lFg6daOBZbT6/BDGIz6Y3WFGn8juu6G+CQ6LHtl0=
+github.com/denverdino/aliyungo v0.0.0-20190730233141-daf435c01246 h1:0DPUNYEpDTZjVQXrucnJbnme1N6CbpJB7Qj+jYTXjAk=
+github.com/denverdino/aliyungo v0.0.0-20190730233141-daf435c01246/go.mod h1:dV8lFg6daOBZbT6/BDGIz6Y3WFGn8juu6G+CQ6LHtl0=
 github.com/dgrijalva/jwt-go v3.2.0+incompatible h1:7qlOGliEKZXTDg6OTjfoBKDXWrumCAMpl/TFQ4/5kLM=
 github.com/dgrijalva/jwt-go v3.2.0+incompatible/go.mod h1:E3ru+11k8xSBh+hMPgOLZmtrrCbhqsmaPHjLKYnJCaQ=
 github.com/dimchansky/utfbom v1.0.0/go.mod h1:rO41eb7gLfo8SF1jd9F8HplJm1Fewwi4mQvIirEdv+8=

--- a/vendor/github.com/denverdino/aliyungo/cs/clusters.go
+++ b/vendor/github.com/denverdino/aliyungo/cs/clusters.go
@@ -136,15 +136,17 @@ type KubernetesStackArgs struct {
 }
 
 type KubernetesCreationArgs struct {
-	DisableRollback bool   `json:"disable_rollback"`
-	Name            string `json:"name"`
-	TimeoutMins     int64  `json:"timeout_mins"`
-	ZoneId          string `json:"zoneid,omitempty"`
-	VPCID           string `json:"vpcid,omitempty"`
-	VSwitchId       string `json:"vswitchid,omitempty"`
-	ImageId         string `json:"image_id"`
-	ContainerCIDR   string `json:"container_cidr,omitempty"`
-	ServiceCIDR     string `json:"service_cidr,omitempty"`
+	DisableRollback bool     `json:"disable_rollback"`
+	Name            string   `json:"name"`
+	TimeoutMins     int64    `json:"timeout_mins"`
+	ZoneId          string   `json:"zoneid,omitempty"`
+	VPCID           string   `json:"vpcid,omitempty"`
+	RegionId        string   `json:"region_id,omitempty"`
+	VSwitchId       string   `json:"vswitchid,omitempty"`
+	VSwitchIds      []string `json:"vswitch_ids,omitempty"`
+	ImageId         string   `json:"image_id"`
+	ContainerCIDR   string   `json:"container_cidr,omitempty"`
+	ServiceCIDR     string   `json:"service_cidr,omitempty"`
 
 	MasterInstanceType       string           `json:"master_instance_type,omitempty"`
 	MasterSystemDiskSize     int64            `json:"master_system_disk_size,omitempty"`
@@ -157,6 +159,7 @@ type KubernetesCreationArgs struct {
 	MasterAutoRenewPeriod    int    `json:"master_auto_renew_period"`
 
 	WorkerInstanceType       string           `json:"worker_instance_type,omitempty"`
+	WorkerInstanceTypes      []string         `json:"worker_instance_types,omitempty"`
 	WorkerSystemDiskSize     int64            `json:"worker_system_disk_size,omitempty"`
 	WorkerSystemDiskCategory ecs.DiskCategory `json:"worker_system_disk_category,omitempty"`
 	WorkerDataDisk           bool             `json:"worker_data_disk"`
@@ -264,6 +267,7 @@ type KubernetesClusterMetaData struct {
 	SubClass          string `json:"SubClass"`
 }
 
+// deprecated
 type KubernetesClusterParameter struct {
 	ServiceCidr       string `json:"ServiceCIDR"`
 	ContainerCidr     string `json:"ContainerCIDR"`
@@ -371,20 +375,7 @@ func (client *Client) DescribeKubernetesCluster(id string) (cluster KubernetesCl
 	cluster.MetaData = metaData
 	cluster.RawMetaData = ""
 
-	cluster.Parameters.WorkerDataDisk = parseBoolOrNil(cluster.Parameters.RawWorkerDataDisk)
-	cluster.Parameters.PublicSLB = parseBoolOrNil(cluster.Parameters.RawPublicSLB)
-	cluster.Parameters.MasterAutoRenew = parseBoolOrNil(cluster.Parameters.RawMasterAutoRenew)
-	cluster.Parameters.WorkerAutoRenew = parseBoolOrNil(cluster.Parameters.RawWorkerAutoRenew)
-
 	return
-}
-
-func parseBoolOrNil(rawField string) *bool {
-	boolVal, err := strconv.ParseBool(rawField)
-	if err == nil {
-		return &boolVal
-	}
-	return nil
 }
 
 type ClusterResizeArgs struct {
@@ -406,7 +397,7 @@ func (client *Client) ResizeCluster(clusterID string, args *ClusterResizeArgs) e
 }
 
 // deprecated
-// use ResizeKubernetesCluster instead
+// use ScaleKubernetesCluster instead
 func (client *Client) ResizeKubernetes(clusterID string, args *KubernetesCreationArgs) error {
 	return client.Invoke("", http.MethodPut, "/clusters/"+clusterID, nil, args, nil)
 }
@@ -417,8 +408,9 @@ type KubernetesClusterResizeArgs struct {
 	LoginPassword   string `json:"login_password,omitempty"`
 
 	// Single AZ
-	WorkerInstanceType string `json:"worker_instance_type"`
-	NumOfNodes         int64  `json:"num_of_nodes"`
+	WorkerInstanceType  string   `json:"worker_instance_type"`
+	WorkerInstanceTypes []string `json:"worker_instance_types"`
+	NumOfNodes          int64    `json:"num_of_nodes"`
 
 	// Multi AZ
 	WorkerInstanceTypeA string `json:"worker_instance_type_a"`
@@ -429,8 +421,24 @@ type KubernetesClusterResizeArgs struct {
 	NumOfNodesC         int64  `json:"num_of_nodes_c"`
 }
 
+// deprecated
+// use ScaleKubernetesCluster instead
 func (client *Client) ResizeKubernetesCluster(clusterID string, args *KubernetesClusterResizeArgs) error {
 	return client.Invoke("", http.MethodPut, "/clusters/"+clusterID, nil, args, nil)
+}
+
+type KubernetesClusterScaleArgs struct {
+	LoginPassword            string           `json:"login_password,omitempty"`
+	KeyPair                  string           `json:"key_pair,omitempty"`
+	WorkerInstanceTypes      []string         `json:"worker_instance_types"`
+	WorkerSystemDiskSize     int64            `json:"worker_system_disk_size"`
+	WorkerSystemDiskCategory ecs.DiskCategory `json:"worker_system_disk_category"`
+	WorkerDataDisk           bool             `json:"worker_data_disk"`
+	Count                    int              `json:"count"`
+}
+
+func (client *Client) ScaleKubernetesCluster(clusterID string, args *KubernetesClusterScaleArgs) error {
+	return client.Invoke("", http.MethodPost, "/api/v2/clusters/"+clusterID, nil, args, nil)
 }
 
 func (client *Client) ModifyClusterName(clusterID, clusterName string) error {

--- a/vendor/github.com/denverdino/aliyungo/ecs/disks.go
+++ b/vendor/github.com/denverdino/aliyungo/ecs/disks.go
@@ -141,6 +141,7 @@ type CreateDiskArgs struct {
 	Size         int
 	SnapshotId   string
 	ClientToken  string
+	KMSKeyID     string
 }
 
 type CreateDisksResponse struct {

--- a/vendor/github.com/denverdino/aliyungo/ecs/router_interface.go
+++ b/vendor/github.com/denverdino/aliyungo/ecs/router_interface.go
@@ -238,7 +238,7 @@ func (client *Client) WaitForRouterInterfaceAsyn(regionId common.Region, interfa
 	for {
 		interfaces, err := client.DescribeRouterInterfaces(&DescribeRouterInterfacesArgs{
 			RegionId: regionId,
-			Filter:   []Filter{Filter{Key: "RouterInterfaceId", Value: []string{interfaceId}}},
+			Filter:   []Filter{{Key: "RouterInterfaceId", Value: []string{interfaceId}}},
 		})
 		if err != nil {
 			return err

--- a/vendor/github.com/denverdino/aliyungo/ecs/vpcs.go
+++ b/vendor/github.com/denverdino/aliyungo/ecs/vpcs.go
@@ -76,12 +76,12 @@ type VpcSetType struct {
 	VSwitchIds struct {
 		VSwitchId []string
 	}
-	CidrBlock    string
-	VRouterId    string
-	Description  string
-	IsDefault    bool
-	CreationTime util.ISO6801Time
-	RouterTableIds struct{
+	CidrBlock      string
+	VRouterId      string
+	Description    string
+	IsDefault      bool
+	CreationTime   util.ISO6801Time
+	RouterTableIds struct {
 		RouterTableIds []string
 	}
 }

--- a/vendor/github.com/denverdino/aliyungo/util/encoding.go
+++ b/vendor/github.com/denverdino/aliyungo/util/encoding.go
@@ -47,7 +47,7 @@ func setQueryValues(i interface{}, values *url.Values, prefix string) {
 	// add to support url.Values
 	mapValues, ok := i.(url.Values)
 	if ok {
-		for k, _ := range mapValues {
+		for k := range mapValues {
 			values.Set(k, mapValues.Get(k))
 		}
 		return
@@ -191,7 +191,7 @@ func setQueryValuesByFlattenMethod(i interface{}, values *url.Values, prefix str
 	// add to support url.Values
 	mapValues, ok := i.(url.Values)
 	if ok {
-		for k, _ := range mapValues {
+		for k := range mapValues {
 			values.Set(k, mapValues.Get(k))
 		}
 		return

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -32,6 +32,7 @@ github.com/aliyun/alibaba-cloud-sdk-go/services/ess
 github.com/aliyun/alibaba-cloud-sdk-go/services/gpdb
 github.com/aliyun/alibaba-cloud-sdk-go/services/kms
 github.com/aliyun/alibaba-cloud-sdk-go/services/nas
+github.com/aliyun/alibaba-cloud-sdk-go/services/ons
 github.com/aliyun/alibaba-cloud-sdk-go/services/ots
 github.com/aliyun/alibaba-cloud-sdk-go/services/pvtz
 github.com/aliyun/alibaba-cloud-sdk-go/services/r-kvstore
@@ -112,7 +113,7 @@ github.com/blang/semver
 github.com/cenkalti/backoff
 # github.com/davecgh/go-spew v1.1.1
 github.com/davecgh/go-spew/spew
-# github.com/denverdino/aliyungo v0.0.0-20190308225517-f1fa5f5452ee
+# github.com/denverdino/aliyungo v0.0.0-20190730233141-daf435c01246
 github.com/denverdino/aliyungo/cdn
 github.com/denverdino/aliyungo/common
 github.com/denverdino/aliyungo/cs

--- a/website/docs/d/cs_managed_kubernetes_clusters.html.markdown
+++ b/website/docs/d/cs_managed_kubernetes_clusters.html.markdown
@@ -49,21 +49,10 @@ The following attributes are exported in addition to the arguments listed above:
   * `worker_numbers` - The ECS instance node number in the current container cluster.
   * `vswitch_ids` - The ID of VSwitches where the current cluster is located.
   * `vpc_id` - The ID of VPC where the current cluster is located.
-  * `slb_internet_enabled` - Whether internet load balancer for API Server is created
   * `security_group_id` - The ID of security group where the current cluster worker node is located.
-  * `image_id` - The ID of node image.
   * `nat_gateway_id` - The ID of nat gateway used to launch kubernetes cluster.
-  * `worker_instance_types` - The instance type of worker node.
-  * `worker_disk_category` - The system disk category of worker node.
-  * `worker_disk_size` - The system disk size of worker node.
-  * `worker_data_disk_category` - The data disk size of worker node.
-  * `worker_data_disk_size` - The data disk category of worker node.
   * `worker_nodes` - List of cluster worker nodes. It contains several attributes to `Block Nodes`.
   * `connections` - Map of kubernetes cluster connection information. It contains several attributes to `Block Connections`.
-  * `node_cidr_mask` - The network mask used on pods for each node.
-  * `log_config` - A list of one element containing information about the associated log store. It contains the following attributes:
-    * `type` - Type of collecting logs.
-    * `project` - Log Service project name.
 
 ### Block Nodes
 

--- a/website/docs/r/cs_managed_kubernetes.html.markdown
+++ b/website/docs/r/cs_managed_kubernetes.html.markdown
@@ -10,13 +10,15 @@ description: |-
 
 This resource will help you to manager a Managed Kubernetes Cluster. The cluster is same as container service created by web console.
 
--> **NOTE:** Managed Kubernetes cluster only supports single availability zone currently. Arguments `vswitch_ids`, `worker_numbers`, `worker_instance_types` only accept one item.
+-> **NOTE:** From version 1.53.0, we provide `force_update`. When you want to change `worker_instance_types` and `vswitch_ids`, you have to set this field to true, then the cluster will be recreated.
+
+-> **NOTE:** From version 1.53.0, `worker_numbers` is deprecated, you should use `worker_number` to indicate a total number of workers.
+
+-> **NOTE:** Managed Kubernetes cluster can support multiple availability zones. Arguments `vswitch_ids`, `worker_instance_types` are string arrays.
 
 -> **NOTE:** Managed Kubernetes cluster only supports VPC network and it can access internet while creating kubernetes cluster.
 A Nat Gateway and configuring a SNAT for it can ensure one VPC network access internet. If there is no nat gateway in the
 VPC, you can set `new_nat_gateway` to "true" to create one automatically.
-
--> **NOTE:** If there is no specified `vswitch_ids`, the resource will create a new VPC and VSwitch while creating managed kubernetes cluster.
 
 -> **NOTE:** Creating managed kubernetes cluster need to install several packages and it will cost about 10 minutes. Please be patient.
 
@@ -83,7 +85,9 @@ It cannot be duplicated with the VPC CIDR and CIDR used by Kubernetes cluster in
 * `worker_disk_category` - (Optional, ForceNew) The system disk category of worker node. Its valid value are `cloud_ssd` and `cloud_efficiency`. Default to `cloud_efficiency`.
 * `worker_data_disk_size` - (Optional, ForceNew) The data disk size of worker node. Its valid value range [20~32768] in GB. When `worker_data_disk_category` is presented, it defaults to 40.
 * `worker_data_disk_category` - (Optional, ForceNew) The data disk category of worker node. Its valid value are `cloud_ssd` and `cloud_efficiency`, if not set, data disk will not be created.
-* `worker_numbers` - (Required) The worker node number of the kubernetes cluster. Default to [3]. It is limited up to 50 and if you want to enlarge it, please apply white list or contact with us.
+* `worker_number` - (Required) The total worker node number of the kubernetes cluster. Default to 3. It is limited up to 50 and if you want to enlarge it, please apply white list or contact with us.
+* `force_update` - (Optional) Default false, when you want to change `worker_instance_types` and `vswitch_ids`, you have to set this field to true, then the cluster will be recreated.
+* `worker_numbers` - (Deprecated from version 1.53.0) The worker node number of the kubernetes cluster. Default to [3]. It is limited up to 50 and if you want to enlarge it, please apply white list or contact with us.
 * `worker_instance_types` - (Required, ForceNew) The instance type of worker node. Specify one type for single AZ Cluster, three types for MultiAZ Cluster.
 You can get the available kubetnetes master node instance types by [datasource instance_types](https://www.terraform.io/docs/providers/alicloud/d/instance_types.html#kubernetes_node_role)
 * `worker_instance_charge_type` - (Optional, ForceNew) Worker payment type. `PrePaid` or `PostPaid`, defaults to `PostPaid`.


### PR DESCRIPTION
Container Service's API has changed, DescribeCluster API will no longer return cluster details in `Parameter` field.

This pr:
1. removes code which uses this Parameter field, a lot of output fields were deleted
2. add multiple az support for managed kubernetes
3. add `force_update` field to let user make sure when he/she is changing `worker_instance_types` or `vswitch_ids`