### PR TITLE
Add resource_group_id to data_source_alicloud_route_tables

### DIFF
--- a/alicloud/data_source_alicloud_route_tables.go
+++ b/alicloud/data_source_alicloud_route_tables.go
@@ -42,6 +42,11 @@ func dataSourceAlicloudRouteTables() *schema.Resource {
 				Computed: true,
 				Elem:     &schema.Schema{Type: schema.TypeString},
 			},
+			"resource_group_id": {
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: true,
+			},
 
 			// Computed values
 			"tables": {
@@ -87,6 +92,7 @@ func dataSourceAlicloudRouteTablesRead(d *schema.ResourceData, meta interface{})
 	request.RegionId = string(client.Region)
 	request.PageSize = requests.NewInteger(PageSizeLarge)
 	request.PageNumber = requests.NewInteger(1)
+	request.ResourceGroupId = d.Get("resource_group_id").(string)
 	idsMap := make(map[string]string)
 	if v, ok := d.GetOk("ids"); ok {
 		for _, vv := range v.([]interface{}) {

--- a/alicloud/data_source_alicloud_route_tables_test.go
+++ b/alicloud/data_source_alicloud_route_tables_test.go
@@ -2,6 +2,7 @@ package alicloud
 
 import (
 	"fmt"
+	"os"
 	"strings"
 	"testing"
 
@@ -48,33 +49,49 @@ func TestAccAlicloudRouteTablesDataSourceBasic(t *testing.T) {
 
 	tagsConfig := dataSourceTestAccConfig{
 		existConfig: testAccCheckAlicloudRouteTablesDataSourceConfigBaisc(rand, map[string]string{
+			"name_regex": `"${alicloud_route_table.default.name}"`,
 			"tags": `{
 							Created = "TF"
 							For 	= "acceptance test"
 					  }`,
 		}),
 		fakeConfig: testAccCheckAlicloudRouteTablesDataSourceConfigBaisc(rand, map[string]string{
+			"name_regex": `"${alicloud_route_table.default.name}"`,
 			"tags": `{
 							Created = "TF-fake"
-							For 	= "acceptance test"
+							For 	= "acceptance test-fake"
 					  }`,
+		}),
+	}
+
+	resourceGroupIdConfig := dataSourceTestAccConfig{
+		existConfig: testAccCheckAlicloudRouteTablesDataSourceConfigBaisc(rand, map[string]string{
+			"name_regex": `"${alicloud_route_table.default.name}"`,
+			// The resource route tables do not support resource_group_id, so it was set empty.
+			"resource_group_id": `""`,
+		}),
+		fakeConfig: testAccCheckAlicloudRouteTablesDataSourceConfigBaisc(rand, map[string]string{
+			"name_regex":        `"${alicloud_route_table.default.name}"`,
+			"resource_group_id": fmt.Sprintf(`"%s_fake"`, os.Getenv("ALICLOUD_RESOURCE_GROUP_ID")),
 		}),
 	}
 
 	allConfig := dataSourceTestAccConfig{
 		existConfig: testAccCheckAlicloudRouteTablesDataSourceConfigBaisc(rand, map[string]string{
-			"name_regex": `"${alicloud_route_table.default.name}"`,
-			"vpc_id":     `"${alicloud_vpc.default.id}"`,
-			"ids":        `[ "${alicloud_route_table.default.id}" ]`,
+			"name_regex":        `"${alicloud_route_table.default.name}"`,
+			"vpc_id":            `"${alicloud_vpc.default.id}"`,
+			"ids":               `[ "${alicloud_route_table.default.id}" ]`,
+			"resource_group_id": `""`,
 		}),
 		fakeConfig: testAccCheckAlicloudRouteTablesDataSourceConfigBaisc(rand, map[string]string{
-			"name_regex": `"${alicloud_route_table.default.name}_fake"`,
-			"vpc_id":     `"${alicloud_vpc.default.id}"`,
-			"ids":        `[ "${alicloud_route_table.default.id}" ]`,
+			"name_regex":        `"${alicloud_route_table.default.name}_fake"`,
+			"vpc_id":            `"${alicloud_vpc.default.id}"`,
+			"ids":               `[ "${alicloud_route_table.default.id}" ]`,
+			"resource_group_id": `""`,
 		}),
 	}
 
-	routeTablesCheckInfo.dataSourceTestCheckWithPreCheck(t, rand, preCheck, nameRegexConfig, vpcIdConfig, idsConfig, tagsConfig, allConfig)
+	routeTablesCheckInfo.dataSourceTestCheckWithPreCheck(t, rand, preCheck, nameRegexConfig, vpcIdConfig, idsConfig, tagsConfig, resourceGroupIdConfig, allConfig)
 }
 
 func testAccCheckAlicloudRouteTablesDataSourceConfigBaisc(rand int, attrMap map[string]string) string {

--- a/website/docs/d/route_tables.html.markdown
+++ b/website/docs/d/route_tables.html.markdown
@@ -48,6 +48,7 @@ The following arguments are supported:
 * `vpc_id` - (Optional) Vpc id of the route table.
 * `tags` - (Optional, Available in v1.55.3+) A mapping of tags to assign to the resource.
 * `output_file` - (Optional) File name where to save data source results (after running `terraform plan`).
+* `resource_group_id` - (Optional, ForceNew, Available in 1.60.0+) The Id of resource group which route tables belongs.
 
 ## Attributes Reference
 
@@ -62,4 +63,5 @@ The following attributes are exported in addition to the arguments listed above:
   * `name` - Name of the route table.
   * `description` - The description of the route table instance.
   * `creation_time` - Time of creation.
+  * `resource_group_id` - The Id of resource group which route tables belongs.
 


### PR DESCRIPTION
Test Result: 

go test -v ./alicloud -run=TestAccAlicloudRoute -timeout=300m
=== RUN   TestAccAlicloudRouteEntriesDataSourceBasic
--- PASS: TestAccAlicloudRouteEntriesDataSourceBasic (152.50s)
=== RUN   TestAccAlicloudRouteTablesDataSourceBasic
--- PASS: TestAccAlicloudRouteTablesDataSourceBasic (47.08s)
=== RUN   TestAccAlicloudRouterInterfacesDataSourceBasic
--- PASS: TestAccAlicloudRouterInterfacesDataSourceBasic (113.18s)
=== RUN   TestAccAlicloudRouteEntryInstance
--- PASS: TestAccAlicloudRouteEntryInstance (114.98s)
=== RUN   TestAccAlicloudRouteEntryInterface
--- PASS: TestAccAlicloudRouteEntryInterface (31.29s)
=== RUN   TestAccAlicloudRouteEntryNatGateway
--- PASS: TestAccAlicloudRouteEntryNatGateway (51.01s)
=== RUN   TestAccAlicloudRouteEntryMulti
--- PASS: TestAccAlicloudRouteEntryMulti (72.70s)
=== RUN   TestAccAlicloudRouteTableAttachmentBasic
--- PASS: TestAccAlicloudRouteTableAttachmentBasic (30.85s)
=== RUN   TestAccAlicloudRouteTableAttachmentMulti
--- PASS: TestAccAlicloudRouteTableAttachmentMulti (37.85s)
=== RUN   TestAccAlicloudRouteTableBasic
--- PASS: TestAccAlicloudRouteTableBasic (24.60s)
=== RUN   TestAccAlicloudRouteTableMulti
--- PASS: TestAccAlicloudRouteTableMulti (35.26s)
=== RUN   TestAccAlicloudRouterInterfaceConnectionBasic
--- PASS: TestAccAlicloudRouterInterfaceConnectionBasic (36.67s)
=== RUN   TestAccAlicloudRouterInterfaceBasic
--- PASS: TestAccAlicloudRouterInterfaceBasic (33.41s)
=== RUN   TestAccAlicloudRouterInterfaceMulti
--- PASS: TestAccAlicloudRouterInterfaceMulti (20.82s)
PASS
ok      github.com/terraform-providers/terraform-provider-alicloud/alicloud     804.892s
