### PR TITLE
add support to vpn-route-entry

### DIFF
--- a/alicloud/provider.go
+++ b/alicloud/provider.go
@@ -318,6 +318,7 @@ func Provider() terraform.ResourceProvider {
 			"alicloud_fc_trigger":                          resourceAlicloudFCTrigger(),
 			"alicloud_vpn_gateway":                         resourceAliyunVpnGateway(),
 			"alicloud_vpn_customer_gateway":                resourceAliyunVpnCustomerGateway(),
+			"alicloud_vpn_route_entry":                     resourceAliyunVpnRouteEntry(),
 			"alicloud_vpn_connection":                      resourceAliyunVpnConnection(),
 			"alicloud_ssl_vpn_server":                      resourceAliyunSslVpnServer(),
 			"alicloud_ssl_vpn_client_cert":                 resourceAliyunSslVpnClientCert(),

--- a/alicloud/resource_alicloud_vpn_route_entry.go
+++ b/alicloud/resource_alicloud_vpn_route_entry.go
@@ -1,0 +1,249 @@
+package alicloud
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/aliyun/alibaba-cloud-sdk-go/sdk/requests"
+	"github.com/aliyun/alibaba-cloud-sdk-go/services/vpc"
+	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/helper/schema"
+	"github.com/terraform-providers/terraform-provider-alicloud/alicloud/connectivity"
+)
+
+func resourceAliyunVpnRouteEntry() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceAliyunVpnRouteEntryCreate,
+		Read:   resourceAliyunVpnRouteEntryRead,
+		Update: resourceAliyunVpnRouteEntryUpdate,
+		Delete: resourceAliyunVpnRouteEntryDelete,
+
+		Schema: map[string]*schema.Schema{
+			"vpn_gateway_id": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+
+			"next_hop": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+
+			"route_dest": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+
+			"weight": {
+				Type:         schema.TypeInt,
+				Required:     true,
+				ValidateFunc: validateVpnBandwidth([]int{0, 100}),
+			},
+
+			"publish_vpc": {
+				Type:     schema.TypeBool,
+				Required: true,
+			},
+
+			"client_token": {
+				Type:     schema.TypeString,
+				Optional: true,
+				ValidateFunc: func(v interface{}, k string) (ws []string, errors []error) {
+					value := v.(string)
+					if len(value) < 1 || len(value) > 64 {
+						errors = append(errors, fmt.Errorf("%q cannot be longer than 64 characters or shorter than 1", k))
+					}
+					return
+				},
+			},
+
+			"description": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+
+			// Computed values
+			"create_time": {
+				Type:     schema.TypeFloat,
+				Computed: true,
+			},
+
+			"old_weight": {
+				Type:     schema.TypeInt,
+				Computed: true,
+			},
+
+			"state": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func resourceAliyunVpnRouteEntryCreate(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*connectivity.AliyunClient)
+	vpnRouteEntryService := VpnRouteEntryService{client}
+	request := vpc.CreateCreateVpnRouteEntryRequest()
+	request.RegionId = client.RegionId
+	request.VpnGatewayId = d.Get("vpn_gateway_id").(string)
+	request.RouteDest = d.Get("route_dest").(string)
+	request.NextHop = d.Get("next_hop").(string)
+	request.Weight = requests.NewInteger(d.Get("weight").(int))
+	request.PublishVpc = requests.NewBoolean(d.Get("publish_vpc").(bool))
+
+	if v, ok := d.GetOk("description"); ok && v.(string) != "" {
+		request.Description = d.Get("description").(string)
+	}
+
+	if v, ok := d.GetOk("client_token"); ok && v.(string) != "" {
+		request.ClientToken = d.Get("client_token").(string)
+	}
+
+	time.Sleep(7 * time.Second)
+	raw, err := client.WithVpcClient(func(vpcClient *vpc.Client) (interface{}, error) {
+		return vpcClient.CreateVpnRouteEntry(request)
+	})
+
+	if err != nil {
+		return WrapErrorf(err, DefaultErrorMsg, "alicloud_vpn_route_entry", request.GetActionName(), AlibabaCloudSdkGoERROR)
+	}
+	addDebug(request.GetActionName(), raw)
+	response, _ := raw.(*vpc.CreateVpnRouteEntryResponse)
+
+	id := response.VpnInstanceId + ":" + response.NextHop + response.RouteDest
+	d.SetId(id)
+	d.Set("old_weight", d.Get("weight").(int))
+
+	time.Sleep(10 * time.Second)
+	if err := vpnRouteEntryService.WaitForVpnRouteEntry(d.Id(), Active, 2*DefaultTimeout); err != nil {
+		return WrapError(err)
+	}
+
+	return resourceAliyunVpnRouteEntryUpdate(d, meta)
+}
+
+func resourceAliyunVpnRouteEntryRead(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*connectivity.AliyunClient)
+	vpnRouteEntryService := VpnRouteEntryService{client}
+
+	object, err := vpnRouteEntryService.DescribeVpnRouteEntry(d.Id())
+	if err != nil {
+		if NotFoundError(err) {
+			d.SetId("")
+			return nil
+		}
+		return WrapError(err)
+	}
+
+	d.Set("create_time", object.CreateTime)
+	d.Set("state", object.State)
+	return nil
+}
+
+func resourceAliyunVpnRouteEntryUpdate(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*connectivity.AliyunClient)
+	pubChange := d.HasChange("publish_vpc")
+	weightChange := d.HasChange("weight")
+	d.Partial(true)
+
+	if pubChange {
+		request := vpc.CreatePublishVpnRouteEntryRequest()
+		request.RegionId = client.RegionId
+		request.VpnGatewayId = d.Get("vpn_gateway_id").(string)
+		request.RouteDest = d.Get("route_dest").(string)
+		request.NextHop = d.Get("next_hop").(string)
+		request.RouteType = "dbr"
+		request.PublishVpc = requests.NewBoolean(d.Get("publish_vpc").(bool))
+
+		raw, err := client.WithVpcClient(func(vpcClient *vpc.Client) (interface{}, error) {
+			return vpcClient.PublishVpnRouteEntry(request)
+		})
+		if err != nil {
+			return WrapErrorf(err, DefaultErrorMsg, d.Id(), request.GetActionName(), AlibabaCloudSdkGoERROR)
+		}
+		addDebug(request.GetActionName(), raw)
+		d.SetPartial("publish_vpc")
+	}
+
+	if weightChange {
+		request := vpc.CreateModifyVpnRouteEntryWeightRequest()
+		request.RegionId = client.RegionId
+		request.VpnGatewayId = d.Get("vpn_gateway_id").(string)
+		request.RouteDest = d.Get("route_dest").(string)
+		request.NextHop = d.Get("next_hop").(string)
+		newWeight := d.Get("weight").(int)
+		request.Weight = requests.NewInteger(d.Get("old_weight").(int))
+		request.NewWeight = requests.NewInteger(newWeight)
+
+		raw, err := client.WithVpcClient(func(vpcClient *vpc.Client) (interface{}, error) {
+			return vpcClient.ModifyVpnRouteEntryWeight(request)
+		})
+		if err != nil {
+			return WrapErrorf(err, DefaultErrorMsg, d.Id(), request.GetActionName(), AlibabaCloudSdkGoERROR)
+		}
+		addDebug(request.GetActionName(), raw)
+
+		d.Set("weight", newWeight)
+		d.Set("old_weight", newWeight)
+	}
+
+	if d.IsNewResource() {
+		d.Partial(false)
+		return resourceAliyunVpnRouteEntryRead(d, meta)
+	}
+
+	if d.HasChange("route_dest") {
+		return fmt.Errorf("Now Cann't Support modify vpn RouteDest, try to modify on the web console")
+	}
+	if d.HasChange("next_hop") {
+		return fmt.Errorf("Now Cann't Support modify vpn NextHop, try to modify on the web console")
+	}
+
+	d.Partial(false)
+	return resourceAliyunVpnRouteEntryRead(d, meta)
+
+}
+
+func resourceAliyunVpnRouteEntryDelete(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*connectivity.AliyunClient)
+	vpnRouteEntryService := VpnRouteEntryService{client}
+
+	request := vpc.CreateDeleteVpnRouteEntryRequest()
+	request.VpnGatewayId = d.Get("vpn_gateway_id").(string)
+	request.RouteDest = d.Get("route_dest").(string)
+	request.NextHop = d.Get("next_hop").(string)
+	request.Weight = requests.NewInteger(d.Get("weight").(int))
+
+	request.ClientToken = buildClientToken(request.GetActionName())
+
+	err := resource.Retry(5*time.Minute, func() *resource.RetryError {
+		args := *request
+		raw, err := client.WithVpcClient(func(vpcClient *vpc.Client) (interface{}, error) {
+			return vpcClient.DeleteVpnRouteEntry(&args)
+		})
+		if err != nil {
+			if IsExceptedError(err, VpnConfiguring) {
+				time.Sleep(10 * time.Second)
+				return resource.RetryableError(err)
+			}
+			/*Vpn known issue: while the vpn is configuring, it will return unknown error*/
+			if IsExceptedError(err, UnknownError) {
+				return resource.RetryableError(err)
+			}
+			return resource.NonRetryableError(err)
+		}
+		addDebug(request.GetActionName(), raw)
+		return nil
+	})
+
+	if err != nil {
+		if IsExceptedError(err, VpnNotFound) {
+			return nil
+		}
+		return WrapErrorf(err, DefaultErrorMsg, d.Id(), request.GetActionName(), AlibabaCloudSdkGoERROR)
+	}
+
+	return WrapError(vpnRouteEntryService.WaitForVpnRouteEntry(d.Id(), Deleted, DefaultTimeoutMedium))
+}

