### PR TITLE
Terraform registry docs

### DIFF
--- a/website/alicloud.erb
+++ b/website/alicloud.erb
@@ -122,6 +122,20 @@
                   <a href="#">API Gateway</a>
                   <ul class="nav">
                       <li>
+                        <a href="#">Data Sources</a>
+                        <ul class="nav nav-auto-expand">
+                          <li>
+                            <a href="/docs/providers/alicloud/d/api_gateway_apis.html">alicloud_api_gateway_apis</a>
+                          </li>
+                          <li>
+                            <a href="/docs/providers/alicloud/d/api_gateway_apps.html">alicloud_api_gateway_apps</a>
+                          </li>
+                          <li>
+                            <a href="/docs/providers/alicloud/d/api_gateway_groups.html">alicloud_api_gateway_groups</a>
+                          </li>
+                        </ul>
+                      </li>
+                      <li>
                           <a href="#">Resources</a>
                           <ul class="nav nav-auto-expand">
                             <li>
@@ -205,6 +219,9 @@
                       <li>
                         <a href="#">Data Sources</a>
                         <ul class="nav nav-auto-expand">
+                          <li>
+                            <a href="/docs/providers/alicloud/d/ddosbgp_instances.html">alicloud_ddosbgp_instances</a>
+                          </li>
                           <li>
                             <a href="/docs/providers/alicloud/d/ddoscoo_instances.html">alicloud_ddoscoo_instances</a>
                           </li>
@@ -366,6 +383,9 @@
                           <li>
                             <a href="/docs/providers/alicloud/d/cs_managed_kubernetes_clusters.html">alicloud_cs_managed_kubernetes_clusters</a>
                           </li>
+                          <li>
+                            <a href="/docs/providers/alicloud/d/cs_serverless_kubernetes_clusters.html">alicloud_cs_serverless_kubernetes_clusters</a>
+                          </li>
                         </ul>
                       </li>
                       <li>
@@ -518,6 +538,9 @@
                           </li>
                           <li>
                             <a href="/docs/providers/alicloud/d/images.html">alicloud_images</a>
+                          </li>
+                          <li>
+                            <a href="/docs/providers/alicloud/d/instance_type_families.html">alicloud_instance_type_families</a>
                           </li>
                           <li>
                             <a href="/docs/providers/alicloud/d/instance_types.html">alicloud_instance_types</a>
@@ -1118,10 +1141,16 @@
                                 <a href="/docs/providers/alicloud/d/slb_attachments.html">alicloud_slb_attachments</a>
                             </li>
                             <li>
+                                <a href="/docs/providers/alicloud/d/slb_backend_servers.html">alicloud_slb_backend_servers</a>
+                            </li>
+                            <li>
                                 <a href="/docs/providers/alicloud/d/slb_ca_certificates.html">alicloud_slb_ca_certificates</a>
                             </li>
                             <li>
                                 <a href="/docs/providers/alicloud/d/slb_listeners.html">alicloud_slb_listeners</a>
+                            </li>
+                            <li>
+                                <a href="/docs/providers/alicloud/d/slb_master_slave_server_groups.html">alicloud_slb_master_slave_server_groups</a>
                             </li>
                             <li>
                                 <a href="/docs/providers/alicloud/d/slb_rules.html">alicloud_slb_rules</a>
@@ -1153,10 +1182,16 @@
                                 <a href="/docs/providers/alicloud/r/slb_attachment.html">alicloud_slb_attachment</a>
                             </li>
                             <li>
+                                <a href="/docs/providers/alicloud/r/slb_backend_server.html">alicloud_slb_backend_server</a>
+                            </li>
+                            <li>
                                 <a href="/docs/providers/alicloud/r/slb_ca_certificate.html">alicloud_slb_ca_certificate</a>
                             </li>
                             <li>
                                 <a href="/docs/providers/alicloud/r/slb_listener.html">alicloud_slb_listener</a>
+                            </li>
+                            <li>
+                                <a href="/docs/providers/alicloud/r/slb_master_slave_server_group.html">alicloud_slb_master_slave_server_group</a>
                             </li>
                             <li>
                                 <a href="/docs/providers/alicloud/r/slb_rule.html">alicloud_slb_rule</a>

--- a/website/docs/d/actiontrails.html.markdown
+++ b/website/docs/d/actiontrails.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Actiontrail"
 layout: "alicloud"
 page_title: "Alicloud: alicloud_actiontrails"
 sidebar_current: "docs-alicloud-datasource-actiontrails"

--- a/website/docs/d/alikafka_consumer_groups.html.markdown
+++ b/website/docs/d/alikafka_consumer_groups.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Alikafka"
 layout: "alicloud"
 page_title: "Alicloud: alicloud_alikafka_consumer_groups"
 sidebar_current: "docs-alicloud-datasource-alikafka-consumer-groups"

--- a/website/docs/d/alikafka_instances.html.markdown
+++ b/website/docs/d/alikafka_instances.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Alikafka"
 layout: "alicloud"
 page_title: "Alicloud: alicloud_alikafka_instances"
 sidebar_current: "docs-alicloud-datasource-alikafka-instances"

--- a/website/docs/d/alikafka_topics.html.markdown
+++ b/website/docs/d/alikafka_topics.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Alikafka"
 layout: "alicloud"
 page_title: "Alicloud: alicloud_alikafka_topics"
 sidebar_current: "docs-alicloud-datasource-alikafka-topics"

--- a/website/docs/d/api_gateway_apis.html.markdown
+++ b/website/docs/d/api_gateway_apis.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "API Gateway"
 layout: "alicloud"
 page_title: "Alicloud: alicloud_api_gateway_apis"
 sidebar_current: "docs-alicloud-datasource-api-gateway-apis"

--- a/website/docs/d/api_gateway_apps.html.markdown
+++ b/website/docs/d/api_gateway_apps.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "API Gateway"
 layout: "alicloud"
 page_title: "Alicloud: alicloud_api_gateway_apps"
 sidebar_current: "docs-alicloud-datasource-api-gateway-apps"

--- a/website/docs/d/api_gateway_groups.html.markdown
+++ b/website/docs/d/api_gateway_groups.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "API Gateway"
 layout: "alicloud"
 page_title: "Alicloud: alicloud_api_gateway_groups"
 sidebar_current: "docs-alicloud-datasource-api-gateway-groups"

--- a/website/docs/d/cas_certificates.html.markdown
+++ b/website/docs/d/cas_certificates.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "SSL Certificates"
 layout: "alicloud"
 page_title: "Alicloud: alicloud_cas_certificates"
 sidebar_current: "docs-alicloud-datasource-cas-certificates"

--- a/website/docs/d/cen_bandwidth_limits.html.markdown
+++ b/website/docs/d/cen_bandwidth_limits.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Cloud Enterprise Network (CEN)"
 layout: "alicloud"
 page_title: "Alicloud: alicloud_cen_bandwidth_limits"
 sidebar_current: "docs-alicloud-datasource-cen-bandwidth-limits"

--- a/website/docs/d/cen_bandwidth_packages.html.markdown
+++ b/website/docs/d/cen_bandwidth_packages.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Cloud Enterprise Network (CEN)"
 layout: "alicloud"
 page_title: "Alicloud: alicloud_cen_bandwidth_packages"
 sidebar_current: "docs-alicloud-datasource-cen-bandwidth-packages"

--- a/website/docs/d/cen_instances.html.markdown
+++ b/website/docs/d/cen_instances.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Cloud Enterprise Network (CEN)"
 layout: "alicloud"
 page_title: "Alicloud: alicloud_cen_instances"
 sidebar_current: "docs-alicloud-datasource-cen-instances"

--- a/website/docs/d/cen_region_route_entries.html.markdown
+++ b/website/docs/d/cen_region_route_entries.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Cloud Enterprise Network (CEN)"
 layout: "alicloud"
 page_title: "Alicloud: alicloud_cen_region_route_entries"
 sidebar_current: "docs-alicloud-datasource-cen-region-route-entries"

--- a/website/docs/d/cen_route_entries.html.markdown
+++ b/website/docs/d/cen_route_entries.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Cloud Enterprise Network (CEN)"
 layout: "alicloud"
 page_title: "Alicloud: alicloud_cen_route_entries"
 sidebar_current: "docs-alicloud-datasource-cen-route-entries"

--- a/website/docs/d/cloud_connect_networks.html.markdown
+++ b/website/docs/d/cloud_connect_networks.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Cloud Connect Network"
 layout: "alicloud"
 page_title: "Alicloud: alicloud_cloud_connect_networks"
 sidebar_current: "docs-alicloud-datasource-cloud-connect-networks"

--- a/website/docs/d/common_bandwidth_packages.html.markdown
+++ b/website/docs/d/common_bandwidth_packages.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "VPC"
 layout: "alicloud"
 page_title: "Alicloud: alicloud_common_bandwidth_packages"
 sidebar_current: "docs-alicloud-datasource-common-bandwidth-packages"

--- a/website/docs/d/cr_namespaces.html.markdown
+++ b/website/docs/d/cr_namespaces.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Container Registry (CR)"
 layout: "alicloud"
 page_title: "Alicloud: alicloud_cr_namespaces"
 sidebar_current: "docs-alicloud-datasource-cr-namespaces"

--- a/website/docs/d/cr_repos.html.markdown
+++ b/website/docs/d/cr_repos.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Container Registry (CR)"
 layout: "alicloud"
 page_title: "Alicloud: alicloud_cr_repos"
 sidebar_current: "docs-alicloud-datasource-cr-repos"

--- a/website/docs/d/cs_kubernetes_clusters.html.markdown
+++ b/website/docs/d/cs_kubernetes_clusters.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Container Service (CS)"
 layout: "alicloud"
 page_title: "Alicloud: alicloud_cs_kubernetes_clusters"
 sidebar_current: "docs-alicloud-datasource-cs-kubernetes-clusters"

--- a/website/docs/d/cs_managed_kubernetes_clusters.html.markdown
+++ b/website/docs/d/cs_managed_kubernetes_clusters.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Container Service (CS)"
 layout: "alicloud"
 page_title: "Alicloud: alicloud_cs_managed_kubernetes_clusters"
 sidebar_current: "docs-alicloud-datasource-cs-managed-kubernetes-clusters"

--- a/website/docs/d/cs_serverless_kubernetes_clusters.html.markdown
+++ b/website/docs/d/cs_serverless_kubernetes_clusters.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Container Service (CS)"
 layout: "alicloud"
 page_title: "Alicloud: alicloud_cs_serverless_kubernetes_clusters"
 sidebar_current: "docs-alicloud-datasource-cs-serverless-kubernetes-clusters"

