### PR TITLE
Add password to resource_alicloud_ess_scalingconfiguration

### DIFF
--- a/alicloud/resource_alicloud_ess_scalingconfiguration_test.go
+++ b/alicloud/resource_alicloud_ess_scalingconfiguration_test.go
@@ -48,6 +48,7 @@ func TestAccAlicloudEssScalingConfigurationUpdate(t *testing.T) {
 					"instance_type":     "${data.alicloud_instance_types.default.instance_types.0.id}",
 					"security_group_id": "${alicloud_security_group.default.id}",
 					"force_delete":      "true",
+					"password":          "123-abcABC",
 				}),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheck(nil),
@@ -57,7 +58,7 @@ func TestAccAlicloudEssScalingConfigurationUpdate(t *testing.T) {
 				ResourceName:            resourceId,
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"force_delete", "instance_type", "security_group_id"},
+				ImportStateVerifyIgnore: []string{"force_delete", "instance_type", "security_group_id", "password", "kms_encrypted_password", "kms_encryption_context"},
 			},
 			{
 				Config: testAccConfig(map[string]interface{}{
@@ -314,6 +315,7 @@ func TestAccAlicloudEssScalingConfigurationMulti(t *testing.T) {
 					"instance_type":     "${data.alicloud_instance_types.default.instance_types.0.id}",
 					"security_group_id": "${alicloud_security_group.default.id}",
 					"force_delete":      "true",
+					"password":          "123-abcABC",
 				}),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheck(nil),

--- a/website/docs/r/ess_scaling_configuration.html.markdown
+++ b/website/docs/r/ess_scaling_configuration.html.markdown
@@ -114,6 +114,9 @@ The following arguments are supported:
     - Key: It can be up to 64 characters in length. It cannot begin with "aliyun", "http://", or "https://". It cannot be a null string.
     - Value: It can be up to 128 characters in length. It cannot begin with "aliyun", "http://", or "https://" It can be a null string.
 * `override` - (Optional, Available in 1.46.0+) Indicates whether to overwrite the existing data. Default to false.
+* `password` - (Optional, ForceNew, Available in 1.60.0+) The password of the ECS instance. The password must be 8 to 30 characters in length. It must contains at least three of the following character types: uppercase letters, lowercase letters, digits, and special characters. Special characters include `() ~!@#$%^&*-_+=\|{}[]:;'<>,.?/`, The password of Windows-based instances cannot start with a forward slash (/).
+* `kms_encrypted_password` - (Optional, ForceNew, Available in 1.60.0+) An KMS encrypts password used to a db account. If the `password` is filled in, this field will be ignored.
+* `kms_encryption_context` - (Optional, MapString, Available in 1.60.0+) An KMS encryption context used to decrypt `kms_encrypted_password` before creating or updating a db account with `kms_encrypted_password`. See [Encryption Context](https://www.alibabacloud.com/help/doc-detail/42975.htm). It is valid when `kms_encrypted_password` is set.
 
 -> **NOTE:** Before enabling the scaling group, it must have a active scaling configuration.
 


### PR DESCRIPTION
Add password to resource_alicloud_ess_scalingconfiguration(CreateScalingConfiguration: https://help.aliyun.com/document_detail/106455.html), the corresponding data source method do not support password checking(DescribeScalingConfigurations: https://help.aliyun.com/document_detail/106456.html)

Test result: 

go test -v ./alicloud -run=TestAccAlicloudEssScaling -timeout=300m
=== RUN   TestAccAlicloudEssScalingconfigurationsDataSource
--- PASS: TestAccAlicloudEssScalingconfigurationsDataSource (77.26s)
=== RUN   TestAccAlicloudEssScalinggroupsDataSource
--- PASS: TestAccAlicloudEssScalinggroupsDataSource (61.29s)
=== RUN   TestAccAlicloudEssScalingrulesDataSource
--- PASS: TestAccAlicloudEssScalingrulesDataSource (112.80s)
=== RUN   TestAccAlicloudEssScalingConfigurationUpdate
--- PASS: TestAccAlicloudEssScalingConfigurationUpdate (199.88s)
=== RUN   TestAccAlicloudEssScalingConfigurationMulti
--- PASS: TestAccAlicloudEssScalingConfigurationMulti (55.72s)
=== RUN   TestAccAlicloudEssScalingGroup_basic
--- PASS: TestAccAlicloudEssScalingGroup_basic (89.08s)
=== RUN   TestAccAlicloudEssScalingGroup_costoptimized
--- PASS: TestAccAlicloudEssScalingGroup_costoptimized (62.17s)
=== RUN   TestAccAlicloudEssScalingGroup_vpc
--- PASS: TestAccAlicloudEssScalingGroup_vpc (101.12s)
=== RUN   TestAccAlicloudEssScalingGroup_slb
--- PASS: TestAccAlicloudEssScalingGroup_slb (124.90s)
=== RUN   TestAccAlicloudEssScalingRule_basic
--- PASS: TestAccAlicloudEssScalingRule_basic (74.38s)
=== RUN   TestAccAlicloudEssScalingRule_target_tracking_rule_basic
--- PASS: TestAccAlicloudEssScalingRule_target_tracking_rule_basic (73.48s)
=== RUN   TestAccAlicloudEssScalingRule_step_rule_basic
--- PASS: TestAccAlicloudEssScalingRule_step_rule_basic (42.47s)
=== RUN   TestAccAlicloudEssScalingRuleMulti
--- PASS: TestAccAlicloudEssScalingRuleMulti (40.60s)
PASS
ok      github.com/terraform-providers/terraform-provider-alicloud/alicloud     1117.238s