--- a/alicloud/resource_alicloud_vpn_route_entry_test.go
+++ b/alicloud/resource_alicloud_vpn_route_entry_test.go
@@ -1,0 +1,191 @@
+package alicloud
+
+import (
+	"fmt"
+	"log"
+
+	"testing"
+	"time"
+
+	"github.com/aliyun/alibaba-cloud-sdk-go/sdk/requests"
+	"github.com/aliyun/alibaba-cloud-sdk-go/services/vpc"
+	"github.com/hashicorp/terraform/helper/acctest"
+	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/terraform"
+	"github.com/terraform-providers/terraform-provider-alicloud/alicloud/connectivity"
+)
+
+func init() {
+	resource.AddTestSweepers("alicloud_vpn_router_entry", &resource.Sweeper{
+		Name: "alicloud_vpn_router_entry",
+		F:    testSweepVPNRouterEntry,
+	})
+}
+
+func testSweepVPNRouterEntry(region string) error {
+	rawClient, err := sharedClientForRegion(region)
+	if err != nil {
+		return WrapError(err)
+	}
+	client := rawClient.(*connectivity.AliyunClient)
+
+	var gws []vpc.VpnRouteEntry
+	request := vpc.CreateDescribeVpnRouteEntriesRequest()
+	request.RegionId = client.RegionId
+	request.PageSize = requests.NewInteger(PageSizeLarge)
+	request.PageNumber = requests.NewInteger(1)
+
+	for {
+		raw, err := client.WithVpcClient(func(vpcClient *vpc.Client) (interface{}, error) {
+			return vpcClient.DescribeVpnRouteEntries(request)
+		})
+		if err != nil {
+			return WrapError(err)
+		}
+		addDebug(request.GetActionName(), raw)
+		response, _ := raw.(*vpc.DescribeVpnRouteEntriesResponse)
+		if len(response.VpnRouteEntries.VpnRouteEntry) < 1 {
+			break
+		}
+		gws = response.VpnRouteEntries.VpnRouteEntry
+
+		if len(response.VpnRouteEntries.VpnRouteEntry) < PageSizeLarge {
+			break
+		}
+
+		if page, err := getNextpageNumber(request.PageNumber); err != nil {
+			return WrapError(err)
+		} else {
+			request.PageNumber = page
+		}
+	}
+
+	sweeped := false
+	for _, v := range gws {
+		id := v.VpnInstanceId
+
+		sweeped = true
+		log.Printf("[INFO] Deleting VPN route entry: (%s)", id)
+		req := vpc.CreateDeleteVpnRouteEntryRequest()
+		req.VpnGatewayId = id
+		req.RouteDest = v.RouteDest
+		req.NextHop = v.NextHop
+		req.Weight = requests.NewInteger(v.Weight)
+
+		_, err := client.WithVpcClient(func(vpcClient *vpc.Client) (interface{}, error) {
+			return vpcClient.DeleteVpnRouteEntry(req)
+		})
+		if err != nil {
+			log.Printf("[ERROR] Failed to delete VPN route entry(%s): %s", id, err)
+		}
+	}
+	if sweeped {
+		time.Sleep(5 * time.Second)
+	}
+	return nil
+
+}
+
+func testAccCheckVpnRouteEntryDestroy(s *terraform.State) error {
+	client := testAccProvider.Meta().(*connectivity.AliyunClient)
+	vpnRouteEntryService := VpnRouteEntryService{client}
+
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "alicloud_vpn_route_entry" {
+			continue
+		}
+
+		fmt.Printf("rs: %v \t %[1]T\n\n\n", rs)
+		_, err := vpnRouteEntryService.DescribeVpnRouteEntry(rs.Primary.ID)
+
+		if err != nil {
+			if NotFoundError(err) {
+				continue
+			}
+			return WrapError(err)
+		}
+	}
+
+	return nil
+}
+
+func TestAccAlicloudVpnRouteEntryMulti(t *testing.T) {
+	var v VpnState
+
+	resourceId := "alicloud_vpn_route_entry.default"
+	ra := resourceAttrInit(resourceId, nil)
+	serviceFunc := func() interface{} {
+		return &VpnRouteEntryService{testAccProvider.Meta().(*connectivity.AliyunClient)}
+	}
+	rc := resourceCheckInit(resourceId, &v, serviceFunc)
+	rac := resourceAttrCheckInit(rc, ra)
+	testAccCheck := rac.resourceAttrMapUpdateSet()
+	rand := acctest.RandIntRange(100, 200)
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+		},
+
+		// module name
+		IDRefreshName: resourceId,
+		Providers:     testAccProviders,
+		CheckDestroy:  testAccCheckVpnRouteEntryDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccVpnRouteEntryConfigAll(rand),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"publish_vpc": fmt.Sprintf("%t", true),
+						"description": fmt.Sprintf("tf-testAccVpnRouteEntryConfig%d", rand),
+						"weight":      fmt.Sprintf("%d", 100),
+					}),
+				),
+			},
+		},
+	})
+}
+
+func testAccVpnRouteEntryConfigAll(rand int) string {
+	return fmt.Sprintf(`
+resource "alicloud_vpc" "default" {
+  name       = "tf-testAccVpnRouteEntryConfig"
+  cidr_block = "172.16.0.0/12"
+}
+
+resource "alicloud_vswitch" "default" {
+  vpc_id            = "${alicloud_vpc.default.id}"
+  cidr_block        = "172.16.1.0/24"
+  availability_zone = "cn-hangzhou-b"
+}
+
+resource "alicloud_vpn_gateway" "default" {
+  name       = "tf-testAccVpnRouteEntryConfig"
+  vpc_id =  "${alicloud_vpc.default.id}"
+  bandwidth = 10
+  instance_charge_type = "PostPaid"
+  enable_ssl = false
+}
+
+resource "alicloud_vpn_connection" "default" {
+  name = "tf-testAccVpnRouteEntryConfig"
+  customer_gateway_id = "${alicloud_vpn_customer_gateway.default.id}"
+  vpn_gateway_id = "${alicloud_vpn_gateway.default.id}"
+  local_subnet = ["192.168.2.0/24"]
+  remote_subnet = ["192.168.3.0/24"]
+}
+
+resource "alicloud_vpn_customer_gateway" "default" {
+  name = "tf-testAccVpnRouteEntryConfig"
+  ip_address = "192.168.1.1"
+}
+
+resource "alicloud_vpn_route_entry" "default" {
+  description       = "tf-testAccVpnRouteEntryConfig%d"
+  vpn_gateway_id = "${alicloud_vpn_gateway.default.id}"
+  route_dest = "12.0.0.2/32"
+  next_hop = "${alicloud_vpn_connection.default.id}"
+  weight =100
+  publish_vpc = true
+}
+`, rand)
+}