--- a/website/docs/d/db_instance_classes.html.markdown
+++ b/website/docs/d/db_instance_classes.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "RDS"
 layout: "alicloud"
 page_title: "Alicloud: alicloud_db_instance_classes"
 sidebar_current: "docs-alicloud-datasource-db-instance-classes"

--- a/website/docs/d/db_instance_engines.html.markdown
+++ b/website/docs/d/db_instance_engines.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "RDS"
 layout: "alicloud"
 page_title: "Alicloud: alicloud_db_instance_engines"
 sidebar_current: "docs-alicloud-datasource-db-instance-engines"

--- a/website/docs/d/db_instances.html.markdown
+++ b/website/docs/d/db_instances.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "RDS"
 layout: "alicloud"
 page_title: "Alicloud: alicloud_db_instances"
 sidebar_current: "docs-alicloud-datasource-db-instances"

--- a/website/docs/d/ddosbgp_instances.html.markdown
+++ b/website/docs/d/ddosbgp_instances.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "BGP-Line Anti-DDoS"
 layout: "alicloud"
 page_title: "Alicloud: alicloud_ddoscoo_instances"
 sidebar_current: "docs-alicloud-datasource-ddoscoo-instances"

--- a/website/docs/d/ddoscoo_instances.html.markdown
+++ b/website/docs/d/ddoscoo_instances.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "BGP-Line Anti-DDoS"
 layout: "alicloud"
 page_title: "Alicloud: alicloud_ddoscoo_instances"
 sidebar_current: "docs-alicloud-datasource-ddoscoo-instances"

--- a/website/docs/d/disks.html.markdown
+++ b/website/docs/d/disks.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "ECS"
 layout: "alicloud"
 page_title: "Alicloud: alicloud_disks"
 sidebar_current: "docs-alicloud-datasource-disks"

--- a/website/docs/d/dns_domain_groups.html.markdown
+++ b/website/docs/d/dns_domain_groups.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "DNS"
 layout: "alicloud"
 page_title: "Alicloud: alicloud_dns_domain_groups"
 sidebar_current: "docs-alicloud-datasource-dns-domain-groups"

--- a/website/docs/d/dns_domain_records.html.markdown
+++ b/website/docs/d/dns_domain_records.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "DNS"
 layout: "alicloud"
 page_title: "Alicloud: alicloud_dns_domain_records"
 sidebar_current: "docs-alicloud-datasource-dns-domain-records"

--- a/website/docs/d/dns_domains.html.markdown
+++ b/website/docs/d/dns_domains.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "DNS"
 layout: "alicloud"
 page_title: "Alicloud: alicloud_dns_domains"
 sidebar_current: "docs-alicloud-datasource-dns-domains"

--- a/website/docs/d/dns_groups.html.markdown
+++ b/website/docs/d/dns_groups.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "DNS"
 layout: "alicloud"
 page_title: "Alicloud: alicloud_dns_groups"
 sidebar_current: "docs-alicloud-datasource-dns-groups"

--- a/website/docs/d/dns_records.html.markdown
+++ b/website/docs/d/dns_records.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "DNS"
 layout: "alicloud"
 page_title: "Alicloud: alicloud_dns_records"
 sidebar_current: "docs-alicloud-datasource-dns-records"

--- a/website/docs/d/dns_resolution_lines.html.markdown
+++ b/website/docs/d/dns_resolution_lines.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "DNS"
 layout: "alicloud"
 page_title: "Alicloud: alicloud_dns_domains"
 sidebar_current: "docs-alicloud-datasource-dns-domains"

--- a/website/docs/d/drds_instances.html.markdown
+++ b/website/docs/d/drds_instances.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Distributed Relational Database Service (DRDS)"
 layout: "alicloud"
 page_title: "Alicloud: alicloud_drds_instances"
 sidebar_current: "docs-alicloud-drds-instances"

--- a/website/docs/d/eips.html.markdown
+++ b/website/docs/d/eips.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "VPC"
 layout: "alicloud"
 page_title: "Alicloud: alicloud_eips"
 sidebar_current: "docs-alicloud-datasource-eips"

--- a/website/docs/d/elasticsearch.html.markdown
+++ b/website/docs/d/elasticsearch.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Elasticsearch"
 layout: "alicloud"
 page_title: "Alicloud: alicloud_elasticsearch_instances"
 sidebar_current: "docs-alicloud-datasource-elasticsearch-instances"

--- a/website/docs/d/emr_disk_types.html.markdown
+++ b/website/docs/d/emr_disk_types.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "E-MapReduce"
 layout: "alicloud"
 page_title: "Alicloud: alicloud_emr_disk_types"
 sidebar_current: "docs-alicloud-datasource-emr-disk-types"

--- a/website/docs/d/emr_instance_types.html.markdown
+++ b/website/docs/d/emr_instance_types.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "E-MapReduce"
 layout: "alicloud"
 page_title: "Alicloud: alicloud_emr_instance_types"
 sidebar_current: "docs-alicloud-datasource-emr-instance-types"

--- a/website/docs/d/emr_main_versions.html.markdown
+++ b/website/docs/d/emr_main_versions.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "E-MapReduce"
 layout: "alicloud"
 page_title: "Alicloud: alicloud_emr_main_versions"
 sidebar_current: "docs-alicloud-datasource-emr-main-versions"

--- a/website/docs/d/ess_scaling_configurations.html.markdown
+++ b/website/docs/d/ess_scaling_configurations.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Auto Scaling(ESS)"
 layout: "alicloud"
 page_title: "Alicloud: alicloud_ess_scaling_configurations"
 sidebar_current: "docs-alicloud_ess_scaling_configurations"

--- a/website/docs/d/ess_scaling_groups.html.markdown
+++ b/website/docs/d/ess_scaling_groups.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Auto Scaling(ESS)"
 layout: "alicloud"
 page_title: "Alicloud: alicloud_ess_scaling_groups"
 sidebar_current: "docs-alicloud_ess_scaling_groups"

--- a/website/docs/d/ess_scaling_rules.html.markdown
+++ b/website/docs/d/ess_scaling_rules.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Auto Scaling(ESS)"
 layout: "alicloud"
 page_title: "Alicloud: alicloud_ess_scaling_rules"
 sidebar_current: "docs-alicloud_ess_scaling_rules"

--- a/website/docs/d/fc_functions.html.markdown
+++ b/website/docs/d/fc_functions.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Function Compute Service"
 layout: "alicloud"
 page_title: "Alicloud: alicloud_fc_functions"
 sidebar_current: "docs-alicloud-datasource-fc-functions"

--- a/website/docs/d/fc_services.html.markdown
+++ b/website/docs/d/fc_services.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Function Compute Service"
 layout: "alicloud"
 page_title: "Alicloud: alicloud_fc_services"
 sidebar_current: "docs-alicloud-datasource-fc-services"

--- a/website/docs/d/fc_triggers.html.markdown
+++ b/website/docs/d/fc_triggers.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Function Compute Service"
 layout: "alicloud"
 page_title: "Alicloud: alicloud_fc_triggers"
 sidebar_current: "docs-alicloud-datasource-fc-triggers"

--- a/website/docs/d/forward_entries.html.markdown
+++ b/website/docs/d/forward_entries.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "VPC"
 layout: "alicloud"
 page_title: "Alicloud: alicloud_forward_entries"
 sidebar_current: "docs-alicloud-datasource-forward-entries"

--- a/website/docs/d/gpdb_instances.html.markdown
+++ b/website/docs/d/gpdb_instances.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "AnalyticDB for PostgreSQL (GPDB)"
 layout: "alicloud"
 page_title: "Alicloud: alicloud_gpdb_instances"
 sidebar_current: "docs-alicloud-datasource-gpdb-instances"

--- a/website/docs/d/images.html.markdown
+++ b/website/docs/d/images.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "ECS"
 layout: "alicloud"
 page_title: "Alicloud: alicloud_images"
 sidebar_current: "docs-alicloud-datasource-images"

--- a/website/docs/d/instance_type_families.html.markdown
+++ b/website/docs/d/instance_type_families.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "ECS"
 layout: "alicloud"
 page_title: "Alicloud: alicloud_instance_type_families"
 sidebar_current: "docs-alicloud-datasource-instance-type-families"

--- a/website/docs/d/instance_types.html.markdown
+++ b/website/docs/d/instance_types.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "ECS"
 layout: "alicloud"
 page_title: "Alicloud: alicloud_instance_types"
 sidebar_current: "docs-alicloud-datasource-instance-types"

--- a/website/docs/d/instances.html.markdown
+++ b/website/docs/d/instances.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "ECS"
 layout: "alicloud"
 page_title: "Alicloud: alicloud_instances"
 sidebar_current: "docs-alicloud-datasource-instances"

--- a/website/docs/d/key_pairs.html.markdown
+++ b/website/docs/d/key_pairs.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "ECS"
 layout: "alicloud"
 page_title: "Alicloud: alicloud_key_pairs"
 sidebar_current: "docs-alicloud-datasource-key-pairs"

--- a/website/docs/d/kms_keys.html.markdown
+++ b/website/docs/d/kms_keys.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "KMS"
 layout: "alicloud"
 page_title: "Alicloud: alicloud_kms_keys"
 sidebar_current: "docs-alicloud-datasource-kms-keys"

--- a/website/docs/d/kvstore_instance_classes.html.markdown
+++ b/website/docs/d/kvstore_instance_classes.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Redis And Memcache (KVStore)"
 layout: "alicloud"
 page_title: "Alicloud: alicloud_kvstore_instance_classes"
 sidebar_current: "docs-alicloud-datasource-kvstore-instance-classes"

--- a/website/docs/d/kvstore_instance_engines.html.markdown
+++ b/website/docs/d/kvstore_instance_engines.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Redis And Memcache (KVStore)"
 layout: "alicloud"
 page_title: "Alicloud: alicloud_kvstore_instance_engines"
 sidebar_current: "docs-alicloud-datasource-kvstore-instance-engines"

--- a/website/docs/d/kvstore_instances.html.markdown
+++ b/website/docs/d/kvstore_instances.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Redis And Memcache (KVStore)"
 layout: "alicloud"
 page_title: "Alicloud: alicloud_kvstore_instances"
 sidebar_current: "docs-alicloud-datasource-kvstore-instances"

--- a/website/docs/d/mns_queues.html.markdown
+++ b/website/docs/d/mns_queues.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Message Notification Service (MNS)"
 layout: "alicloud"
 page_title: "Alicloud: alicloud_mns_queues"
 sidebar_current: "docs-alicloud-datasource-mns-queues"

