### PR TITLE
Rename resource name that is not start with a letter

### DIFF
--- a/alicloud/data_source_alicloud_instance_types.go
+++ b/alicloud/data_source_alicloud_instance_types.go
@@ -236,7 +236,7 @@ func dataSourceAlicloudInstanceTypesRead(d *schema.ResourceData, meta interface{
 			if eniAmount > types.EniQuantity {
 				continue
 			}
-			// Kubernetes node does not support instance types which family is "ecs.t5" and spec less that 2c4g
+			// Kubernetes node does not support instance types which family is "ecs.t5" and spec less that c2g4
 			// Kubernetes master node does not support gpu instance types which family prefixes with "ecs.gn"
 			if k8sNode != "" {
 				if types.InstanceTypeFamily == "ecs.t5" {

--- a/examples/build-lnmp/main.tf
+++ b/examples/build-lnmp/main.tf
@@ -2,7 +2,7 @@ provider "alicloud" {
   region = "${var.region}"
 }
 
-data "alicloud_instance_types" "2c4g" {
+data "alicloud_instance_types" "c2g4" {
   cpu_core_count       = 2
   memory_size          = 4
   instance_type_family = "ecs.n4"
@@ -14,7 +14,7 @@ data "alicloud_images" "centos" {
 }
 
 data "alicloud_zones" "default" {
-  available_instance_type = "${data.alicloud_instance_types.2c4g.instance_types.0.id}"
+  available_instance_type = "${data.alicloud_instance_types.c2g4.instance_types.0.id}"
   available_disk_category  = "${var.disk_category}"
 }
 
@@ -61,7 +61,7 @@ resource "alicloud_instance" "webserver" {
 
   # series II
   instance_charge_type       = "PostPaid"
-  instance_type              = "${data.alicloud_instance_types.2c4g.instance_types.0.id}"
+  instance_type              = "${data.alicloud_instance_types.c2g4.instance_types.0.id}"
   internet_max_bandwidth_out = 0
 
   system_disk_category = "${var.disk_category}"

--- a/website/docs/index.html.markdown
+++ b/website/docs/index.html.markdown
@@ -30,7 +30,7 @@ provider "alicloud" {
   region     = "${var.region}"
 }
 
-data "alicloud_instance_types" "2c4g" {
+data "alicloud_instance_types" "c2g4" {
   cpu_core_count = 2
   memory_size = 4
 }
@@ -46,7 +46,7 @@ resource "alicloud_instance" "web" {
   image_id          = "${data.alicloud_images.default.images.0.id}"
   internet_charge_type  = "PayByBandwidth"
 
-  instance_type        = "${data.alicloud_instance_types.2c4g.instance_types.0.id}"
+  instance_type        = "${data.alicloud_instance_types.c2g4.instance_types.0.id}"
   system_disk_category = "cloud_efficiency"
   security_groups      = ["${alicloud_security_group.default.id}"]
   instance_name        = "web"


### PR DESCRIPTION
To avoid the error:
---
    terraform 0.12checklist
    - [ ] `data "alicloud_instance_types" "2c4g"` has a name that is not a valid identifier.

      In Terraform 0.12, resource names must start with a letter. To fix this, rename the resource in the configuration and then use `terraform state mv` to mirror that name change in the state.

---

I did the following:

```
git grep 2c4g | awk -F':' '{print $1}' | xargs sed -i '' 's/2c4g/c2g4/g'
```