### PR TITLE
fix(cdn_domain_new): constant timeout waiting for server cert

### DIFF
--- a/alicloud/resource_alicloud_cdn_domain_new.go
+++ b/alicloud/resource_alicloud_cdn_domain_new.go
@@ -404,7 +404,7 @@ func certificateConfigUpdateNew(client *connectivity.AliyunClient, d *schema.Res
 		return WrapErrorf(err, DefaultErrorMsg, d.Id(), request.GetActionName(), AlibabaCloudSdkGoERROR)
 	}
 	d.SetPartial("certificate_config")
-	if okServerCertificate && request.ServerCertificateStatus != "off" {
+	if serverCertificate != "" && request.ServerCertificateStatus != "off" {
 		err := cdnService.WaitForServerCertificateNew(d.Id(), request.ServerCertificate, DefaultTimeout)
 		if err != nil {
 			return WrapError(err)


### PR DESCRIPTION
`okServerCertificate` is always `true` since it was set in [`resourceAlicloudCdnDomainReadNew`](https://github.com/terraform-providers/terraform-provider-alicloud/blob/ed309f497fc2414c39f7f957ddca10f4dd81ddfe/alicloud/resource_alicloud_cdn_domain_new.go#L288):

```

	config[0] = map[string]interface{}{
		"server_certificate":        certInfo.ServerCertificate,
		"server_certificate_status": serverCertificateStatus,
		"cert_name":                 certInfo.CertName,
		"cert_type":                 certInfo.CertType,
	}
```

If I understand the API right, I should be able to provide these configurations in HCL and the apply should still works:

```
resource "alicloud_cdn_domain_new" "foobar" {
  domain_name = "foo.example.com"
  cdn_type    = "web"
  scope       = "domestic"

  sources {
    content = "foobar.oss-cn-shanghai.aliyuncs.com"
    type    = "oss"
    port    = 80
  }

  certificate_config {
    server_certificate_status = "on"
    cert_type = "cas"
    cert_name = "foo.example.com"
  }
}
```

This PR addresses the issue when the above configuration is provided, but `terraform apply` throws error:

```
Error: Error applying plan:

1 error(s) occurred:

* alicloud_cdn_domain_new.foobar: 1 error(s) occurred:

* alicloud_cdn_domain_new.sales-wizard-production: [ERROR] terraform-provider-alicloud/alicloud/resource_alicloud_cdn_domain_new.go:226:
[ERROR] terraform-provider-alicloud/alicloud/resource_alicloud_cdn_domain_new.go:410:
[ERROR] terraform-provider-alicloud/alicloud/service_alicloud_cdn.go:121: Resource foo.example.com WaitForServerCertificateNew Timeout In 120 Seconds. Got: -----BEGIN CERTIFICATE-----
<certificate>
-----END CERTIFICATE----- Expected:  !!! [Provider ERROR]:
<nil cause>

Terraform does not automatically rollback in the face of errors.
Instead, your Terraform state file has been partially updated with
any resources that successfully completed. Please address the error
above and apply again to incrementally change your infrastructure.
```