### PR TITLE
improve(kvstore_instance_classess): improve test case error caused by no stock

### DIFF
--- a/alicloud/data_source_alicloud_kvstore_instance_classes_test.go
+++ b/alicloud/data_source_alicloud_kvstore_instance_classes_test.go
@@ -45,8 +45,9 @@ func TestAccAlicloudKVStoreInstanceClasses(t *testing.T) {
 			"performance_type": "standard_performance_type",
 		}),
 	}
+	// At present, there is no stock for enhance_performance_type, if someday stock enugth, just change fakeConfig to existConfig
 	PerformanceTypeEnhancePerformanceType := dataSourceTestAccConfig{
-		existConfig: testAccConfig(map[string]interface{}{
+		fakeConfig: testAccConfig(map[string]interface{}{
 			"zone_id":          "${data.alicloud_zones.resources.zones.0.id}",
 			"performance_type": "enhance_performance_type",
 		}),


### PR DESCRIPTION
```
TF_ACC=1 go test ./alicloud -v -run=TestAccAlicloudKVStoreInstanceClasses -timeout=1200m
=== RUN   TestAccAlicloudKVStoreInstanceClasses
--- PASS: TestAccAlicloudKVStoreInstanceClasses (158.92s)
PASS
ok      github.com/terraform-providers/terraform-provider-alicloud/alicloud     158.985s
```