--- a/alicloud/service_alicloud_vpn_route_entry.go
+++ b/alicloud/service_alicloud_vpn_route_entry.go
@@ -1,0 +1,97 @@
+package alicloud
+
+import (
+	"crypto/md5"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/aliyun/alibaba-cloud-sdk-go/services/vpc"
+	"github.com/terraform-providers/terraform-provider-alicloud/alicloud/connectivity"
+)
+
+type VpnRouteEntryService struct {
+	client *connectivity.AliyunClient
+}
+
+type VpnState struct {
+	State        string
+	CreateTime   int64
+	Status       Status
+	VpnGatewayId string
+	RouteDest    string
+	NextHop      string
+	Weight       int
+	PublishVpc   string
+}
+
+func (s *VpnRouteEntryService) DescribeVpnRouteEntry(ids string) (v VpnState, err error) {
+	request := vpc.CreateDescribeVpnRouteEntriesRequest()
+
+	a := strings.Split(ids, ":")
+	gatewayId := a[0]
+	id := a[1]
+	request.VpnGatewayId = gatewayId
+
+	raw, err := s.client.WithVpcClient(func(vpcClient *vpc.Client) (interface{}, error) {
+		return vpcClient.DescribeVpnRouteEntries(request)
+	})
+	if err != nil {
+		if IsExceptedErrors(err, []string{VpnForbidden, VpnNotFound}) {
+			return v, WrapErrorf(Error(GetNotFoundMessage("VpnRouterEntry", id)), NotFoundMsg, ProviderERROR)
+		}
+		return v, WrapErrorf(err, DefaultErrorMsg, id, request.GetActionName(), AlibabaCloudSdkGoERROR)
+	}
+	addDebug(request.GetActionName(), raw)
+	response, _ := raw.(*vpc.DescribeVpnRouteEntriesResponse)
+
+	for _, resp := range response.VpnRouteEntries.VpnRouteEntry {
+		i := gatewayId + ":" + resp.NextHop + resp.RouteDest
+
+		if ids == i {
+			data := VpnState{
+				resp.State,
+				resp.CreateTime,
+				Active,
+				resp.VpnInstanceId,
+				resp.RouteDest,
+				resp.NextHop,
+				resp.Weight,
+				resp.State,
+			}
+			return data, nil
+		}
+	}
+	return v, WrapErrorf(Error(GetNotFoundMessage("VpnRouterEntry", gatewayId)), NotFoundMsg, ProviderERROR)
+}
+
+func (s *VpnRouteEntryService) WaitForVpnRouteEntry(ids string, status Status, timeout int) error {
+	deadline := time.Now().Add(time.Duration(timeout) * time.Second)
+	for {
+		object, err := s.DescribeVpnRouteEntry(ids)
+		if err != nil {
+			if NotFoundError(err) {
+				if status == Deleted {
+					return nil
+				}
+			} else {
+				return WrapError(err)
+			}
+		}
+
+		if strings.EqualFold(string(object.Status), string(status)) {
+			return nil
+		}
+		if time.Now().After(deadline) {
+			return WrapErrorf(err, WaitTimeoutMsg, ids, GetFunc(1), timeout, object.Status, string(status), ProviderERROR)
+		}
+		time.Sleep(DefaultIntervalShort * time.Second)
+	}
+}
+
+// func getMd5FromStr(str string) string {
+// 	Md5Inst := md5.New()
+// 	Md5Inst.Write([]byte(str))
+// 	Result := Md5Inst.Sum([]byte(""))
+// 	return fmt.Sprintf("%x", Result)
+// }

