### PR TITLE
Add resource_group_id to 5 data_datasources

### DIFF
--- a/alicloud/data_source_alicloud_slb_acls.go
+++ b/alicloud/data_source_alicloud_slb_acls.go
@@ -30,6 +30,11 @@ func dataSourceAlicloudSlbAcls() *schema.Resource {
 				Type:     schema.TypeString,
 				Optional: true,
 			},
+			"resource_group_id": {
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: true,
+			},
 			// Computed values
 			"names": {
 				Type:     schema.TypeList,
@@ -106,6 +111,7 @@ func dataSourceAlicloudSlbAclsRead(d *schema.ResourceData, meta interface{}) err
 	client := meta.(*connectivity.AliyunClient)
 	request := slb.CreateDescribeAccessControlListsRequest()
 	request.RegionId = client.RegionId
+	request.ResourceGroupId = d.Get("resource_group_id").(string)
 	idsMap := make(map[string]string)
 	if v, ok := d.GetOk("ids"); ok {
 		for _, vv := range v.([]interface{}) {

--- a/alicloud/data_source_alicloud_slb_acls_test.go
+++ b/alicloud/data_source_alicloud_slb_acls_test.go
@@ -2,6 +2,7 @@ package alicloud
 
 import (
 	"fmt"
+	"os"
 	"strings"
 	"testing"
 
@@ -28,14 +29,28 @@ func TestAccAlicloudSlbAclsDataSource_basic(t *testing.T) {
 		}),
 	}
 
+	resourceGroupIdConf := dataSourceTestAccConfig{
+		existConfig: testAccCheckAlicloudSlbAclsDataSourceConfig(rand, map[string]string{
+			"ids":               `["${alicloud_slb_acl.default.id}"]`,
+			"resource_group_id": `""`,
+		}),
+		fakeConfig: testAccCheckAlicloudSlbAclsDataSourceConfig(rand, map[string]string{
+			"ids":               `["${alicloud_slb_acl.default.id}_fake"]`,
+			"resource_group_id": fmt.Sprintf(`"%s_fake"`, os.Getenv("ALICLOUD_RESOURCE_GROUP_ID")),
+		}),
+	}
+
 	allConf := dataSourceTestAccConfig{
 		existConfig: testAccCheckAlicloudSlbAclsDataSourceConfig(rand, map[string]string{
 			"ids":        `["${alicloud_slb_acl.default.id}"]`,
 			"name_regex": `"${alicloud_slb_acl.default.name}"`,
+			// The resource route tables do not support resource_group_id, so it was set empty.
+			"resource_group_id": `""`,
 		}),
 		fakeConfig: testAccCheckAlicloudSlbAclsDataSourceConfig(rand, map[string]string{
-			"ids":        `["${alicloud_slb_acl.default.id}_fake"]`,
-			"name_regex": `"${alicloud_slb_acl.default.name}"`,
+			"ids":               `["${alicloud_slb_acl.default.id}_fake"]`,
+			"name_regex":        `"${alicloud_slb_acl.default.name}"`,
+			"resource_group_id": `""`,
 		}),
 	}
 
@@ -66,7 +81,7 @@ func TestAccAlicloudSlbAclsDataSource_basic(t *testing.T) {
 		fakeMapFunc:  fakeDnsRecordsMapFunc,
 	}
 
-	slbaclsCheckInfo.dataSourceTestCheck(t, rand, nameRegexConf, idsConf, allConf)
+	slbaclsCheckInfo.dataSourceTestCheck(t, rand, nameRegexConf, idsConf, resourceGroupIdConf, allConf)
 }
 
 func testAccCheckAlicloudSlbAclsDataSourceConfig(rand int, attrMap map[string]string) string {

--- a/alicloud/data_source_alicloud_slb_ca_certificates.go
+++ b/alicloud/data_source_alicloud_slb_ca_certificates.go
@@ -35,6 +35,11 @@ func dataSourceAlicloudSlbCACertificates() *schema.Resource {
 				Computed: true,
 				Elem:     &schema.Schema{Type: schema.TypeString},
 			},
+			"resource_group_id": {
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: true,
+			},
 			// Computed values
 			"certificates": {
 				Type:     schema.TypeList,
@@ -93,6 +98,7 @@ func dataSourceAlicloudSlbCACertificatesRead(d *schema.ResourceData, meta interf
 
 	request := slb.CreateDescribeCACertificatesRequest()
 	request.RegionId = client.RegionId
+	request.ResourceGroupId = d.Get("resource_group_id").(string)
 	idsMap := make(map[string]string)
 	if v, ok := d.GetOk("ids"); ok {
 		for _, vv := range v.([]interface{}) {

--- a/alicloud/data_source_alicloud_slb_ca_certificates_test.go
+++ b/alicloud/data_source_alicloud_slb_ca_certificates_test.go
@@ -2,6 +2,7 @@ package alicloud
 
 import (
 	"fmt"
+	"os"
 	"strings"
 	"testing"
 
@@ -28,14 +29,27 @@ func TestAccAlicloudSlbCACertificatesDataSource_basic(t *testing.T) {
 		}),
 	}
 
-	allConf := dataSourceTestAccConfig{
+	resourceGroupIdConf := dataSourceTestAccConfig{
 		existConfig: testAccCheckAlicloudSlbCaCertificatesDataSourceConfig(rand, map[string]string{
-			"ids":        `["${alicloud_slb_ca_certificate.default.id}"]`,
-			"name_regex": `"${alicloud_slb_ca_certificate.default.name}"`,
+			"ids":               `["${alicloud_slb_ca_certificate.default.id}"]`,
+			"resource_group_id": `""`,
 		}),
 		fakeConfig: testAccCheckAlicloudSlbCaCertificatesDataSourceConfig(rand, map[string]string{
-			"ids":        `["${alicloud_slb_ca_certificate.default.id}_fake"]`,
-			"name_regex": `"${alicloud_slb_ca_certificate.default.name}"`,
+			"ids":               `["${alicloud_slb_ca_certificate.default.id}_fake"]`,
+			"resource_group_id": fmt.Sprintf(`"%s_fake"`, os.Getenv("ALICLOUD_RESOURCE_GROUP_ID")),
+		}),
+	}
+
+	allConf := dataSourceTestAccConfig{
+		existConfig: testAccCheckAlicloudSlbCaCertificatesDataSourceConfig(rand, map[string]string{
+			"ids":               `["${alicloud_slb_ca_certificate.default.id}"]`,
+			"name_regex":        `"${alicloud_slb_ca_certificate.default.name}"`,
+			"resource_group_id": `""`,
+		}),
+		fakeConfig: testAccCheckAlicloudSlbCaCertificatesDataSourceConfig(rand, map[string]string{
+			"ids":               `["${alicloud_slb_ca_certificate.default.id}_fake"]`,
+			"name_regex":        `"${alicloud_slb_ca_certificate.default.name}"`,
+			"resource_group_id": `""`,
 		}),
 	}
 
@@ -71,7 +85,7 @@ func TestAccAlicloudSlbCACertificatesDataSource_basic(t *testing.T) {
 		fakeMapFunc:  fakeDnsRecordsMapFunc,
 	}
 
-	slbCaCertificatesCheckInfo.dataSourceTestCheck(t, rand, nameRegexConf, idsConf, allConf)
+	slbCaCertificatesCheckInfo.dataSourceTestCheck(t, rand, nameRegexConf, idsConf, resourceGroupIdConf, allConf)
 
 }
 

--- a/alicloud/data_source_alicloud_slbs.go
+++ b/alicloud/data_source_alicloud_slbs.go
@@ -74,6 +74,11 @@ func dataSourceAlicloudSlbs() *schema.Resource {
 				Computed: true,
 				Elem:     &schema.Schema{Type: schema.TypeString},
 			},
+			"resource_group_id": {
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: true,
+			},
 			// Computed values
 			"slbs": {
 				Type:     schema.TypeList,
@@ -145,6 +150,7 @@ func dataSourceAlicloudSlbsRead(d *schema.ResourceData, meta interface{}) error 
 
 	request := slb.CreateDescribeLoadBalancersRequest()
 	request.RegionId = client.RegionId
+	request.ResourceGroupId = d.Get("resource_group_id").(string)
 	if v, ok := d.GetOk("master_availability_zone"); ok && v.(string) != "" {
 		request.MasterZoneId = v.(string)
 	}

--- a/alicloud/data_source_alicloud_slbs_test.go
+++ b/alicloud/data_source_alicloud_slbs_test.go
@@ -2,6 +2,7 @@ package alicloud
 
 import (
 	"fmt"
+	"os"
 	"strings"
 	"testing"
 
@@ -79,6 +80,17 @@ func TestAccAlicloudSlbsDataSource(t *testing.T) {
 		}),
 	}
 
+	resourceGroupIdConf := dataSourceTestAccConfig{
+		existConfig: testAccCheckAlicloudSlbDataSourceConfig(rand, map[string]string{
+			"name_regex":        `"${alicloud_slb.default.name}"`,
+			"resource_group_id": fmt.Sprintf(`"%s"`, os.Getenv("ALICLOUD_RESOURCE_GROUP_ID")),
+		}),
+		fakeConfig: testAccCheckAlicloudSlbDataSourceConfig(rand, map[string]string{
+			"name_regex":        `"${alicloud_slb.default.name}"`,
+			"resource_group_id": fmt.Sprintf(`"%s_fake"`, os.Getenv("ALICLOUD_RESOURCE_GROUP_ID")),
+		}),
+	}
+
 	allConf := dataSourceTestAccConfig{
 		existConfig: testAccCheckAlicloudSlbDataSourceConfig(rand, map[string]string{
 			"name_regex":               `"${alicloud_slb.default.name}"`,
@@ -88,6 +100,7 @@ func TestAccAlicloudSlbsDataSource(t *testing.T) {
 			"network_type":             `"vpc"`,
 			"tags":                     `{tag_f = 6}`,
 			"master_availability_zone": `"${data.alicloud_zones.default.zones.0.id}"`,
+			"resource_group_id":        fmt.Sprintf(`"%s"`, os.Getenv("ALICLOUD_RESOURCE_GROUP_ID")),
 		}),
 		fakeConfig: testAccCheckAlicloudSlbDataSourceConfig(rand, map[string]string{
 			"name_regex":               `"${alicloud_slb.default.name}_fake"`,
@@ -97,6 +110,7 @@ func TestAccAlicloudSlbsDataSource(t *testing.T) {
 			"network_type":             `"vpc"`,
 			"tags":                     `{tag_f = 6}`,
 			"master_availability_zone": `"${data.alicloud_zones.default.zones.0.id}"`,
+			"resource_group_id":        fmt.Sprintf(`"%s"`, os.Getenv("ALICLOUD_RESOURCE_GROUP_ID")),
 		}),
 	}
 
@@ -136,7 +150,7 @@ func TestAccAlicloudSlbsDataSource(t *testing.T) {
 		fakeMapFunc:  fakeDnsRecordsMapFunc,
 	}
 
-	slbsRecordsCheckInfo.dataSourceTestCheck(t, rand, nameRegexConf, idsConf, vpcIDConf, vswitchConf, netWorkTypeConf, tagsConf, masterZoneConf, allConf)
+	slbsRecordsCheckInfo.dataSourceTestCheck(t, rand, nameRegexConf, idsConf, vpcIDConf, vswitchConf, netWorkTypeConf, tagsConf, masterZoneConf, resourceGroupIdConf, allConf)
 
 }
 
@@ -181,11 +195,12 @@ resource "alicloud_slb" "default" {
     tag_g = 7
     tag_h = 8
   }
+  resource_group_id = "%s"
 }
 
 data "alicloud_slbs" "default" {
   %s
 }
-`, rand, strings.Join(pairs, "\n  "))
+`, rand, os.Getenv("ALICLOUD_RESOURCE_GROUP_ID"), strings.Join(pairs, "\n  "))
 	return config
 }

--- a/alicloud/data_source_alicloud_vpcs.go
+++ b/alicloud/data_source_alicloud_vpcs.go
@@ -55,6 +55,11 @@ func dataSourceAlicloudVpcs() *schema.Resource {
 				Computed: true,
 				Elem:     &schema.Schema{Type: schema.TypeString},
 			},
+			"resource_group_id": {
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: true,
+			},
 			// Computed values
 			"vpcs": {
 				Type:     schema.TypeList,
@@ -120,7 +125,7 @@ func dataSourceAlicloudVpcsRead(d *schema.ResourceData, meta interface{}) error 
 	request.RegionId = string(client.Region)
 	request.PageSize = requests.NewInteger(PageSizeLarge)
 	request.PageNumber = requests.NewInteger(1)
-
+	request.ResourceGroupId = d.Get("resource_group_id").(string)
 	var allVpcs []vpc.Vpc
 	invoker := NewInvoker()
 	for {

--- a/alicloud/data_source_alicloud_vpcs_test.go
+++ b/alicloud/data_source_alicloud_vpcs_test.go
@@ -2,6 +2,7 @@ package alicloud
 
 import (
 	"fmt"
+	"os"
 	"strings"
 	"testing"
 
@@ -73,38 +74,48 @@ func TestAccAlicloudVpcsDataSourceBasic(t *testing.T) {
 	}
 	tagsConf := dataSourceTestAccConfig{
 		existConfig: testAccCheckAlicloudVpcsDataSourceConfig(rand, map[string]string{
+			"name_regex": `"${var.name}"`,
 			"tags": `{
 							Created = "TF"
 							For 	= "acceptance test"
 					  }`,
 		}),
 		fakeConfig: testAccCheckAlicloudVpcsDataSourceConfig(rand, map[string]string{
+			"name_regex": `"${var.name}"`,
 			"tags": `{
 							Created = "TF-fake"
-							For 	= "acceptance test"
+							For 	= "acceptance test-fake"
 					  }`,
+		}),
+	}
+	resourceGroupIdConf := dataSourceTestAccConfig{
+		existConfig: testAccCheckAlicloudVpcsDataSourceConfig(rand, map[string]string{
+			"name_regex":        `"${var.name}"`,
+			"resource_group_id": fmt.Sprintf(`"%s"`, os.Getenv("ALICLOUD_RESOURCE_GROUP_ID")),
 		}),
 	}
 	allConf := dataSourceTestAccConfig{
 		existConfig: testAccCheckAlicloudVpcsDataSourceConfig(rand, map[string]string{
-			"name_regex": `"${var.name}"`,
-			"ids":        `[ "${alicloud_vpc.default.id}" ]`,
-			"cidr_block": `"172.16.0.0/12"`,
-			"status":     `"Available"`,
-			"is_default": `"false"`,
-			"vswitch_id": `"${alicloud_vswitch.default.id}"`,
+			"name_regex":        `"${var.name}"`,
+			"ids":               `[ "${alicloud_vpc.default.id}" ]`,
+			"cidr_block":        `"172.16.0.0/12"`,
+			"status":            `"Available"`,
+			"is_default":        `"false"`,
+			"vswitch_id":        `"${alicloud_vswitch.default.id}"`,
+			"resource_group_id": fmt.Sprintf(`"%s"`, os.Getenv("ALICLOUD_RESOURCE_GROUP_ID")),
 		}),
 		fakeConfig: testAccCheckAlicloudVpcsDataSourceConfig(rand, map[string]string{
-			"name_regex": `"${var.name}"`,
-			"ids":        `[ "${alicloud_vpc.default.id}" ]`,
-			"cidr_block": `"172.16.0.0/16"`,
-			"status":     `"Available"`,
-			"is_default": `"false"`,
-			"vswitch_id": `"${alicloud_vswitch.default.id}_fake"`,
+			"name_regex":        `"${var.name}"`,
+			"ids":               `[ "${alicloud_vpc.default.id}" ]`,
+			"cidr_block":        `"172.16.0.0/16"`,
+			"status":            `"Available"`,
+			"is_default":        `"false"`,
+			"vswitch_id":        `"${alicloud_vswitch.default.id}_fake"`,
+			"resource_group_id": fmt.Sprintf(`"%s"`, os.Getenv("ALICLOUD_RESOURCE_GROUP_ID")),
 		}),
 	}
 
-	vpcsCheckInfo.dataSourceTestCheck(t, rand, initVswitchConf, nameRegexConf, idsConf, cidrBlockConf, statusConf, idDefaultConf, vswitchIdConf, tagsConf, allConf)
+	vpcsCheckInfo.dataSourceTestCheck(t, rand, initVswitchConf, nameRegexConf, idsConf, cidrBlockConf, statusConf, idDefaultConf, vswitchIdConf, tagsConf, resourceGroupIdConf, allConf)
 }
 
 func testAccCheckAlicloudVpcsDataSourceConfig(rand int, attrMap map[string]string) string {
@@ -125,6 +136,7 @@ resource "alicloud_vpc" "default" {
 		Created = "TF"
 		For 	= "acceptance test"
   }
+  resource_group_id = "%s"
 }
 
 data "alicloud_zones" "default" {
@@ -141,7 +153,7 @@ resource "alicloud_vswitch" "default" {
 data "alicloud_vpcs" "default" {
   %s
 }
-`, rand, strings.Join(pairs, "\n  "))
+`, rand, os.Getenv("ALICLOUD_RESOURCE_GROUP_ID"), strings.Join(pairs, "\n  "))
 	return config
 }
 

--- a/alicloud/data_source_alicloud_vswitches.go
+++ b/alicloud/data_source_alicloud_vswitches.go
@@ -56,6 +56,11 @@ func dataSourceAlicloudVSwitches() *schema.Resource {
 				Computed: true,
 				Elem:     &schema.Schema{Type: schema.TypeString},
 			},
+			"resource_group_id": {
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: true,
+			},
 			// Computed values
 			"vswitches": {
 				Type:     schema.TypeList,
@@ -111,6 +116,7 @@ func dataSourceAlicloudVSwitchesRead(d *schema.ResourceData, meta interface{}) e
 
 	request := vpc.CreateDescribeVSwitchesRequest()
 	request.RegionId = string(client.Region)
+	request.ResourceGroupId = d.Get("resource_group_id").(string)
 	// API DescribeVSwitches has some limitations
 	// If there is no vpc_id, setting PageSizeSmall can avoid ServiceUnavailable Error
 	request.PageSize = requests.NewInteger(PageSizeSmall)

--- a/alicloud/data_source_alicloud_vswitches_test.go
+++ b/alicloud/data_source_alicloud_vswitches_test.go
@@ -2,6 +2,7 @@ package alicloud
 
 import (
 	"fmt"
+	"os"
 	"strings"
 	"testing"
 
@@ -73,12 +74,14 @@ func TestAccAlicloudVSwitchesDataSourceBasic(t *testing.T) {
 
 	tagsConf := dataSourceTestAccConfig{
 		existConfig: testAccCheckAlicloudVSwitchesDataSourceConfig(rand, map[string]string{
+			"name_regex": `"${alicloud_vswitch.default.name}"`,
 			"tags": `{
 							Created = "TF"
 							For 	= "acceptance test"
 					  }`,
 		}),
 		fakeConfig: testAccCheckAlicloudVSwitchesDataSourceConfig(rand, map[string]string{
+			"name_regex": `"${alicloud_vswitch.default.name}"`,
 			"tags": `{
 							Created = "TF-fake"
 							For 	= "acceptance test"
@@ -86,26 +89,39 @@ func TestAccAlicloudVSwitchesDataSourceBasic(t *testing.T) {
 		}),
 	}
 
-	allConf := dataSourceTestAccConfig{
+	resourceGroupIdConf := dataSourceTestAccConfig{
 		existConfig: testAccCheckAlicloudVSwitchesDataSourceConfig(rand, map[string]string{
 			"name_regex": `"${alicloud_vswitch.default.name}"`,
-			"ids":        `[ "${alicloud_vswitch.default.id}" ]`,
-			"cidr_block": `"172.16.0.0/24"`,
-			"is_default": `"false"`,
-			"vpc_id":     `"${alicloud_vpc.default.id}"`,
-			"zone_id":    `"${data.alicloud_zones.default.zones.0.id}"`,
+			// The resource route tables do not support resource_group_id, so it was set empty.
+			"resource_group_id": `""`,
 		}),
 		fakeConfig: testAccCheckAlicloudVSwitchesDataSourceConfig(rand, map[string]string{
-			"name_regex": `"${alicloud_vswitch.default.name}"`,
-			"ids":        `[ "${alicloud_vswitch.default.id}" ]`,
-			"cidr_block": `"172.16.0.0/24"`,
-			"is_default": `"false"`,
-			"vpc_id":     `"${alicloud_vpc.default.id}"`,
-			"zone_id":    `"${data.alicloud_zones.default.zones.0.id}_fake"`,
+			"name_regex":        `"${alicloud_vswitch.default.name}"`,
+			"resource_group_id": fmt.Sprintf(`"%s_fake"`, os.Getenv("ALICLOUD_RESOURCE_GROUP_ID")),
+		}),
+	}
+	allConf := dataSourceTestAccConfig{
+		existConfig: testAccCheckAlicloudVSwitchesDataSourceConfig(rand, map[string]string{
+			"name_regex":        `"${alicloud_vswitch.default.name}"`,
+			"ids":               `[ "${alicloud_vswitch.default.id}" ]`,
+			"cidr_block":        `"172.16.0.0/24"`,
+			"is_default":        `"false"`,
+			"vpc_id":            `"${alicloud_vpc.default.id}"`,
+			"zone_id":           `"${data.alicloud_zones.default.zones.0.id}"`,
+			"resource_group_id": `""`,
+		}),
+		fakeConfig: testAccCheckAlicloudVSwitchesDataSourceConfig(rand, map[string]string{
+			"name_regex":        `"${alicloud_vswitch.default.name}"`,
+			"ids":               `[ "${alicloud_vswitch.default.id}" ]`,
+			"cidr_block":        `"172.16.0.0/24"`,
+			"is_default":        `"false"`,
+			"vpc_id":            `"${alicloud_vpc.default.id}"`,
+			"zone_id":           `"${data.alicloud_zones.default.zones.0.id}_fake"`,
+			"resource_group_id": `""`,
 		}),
 	}
 
-	vswitchesCheckInfo.dataSourceTestCheck(t, rand, nameRegexConf, idsConf, cidrBlockConf, idDefaultConf, vpcIdConf, zoneIdConf, tagsConf, allConf)
+	vswitchesCheckInfo.dataSourceTestCheck(t, rand, nameRegexConf, idsConf, cidrBlockConf, idDefaultConf, vpcIdConf, zoneIdConf, tagsConf, resourceGroupIdConf, allConf)
 
 }
 

--- a/website/docs/d/slb_acls.html.markdown
+++ b/website/docs/d/slb_acls.html.markdown
@@ -28,6 +28,7 @@ The following arguments are supported:
 * `ids` - (Optional) A list of acls IDs to filter results.
 * `name_regex` - (Optional) A regex string to filter results by acl name.
 * `output_file` - (Optional) File name where to save data source results (after running `terraform plan`).
+* `resource_group_id` - (Optional, ForceNew, Available in 1.60.0+) The Id of resource group which acl belongs.
 
 ## Attributes Reference
 

--- a/website/docs/d/slb_ca_certificates.html.markdown
+++ b/website/docs/d/slb_ca_certificates.html.markdown
@@ -27,6 +27,7 @@ The following arguments are supported:
 * `ids` - (Optional) A list of ca certificates IDs to filter results.
 * `name_regex` - (Optional) A regex string to filter results by ca certificate name.
 * `output_file` - (Optional) File name where to save data source results (after running `terraform plan`).
+* `resource_group_id` - (Optional, ForceNew, Available in 1.60.0+) The Id of resource group which ca certificates belongs.
 
 ## Attributes Reference
 

--- a/website/docs/d/slbs.html.markdown
+++ b/website/docs/d/slbs.html.markdown
@@ -44,6 +44,7 @@ The following arguments are supported:
   }
   ```
 * `output_file` - (Optional) File name where to save data source results (after running `terraform plan`).
+* `resource_group_id` - (Optional, ForceNew, Available in 1.60.0+) The Id of resource group which SLB belongs.
 
 ## Attributes Reference
 

--- a/website/docs/d/vpcs.html.markdown
+++ b/website/docs/d/vpcs.html.markdown
@@ -36,6 +36,7 @@ The following arguments are supported:
 * `tags` - (Optional, Available in v1.55.3+) A mapping of tags to assign to the resource.
 * `output_file` - (Optional) File name where to save data source results (after running `terraform plan`).
 * `ids` - (Optional, Available in 1.52.0+) A list of VPC IDs.
+* `resource_group_id` - (Optional, ForceNew, Available in 1.60.0+) The Id of resource group which VPC belongs.
 
 ## Attributes Reference
 

--- a/website/docs/d/vswitches.html.markdown
+++ b/website/docs/d/vswitches.html.markdown
@@ -47,6 +47,7 @@ The following arguments are supported:
 * `tags` - (Optional, Available in v1.55.3+) A mapping of tags to assign to the resource.
 * `output_file` - (Optional) File name where to save data source results (after running `terraform plan`).
 * `ids` - (Optional, Available in 1.52.0+) A list of VSwitch IDs.
+* `resource_group_id` - (Optional, ForceNew, Available in 1.60.0+) The Id of resource group which VSWitch belongs.
 
 ## Attributes Reference
 


### PR DESCRIPTION
Test Result:

1. 
go test -v ./alicloud -run=TestAccAlicloudVpcs -timeout=300m
=== RUN   TestAccAlicloudVpcsDataSourceBasic
--- PASS: TestAccAlicloudVpcsDataSourceBasic (86.32s)
PASS
ok      github.com/terraform-providers/terraform-provider-alicloud/alicloud     88.243s

2.
go test -v ./alicloud -run=TestAccAlicloudVSwitches -timeout=300m
=== RUN   TestAccAlicloudVSwitchesDataSourceBasic
--- PASS: TestAccAlicloudVSwitchesDataSourceBasic (160.57s)
PASS
ok      github.com/terraform-providers/terraform-provider-alicloud/alicloud     162.522s

3, 

go test -v ./alicloud -run=TestAccAlicloudSlbs -timeout=300m
=== RUN   TestAccAlicloudSlbsDataSource
--- PASS: TestAccAlicloudSlbsDataSource (212.64s)
PASS
ok      github.com/terraform-providers/terraform-provider-alicloud/alicloud     214.600s

4. 
go test -v ./alicloud -run=TestAccAlicloudSlb -timeout=300m
=== RUN   TestAccAlicloudSlbAclsDataSource_basic
--- PASS: TestAccAlicloudSlbAclsDataSource_basic (10.86s)
=== RUN   TestAccAlicloudSlbAttachmentsDataSource_basic
--- PASS: TestAccAlicloudSlbAttachmentsDataSource_basic (113.95s)
=== RUN   TestAccAlicloudSlbBackendServersDataSource_basic
--- PASS: TestAccAlicloudSlbBackendServersDataSource_basic (131.00s)
=== RUN   TestAccAlicloudSlbCACertificatesDataSource_basic
--- PASS: TestAccAlicloudSlbCACertificatesDataSource_basic (7.65s)
=== RUN   TestAccAlicloudSlbDomainExtensionsDataSource_basic
--- PASS: TestAccAlicloudSlbDomainExtensionsDataSource_basic (14.77s)
=== RUN   TestAccAlicloudSlbListenersDataSourceUpdate_http
--- PASS: TestAccAlicloudSlbListenersDataSourceUpdate_http (41.55s)
=== RUN   TestAccAlicloudSlbListenersDataSource_https
--- PASS: TestAccAlicloudSlbListenersDataSource_https (17.64s)
=== RUN   TestAccAlicloudSlbListenersDataSource_tcp
--- PASS: TestAccAlicloudSlbListenersDataSource_tcp (41.05s)
=== RUN   TestAccAlicloudSlbListenersDataSource_udp
--- PASS: TestAccAlicloudSlbListenersDataSource_udp (41.52s)
=== RUN   TestAccAlicloudSlbMasterSlaveServerGroupsDataSource_basic
--- PASS: TestAccAlicloudSlbMasterSlaveServerGroupsDataSource_basic (153.03s)
=== RUN   TestAccAlicloudSlbRulesDataSource_basic
--- PASS: TestAccAlicloudSlbRulesDataSource_basic (137.85s)
=== RUN   TestAccAlicloudSlbServerCertificatesDataSource_basic
--- PASS: TestAccAlicloudSlbServerCertificatesDataSource_basic (6.81s)
=== RUN   TestAccAlicloudSlbServerGroupsDataSource_basic
--- PASS: TestAccAlicloudSlbServerGroupsDataSource_basic (135.21s)
=== RUN   TestAccAlicloudSlbsDataSource
--- PASS: TestAccAlicloudSlbsDataSource (95.86s)
=== RUN   TestAccAlicloudSlbAcl_basic
--- PASS: TestAccAlicloudSlbAcl_basic (5.48s)
=== RUN   TestAccAlicloudSlbAcl_muilt
--- PASS: TestAccAlicloudSlbAcl_muilt (12.11s)
=== RUN   TestAccAlicloudSlbAttachment_basic
--- PASS: TestAccAlicloudSlbAttachment_basic (180.32s)
=== RUN   TestAccAlicloudSlbAttachment_multi
--- PASS: TestAccAlicloudSlbAttachment_multi (125.25s)
=== RUN   TestAccAlicloudSlbAttachment_classic_basic
--- PASS: TestAccAlicloudSlbAttachment_classic_basic (168.48s)
=== RUN   TestAccAlicloudSlbBackendServers_vpc
--- PASS: TestAccAlicloudSlbBackendServers_vpc (374.96s)
=== RUN   TestAccAlicloudSlbBackendServers_multi_vpc
--- PASS: TestAccAlicloudSlbBackendServers_multi_vpc (135.47s)
=== RUN   TestAccAlicloudSlbBackendServers_classic
--- PASS: TestAccAlicloudSlbBackendServers_classic (142.37s)
=== RUN   TestAccAlicloudSlbCACertificate_basic
--- PASS: TestAccAlicloudSlbCACertificate_basic (3.26s)
=== RUN   TestAccAlicloudSlbCACertificate_multi
--- PASS: TestAccAlicloudSlbCACertificate_multi (9.72s)
=== RUN   TestAccAlicloudSlbDomainExtensionBasic
--- PASS: TestAccAlicloudSlbDomainExtensionBasic (18.06s)
=== RUN   TestAccAlicloudSlbListener_http_basic
--- PASS: TestAccAlicloudSlbListener_http_basic (79.50s)
=== RUN   TestAccAlicloudSlbListener_same_port
--- PASS: TestAccAlicloudSlbListener_same_port (12.47s)
=== RUN   TestAccAlicloudSlbListener_https_update
--- PASS: TestAccAlicloudSlbListener_https_update (72.69s)
=== RUN   TestAccAlicloudSlbListener_tcp_basic
--- PASS: TestAccAlicloudSlbListener_tcp_basic (53.53s)
=== RUN   TestAccAlicloudSlbListener_tcp_server_group
--- PASS: TestAccAlicloudSlbListener_tcp_server_group (118.95s)
=== RUN   TestAccAlicloudSlbListener_udp_basic
--- PASS: TestAccAlicloudSlbListener_udp_basic (40.16s)
=== RUN   TestAccAlicloudSlbMasterSlaveServerGroup_vpc
--- PASS: TestAccAlicloudSlbMasterSlaveServerGroup_vpc (121.95s)
=== RUN   TestAccAlicloudSlbMasterSlaveServerGroup_multi_vpc
--- PASS: TestAccAlicloudSlbMasterSlaveServerGroup_multi_vpc (128.42s)
=== RUN   TestAccAlicloudSlbRuleUpdate
--- PASS: TestAccAlicloudSlbRuleUpdate (267.33s)
=== RUN   TestAccAlicloudSlbServerCertificate_basic
--- PASS: TestAccAlicloudSlbServerCertificate_basic (4.13s)
=== RUN   TestAccAlicloudSlbServerGroup_vpc
--- PASS: TestAccAlicloudSlbServerGroup_vpc (450.83s)
=== RUN   TestAccAlicloudSlbServerGroup_multi_vpc
--- PASS: TestAccAlicloudSlbServerGroup_multi_vpc (130.93s)
=== RUN   TestAccAlicloudSlbServerGroup_classic
--- PASS: TestAccAlicloudSlbServerGroup_classic (111.09s)
=== RUN   TestAccAlicloudSlb_classictest
--- PASS: TestAccAlicloudSlb_classictest (30.57s)
=== RUN   TestAccAlicloudSlb_vpctest
--- PASS: TestAccAlicloudSlb_vpctest (74.51s)
=== RUN   TestAccAlicloudSlb_vpcmulti
--- PASS: TestAccAlicloudSlb_vpcmulti (66.24s)
PASS
ok      github.com/terraform-providers/terraform-provider-alicloud/alicloud     3889.474s