### PR TITLE
fix(ons): fix the create group error in testcase

### DIFF
--- a/alicloud/data_source_alicloud_ons_groups_test.go
+++ b/alicloud/data_source_alicloud_ons_groups_test.go
@@ -10,7 +10,7 @@ import (
 func TestAccAlicloudOnsGroupsDataSource(t *testing.T) {
 	rand := acctest.RandInt()
 	resourceId := "data.alicloud_ons_groups.default"
-	name := fmt.Sprintf("GID-tf-testacc%sonsgroup%v", defaultRegionToTest, rand)
+	name := fmt.Sprintf("GID-tf-testacconsgroup%v", rand)
 
 	testAccConfig := dataSourceTestAccConfigFunc(resourceId, name, dataSourceOnsGroupsConfigDependence)
 
@@ -29,7 +29,7 @@ func TestAccAlicloudOnsGroupsDataSource(t *testing.T) {
 		return map[string]string{
 			"ids.#":                       "1",
 			"groups.#":                    "1",
-			"groups.0.id":                 fmt.Sprintf("GID-tf-testacc%sonsgroup%v", defaultRegionToTest, rand),
+			"groups.0.id":                 fmt.Sprintf("GID-tf-testacconsgroup%v", rand),
 			"groups.0.independent_naming": "true",
 			"groups.0.remark":             "alicloud_ons_group_remark",
 		}

--- a/alicloud/resource_alicloud_ons_group_test.go
+++ b/alicloud/resource_alicloud_ons_group_test.go
@@ -112,7 +112,7 @@ func TestAccAlicloudOnsGroup_basic(t *testing.T) {
 
 	rand := acctest.RandInt()
 	testAccCheck := rac.resourceAttrMapUpdateSet()
-	name := fmt.Sprintf("GID-tf-testacc%sonsgroupbasic%v", defaultRegionToTest, rand)
+	name := fmt.Sprintf("GID-tf-testacconsgroupbasic%v", rand)
 	testAccConfig := resourceTestAccConfigFunc(resourceId, name, resourceOnsGroupConfigDependence)
 
 	resource.Test(t, resource.TestCase{
@@ -132,7 +132,7 @@ func TestAccAlicloudOnsGroup_basic(t *testing.T) {
 				}),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheck(map[string]string{
-						"group_id": fmt.Sprintf("GID-tf-testacc%sonsgroupbasic%v", defaultRegionToTest, rand),
+						"group_id": fmt.Sprintf("GID-tf-testacconsgroupbasic%v", rand),
 						"remark":   "alicloud_ons_group_remark",
 					}),
 				),
@@ -150,7 +150,7 @@ func TestAccAlicloudOnsGroup_basic(t *testing.T) {
 				}),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheck(map[string]string{
-						"group_id": fmt.Sprintf("GID-tf-testacc%sonsgroupbasic%v_change", defaultRegionToTest, rand)}),
+						"group_id": fmt.Sprintf("GID-tf-testacconsgroupbasic%v_change", rand)}),
 				),
 			},
 
@@ -161,7 +161,7 @@ func TestAccAlicloudOnsGroup_basic(t *testing.T) {
 				}),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheck(map[string]string{
-						"group_id": fmt.Sprintf("GID-tf-testacc%sonsgroupbasic%v", defaultRegionToTest, rand),
+						"group_id": fmt.Sprintf("GID-tf-testacconsgroupbasic%v", rand),
 						"remark":   "alicloud_ons_group_remark",
 					}),
 				),


### PR DESCRIPTION
fix the create group error in testcase
the reason of creating group failure is that the length of groupid is too long.