--- a/examples/vpn-route-entry/main.tf
+++ b/examples/vpn-route-entry/main.tf
@@ -1,0 +1,41 @@
+resource "alicloud_vpc" "default" {
+  name       = "tf_vpc_test"
+  cidr_block = "${var.vpc_cidr}"
+}
+
+resource "alicloud_vswitch" "default" {
+  vpc_id            = "${alicloud_vpc.default.id}"
+  cidr_block        = "${var.cidr_blocks}"
+  availability_zone = "${var.availability_zones}"
+}
+
+resource "alicloud_vpn_gateway" "default" {
+  name                 = "tf_vpn_gateway_test"
+  vpc_id               = "${alicloud_vpc.default.id}"
+  bandwidth            = "${var.bandwidth}"
+  instance_charge_type = "${var.instance_charge_type}"
+  enable_ssl           = false
+}
+
+
+resource "alicloud_vpn_connection" "default" {
+  name                = "tf_vpn_connection_test"
+  customer_gateway_id = "${alicloud_vpn_customer_gateway.default.id}"
+  vpn_gateway_id      = "${alicloud_vpn_gateway.default.id}"
+  local_subnet        = ["192.168.2.0/24"]
+  remote_subnet       = ["192.168.3.0/24"]
+}
+
+resource "alicloud_vpn_customer_gateway" "default" {
+  name       = "tf_customer_gateway_test"
+  ip_address = "192.168.1.1"
+}
+
+resource "alicloud_vpn_route_entry" "default" {
+  description    = "tf_vpn_route_entry_test"
+  vpn_gateway_id = "${alicloud_vpn_gateway.default.id}"
+  route_dest     = "${var.route_dest}"
+  next_hop       = "${alicloud_vpn_connection.default.id}"
+  weight         = "${var.weight}"
+  publish_vpc    = "${var.publish_vpc}"
+}