--- a/website/docs/d/mns_topic_subscriptions.html.markdown
+++ b/website/docs/d/mns_topic_subscriptions.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Message Notification Service (MNS)"
 layout: "alicloud"
 page_title: "Alicloud: alicloud_mns_topic_subscriptions"
 sidebar_current: "docs-alicloud-datasource-mns-topic-subscriptions"

--- a/website/docs/d/mns_topics.html.markdown
+++ b/website/docs/d/mns_topics.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Message Notification Service (MNS)"
 layout: "alicloud"
 page_title: "Alicloud: alicloud_mns_topics"
 sidebar_current: "docs-alicloud-datasource-mns-topics"

--- a/website/docs/d/mongodb_instances.html.markdown
+++ b/website/docs/d/mongodb_instances.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "MongoDB"
 layout: "alicloud"
 page_title: "Alicloud: alicloud_mongodb_instances"
 sidebar_current: "docs-alicloud-datasource-mongodb-instances"

--- a/website/docs/d/nas_access_groups.html.markdown
+++ b/website/docs/d/nas_access_groups.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Network Attached Storage (NAS)"
 layout: "alicloud"
 page_title: "Alicloud: alicloud_nas_access_groups"
 sidebar_current: "docs-alicloud-datasource-nas-access-groups"

--- a/website/docs/d/nas_access_rules.html.markdown
+++ b/website/docs/d/nas_access_rules.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Network Attached Storage (NAS)"
 layout: "alicloud"
 page_title: "Alicloud: alicloud_nas_access_rules"
 sidebar_current: "docs-alicloud-datasource-nas-access-rules"

--- a/website/docs/d/nas_file_systems.html.markdown
+++ b/website/docs/d/nas_file_systems.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Network Attached Storage (NAS)"
 layout: "alicloud"
 page_title: "Alicloud: alicloud_nas_file_systems"
 sidebar_current: "docs-alicloud-datasource-nas-file-systems"

--- a/website/docs/d/nas_mount_targets.html.markdown
+++ b/website/docs/d/nas_mount_targets.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Network Attached Storage (NAS)"
 layout: "alicloud"
 page_title: "Alicloud: alicloud_nas_mount_targets"
 sidebar_current: "docs-alicloud-datasource-nas-mount-targets"

--- a/website/docs/d/nas_protocols.html.markdown
+++ b/website/docs/d/nas_protocols.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Network Attached Storage (NAS)"
 layout: "alicloud"
 page_title: "Alicloud: alicloud_nas_protocols"
 sidebar_current: "docs-alicloud-datasource-nas-protocols"

--- a/website/docs/d/nat_gateways.html.markdown
+++ b/website/docs/d/nat_gateways.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "VPC"
 layout: "alicloud"
 page_title: "Alicloud: alicloud_nat_gateways"
 sidebar_current: "docs-alicloud-datasource-nat-gateways"

--- a/website/docs/d/network_interfaces.html.markdown
+++ b/website/docs/d/network_interfaces.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "ECS"
 layout: "alicloud"
 page_title: "Alicloud: alicloud_network_interfaces"
 sidebar_current: "docs-alicloud-datasource-network-interfaces"

--- a/website/docs/d/ons_groups.html.markdown
+++ b/website/docs/d/ons_groups.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "RocketMQ"
 layout: "alicloud"
 page_title: "Alicloud: alicloud_ons_groups"
 sidebar_current: "docs-alicloud-datasource-ons-groups"

--- a/website/docs/d/ons_instances.html.markdown
+++ b/website/docs/d/ons_instances.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "RocketMQ"
 layout: "alicloud"
 page_title: "Alicloud: alicloud_ons_instances"
 sidebar_current: "docs-alicloud-datasource-ons-instances"

--- a/website/docs/d/ons_topics.html.markdown
+++ b/website/docs/d/ons_topics.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "RocketMQ"
 layout: "alicloud"
 page_title: "Alicloud: alicloud_ons_topics"
 sidebar_current: "docs-alicloud-datasource-ons-topics"

--- a/website/docs/d/oss_bucket_objects.html.markdown
+++ b/website/docs/d/oss_bucket_objects.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "OSS"
 layout: "alicloud"
 page_title: "Alicloud: alicloud_oss_bucket_objects"
 sidebar_current: "docs-alicloud-datasource-oss-bucket-objects"

--- a/website/docs/d/oss_buckets.html.markdown
+++ b/website/docs/d/oss_buckets.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "OSS"
 layout: "alicloud"
 page_title: "Alicloud: alicloud_oss_buckets"
 sidebar_current: "docs-alicloud-datasource-oss-buckets"

--- a/website/docs/d/ots_instance_attachments.html.markdown
+++ b/website/docs/d/ots_instance_attachments.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Table Store (OTS)"
 layout: "alicloud"
 page_title: "Alicloud: alicloud_ots_instance_attachments"
 sidebar_current: "docs-alicloud-datasource-ots-instance-attachments"

--- a/website/docs/d/ots_instances.html.markdown
+++ b/website/docs/d/ots_instances.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Table Store (OTS)"
 layout: "alicloud"
 page_title: "Alicloud: alicloud_ots_instances"
 sidebar_current: "docs-alicloud-datasource-ots-instances"

--- a/website/docs/d/ots_tables.html.markdown
+++ b/website/docs/d/ots_tables.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Table Store (OTS)"
 layout: "alicloud"
 page_title: "Alicloud: alicloud_ots_tables"
 sidebar_current: "docs-alicloud-datasource-ots-tables"

--- a/website/docs/d/pvtz_zone_records.html.markdown
+++ b/website/docs/d/pvtz_zone_records.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Private Zone"
 layout: "alicloud"
 page_title: "Alicloud: alicloud_pvtz_zone_records"
 sidebar_current: "docs-alicloud-datasource-pvtz-zone-records"

--- a/website/docs/d/pvtz_zones.html.markdown
+++ b/website/docs/d/pvtz_zones.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Private Zone"
 layout: "alicloud"
 page_title: "Alicloud: alicloud_pvtz_zones"
 sidebar_current: "docs-alicloud-datasource-pvtz-zones"

--- a/website/docs/d/ram_account_aliases.html.markdown
+++ b/website/docs/d/ram_account_aliases.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "RAM"
 layout: "alicloud"
 page_title: "Alicloud: alicloud_ram_account_aliases"
 sidebar_current: "docs-alicloud-datasource-ram-account-alias"

--- a/website/docs/d/ram_alias.html.markdown
+++ b/website/docs/d/ram_alias.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "RAM"
 layout: "alicloud"
 page_title: "Alicloud: alicloud_ram_account_alias"
 sidebar_current: "docs-alicloud-datasource-ram-account-alias"

--- a/website/docs/d/ram_groups.html.markdown
+++ b/website/docs/d/ram_groups.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "RAM"
 layout: "alicloud"
 page_title: "Alicloud: alicloud_ram_groups"
 sidebar_current: "docs-alicloud-datasource-ram-groups"

--- a/website/docs/d/ram_policies.html.markdown
+++ b/website/docs/d/ram_policies.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "RAM"
 layout: "alicloud"
 page_title: "Alicloud: alicloud_ram_policies"
 sidebar_current: "docs-alicloud-datasource-ram-policies"

--- a/website/docs/d/ram_roles.html.markdown
+++ b/website/docs/d/ram_roles.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "RAM"
 layout: "alicloud"
 page_title: "Alicloud: alicloud_ram_roles"
 sidebar_current: "docs-alicloud-datasource-ram-roles"

--- a/website/docs/d/ram_users.html.markdown
+++ b/website/docs/d/ram_users.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "RAM"
 layout: "alicloud"
 page_title: "Alicloud: alicloud_ram_users"
 sidebar_current: "docs-alicloud-datasource-ram-users"

--- a/website/docs/d/route_entries.html.markdown
+++ b/website/docs/d/route_entries.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "VPC"
 layout: "alicloud"
 page_title: "Alicloud: alicloud_route_entries"
 sidebar_current: "docs-alicloud-datasource-route-entries"

--- a/website/docs/d/route_tables.html.markdown
+++ b/website/docs/d/route_tables.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "VPC"
 layout: "alicloud"
 page_title: "Alicloud: alicloud_route_tables"
 sidebar_current: "docs-alicloud-datasource-route-tables"

--- a/website/docs/d/router_interfaces.html.markdown
+++ b/website/docs/d/router_interfaces.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "VPC"
 layout: "alicloud"
 page_title: "Alicloud: alicloud_router_interfaces"
 sidebar_current: "docs-alicloud-datasource-router-interfaces"

--- a/website/docs/d/sag_acls.html.markdown
+++ b/website/docs/d/sag_acls.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Smart Access Gateway"
 layout: "alicloud"
 page_title: "Alicloud: alicloud_sag_acls"
 sidebar_current: "docs-alicloud-resource-sag-acls"

--- a/website/docs/d/security_group_rules.html.markdown
+++ b/website/docs/d/security_group_rules.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "ECS"
 layout: "alicloud"
 page_title: "Alicloud: alicloud_security_group_rules"
 sidebar_current: "docs-alicloud-datasource-security-group-rules"

--- a/website/docs/d/security_groups.html.markdown
+++ b/website/docs/d/security_groups.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "ECS"
 layout: "alicloud"
 page_title: "Alicloud: alicloud_security_groups"
 sidebar_current: "docs-alicloud-datasource-security-groups"

--- a/website/docs/d/slb_acls.html.markdown
+++ b/website/docs/d/slb_acls.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Server Load Balancer (SLB)"
 layout: "alicloud"
 page_title: "Alicloud: alicloud_slb_acls"
 sidebar_current: "docs-alicloud-datasource-slb-acls"

--- a/website/docs/d/slb_attachments.html.markdown
+++ b/website/docs/d/slb_attachments.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Server Load Balancer (SLB)"
 layout: "alicloud"
 page_title: "Alicloud: alicloud_slb_attachments"
 sidebar_current: "docs-alicloud-datasource-slb-attachments"

--- a/website/docs/d/slb_backend_servers.html.markdown
+++ b/website/docs/d/slb_backend_servers.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Server Load Balancer (SLB)"
 layout: "alicloud"
 page_title: "Alicloud: alicloud_slb_backend_servers"
 sidebar_current: "docs-alicloud-datasource-slb-backend_servers"

--- a/website/docs/d/slb_ca_certificates.html.markdown
+++ b/website/docs/d/slb_ca_certificates.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Server Load Balancer (SLB)"
 layout: "alicloud"
 page_title: "Alicloud: alicloud_slb_ca_certificates"
 sidebar_current: "docs-alicloud-datasource-slb-ca-certificates"

--- a/website/docs/d/slb_domain_extensions.html.markdown
+++ b/website/docs/d/slb_domain_extensions.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Server Load Balancer (SLB)"
 layout: "alicloud"
 page_title: "Alicloud: alicloud_slb_domain_extensions"
 sidebar_current: "docs-alicloud-resource-slb-domain-extensions"

