### PR TITLE
fix(kms): correct test case errors

### DIFF
--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -91,6 +91,7 @@ groups:
       - Sag
       - YundunDbaudit
       - YundunBastionhost
+      - Market
       - Sweeper-1
       - Sweeper-2
       - Sweeper-3
@@ -1163,6 +1164,19 @@ jobs:
         params:
           <<: *run-params
           TEST_CASE_CODE: "YundunBastionhost"
+
+  - name: Market
+    plan:
+      - <<: *clone-provider
+      - get: trigger
+        trigger: true
+        resource: 17
+      - aggregate:
+          - *get-aliyun-cli
+      - <<: *run
+        params:
+          <<: *run-params
+          TEST_CASE_CODE: "Market"
 
   - name: SweeperAfter
     plan:

--- a/ci/tasks/run.sh
+++ b/ci/tasks/run.sh
@@ -58,10 +58,10 @@ if [[ ${SWEEPER} = true ]]; then
     echo -e "\n--------------- Running Sweeper Test Cases ---------------"
     if [[ ${TEST_SWEEPER_CASE_CODE} == "alicloud_"* ]]; then
         echo -e "TF_ACC=1 go test ./alicloud -v  -sweep=${ALICLOUD_REGION} -sweep-run=${TEST_SWEEPER_CASE_CODE}"
-        TF_ACC=1 go test ./alicloud -v  -sweep=${ALICLOUD_REGION} -sweep-run=${TEST_SWEEPER_CASE_CODE}
+        TF_ACC=1 go test ./alicloud -v  -sweep=${ALICLOUD_REGION} -sweep-run=${TEST_SWEEPER_CASE_CODE} -timeout=60m
     else
         echo -e "TF_ACC=1 go test ./alicloud -v  -sweep=${ALICLOUD_REGION}"
-        TF_ACC=1 go test ./alicloud -v  -sweep=${ALICLOUD_REGION}
+        TF_ACC=1 go test ./alicloud -v  -sweep=${ALICLOUD_REGION} -timeout=60m
     fi
     echo -e "\n--------------- END ---------------"
     exit 0


### PR DESCRIPTION
```
TF_ACC=1 go test ./alicloud -v -run=TestAccAlicloudKmsCiphertext_ -timeout=1200m=== RUN   TestAccAlicloudKmsCiphertext_basic
=== PAUSE TestAccAlicloudKmsCiphertext_basic
=== RUN   TestAccAlicloudKmsCiphertext_validate
=== PAUSE TestAccAlicloudKmsCiphertext_validate
=== RUN   TestAccAlicloudKmsCiphertext_validate_withContext
=== PAUSE TestAccAlicloudKmsCiphertext_validate_withContext
=== CONT  TestAccAlicloudKmsCiphertext_basic
=== CONT  TestAccAlicloudKmsCiphertext_validate_withContext
=== CONT  TestAccAlicloudKmsCiphertext_validate
--- PASS: TestAccAlicloudKmsCiphertext_basic (1.96s)
--- PASS: TestAccAlicloudKmsCiphertext_validate (2.50s)
--- PASS: TestAccAlicloudKmsCiphertext_validate_withContext (2.64s)
PASS
ok      github.com/terraform-providers/terraform-provider-alicloud/alicloud     2.725s
```