### PR TITLE
Add missing routing rules for alicloud_dns_record

### DIFF
--- a/alicloud/data_source_alicloud_dns_records.go
+++ b/alicloud/data_source_alicloud_dns_records.go
@@ -38,10 +38,9 @@ func dataSourceAlicloudDnsRecords() *schema.Resource {
 				ValidateFunc: validateDomainRecordType,
 			},
 			"line": {
-				Type:         schema.TypeString,
-				Optional:     true,
-				ForceNew:     true,
-				ValidateFunc: validateDomainRecordLine,
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: true,
 			},
 			"status": {
 				Type:     schema.TypeString,

--- a/alicloud/resource_alicloud_dns_record.go
+++ b/alicloud/resource_alicloud_dns_record.go
@@ -52,10 +52,9 @@ func resourceAlicloudDnsRecord() *schema.Resource {
 				DiffSuppressFunc: dnsPriorityDiffSuppressFunc,
 			},
 			"routing": {
-				Type:         schema.TypeString,
-				Optional:     true,
-				ValidateFunc: validateDomainRecordLine,
-				Default:      "default",
+				Type:     schema.TypeString,
+				Optional: true,
+				Default:  "default",
 			},
 			"status": {
 				Type:     schema.TypeString,

--- a/website/docs/d/dns_records.html.markdown
+++ b/website/docs/d/dns_records.html.markdown
@@ -34,7 +34,7 @@ The following arguments are supported:
 * `host_record_regex` - (Optional) Host record regex. 
 * `value_regex` - (Optional) Host record value regex. 
 * `type` - (Optional) Record type. Valid items are `A`, `NS`, `MX`, `TXT`, `CNAME`, `SRV`, `AAAA`, `REDIRECT_URL`, `FORWORD_URL` .
-* `line` - (Optional) ISP line. Valid items are `default`, `telecom`, `unicom`, `mobile`, `oversea`, `edu`.
+* `line` - (Optional) ISP line. Valid items are `default`, `telecom`, `unicom`, `mobile`, `oversea`, `edu`, `drpeng`, `btvn`, .etc. For checking all resolution lines enumeration please visit [Alibaba Cloud DNS doc](https://www.alibabacloud.com/help/doc-detail/34339.htm) 
 * `status` - (Optional) Record status. Valid items are `ENABLE` and `DISABLE`.
 * `is_locked` - (Optional, type: bool) Whether the record is locked or not.
 * `ids` - (Optional, Available 1.52.2+) A list of record IDs.

--- a/website/docs/r/dns_record.html.markdown
+++ b/website/docs/r/dns_record.html.markdown
@@ -34,7 +34,7 @@ The following arguments are supported:
 * `value` - (Required) The value of domain record, When the `type` is `MX`,`NS`,`CNAME`,`SRV`, the server will treat the `value` as a fully qualified domain name, so it's no need to add a `.` at the end.
 * `ttl` - (Optional) The effective time of domain record. Its scope depends on the edition of the cloud resolution. Free is `[600, 86400]`, Basic is `[120, 86400]`, Standard is `[60, 86400]`, Ultimate is `[10, 86400]`, Exclusive is `[1, 86400]`. Default value is `600`.
 * `priority` - (Optional) The priority of domain record. Valid values are `[1-10]`. When the `type` is `MX`, this parameter is required.
-* `routing` - (Optional) The parsing line of domain record. Valid values are `default`, `telecom`, `unicom`, `mobile`, `oversea` and `edu`. When the `type` is `FORWORD_URL`, this parameter must be `default`. Default value is `default`.
+* `routing` - (Optional) The parsing line of domain record. Valid values are `default`, `telecom`, `unicom`, `mobile`, `oversea`, `edu`, `drpeng`, `btvn`, .etc. When the `type` is `FORWORD_URL`, this parameter must be `default`. Default value is `default`. For checking all resolution lines enumeration please visit [Alibaba Cloud DNS doc](https://www.alibabacloud.com/help/doc-detail/34339.htm) 
 
 ## Attributes Reference
 


### PR DESCRIPTION
Update below:
> According to [this](https://help.aliyun.com/document_detail/29807.html?spm=a2c4g.11186623.2.16.86ef10960KSKAG#h2-u57FAu7840u7EBFu8DEF1) doc, there are multiple routing rules missed in [alicloud_dns_record](https://www.terraform.io/docs/providers/alicloud/r/dns_record.html#routing) resource, such like:
> 
> drpeng
> btvn
> ...
> It would be great if we complete the routing types list.