--- a/website/docs/d/slb_listeners.html.markdown
+++ b/website/docs/d/slb_listeners.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Server Load Balancer (SLB)"
 layout: "alicloud"
 page_title: "Alicloud: alicloud_slb_listeners"
 sidebar_current: "docs-alicloud-datasource-slb-listeners"

--- a/website/docs/d/slb_master_slave_server_groups.html.markdown
+++ b/website/docs/d/slb_master_slave_server_groups.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Server Load Balancer (SLB)"
 layout: "alicloud"
 page_title: "Alicloud: alicloud_slb_master_slave_server_groups"
 sidebar_current: "docs-alicloud-datasource-slb-master-slave-server-groups"

--- a/website/docs/d/slb_rules.html.markdown
+++ b/website/docs/d/slb_rules.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Server Load Balancer (SLB)"
 layout: "alicloud"
 page_title: "Alicloud: alicloud_slb_rules"
 sidebar_current: "docs-alicloud-datasource-slb-rules"

--- a/website/docs/d/slb_server_certificates.html.markdown
+++ b/website/docs/d/slb_server_certificates.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Server Load Balancer (SLB)"
 layout: "alicloud"
 page_title: "Alicloud: alicloud_slb_server_certificates"
 sidebar_current: "docs-alicloud-datasource-slb-server-certificates"

--- a/website/docs/d/slb_server_groups.html.markdown
+++ b/website/docs/d/slb_server_groups.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Server Load Balancer (SLB)"
 layout: "alicloud"
 page_title: "Alicloud: alicloud_slb_server_groups"
 sidebar_current: "docs-alicloud-datasource-slb-server_groups"

--- a/website/docs/d/slbs.html.markdown
+++ b/website/docs/d/slbs.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Server Load Balancer (SLB)"
 layout: "alicloud"
 page_title: "Alicloud: alicloud_slbs"
 sidebar_current: "docs-alicloud-datasource-slbs"

--- a/website/docs/d/snapshots.html.markdown
+++ b/website/docs/d/snapshots.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "ECS"
 layout: "alicloud"
 page_title: "Alicloud: alicloud_snapshots"
 sidebar_current: "docs-alicloud-datasource-snapshots"

--- a/website/docs/d/snat_entries.html.markdown
+++ b/website/docs/d/snat_entries.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "VPC"
 layout: "alicloud"
 page_title: "Alicloud: alicloud_snat_entries"
 sidebar_current: "docs-alicloud-datasource-snat-entries"

--- a/website/docs/d/ssl_vpn_client_certs.html.markdown
+++ b/website/docs/d/ssl_vpn_client_certs.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "VPN"
 layout: "alicloud"
 page_title: "Alicloud: alicloud_ssl_vpn_client_certs"
 sidebar_current: "docs-alicloud-datasource-ssl-vpn-client-certs"

--- a/website/docs/d/ssl_vpn_servers.html.markdown
+++ b/website/docs/d/ssl_vpn_servers.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "VPN"
 layout: "alicloud"
 page_title: "Alicloud: alicloud_ssl_vpn_servers"
 sidebar_current: "docs-alicloud-datasource-ssl-vpn-servers"

--- a/website/docs/d/vpcs.html.markdown
+++ b/website/docs/d/vpcs.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "VPC"
 layout: "alicloud"
 page_title: "Alicloud: alicloud_vpcs"
 sidebar_current: "docs-alicloud-datasource-vpcs"

--- a/website/docs/d/vpn_connections.html.markdown
+++ b/website/docs/d/vpn_connections.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "VPN"
 layout: "alicloud"
 page_title: "Alicloud: alicloud_vpn_connections"
 sidebar_current: "docs-alicloud-datasource-vpn-connections"

--- a/website/docs/d/vpn_customer_gateways.html.markdown
+++ b/website/docs/d/vpn_customer_gateways.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "VPN"
 layout: "alicloud"
 page_title: "Alicloud: alicloud_vpn_customer_gateways"
 sidebar_current: "docs-alicloud-datasource-vpn-customer-gateways"

--- a/website/docs/d/vpn_gateways.html.markdown
+++ b/website/docs/d/vpn_gateways.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "VPN"
 layout: "alicloud"
 page_title: "Alicloud: alicloud_vpn_gateways"
 sidebar_current: "docs-alicloud-datasource-vpn-gateways"

--- a/website/docs/d/vswitches.html.markdown
+++ b/website/docs/d/vswitches.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "VPC"
 layout: "alicloud"
 page_title: "Alicloud: alicloud_vswitches"
 sidebar_current: "docs-alicloud-datasource-vswitches"

--- a/website/docs/d/yundun_dbaudit_instances.html.markdown
+++ b/website/docs/d/yundun_dbaudit_instances.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Cloud DBAudit"
 layout: "alicloud"
 page_title: "Alicloud: alicloud_yundun_dbaudit_instances"
 sidebar_current: "docs-alicloud-yundun_dbaudit-instances"

--- a/website/docs/r/actiontrail.html.markdown
+++ b/website/docs/r/actiontrail.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Actiontrail"
 layout: "alicloud"
 page_title: "Alicloud: alicloud_actiontrail"
 sidebar_current: "docs-alicloud-resource-actiontrail"

--- a/website/docs/r/alikafka_consumer_group.html.markdown
+++ b/website/docs/r/alikafka_consumer_group.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Alikafka"
 layout: "alicloud"
 page_title: "Alicloud: alicloud_alikafka_consumer_group"
 sidebar_current: "docs-alicloud-resource-alikafka-consumer-group"

--- a/website/docs/r/alikafka_instance.html.markdown
+++ b/website/docs/r/alikafka_instance.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Alikafka"
 layout: "alicloud"
 page_title: "Alicloud: alicloud_alikafka_instance"
 sidebar_current: "docs-alicloud-resource-alikafka-instance"

--- a/website/docs/r/alikafka_topic.html.markdown
+++ b/website/docs/r/alikafka_topic.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Alikafka"
 layout: "alicloud"
 page_title: "Alicloud: alicloud_alikafka_topic"
 sidebar_current: "docs-alicloud-resource-alikafka-topic"

--- a/website/docs/r/api_gateway_api.html.markdown
+++ b/website/docs/r/api_gateway_api.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "API Gateway"
 layout: "alicloud"
 page_title: "Alicloud: alicloud_api_gateway_api"
 sidebar_current: "docs-alicloud-resource-api-gateway-api"

--- a/website/docs/r/api_gateway_app.html.markdown
+++ b/website/docs/r/api_gateway_app.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "API Gateway"
 layout: "alicloud"
 page_title: "Alicloud: alicloud_api_gateway_app"
 sidebar_current: "docs-alicloud-resource-api-gateway-app"

--- a/website/docs/r/api_gateway_app_attachment.html.markdown
+++ b/website/docs/r/api_gateway_app_attachment.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "API Gateway"
 layout: "alicloud"
 page_title: "Alicloud: alicloud_api_gateway_app_attachment"
 sidebar_current: "docs-alicloud-resource-api-gateway-app-attachment"

--- a/website/docs/r/api_gateway_group.html.markdown
+++ b/website/docs/r/api_gateway_group.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "API Gateway"
 layout: "alicloud"
 page_title: "Alicloud: alicloud_api_gateway_group"
 sidebar_current: "docs-alicloud-resource-api-gateway-group"

--- a/website/docs/r/api_gateway_vpc_access.html.markdown
+++ b/website/docs/r/api_gateway_vpc_access.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "API Gateway"
 layout: "alicloud"
 page_title: "Alicloud: alicloud_api_gateway_vpc_access"
 sidebar_current: "docs-alicloud-resource-api-gateway-vpc-access"

--- a/website/docs/r/cas_certificate.html.markdown
+++ b/website/docs/r/cas_certificate.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "SSL Certificates"
 layout: "alicloud"
 page_title: "Alicloud: alicloud_cas_certificate"
 sidebar_current: "docs-alicloud-resource-cas-certificate"

--- a/website/docs/r/cdn_domain.html.markdown
+++ b/website/docs/r/cdn_domain.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "CDN"
 layout: "alicloud"
 page_title: "Alicloud: alicloud_cdn_domain"
 sidebar_current: "docs-alicloud-resource-cdn-domain"

--- a/website/docs/r/cdn_domain_config.html.markdown
+++ b/website/docs/r/cdn_domain_config.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "CDN"
 layout: "alicloud"
 page_title: "Alicloud: alicloud_cdn_doamin_config"
 sidebar_current: "docs-alicloud-resource-cdn-domain-config"

--- a/website/docs/r/cdn_domain_new.html.markdown
+++ b/website/docs/r/cdn_domain_new.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "CDN"
 layout: "alicloud"
 page_title: "Alicloud: alicloud_cdn_domain_new"
 sidebar_current: "docs-alicloud-resource-cdn-domain-new"

--- a/website/docs/r/cen_bandwidth_limit.html.markdown
+++ b/website/docs/r/cen_bandwidth_limit.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Cloud Enterprise Network (CEN)"
 layout: "alicloud"
 page_title: "Alicloud: alicloud_cen_bandwidth_limit"
 sidebar_current: "docs-alicloud-resource-cen-bandwidth-limit"

--- a/website/docs/r/cen_bandwidth_package.html.markdown
+++ b/website/docs/r/cen_bandwidth_package.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Cloud Enterprise Network (CEN)"
 layout: "alicloud"
 page_title: "Alicloud: alicloud_cen_bandwidth_package"
 sidebar_current: "docs-alicloud-resource-cen-bandwidth-package"

--- a/website/docs/r/cen_bandwidth_package_attachment.html.markdown
+++ b/website/docs/r/cen_bandwidth_package_attachment.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Cloud Enterprise Network (CEN)"
 layout: "alicloud"
 page_title: "Alicloud: alicloud_cen_bandwidth_package_attachment"
 sidebar_current: "docs-alicloud-resource-cen-bandwidth-package-attachment"

--- a/website/docs/r/cen_instance.html.markdown
+++ b/website/docs/r/cen_instance.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Cloud Enterprise Network (CEN)"
 layout: "alicloud"
 page_title: "Alicloud: alicloud_cen_instance"
 sidebar_current: "docs-alicloud-resource-cen-instance"

--- a/website/docs/r/cen_instance_attachment.html.markdown
+++ b/website/docs/r/cen_instance_attachment.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Cloud Enterprise Network (CEN)"
 layout: "alicloud"
 page_title: "Alicloud: alicloud_cen_instance_attachment"
 sidebar_current: "docs-alicloud-resource-cen-instance-attachment"

