### PR TITLE
Do not assume `private_zone` is returned from API

### DIFF
--- a/alicloud/data_source_alicloud_cs_serverless_kubernetes_clusters.go
+++ b/alicloud/data_source_alicloud_cs_serverless_kubernetes_clusters.go
@@ -60,10 +60,6 @@ func dataSourceAlicloudCSServerlessKubernetesClusters() *schema.Resource {
 							Type:     schema.TypeBool,
 							Computed: true,
 						},
-						"private_zone": {
-							Type:     schema.TypeBool,
-							Computed: true,
-						},
 						"deletion_protection": {
 							Type:     schema.TypeBool,
 							Computed: true,
@@ -214,7 +210,6 @@ func csServerlessKubernetesClusterDescriptionAttributes(d *schema.ResourceData, 
 		mapping["vpc_id"] = ct.VpcId
 		mapping["vswitch_id"] = ct.VSwitchId
 		mapping["security_group_id"] = ct.SecurityGroupId
-		mapping["private_zone"] = ct.PrivateZone
 		mapping["deletion_protection"] = ct.DeletionProtection
 		mapping["tags"] = csService.tagsToMap(ct.Tags)
 		//set default value

--- a/alicloud/resource_alicloud_cs_serverless_kubernetes.go
+++ b/alicloud/resource_alicloud_cs_serverless_kubernetes.go
@@ -201,7 +201,6 @@ func resourceAlicloudCSServerlessKubernetesRead(d *schema.ResourceData, meta int
 	_ = d.Set("vpc_id", object.VpcId)
 	_ = d.Set("vswitch_id", object.VSwitchId)
 	_ = d.Set("security_group_id", object.SecurityGroupId)
-	_ = d.Set("private_zone", object.PrivateZone)
 	_ = d.Set("deletion_protection", object.DeletionProtection)
 	_ = d.Set("tags", object.Tags)
 


### PR DESCRIPTION
Container Service endpoint `/clusters` does not return information about whether or not a private zone was configured for the cluster. Currently, if a cluster is created in Terraform with the `private_zone` property set to `true`, every deploy will cause a new cluster to be created as Golang booleans default to `false` and that property has `ForceNew` set to `true`.

Resolves #1866 