### PR TITLE
Always set PolicyDocument for RAM policy update

### DIFF
--- a/alicloud/resource_alicloud_ram_policy.go
+++ b/alicloud/resource_alicloud_ram_policy.go
@@ -341,12 +341,13 @@ func buildAlicloudRamPolicyUpdateArgs(d *schema.ResourceData, meta interface{}) 
 	request.SetAsDefault = "true"
 	request.PolicyName = d.Id()
 
-	if d.HasChange("document") {
-		d.SetPartial("document")
-		request.PolicyDocument = d.Get("document").(string)
+	if document, ok := d.GetOk("document"); ok {
+		if d.HasChange("document") {
+			d.SetPartial("document")
+		}
 
-	} else if d.HasChange("statement") || d.HasChange("version") {
-
+		request.PolicyDocument = document.(string)
+	} else {
 		if d.HasChange("statement") {
 			d.SetPartial("statement")
 		}
@@ -358,6 +359,7 @@ func buildAlicloudRamPolicyUpdateArgs(d *schema.ResourceData, meta interface{}) 
 		if err != nil {
 			return &ram.CreatePolicyVersionRequest{}, err
 		}
+
 		request.PolicyDocument = document
 	}
 


### PR DESCRIPTION
According to the documentation, you can set `force = true` to resources the resource can be deleted more easily. However, if you want to set it for an existing resource that you don't want to delete yet, an error occurs:

```
Error: [ERROR] terraform-provider-alicloud/alicloud/resource_alicloud_ram_policy.go:143: Resource AssumePowerUserRoleProduction CreatePolicyVersion Failed!!! [SDK alibaba-cloud-sdk-go ERROR]:
SDK.ServerError
ErrorCode: MissingParameter
Recommend: 
RequestId: 733B529F-1C31-40DE-8E9A-11107C28FE17
Message: Parameter PolicyDocument is required.
```

The PolicyDocument request parameter is not set currently in `buildAlicloudRamPolicyUpdateArgs()` starting from line 336 in resource_alicloud_ram_policy.go. This PR ensures that it is always set, also if you didn't change the policy document.