--- a/website/docs/r/cen_instance_grant.html.markdown
+++ b/website/docs/r/cen_instance_grant.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Cloud Enterprise Network (CEN)"
 layout: "alicloud"
 page_title: "Alicloud: alicloud_cen_instance_grant"
 sidebar_current: "docs-alicloud-resource-cen-instance-grant"

--- a/website/docs/r/cen_route_entry.html.markdown
+++ b/website/docs/r/cen_route_entry.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Cloud Enterprise Network (CEN)"
 layout: "alicloud"
 page_title: "Alicloud: alicloud_cen_route_entry"
 sidebar_current: "docs-alicloud-resource-cen-route-entry"

--- a/website/docs/r/cloud_connect_network.html.markdown
+++ b/website/docs/r/cloud_connect_network.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Cloud Connect Network"
 layout: "alicloud"
 page_title: "Alicloud: alicloud_cloud_connect_network"
 sidebar_current: "docs-alicloud-resource-cloud-connect-network"

--- a/website/docs/r/cms_alarm.html.markdown
+++ b/website/docs/r/cms_alarm.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Cloud Monitor"
 layout: "alicloud"
 page_title: "Alicloud: alicloud_cms_alarm"
 sidebar_current: "docs-alicloud-resource-cms-alarm"

--- a/website/docs/r/common_bandwidth_package.html.markdown
+++ b/website/docs/r/common_bandwidth_package.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "VPC"
 layout: "alicloud"
 page_title: "Alicloud: alicloud_common_bandwidth_package"
 sidebar_current: "docs-alicloud-resource-common-bandwidth-package"

--- a/website/docs/r/common_bandwidth_package_attachment.html.markdown
+++ b/website/docs/r/common_bandwidth_package_attachment.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "VPC"
 layout: "alicloud"
 page_title: "Alicloud: alicloud_common_bandwidth_package_attachment"
 sidebar_current: "docs-alicloud-resource-common-bandwidth-package-attachment"

--- a/website/docs/r/container_cluster.html.markdown
+++ b/website/docs/r/container_cluster.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Container Service (CS)"
 layout: "alicloud"
 page_title: "Alicloud: alicloud_container_cluster"
 sidebar_current: "docs-alicloud-resource-container-cluster"

--- a/website/docs/r/cr_namespace.html.markdown
+++ b/website/docs/r/cr_namespace.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Container Registry (CR)"
 layout: "alicloud"
 page_title: "Alicloud: alicloud_cr_namespace"
 sidebar_current: "docs-alicloud-resource-container-registry"

--- a/website/docs/r/cr_repo.html.markdown
+++ b/website/docs/r/cr_repo.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Container Registry (CR)"
 layout: "alicloud"
 page_title: "Alicloud: alicloud_cr_repo"
 sidebar_current: "docs-alicloud-resource-container-registry"

--- a/website/docs/r/cs_application.html.markdown
+++ b/website/docs/r/cs_application.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Container Service (CS)"
 layout: "alicloud"
 page_title: "Alicloud: alicloud_cs_application"
 sidebar_current: "docs-alicloud-resource-cs-application"

--- a/website/docs/r/cs_kubernetes.html.markdown
+++ b/website/docs/r/cs_kubernetes.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Container Service (CS)"
 layout: "alicloud"
 page_title: "Alicloud: alicloud_cs_kubernetes"
 sidebar_current: "docs-alicloud-resource-cs-kubernetes"

--- a/website/docs/r/cs_managed_kubernetes.html.markdown
+++ b/website/docs/r/cs_managed_kubernetes.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Container Service (CS)"
 layout: "alicloud"
 page_title: "Alicloud: alicloud_cs_managed_kubernetes"
 sidebar_current: "docs-alicloud-resource-cs-managed-kubernetes"

--- a/website/docs/r/cs_serverless_kubernetes.html.markdown
+++ b/website/docs/r/cs_serverless_kubernetes.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Container Service (CS)"
 layout: "alicloud"
 page_title: "Alicloud: alicloud_cs_serverless_kubernetes"
 sidebar_current: "docs-alicloud-resource-cs-serverless-kubernetes"

--- a/website/docs/r/cs_swarm.html.markdown
+++ b/website/docs/r/cs_swarm.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Container Service (CS)"
 layout: "alicloud"
 page_title: "Alicloud: alicloud_cs_swarm"
 sidebar_current: "docs-alicloud-resource-cs-swarm"

--- a/website/docs/r/datahub_project.html.markdown
+++ b/website/docs/r/datahub_project.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Datahub Service"
 layout: "alicloud"
 page_title: "Alicloud: alicloud_datahub_project"
 sidebar_current: "docs-alicloud-resource-datahub-project"

--- a/website/docs/r/datahub_subscription.html.markdown
+++ b/website/docs/r/datahub_subscription.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Datahub Service"
 layout: "alicloud"
 page_title: "Alicloud: alicloud_datahub_subscription"
 sidebar_current: "docs-alicloud-resource-datahub-subscription"

--- a/website/docs/r/datahub_topic.html.markdown
+++ b/website/docs/r/datahub_topic.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Datahub Service"
 layout: "alicloud"
 page_title: "Alicloud: alicloud_datahub_topic"
 sidebar_current: "docs-alicloud-resource-datahub-topic"

--- a/website/docs/r/db_account.html.markdown
+++ b/website/docs/r/db_account.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "RDS"
 layout: "alicloud"
 page_title: "Alicloud: alicloud_db_account"
 sidebar_current: "docs-alicloud-resource-db-account"

--- a/website/docs/r/db_account_privilege.html.markdown
+++ b/website/docs/r/db_account_privilege.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "RDS"
 layout: "alicloud"
 page_title: "Alicloud: alicloud_db_account_privilege"
 sidebar_current: "docs-alicloud-resource-db-account-privilege"

--- a/website/docs/r/db_backup_policy.html.markdown
+++ b/website/docs/r/db_backup_policy.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "RDS"
 layout: "alicloud"
 page_title: "Alicloud: alicloud_db_backup_policy"
 sidebar_current: "docs-alicloud-resource-db-backup-policy"

--- a/website/docs/r/db_connection.html.markdown
+++ b/website/docs/r/db_connection.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "RDS"
 layout: "alicloud"
 page_title: "Alicloud: alicloud_db_connection"
 sidebar_current: "docs-alicloud-resource-db-connection"

--- a/website/docs/r/db_database.html.markdown
+++ b/website/docs/r/db_database.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "RDS"
 layout: "alicloud"
 page_title: "Alicloud: alicloud_db_database"
 sidebar_current: "docs-alicloud-resource-db-database"

--- a/website/docs/r/db_instance.html.markdown
+++ b/website/docs/r/db_instance.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "RDS"
 layout: "alicloud"
 page_title: "Alicloud: alicloud_db_instance"
 sidebar_current: "docs-alicloud-resource-db-instance"

--- a/website/docs/r/db_read_write_splitting_connection.html.markdown
+++ b/website/docs/r/db_read_write_splitting_connection.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "RDS"
 layout: "alicloud"
 page_title: "Alicloud: alicloud_db_read_write_splitting_connection"
 sidebar_current: "docs-alicloud-resource-db-read-write-splitting-connection"

--- a/website/docs/r/db_readonly_instance.html.markdown
+++ b/website/docs/r/db_readonly_instance.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "RDS"
 layout: "alicloud"
 page_title: "Alicloud: alicloud_db_readonly_instance"
 sidebar_current: "docs-alicloud-resource-db-readonly-instance"

--- a/website/docs/r/ddosbgp_instance.html.markdown
+++ b/website/docs/r/ddosbgp_instance.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "BGP-Line Anti-DDoS"
 layout: "alicloud"
 page_title: "Alicloud: alicloud_ddosbgp_instance"
 sidebar_current: "docs-alicloud-resource-ddosbgp-instance"

--- a/website/docs/r/ddoscoo_instance.html.markdown
+++ b/website/docs/r/ddoscoo_instance.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "BGP-Line Anti-DDoS"
 layout: "alicloud"
 page_title: "Alicloud: alicloud_ddoscoo_instance"
 sidebar_current: "docs-alicloud-resource-ddoscoo-instance"

--- a/website/docs/r/disk.html.markdown
+++ b/website/docs/r/disk.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "ECS"
 layout: "alicloud"
 page_title: "Alicloud: alicloud_disk"
 sidebar_current: "docs-alicloud-resource-disk"

--- a/website/docs/r/disk_attachment.html.markdown
+++ b/website/docs/r/disk_attachment.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "ECS"
 layout: "alicloud"
 page_title: "Alicloud: alicloud_disk_attachment"
 sidebar_current: "docs-alicloud-resource-disk-attachment"

--- a/website/docs/r/dns.html.markdown
+++ b/website/docs/r/dns.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "DNS"
 layout: "alicloud"
 page_title: "Alicloud: alicloud_dns"
 sidebar_current: "docs-alicloud-resource-dns"

--- a/website/docs/r/dns_group.html.markdown
+++ b/website/docs/r/dns_group.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "DNS"
 layout: "alicloud"
 page_title: "Alicloud: alicloud_dns_group"
 sidebar_current: "docs-alicloud-resource-dns-group"

--- a/website/docs/r/dns_record.html.markdown
+++ b/website/docs/r/dns_record.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "DNS"
 layout: "alicloud"
 page_title: "Alicloud: alicloud_dns_record"
 sidebar_current: "docs-alicloud-resource-dns-record"

--- a/website/docs/r/drds_instance.html.markdown
+++ b/website/docs/r/drds_instance.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Distributed Relational Database Service (DRDS)"
 layout: "alicloud"
 page_title: "Alicloud: alicloud_drds_instance"
 sidebar_current: "docs-alicloud-resource-drds-instance"

--- a/website/docs/r/eip.html.markdown
+++ b/website/docs/r/eip.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "VPC"
 layout: "alicloud"
 page_title: "Alicloud: alicloud_eip"
 sidebar_current: "docs-alicloud-resource-eip"

--- a/website/docs/r/eip_association.html.markdown
+++ b/website/docs/r/eip_association.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "VPC"
 layout: "alicloud"
 page_title: "Alicloud: alicloud_eip_association"
 sidebar_current: "docs-alicloud-resource-eip-association"

--- a/website/docs/r/elasticsearch.html.markdown
+++ b/website/docs/r/elasticsearch.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Elasticsearch"
 layout: "alicloud"
 page_title: "Alicloud: alicloud_elasticsearch_instance"
 sidebar_current: "docs-alicloud-resource-elasticsearch-instance"

--- a/website/docs/r/emr_cluster.html.markdown
+++ b/website/docs/r/emr_cluster.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "E-MapReduce"
 layout: "alicloud"
 page_title: "Alicloud: alicloud_emr_cluster"
 sidebar_current: "docs-alicloud-resource-emr-cluster"

