### PR TITLE
add data_source_alicloud_support_lines

### DIFF
--- a/alicloud/data_source_alicloud_dns_resolution_lines.go
+++ b/alicloud/data_source_alicloud_dns_resolution_lines.go
@@ -1,0 +1,171 @@
+package alicloud
+
+import (
+	"github.com/aliyun/alibaba-cloud-sdk-go/services/alidns"
+	"github.com/hashicorp/terraform/helper/schema"
+	"github.com/terraform-providers/terraform-provider-alicloud/alicloud/connectivity"
+)
+
+// https://help.aliyun.com/document_detail/69017.html
+func dataSourceAlicloudDnsResolutionLines() *schema.Resource {
+	return &schema.Resource{
+		Read: dataSourceAlicloudDnsResolutionLinesRead,
+
+		Schema: map[string]*schema.Schema{
+			"line_codes": {
+				Optional: true,
+				Type:     schema.TypeList,
+				ForceNew: true,
+				Computed: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+			},
+			"line_display_names": {
+				Type:     schema.TypeList,
+				Optional: true,
+				ForceNew: true,
+				Computed: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+			},
+			"line_names": {
+				Type:     schema.TypeList,
+				Optional: true,
+				ForceNew: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+			},
+			"domain_name": {
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: true,
+			},
+			"user_client_ip": {
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: true,
+			},
+			"lang": {
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: true,
+			},
+			"output_file": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			// computed values
+			"lines": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"line_code": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"line_display_name": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"line_name": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func dataSourceAlicloudDnsResolutionLinesRead(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*connectivity.AliyunClient)
+	request := alidns.CreateDescribeSupportLinesRequest()
+
+	request.RegionId = client.RegionId
+	request.Lang = d.Get("lang").(string)
+	request.UserClientIp = d.Get("user_client_ip").(string)
+	request.DomainName = d.Get("domain_name").(string)
+
+	raw, err := client.WithDnsClient(func(dnsClient *alidns.Client) (interface{}, error) {
+		return dnsClient.DescribeSupportLines(request)
+	})
+	if err != nil {
+		return WrapErrorf(err, DataDefaultErrorMsg, "alicloud_dns_support_lines", request.GetActionName(), AlibabaCloudSdkGoERROR)
+	}
+	addDebug(request.GetActionName(), raw, request.RpcRequest, request)
+	response, _ := raw.(*alidns.DescribeSupportLinesResponse)
+	allLines := response.RecordLines.RecordLine
+
+	var filteredLines []alidns.RecordLine
+	for _, line := range allLines {
+		if v, ok := d.GetOk("line_codes"); ok {
+			lineCodes, _ := v.([]interface{})
+			if !hasEqualString(lineCodes, line.LineCode) {
+				continue
+			}
+		}
+		if v, ok := d.GetOk("line_display_names"); ok {
+			lineDisplayNames, _ := v.([]interface{})
+			if !hasEqualString(lineDisplayNames, line.LineDisplayName) {
+				continue
+			}
+		}
+		if v, ok := d.GetOk("line_names"); ok {
+			lineNames, _ := v.([]interface{})
+			if !hasEqualString(lineNames, line.LineName) {
+				continue
+			}
+		}
+		filteredLines = append(filteredLines, line)
+	}
+
+	return resolutionLinesDecriptionAttributes(d, filteredLines, meta)
+}
+
+func resolutionLinesDecriptionAttributes(d *schema.ResourceData, Lines []alidns.RecordLine, meta interface{}) error {
+	var s []map[string]interface{}
+	var lineCodes []string
+	var lineDisplayNames []string
+
+	for _, line := range Lines {
+		mapping := map[string]interface{}{
+			"line_code":         line.LineCode,
+			"line_display_name": line.LineDisplayName,
+			"line_name":         line.LineName,
+		}
+		lineCodes = append(lineCodes, line.LineCode)
+		lineDisplayNames = append(lineDisplayNames, line.LineDisplayName)
+		s = append(s, mapping)
+	}
+	d.SetId(dataResourceIdHash(lineCodes))
+
+	if err := d.Set("lines", s); err != nil {
+		return WrapError(err)
+	}
+
+	if err := d.Set("line_codes", lineCodes); err != nil {
+		return WrapError(err)
+	}
+
+	if err := d.Set("line_display_names", lineDisplayNames); err != nil {
+		return WrapError(err)
+	}
+
+	// create a json file in current directory and write data source to it.
+	if output, ok := d.GetOk("output_file"); ok && output.(string) != "" {
+		writeToFile(output.(string), s)
+	}
+	return nil
+}
+
+// to check if a slice has a specific string
+func hasEqualString(s []interface{}, a string) bool {
+	var isEqual bool
+	for _, code := range s {
+		fatherCode, _ := code.(string)
+		if fatherCode == a {
+			isEqual = true
+			return isEqual
+		}
+	}
+	return isEqual
+}

--- a/alicloud/data_source_alicloud_dns_resolution_lines_test.go
+++ b/alicloud/data_source_alicloud_dns_resolution_lines_test.go
@@ -1,0 +1,135 @@
+package alicloud
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform/helper/acctest"
+)
+
+func TestAccAlicloudDnsResolutionLinesDataSource(t *testing.T) {
+	rand := acctest.RandIntRange(1000, 9999)
+	name := fmt.Sprintf("tf-testacc%sdns%v.abc", defaultRegionToTest, rand)
+	testAccConfig := dataSourceTestAccConfigFunc("data.alicloud_dns_resolution_lines.default", name, dataSourceDnsResolutionLinesConfigDependence)
+	lineCodesConf := dataSourceTestAccConfig{
+		existConfig: testAccConfig(map[string]interface{}{
+			"line_codes": []string{"${alicloud_dns_record.default.routing}"},
+		}),
+		fakeConfig: testAccConfig(map[string]interface{}{
+			"line_codes": []string{"${alicloud_dns_record.default.routing}_fake"},
+		}),
+	}
+	lineDisplayNamesConf := dataSourceTestAccConfig{
+		existConfig: testAccConfig(map[string]interface{}{
+			"line_display_names": []string{"中国联通"},
+		}),
+		fakeConfig: testAccConfig(map[string]interface{}{
+			"line_display_names": []string{"中国联通_fake"},
+		}),
+	}
+	lineNamesConf := dataSourceTestAccConfig{
+		existConfig: testAccConfig(map[string]interface{}{
+			"line_codes": []string{"${alicloud_dns_record.default.routing}"},
+			"line_names": []string{"中国联通"},
+		}),
+		fakeConfig: testAccConfig(map[string]interface{}{
+			"line_codes": []string{"${alicloud_dns_record.default.routing}"},
+			"line_names": []string{"中国联通-fake"},
+		}),
+	}
+
+	domainNameConf := dataSourceTestAccConfig{
+		existConfig: testAccConfig(map[string]interface{}{
+			"line_codes":  []string{"${alicloud_dns_record.default.routing}"},
+			"domain_name": "${alicloud_dns_record.default.name}",
+		}),
+		//fakeConfig: testAccConfig(map[string]interface{}{
+		//	"line_codes":  []string{"${alicloud_dns_record.default.routing}"},
+		//	"domain_name": "${alicloud_dns_record.default.name}_fake",
+		//}),
+	}
+
+	userClientIpConf := dataSourceTestAccConfig{
+		existConfig: testAccConfig(map[string]interface{}{
+			"line_codes":     []string{"${alicloud_dns_record.default.routing}"},
+			"user_client_ip": "205.204.117.106",
+		}),
+		/*fakeConfig: testAccConfig(map[string]interface{}{
+			"line_codes":     []string{"cn_unicom_shanxi"},
+			"user_client_ip": "",
+		}),*/
+	}
+	langConf := dataSourceTestAccConfig{
+		existConfig: testAccConfig(map[string]interface{}{
+			"line_codes": []string{"${alicloud_dns_record.default.routing}"},
+			"lang":       "zh",
+		}),
+		// if the lang were set fake, it will be reset as default en(english)
+		/*fakeConfig: testAccConfig(map[string]interface{}{
+			"line_codes": []string{"cn_unicom_shanxi"},
+			"lang":       "zh_fake",
+		}),*/
+	}
+	allConf := dataSourceTestAccConfig{
+		existConfig: testAccConfig(map[string]interface{}{
+			"line_codes":         []string{"${alicloud_dns_record.default.routing}"},
+			"line_display_names": []string{"中国联通"},
+			"domain_name":        "${alicloud_dns_record.default.name}",
+			"user_client_ip":     "205.204.117.106",
+			"lang":               "zh",
+			"line_names":         []string{"中国联通"},
+		}),
+		fakeConfig: testAccConfig(map[string]interface{}{
+			"line_codes":         []string{"${alicloud_dns_record.default.routing}"},
+			"line_display_names": []string{"中国联通"},
+			"domain_name":        "${alicloud_dns_record.default.name}",
+			"user_client_ip":     "205.204.117.106",
+			"lang":               "zh",
+			"line_names":         []string{"中国联通_fake"},
+		}),
+	}
+	dnsSupportLinesCheckInfo.dataSourceTestCheck(t, rand, lineCodesConf, lineDisplayNamesConf, lineNamesConf, domainNameConf, userClientIpConf, langConf, allConf)
+}
+
+func dataSourceDnsResolutionLinesConfigDependence(name string) string {
+	return fmt.Sprintf(`
+resource "alicloud_dns" "default" {
+  name = "%s"
+}
+
+resource "alicloud_dns_record" "default" {
+  name = "${alicloud_dns.default.name}"
+  host_record = "alimail"
+  routing = "unicom"
+  type = "CNAME"
+  value = "mail.mxhichin.com"
+}
+`, name)
+}
+
+var existDnsResolutionLinesMapCheck = func(rand int) map[string]string {
+	return map[string]string{
+		"lines.#":                   "1",
+		"lines.0.line_code":         "unicom",
+		"lines.0.line_display_name": "中国联通",
+		"lines.0.line_name":         "中国联通",
+		"line_codes.#":              "1",
+		"line_codes.0":              "unicom",
+		"line_display_names.#":      "1",
+		"line_display_names.0":      "中国联通",
+	}
+}
+
+var fakeDnsResolutionLinesMapCheck = func(rand int) map[string]string {
+	return map[string]string{
+		"lines.#":              "0",
+		"line_codes.#":         "0",
+		"line_display_names.#": "0",
+	}
+}
+
+var dnsSupportLinesCheckInfo = dataSourceAttr{
+	resourceId:   "data.alicloud_dns_resolution_lines.default",
+	existMapFunc: existDnsResolutionLinesMapCheck,
+	fakeMapFunc:  fakeDnsResolutionLinesMapCheck,
+}

--- a/alicloud/provider.go
+++ b/alicloud/provider.go
@@ -125,6 +125,7 @@ func Provider() terraform.ResourceProvider {
 			"alicloud_eips":                   dataSourceAlicloudEips(),
 			"alicloud_key_pairs":              dataSourceAlicloudKeyPairs(),
 			"alicloud_kms_keys":               dataSourceAlicloudKmsKeys(),
+			"alicloud_dns_resolution_lines":   dataSourceAlicloudDnsResolutionLines(),
 			"alicloud_dns_domains":            dataSourceAlicloudDnsDomains(),
 			"alicloud_dns_groups":             dataSourceAlicloudDnsGroups(),
 			"alicloud_dns_records":            dataSourceAlicloudDnsRecords(),

--- a/website/docs/d/dns_resolution_lines.html.markdown
+++ b/website/docs/d/dns_resolution_lines.html.markdown
@@ -1,0 +1,48 @@
+---
+layout: "alicloud"
+page_title: "Alicloud: alicloud_dns_domains"
+sidebar_current: "docs-alicloud-datasource-dns-domains"
+description: |-
+    Provides a list of domains available to the user.
+---
+
+# alicloud\_dns\_resolution\_lines
+
+This data source provides a list of DNS Resolution Lines in an Alibaba Cloud account according to the specified filters.
+
+-> **NOTE:** Available in 1.60.0.
+
+## Example Usage
+
+```
+data "alicloud_dns_resolution_lines" "resolution_lines_ds" {
+  line_codes = [ "cn_unicom_shanxi" ]
+  output_file       = "support_lines.txt"
+}
+
+output "first_line_code" {
+  value = "${data.alicloud_dns_resolution_lines.resolution_lines_ds.lines.0.line_code}"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `domain_name` - (Optional) Domain Name. 
+* `line_codes` - (Optional) A list of lines codes.
+* `line_display_names` - (Optional) A list of line display names.
+* `user_client_ip` - (Optional) The ip of user client.
+* `lang` - (Optional) language.
+* `output_file` - (Optional) File name where to save data source results (after running `terraform plan`).
+
+## Attributes Reference
+
+The following attributes are exported in addition to the arguments listed above:
+
+* `line_codes` - A list of lines codes.
+* `line_display_names` - A list of line display names.
+* `lines` - A list of cloud resolution line. Each element contains the following attributes:
+  * `line_codes` - Line code.
+  * `line_display_name` - Line display name.
+  * `line_name` - Line name.

--- a/website/docs/r/dns_record.html.markdown
+++ b/website/docs/r/dns_record.html.markdown
@@ -34,7 +34,7 @@ The following arguments are supported:
 * `value` - (Required) The value of domain record, When the `type` is `MX`,`NS`,`CNAME`,`SRV`, the server will treat the `value` as a fully qualified domain name, so it's no need to add a `.` at the end.
 * `ttl` - (Optional) The effective time of domain record. Its scope depends on the edition of the cloud resolution. Free is `[600, 86400]`, Basic is `[120, 86400]`, Standard is `[60, 86400]`, Ultimate is `[10, 86400]`, Exclusive is `[1, 86400]`. Default value is `600`.
 * `priority` - (Optional) The priority of domain record. Valid values are `[1-10]`. When the `type` is `MX`, this parameter is required.
-* `routing` - (Optional) The parsing line of domain record. Valid values are `default`, `telecom`, `unicom`, `mobile`, `oversea`, `edu`, `drpeng`, `btvn`, .etc. When the `type` is `FORWORD_URL`, this parameter must be `default`. Default value is `default`. For checking all resolution lines enumeration please visit [Alibaba Cloud DNS doc](https://www.alibabacloud.com/help/doc-detail/34339.htm) 
+* `routing` - (Optional) The resolution line of domain record. Valid values are `default`, `telecom`, `unicom`, `mobile`, `oversea`, `edu`, `drpeng`, `btvn`, .etc. When the `type` is `FORWORD_URL`, this parameter must be `default`. Default value is `default`. For checking all resolution lines enumeration please visit [Alibaba Cloud DNS doc](https://www.alibabacloud.com/help/doc-detail/34339.htm) or using alicloud_dns_resolution_lines in data source to get the value. 
 
 ## Attributes Reference
 
@@ -47,7 +47,7 @@ The following attributes are exported:
 * `value` - The record value.
 * `ttl` - The record effective time.
 * `priority` - The record priority.
-* `routing` - The record parsing line.
+* `routing` - The record resolution line.
 * `status` - The record status. `Enable` or `Disable`.
 * `Locked` - The record locked state. `true` or `false`.
 


### PR DESCRIPTION
Because there must return back some support lines after inputing any arbitrary values of  domain_name, user_client_ip and lang, these variables can not be an only filter for fakeConfig, so cancelling corresponding fakeConfigs.

Test Result : 
=== RUN   TestAccAlicloudDnsDomainsDataSource
--- PASS: TestAccAlicloudDnsDomainsDataSource (98.85s)
=== RUN   TestAccAlicloudDnsGroupsDataSource
--- PASS: TestAccAlicloudDnsGroupsDataSource (34.49s)
=== RUN   TestAccAlicloudDnsRecordsDataSource
--- PASS: TestAccAlicloudDnsRecordsDataSource (130.03s)
=== RUN   TestAccAlicloudDnsSupportLinesDataSource
--- PASS: TestAccAlicloudDnsSupportLinesDataSource (79.37s)
=== RUN   TestAccAlicloudDnsGroup_basic
--- PASS: TestAccAlicloudDnsGroup_basic (13.33s)
=== RUN   TestAccAlicloudDnsRecord_basic
--- PASS: TestAccAlicloudDnsRecord_basic (79.16s)
=== RUN   TestAccAlicloudDnsRecord_multi
--- PASS: TestAccAlicloudDnsRecord_multi (82.26s)
=== RUN   TestAccAlicloudDns_basic
--- PASS: TestAccAlicloudDns_basic (23.36s)
PASS