--- a/examples/vpn-route-entry/variables.tf
+++ b/examples/vpn-route-entry/variables.tf
@@ -1,0 +1,42 @@
+// default vpc variables
+variable "vpc_cidr" {
+  default = "10.1.0.0/21"
+}
+
+variable "availability_zones" {
+  default = "cn-beijing-c"
+}
+
+variable "cidr_blocks" {
+  default = "10.1.1.0/24"
+}
+
+// default vpn gateway variables
+variable "bandwidth" {
+  default = 10
+}
+
+variable "instance_type" {
+  default = "ecs.n4.small"
+}
+
+variable "internet_charge_type" {
+  default = "PayByTraffic"
+}
+
+variable "instance_charge_type" {
+  default = "PostPaid"
+}
+
+// default vpn varibles
+variable "weight" {
+  default = 100
+}
+
+variable "publish_vpc" {
+  default = false
+}
+
+variable "route_dest" {
+  default = "10.0.0.0/24"
+}

--- a/website/alicloud.erb
+++ b/website/alicloud.erb
@@ -917,6 +917,9 @@
                         <li<%= sidebar_current("docs-alicloud-resource-vpn-gateway") %>>
                             <a href="/docs/providers/alicloud/r/vpn_gateway.html">alicloud_vpn_gateway</a>
                         </li>