--- a/website/docs/r/ess_alarm.html.markdown
+++ b/website/docs/r/ess_alarm.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Auto Scaling(ESS)"
 layout: "alicloud"
 page_title: "Alicloud: alicloud_ess_alarm"
 sidebar_current: "docs-alicloud-resource-ess-alarm"

--- a/website/docs/r/ess_attachment.html.markdown
+++ b/website/docs/r/ess_attachment.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Auto Scaling(ESS)"
 layout: "alicloud"
 page_title: "Alicloud: alicloud_ess_attachment"
 sidebar_current: "docs-alicloud-resource-ess-attachment"

--- a/website/docs/r/ess_notification.html.markdown
+++ b/website/docs/r/ess_notification.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Auto Scaling(ESS)"
 layout: "alicloud"
 page_title: "Alicloud: alicloud_ess_notification"
 sidebar_current: "docs-alicloud-resource-ess-notification"

--- a/website/docs/r/ess_scaling_configuration.html.markdown
+++ b/website/docs/r/ess_scaling_configuration.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Auto Scaling(ESS)"
 layout: "alicloud"
 page_title: "Alicloud: alicloud_ess_scaling_configuration"
 sidebar_current: "docs-alicloud-resource-ess-scaling-configuration"

--- a/website/docs/r/ess_scaling_group.html.markdown
+++ b/website/docs/r/ess_scaling_group.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Auto Scaling(ESS)"
 layout: "alicloud"
 page_title: "Alicloud: alicloud_ess_scaling_group"
 sidebar_current: "docs-alicloud-resource-ess-scaling-group"

--- a/website/docs/r/ess_scaling_lifecycle_hook.html.markdown
+++ b/website/docs/r/ess_scaling_lifecycle_hook.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Auto Scaling(ESS)"
 layout: "alicloud"
 page_title: "Alicloud: alicloud_ess_lifecycle_hook"
 sidebar_current: "docs-alicloud-resource-ess-lifecycle-hook"

--- a/website/docs/r/ess_scaling_rule.html.markdown
+++ b/website/docs/r/ess_scaling_rule.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Auto Scaling(ESS)"
 layout: "alicloud"
 page_title: "Alicloud: alicloud_ess_scaling_rule"
 sidebar_current: "docs-alicloud-resource-ess-scaling-rule"

--- a/website/docs/r/ess_scalinggroup_vserver_groups.markdown
+++ b/website/docs/r/ess_scalinggroup_vserver_groups.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Auto Scaling(ESS)"
 layout: "alicloud"
 page_title: "Alicloud: alicloud_ess_scalinggroup_vserver_groups"
 sidebar_current: "docs-alicloud-resource-ess_scalinggroup_vserver_groups"

--- a/website/docs/r/ess_schedule.html.markdown
+++ b/website/docs/r/ess_schedule.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Auto Scaling(ESS)"
 layout: "alicloud"
 page_title: "Alicloud: alicloud_ess_schedule"
 sidebar_current: "docs-alicloud-resource-ess-schedule"

--- a/website/docs/r/ess_scheduled_task.html.markdown
+++ b/website/docs/r/ess_scheduled_task.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Auto Scaling(ESS)"
 layout: "alicloud"
 page_title: "Alicloud: alicloud_ess_schedule"
 sidebar_current: "docs-alicloud-resource-ess-schedule"

--- a/website/docs/r/fc_function.html.markdown
+++ b/website/docs/r/fc_function.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Function Compute Service"
 layout: "alicloud"
 page_title: "Alicloud: alicloud_fc_function"
 sidebar_current: "docs-alicloud-resource-fc"

--- a/website/docs/r/fc_service.html.markdown
+++ b/website/docs/r/fc_service.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Function Compute Service"
 layout: "alicloud"
 page_title: "Alicloud: alicloud_fc_service"
 sidebar_current: "docs-alicloud-resource-fc"

--- a/website/docs/r/fc_trigger.html.markdown
+++ b/website/docs/r/fc_trigger.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Function Compute Service"
 layout: "alicloud"
 page_title: "Alicloud: alicloud_fc_trigger"
 sidebar_current: "docs-alicloud-resource-fc"

--- a/website/docs/r/forward_entry.html.markdown
+++ b/website/docs/r/forward_entry.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "VPC"
 layout: "alicloud"
 page_title: "Alicloud: alicloud_forward_entry"
 sidebar_current: "docs-alicloud-resource-vpc"

--- a/website/docs/r/gpdb_connection.html.markdown
+++ b/website/docs/r/gpdb_connection.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "AnalyticDB for PostgreSQL (GPDB)"
 layout: "alicloud"
 page_title: "Alicloud: alicloud_gpdb_connection"
 sidebar_current: "docs-alicloud-resource-gpdb-connection"

--- a/website/docs/r/gpdb_instance.html.markdown
+++ b/website/docs/r/gpdb_instance.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "AnalyticDB for PostgreSQL (GPDB)"
 layout: "alicloud"
 page_title: "Alicloud: alicloud_gpdb_instance"
 sidebar_current: "docs-alicloud-resource-gpdb-instance"

--- a/website/docs/r/instance.html.markdown
+++ b/website/docs/r/instance.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "ECS"
 layout: "alicloud"
 page_title: "Alicloud: alicloud_instance"
 sidebar_current: "docs-alicloud-resource-instance"

--- a/website/docs/r/key_pair.html.markdown
+++ b/website/docs/r/key_pair.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "ECS"
 layout: "alicloud"
 page_title: "Alicloud: alicloud_key_pair"
 sidebar_current: "docs-alicloud-resource-key-pair"

--- a/website/docs/r/key_pair_attachment.html.markdown
+++ b/website/docs/r/key_pair_attachment.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "ECS"
 layout: "alicloud"
 page_title: "Alicloud: alicloud_key_pair_attachment"
 sidebar_current: "docs-alicloud-resource-key-pair-attachment"

--- a/website/docs/r/kms_key.html.markdown
+++ b/website/docs/r/kms_key.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "KMS"
 layout: "alicloud"
 page_title: "Alicloud: alicloud_kms_key"
 sidebar_current: "docs-alicloud-resource-kms-key"

--- a/website/docs/r/kvstore_backup_policy.html.markdown
+++ b/website/docs/r/kvstore_backup_policy.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Redis And Memcache (KVStore)"
 layout: "alicloud"
 page_title: "Alicloud: alicloud_kvstore_backup_policy"
 sidebar_current: "docs-alicloud-resource-kvstore-backup-policy"

--- a/website/docs/r/kvstore_instance.html.markdown
+++ b/website/docs/r/kvstore_instance.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Redis And Memcache (KVStore)"
 layout: "alicloud"
 page_title: "Alicloud: alicloud_kvstore_instance"
 sidebar_current: "docs-alicloud-resource-kvstore-instance"

--- a/website/docs/r/launch_template.html.markdown
+++ b/website/docs/r/launch_template.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "ECS"
 layout: "alicloud"
 page_title: "Alicloud: alicloud_launch_template"
 sidebar_current: "docs-alicloud-resource-launch-tempate"

--- a/website/docs/r/log_machine_group.html.markdown
+++ b/website/docs/r/log_machine_group.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Log Service (SLS)"
 layout: "alicloud"
 page_title: "Alicloud: alicloud_log_machine_group"
 sidebar_current: "docs-alicloud-resource-log-machine-group"

--- a/website/docs/r/log_project.html.markdown
+++ b/website/docs/r/log_project.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Log Service (SLS)"
 layout: "alicloud"
 page_title: "Alicloud: alicloud_log_project"
 sidebar_current: "docs-alicloud-resource-log-project"

--- a/website/docs/r/log_store.html.markdown
+++ b/website/docs/r/log_store.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Log Service (SLS)"
 layout: "alicloud"
 page_title: "Alicloud: alicloud_log_store"
 sidebar_current: "docs-alicloud-resource-log-store"

--- a/website/docs/r/log_store_index.html.markdown
+++ b/website/docs/r/log_store_index.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Log Service (SLS)"
 layout: "alicloud"
 page_title: "Alicloud: alicloud_log_store_index"
 sidebar_current: "docs-alicloud-resource-log-store-index"

--- a/website/docs/r/logtail_attachment.html.markdown
+++ b/website/docs/r/logtail_attachment.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Log Service (SLS)"
 layout: "alicloud"
 page_title: "Alicloud: alicloud_logtail_attachment"
 sidebar_current: "docs-alicloud-resource-logtail-attachment"

--- a/website/docs/r/logtail_config.html.markdown
+++ b/website/docs/r/logtail_config.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Log Service (SLS)"
 layout: "alicloud"
 page_title: "Alicloud: alicloud_logtail_config"
 sidebar_current: "docs-alicloud-resource-logtail-config"

--- a/website/docs/r/mns_queue.html.markdown
+++ b/website/docs/r/mns_queue.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Message Notification Service (MNS)"
 layout: "alicloud"
 page_title: "Alicloud: alicloud_mns_queue"
 sidebar_current: "docs-alicloud-resource-mns-queue"

--- a/website/docs/r/mns_topic.html.markdown
+++ b/website/docs/r/mns_topic.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Message Notification Service (MNS)"
 layout: "alicloud"
 page_title: "Alicloud: alicloud_mns_topic"
 sidebar_current: "docs-alicloud-resource-mns-topic"

--- a/website/docs/r/mns_topic_subscription.html.markdown
+++ b/website/docs/r/mns_topic_subscription.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Message Notification Service (MNS)"
 layout: "alicloud"
 page_title: "Alicloud: alicloud_mns_topic_subscription"
 sidebar_current: "docs-alicloud-resource-mns-topic_subscription"

--- a/website/docs/r/mongodb_instance.html.markdown
+++ b/website/docs/r/mongodb_instance.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "MongoDB"
 layout: "alicloud"
 page_title: "Alicloud: alicloud_mongodb_instance"
 sidebar_current: "docs-alicloud-resource-mongodb-instance"

--- a/website/docs/r/mongodb_sharding_instance.html.markdown
+++ b/website/docs/r/mongodb_sharding_instance.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "MongoDB"
 layout: "alicloud"
 page_title: "Alicloud: alicloud_mongodb_sharding_instance"
 sidebar_current: "docs-alicloud-resource-mongodb-instance"

--- a/website/docs/r/nas_access_group.html.markdown
+++ b/website/docs/r/nas_access_group.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Network Attached Storage (NAS)"
 layout: "alicloud"
 page_title: "Alicloud: alicloud_nas_access_group"
 sidebar_current: "docs-alicloud-resource-nas-access-group"

--- a/website/docs/r/nas_access_rule.html.markdown
+++ b/website/docs/r/nas_access_rule.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Network Attached Storage (NAS)"
 layout: "alicloud"
 page_title: "Alicloud: alicloud_nas_access_rule"
 sidebar_current: "docs-alicloud-resource-nas-access-rule"

--- a/website/docs/r/nas_file_system.html.markdown
+++ b/website/docs/r/nas_file_system.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Network Attached Storage (NAS)"
 layout: "alicloud"
 page_title: "Alicloud: alicloud_nas_file_system"
 sidebar_current: "docs-alicloud-resource-nas-file-system"

--- a/website/docs/r/nas_mount_target.html.markdown
+++ b/website/docs/r/nas_mount_target.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Network Attached Storage (NAS)"
 layout: "alicloud"
 page_title: "Alicloud: alicloud_nas_mount_target"
 sidebar_current: "docs-alicloud-resource-nas-mount-target"

--- a/website/docs/r/nat_gateway.html.markdown
+++ b/website/docs/r/nat_gateway.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "VPC"
 layout: "alicloud"
 page_title: "Alicloud: alicloud_nat_gateway"
 sidebar_current: "docs-alicloud-resource-nat-gateway"

--- a/website/docs/r/network_acl.html.markdown
+++ b/website/docs/r/network_acl.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "VPC"
 layout: "alicloud"
 page_title: "Alicloud: alicloud_network_acl"
 sidebar_current: "docs-alicloud-resource-network-acl"

--- a/website/docs/r/network_acl_attachment.html.markdown
+++ b/website/docs/r/network_acl_attachment.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "VPC"
 layout: "alicloud"
 page_title: "Alicloud: alicloud_network_acl_attachment"
 sidebar_current: "docs-alicloud-resource-network-acl-attachment"

--- a/website/docs/r/network_acl_entries.html.markdown
+++ b/website/docs/r/network_acl_entries.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "VPC"
 layout: "alicloud"
 page_title: "Alicloud: alicloud_network_acl_entries"
 sidebar_current: "docs-alicloud-resource-network-acl-entries"

--- a/website/docs/r/network_interface.html.markdown
+++ b/website/docs/r/network_interface.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "ECS"
 layout: "alicloud"
 page_title: "Alicloud: alicloud_network_interface"
 sidebar_current: "docs-alicloud-resource-network-interface"

--- a/website/docs/r/network_interface_attachment.html.markdown
+++ b/website/docs/r/network_interface_attachment.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "ECS"
 layout: "alicloud"
 page_title: "Alicloud: alicloud_network_interface_attachment"
 sidebar_current: "docs-alicloud-resource-network-interface-attachment"

--- a/website/docs/r/ons_group.html.markdown
+++ b/website/docs/r/ons_group.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "RocketMQ"
 layout: "alicloud"
 page_title: "Alicloud: alicloud_ons_group"
 sidebar_current: "docs-alicloud-resource-ons-group"

--- a/website/docs/r/ons_instance.html.markdown
+++ b/website/docs/r/ons_instance.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "RocketMQ"
 layout: "alicloud"
 page_title: "Alicloud: alicloud_ons_instance"
 sidebar_current: "docs-alicloud-resource-ons-instance"

--- a/website/docs/r/ons_topic.html.markdown
+++ b/website/docs/r/ons_topic.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "RocketMQ"
 layout: "alicloud"
 page_title: "Alicloud: alicloud_ons_topic"
 sidebar_current: "docs-alicloud-resource-ons-topic"

--- a/website/docs/r/oss_bucket.html.markdown
+++ b/website/docs/r/oss_bucket.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "OSS"
 layout: "alicloud"
 page_title: "Alicloud: alicloud_oss_bucket"
 sidebar_current: "docs-alicloud-resource-oss-bucket"

--- a/website/docs/r/oss_bucket_object.html.markdown
+++ b/website/docs/r/oss_bucket_object.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "OSS"
 layout: "alicloud"
 page_title: "Alicloud: alicloud_oss_bucket_object"
 sidebar_current: "docs-alicloud-resource-oss-bucket-object"

--- a/website/docs/r/ots_instance.html.markdown
+++ b/website/docs/r/ots_instance.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Table Store (OTS)"
 layout: "alicloud"
 page_title: "Alicloud: alicloud_ots_instance"
 sidebar_current: "docs-alicloud-resource-ots-instance"

--- a/website/docs/r/ots_instance_attachment.html.markdown
+++ b/website/docs/r/ots_instance_attachment.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Table Store (OTS)"
 layout: "alicloud"
 page_title: "Alicloud: alicloud_ots_instance_attachment"
 sidebar_current: "docs-alicloud-resource-ots-instance-attachment"

--- a/website/docs/r/ots_table.html.markdown
+++ b/website/docs/r/ots_table.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Table Store (OTS)"
 layout: "alicloud"
 page_title: "Alicloud: alicloud_ots_table"
 sidebar_current: "docs-alicloud-resource-ots-table"

--- a/website/docs/r/pvtz_zone.html.markdown
+++ b/website/docs/r/pvtz_zone.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Private Zone"
 layout: "alicloud"
 page_title: "Alicloud: alicloud_pvtz_zone"
 sidebar_current: "docs-alicloud-resource-pvtz-zone"

--- a/website/docs/r/pvtz_zone_attachment.html.markdown
+++ b/website/docs/r/pvtz_zone_attachment.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Private Zone"
 layout: "alicloud"
 page_title: "Alicloud: alicloud_pvtz_zone_attachment"
 sidebar_current: "docs-alicloud-resource-pvtz-zone-attachment"

--- a/website/docs/r/pvtz_zone_record.html.markdown
+++ b/website/docs/r/pvtz_zone_record.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Private Zone"
 layout: "alicloud"
 page_title: "Alicloud: alicloud_pvtz_zone_record"
 sidebar_current: "docs-alicloud-resource-pvtz-zone-record"

--- a/website/docs/r/ram_access_key.html.markdown
+++ b/website/docs/r/ram_access_key.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "RAM"
 layout: "alicloud"
 page_title: "Alicloud: alicloud_ram_access_key"
 sidebar_current: "docs-alicloud-resource-ram-access-key"

--- a/website/docs/r/ram_account_alias.html.markdown
+++ b/website/docs/r/ram_account_alias.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "RAM"
 layout: "alicloud"
 page_title: "Alicloud: alicloud_ram_account_alias"
 sidebar_current: "docs-alicloud-resource-ram-account-alias"

--- a/website/docs/r/ram_account_password_policy.html.markdown
+++ b/website/docs/r/ram_account_password_policy.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "RAM"
 layout: "alicloud"
 page_title: "Alicloud: alicloud_ram_account_password_policy"
 sidebar_current: "docs-alicloud-resource-ram-account-password-policy"

--- a/website/docs/r/ram_alias.html.markdown
+++ b/website/docs/r/ram_alias.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "RAM"
 layout: "alicloud"
 page_title: "Alicloud: alicloud_ram_alias"
 sidebar_current: "docs-alicloud-resource-ram-alias"

--- a/website/docs/r/ram_group.html.markdown
+++ b/website/docs/r/ram_group.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "RAM"
 layout: "alicloud"
 page_title: "Alicloud: alicloud_ram_group"
 sidebar_current: "docs-alicloud-resource-ram-group"

--- a/website/docs/r/ram_group_membership.html.markdown
+++ b/website/docs/r/ram_group_membership.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "RAM"
 layout: "alicloud"
 page_title: "Alicloud: alicloud_ram_group_membership"
 sidebar_current: "docs-alicloud-resource-ram-group-membership"

--- a/website/docs/r/ram_group_policy_attachment.html.markdown
+++ b/website/docs/r/ram_group_policy_attachment.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "RAM"
 layout: "alicloud"
 page_title: "Alicloud: alicloud_ram_group_policy_attachment"
 sidebar_current: "docs-alicloud-resource-ram-group-policy-attachment"

--- a/website/docs/r/ram_login_profile.html.markdown
+++ b/website/docs/r/ram_login_profile.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "RAM"
 layout: "alicloud"
 page_title: "Alicloud: alicloud_ram_login_profile"
 sidebar_current: "docs-alicloud-resource-ram-login-profile"

--- a/website/docs/r/ram_policy.html.markdown
+++ b/website/docs/r/ram_policy.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "RAM"
 layout: "alicloud"
 page_title: "Alicloud: alicloud_ram_policy"
 sidebar_current: "docs-alicloud-resource-ram-policy"

--- a/website/docs/r/ram_role.html.markdown
+++ b/website/docs/r/ram_role.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "RAM"
 layout: "alicloud"
 page_title: "Alicloud: alicloud_ram_role"
 sidebar_current: "docs-alicloud-resource-ram-role"

--- a/website/docs/r/ram_role_attachment.html.markdown
+++ b/website/docs/r/ram_role_attachment.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "RAM"
 layout: "alicloud"
 page_title: "Alicloud: alicloud_ram_role_attachment"
 sidebar_current: "docs-alicloud-resource-ram-role-attachment"

--- a/website/docs/r/ram_role_policy_attachment.html.markdown
+++ b/website/docs/r/ram_role_policy_attachment.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "RAM"
 layout: "alicloud"
 page_title: "Alicloud: alicloud_ram_role_policy_attachment"
 sidebar_current: "docs-alicloud-resource-ram-role-policy-attachment"

--- a/website/docs/r/ram_user.html.markdown
+++ b/website/docs/r/ram_user.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "RAM"
 layout: "alicloud"
 page_title: "Alicloud: alicloud_ram_user"
 sidebar_current: "docs-alicloud-resource-ram-user"

--- a/website/docs/r/ram_user_policy_attachment.html.markdown
+++ b/website/docs/r/ram_user_policy_attachment.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "RAM"
 layout: "alicloud"
 page_title: "Alicloud: alicloud_ram_user_policy_attachment"
 sidebar_current: "docs-alicloud-resource-ram-user-policy-attachment"

--- a/website/docs/r/route_entry.html.markdown
+++ b/website/docs/r/route_entry.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "VPC"
 layout: "alicloud"
 page_title: "Alicloud: alicloud_route_entry"
 sidebar_current: "docs-alicloud-resource-route-entry"

--- a/website/docs/r/route_table.html.markdown
+++ b/website/docs/r/route_table.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "VPC"
 layout: "alicloud"
 page_title: "Alicloud: alicloud_route_table"
 sidebar_current: "docs-alicloud-resource-route-table"

--- a/website/docs/r/route_table_attachment.html.markdown
+++ b/website/docs/r/route_table_attachment.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "VPC"
 layout: "alicloud"
 page_title: "Alicloud: alicloud_route_table_attachment"
 sidebar_current: "docs-alicloud-resource-route-table-attachment"