+                        <li<%= sidebar_current("docs-alicloud-resource-vpn-route-entry") %>>
+                            <a href="/docs/providers/alicloud/r/vpn_route_entry.html">alicloud_vpn_route_entry</a>
+                        </li>
                     </ul>
                 </li>
             </ul>

--- a/website/docs/r/vpn_route_entry.html.markdown
+++ b/website/docs/r/vpn_route_entry.html.markdown
@@ -1,0 +1,36 @@
+---
+layout: "alicloud"
+page_title: "Alicloud: alicloud_vpn_route_entry"
+sidebar_current: "docs-alicloud-resource-vpn-route-entry"
+description: |-
+  Provides a Alicloud VPN route resource.
+---
+
+# alicloud\_vpn_route_entry
+
+Provides a VPN route resource.
+
+-> **NOTE:** Terraform will build vpn route instance  while it uses `alicloud_vpn_route_entry` to build a vpn route resource.
+
+## Example Usage
+
+Basic Usage
+
+```
+resource "alicloud_vpn_route_entry" "foo" {
+  next_hop             = "vco-bp15oes1py4i66rmd****"
+  publish_vpc          = true
+  route_dest           = "10.0.0.0/24"
+  vpn_gateway_id       = "vpn-gateway-fakeid"
+  weight               = 10
+}
+```
+## Argument Reference
+
+The following arguments are supported:
+
+* `vpn_gateway_id` - (Required, ForceNew) The id of the vpn gateway.
+* `next_hop` - (Required, ForceNew) The next hop of the destination route.
+* `publish_vpc` - (Required) Whether to issue the destination route to the VPC.
+* `route_dest` - (Required, ForceNew) The destination network segment of the destination route.
+* `weight` - (Required) The value should be 0 or 100.


### PR DESCRIPTION
(zjc) vagrant@ubuntu-xenial:/vagrant/gopath/src/github.com/terraform-providers/terraform-provider-alicloud$ TF_ACC=1 go test ./alicloud -v -run=TestAccAlicloudVpnRouteEntryMulti -timeout=1200s
=== RUN   TestAccAlicloudVpnRouteEntryMulti
rs: Type = alicloud_vpn_route_entry 	 *terraform.ResourceState


--- PASS: TestAccAlicloudVpnRouteEntryMulti (212.77s)
PASS
ok  	github.com/terraform-providers/terraform-provider-alicloud/alicloud	212.784s