--- a/website/docs/r/router_interface.html.markdown
+++ b/website/docs/r/router_interface.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "VPC"
 layout: "alicloud"
 page_title: "Alicloud: alicloud_router_interface"
 sidebar_current: "docs-alicloud-resource-router-interface"

--- a/website/docs/r/router_interface_connection.html.markdown
+++ b/website/docs/r/router_interface_connection.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "VPC"
 layout: "alicloud"
 page_title: "Alicloud: alicloud_router_interface_connection"
 sidebar_current: "docs-alicloud-resource-router-interface-connection"

--- a/website/docs/r/sag_acl.html.markdown
+++ b/website/docs/r/sag_acl.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Smart Access Gateway"
 layout: "alicloud"
 page_title: "Alicloud: alicloud_sag_acl"
 sidebar_current: "docs-alicloud-resource-sag-acl"

--- a/website/docs/r/sag_acl_rule.html.markdown
+++ b/website/docs/r/sag_acl_rule.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Smart Access Gateway"
 layout: "alicloud"
 page_title: "Alicloud: alicloud_sag_acl_rule"
 sidebar_current: "docs-alicloud-resource-sag-acl-rule"

--- a/website/docs/r/sag_qos.html.markdown
+++ b/website/docs/r/sag_qos.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Smart Access Gateway"
 layout: "alicloud"
 page_title: "Alicloud: alicloud_sag_qos"
 sidebar_current: "docs-alicloud-resource-sag-qos"

--- a/website/docs/r/sag_qos_car.html.markdown
+++ b/website/docs/r/sag_qos_car.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Smart Access Gateway"
 layout: "alicloud"
 page_title: "Alicloud: alicloud_sag_qos_car"
 sidebar_current: "docs-alicloud-resource-sag-qos-car"

--- a/website/docs/r/sag_qos_policy.html.markdown
+++ b/website/docs/r/sag_qos_policy.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Smart Access Gateway"
 layout: "alicloud"
 page_title: "Alicloud: alicloud_sag_qos_policy"
 sidebar_current: "docs-alicloud-resource-sag-qos-policy"

--- a/website/docs/r/sag_snat_entry.html.markdown
+++ b/website/docs/r/sag_snat_entry.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Smart Access Gateway"
 layout: "alicloud"
 page_title: "Alicloud: alicloud_sag_snat_entry"
 sidebar_current: "docs-alicloud-resource-sag-snat-entry"

--- a/website/docs/r/security_group.html.markdown
+++ b/website/docs/r/security_group.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "ECS"
 layout: "alicloud"
 page_title: "Alicloud: alicloud_security_group"
 sidebar_current: "docs-alicloud-resource-security-group"

--- a/website/docs/r/security_group_rule.html.markdown
+++ b/website/docs/r/security_group_rule.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "ECS"
 layout: "alicloud"
 page_title: "Alicloud: alicloud_security_group_rule"
 sidebar_current: "docs-alicloud-resource-security-group-rule"

--- a/website/docs/r/slb.html.markdown
+++ b/website/docs/r/slb.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Server Load Balancer (SLB)"
 layout: "alicloud"
 page_title: "Alicloud: alicloud_slb"
 sidebar_current: "docs-alicloud-resource-slb"

--- a/website/docs/r/slb_acl.html.markdown
+++ b/website/docs/r/slb_acl.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Server Load Balancer (SLB)"
 layout: "alicloud"
 page_title: "Alicloud: alicloud_slb_acl"
 sidebar_current: "docs-alicloud-resource-slb-acl"

--- a/website/docs/r/slb_attachment.html.markdown
+++ b/website/docs/r/slb_attachment.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Server Load Balancer (SLB)"
 layout: "alicloud"
 page_title: "Alicloud: alicloud_slb_attachment"
 sidebar_current: "docs-alicloud-resource-slb-attachment"

--- a/website/docs/r/slb_backend_server.html.markdown
+++ b/website/docs/r/slb_backend_server.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Server Load Balancer (SLB)"
 layout: "alicloud"
 page_title: "Alicloud: alicloud_slb_backend_server"
 sidebar_current: "docs-alicloud-resource-slb-backend-server"

--- a/website/docs/r/slb_ca_certificate.html.markdown
+++ b/website/docs/r/slb_ca_certificate.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Server Load Balancer (SLB)"
 layout: "alicloud"
 page_title: "Alicloud: alicloud_slb_ca_certificate"
 sidebar_current: "docs-alicloud-resource-slb-ca-certificate"

--- a/website/docs/r/slb_domain_extension.html.markdown
+++ b/website/docs/r/slb_domain_extension.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Server Load Balancer (SLB)"
 layout: "alicloud"
 page_title: "Alicloud: alicloud_slb_domain_extension"
 sidebar_current: "docs-alicloud-resource-slb-domain-extension"

--- a/website/docs/r/slb_listener.html.markdown
+++ b/website/docs/r/slb_listener.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Server Load Balancer (SLB)"
 layout: "alicloud"
 page_title: "Alicloud: alicloud_slb_listener"
 sidebar_current: "docs-alicloud-resource-slb-listener"

--- a/website/docs/r/slb_master_slave_server_group.html.markdown
+++ b/website/docs/r/slb_master_slave_server_group.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Server Load Balancer (SLB)"
 layout: "alicloud"
 page_title: "Alicloud: alicloud_slb_master_slave_server_group"
 sidebar_current: "docs-alicloud-resource-slb-master-slave-server-group"

--- a/website/docs/r/slb_rule.html.markdown
+++ b/website/docs/r/slb_rule.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Server Load Balancer (SLB)"
 layout: "alicloud"
 page_title: "Alicloud: alicloud_slb_rule"
 sidebar_current: "docs-alicloud-resource-slb-rule"

--- a/website/docs/r/slb_server_certificate.html.markdown
+++ b/website/docs/r/slb_server_certificate.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Server Load Balancer (SLB)"
 layout: "alicloud"
 page_title: "Alicloud: alicloud_slb_server_certificate"
 sidebar_current: "docs-alicloud-resource-slb-server-certificate"

--- a/website/docs/r/slb_server_group.html.markdown
+++ b/website/docs/r/slb_server_group.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Server Load Balancer (SLB)"
 layout: "alicloud"
 page_title: "Alicloud: alicloud_slb_server_group"
 sidebar_current: "docs-alicloud-resource-slb-server-group"

--- a/website/docs/r/snapshot.html.markdown
+++ b/website/docs/r/snapshot.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "ECS"
 layout: "alicloud"
 page_title: "Alicloud: alicloud_snapshot"
 sidebar_current: "docs-alicloud-resource-snapshot"

--- a/website/docs/r/snapshot_policy.html.markdown
+++ b/website/docs/r/snapshot_policy.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "ECS"
 layout: "alicloud"
 page_title: "Alicloud: alicloud_snapshot_policy"
 sidebar_current: "docs-alicloud-resource-snapshot-policy"

--- a/website/docs/r/snat.html.markdown
+++ b/website/docs/r/snat.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "VPC"
 layout: "alicloud"
 page_title: "Alicloud: alicloud_snat_entry"
 sidebar_current: "docs-alicloud-resource-vpc"

--- a/website/docs/r/ssl_vpn_client_cert.html.markdown
+++ b/website/docs/r/ssl_vpn_client_cert.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "VPN"
 layout: "alicloud"
 page_title: "Alicloud: alicloud_ssl_vpn_client_cert"
 sidebar_current: "docs-alicloud-resource-ssl-vpn-client-cert"

--- a/website/docs/r/ssl_vpn_server.html.markdown
+++ b/website/docs/r/ssl_vpn_server.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "VPN"
 layout: "alicloud"
 page_title: "Alicloud: alicloud_ssl_vpn_server"
 sidebar_current: "docs-alicloud-resource-ssl-vpn-server"

--- a/website/docs/r/vpc.html.markdown
+++ b/website/docs/r/vpc.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "VPC"
 layout: "alicloud"
 page_title: "Alicloud: alicloud_vpc"
 sidebar_current: "docs-alicloud-resource-vpc"

--- a/website/docs/r/vpn_connection.html.markdown
+++ b/website/docs/r/vpn_connection.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "VPN"
 layout: "alicloud"
 page_title: "Alicloud: alicloud_vpn_connection"
 sidebar_current: "docs-alicloud-resource-vpn-connection"

--- a/website/docs/r/vpn_customer_gateway.html.markdown
+++ b/website/docs/r/vpn_customer_gateway.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "VPN"
 layout: "alicloud"
 page_title: "Alicloud: alicloud_vpn_customer_gateway"
 sidebar_current: "docs-alicloud-resource-vpn-customer-gateway"

--- a/website/docs/r/vpn_gateway.html.markdown
+++ b/website/docs/r/vpn_gateway.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "VPN"
 layout: "alicloud"
 page_title: "Alicloud: alicloud_vpn_gateway"
 sidebar_current: "docs-alicloud-resource-vpn-gateway"

--- a/website/docs/r/vpn_route_entry.html.markdown
+++ b/website/docs/r/vpn_route_entry.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "VPN"
 layout: "alicloud"
 page_title: "Alicloud: alicloud_vpn_route_entry"
 sidebar_current: "docs-alicloud-resource-vpn-route-entry"

--- a/website/docs/r/vswitch.html.markdown
+++ b/website/docs/r/vswitch.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "VPC"
 layout: "alicloud"
 page_title: "Alicloud: alicloud_vswitch"
 sidebar_current: "docs-alicloud-resource-vswitch"

--- a/website/docs/r/yundun_dbaudit_instance.html.markdown
+++ b/website/docs/r/yundun_dbaudit_instance.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Cloud DBAudit"
 layout: "alicloud"
 page_title: "Alicloud: alicloud_yundun_dbaudit_instance"
 sidebar_current: "docs-alicloud-resource-yundun-dbaudit-instance"


### PR DESCRIPTION
We will soon be displaying documentation for this provider both on [terraform.io](https://www.terraform.io/docs/providers/index.html) and on [the Terraform Registry](https://registry.terraform.io/providers).

Documentation displayed on the Terraform Registry will not use the ERB layout containing the existing navigation, and will instead build the navigation dynamically based on the directory and YAML frontmatter of a file. For providers that group similar resources and data sources by service or use case (subcategories), we'll need to add this information to the Markdown source file.

This PR modifies resource and data source documentation source files by adding a subcategory to the metadata if those files are currently grouped on terraform.io. This also includes adding documentation files to the ERB layout used by terraform.io that were previously not present.

For more information about how documentation is rendered on the Terraform Registry, please see this reference: [Terraform Registry - Provider Documentation](https://www.terraform.io/docs/registry/providers/docs.html).