### PR TITLE
add output to ssl vpn client cert

### DIFF
--- a/alicloud/resource_alicloud_ssl_vpn_client_cert.go
+++ b/alicloud/resource_alicloud_ssl_vpn_client_cert.go
@@ -37,6 +37,26 @@ func resourceAliyunSslVpnClientCert() *schema.Resource {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
+			"ca_cert": {
+				Type:      schema.TypeString,
+				Computed:  true,
+				Sensitive: true,
+			},
+			"client_cert": {
+				Type:      schema.TypeString,
+				Computed:  true,
+				Sensitive: true,
+			},
+			"client_key": {
+				Type:      schema.TypeString,
+				Computed:  true,
+				Sensitive: true,
+			},
+			"client_config": {
+				Type:      schema.TypeString,
+				Computed:  true,
+				Sensitive: true,
+			},
 		},
 	}
 }
@@ -101,6 +121,10 @@ func resourceAliyunSslVpnClientCertRead(d *schema.ResourceData, meta interface{}
 	d.Set("name", object.Name)
 	d.Set("status", object.Status)
 	d.Set("ssl_vpn_server_id", object.SslVpnServerId)
+	d.Set("ca_cert", object.CaCert)
+	d.Set("client_cert", object.ClientCert)
+	d.Set("client_key", object.ClientKey)
+	d.Set("client_config", object.ClientConfig)
 
 	return nil
 }

--- a/alicloud/resource_alicloud_ssl_vpn_client_cert_test.go
+++ b/alicloud/resource_alicloud_ssl_vpn_client_cert_test.go
@@ -132,6 +132,10 @@ func TestAccAlicloudSslVpnClientCert_basic(t *testing.T) {
 					testAccCheck(map[string]string{
 						"name":              fmt.Sprintf("tf-testAccSslVpnClientCertConfig%d", rand),
 						"ssl_vpn_server_id": CHECKSET,
+						"ca_cert":           CHECKSET,
+						"client_cert":       CHECKSET,
+						"client_key":        CHECKSET,
+						"client_config":     CHECKSET,
 						"status":            "normal",
 					}),
 				),
@@ -193,6 +197,10 @@ func TestAccAlicloudSslVpnClientCert_multi(t *testing.T) {
 					testAccCheck(map[string]string{
 						"name":              fmt.Sprintf("tf-testAccSslVpnClientCertConfig%d", rand),
 						"ssl_vpn_server_id": CHECKSET,
+						"ca_cert":           CHECKSET,
+						"client_cert":       CHECKSET,
+						"client_key":        CHECKSET,
+						"client_config":     CHECKSET,
 						"status":            "normal",
 					}),
 				),

--- a/website/docs/r/ssl_vpn_client_cert.html.markdown
+++ b/website/docs/r/ssl_vpn_client_cert.html.markdown
@@ -7,12 +7,13 @@ description: |-
   Provides a Alicloud SSL VPN Client Cert resource.
 ---
 
-# alicloud\_ssl_vpn_client_cert
+# alicloud_ssl_vpn_client_cert
 
 Provides a SSL VPN client cert resource.
 
--> **NOTE:** Terraform will auto build SSL VPN client certs  while it uses `alicloud_ssl_vpn_client_cert` to build a ssl vpn client certs resource.
-             It depends on VPN instance and SSL VPN Server.
+-> **NOTE:** Terraform will auto build SSL VPN client certs while it uses `alicloud_ssl_vpn_client_cert` to build a ssl vpn client certs resource.
+It depends on VPN instance and SSL VPN Server.
+
 ## Example Usage
 
 Basic Usage
@@ -23,20 +24,24 @@ resource "alicloud_ssl_vpn_client_cert" "foo" {
   name              = "sslVpnClientCertExample"
 }
 ```
+
 ## Argument Reference
 
 The following arguments are supported:
 
-* `name` - (Optional) The name of the client certificate.
-* `ssl_vpn_server_id` - (Required, ForceNew) The ID of the SSL-VPN server.
-
+- `name` - (Optional) The name of the client certificate.
+- `ssl_vpn_server_id` - (Required, ForceNew) The ID of the SSL-VPN server.
 
 ## Attributes Reference
 
 The following attributes are exported:
 
-* `id` - The ID of the SSL-VPN client certificate.
-* `status` - The status of the client certificate.
+- `id` - The ID of the SSL-VPN client certificate.
+- `status` - The status of the client certificate.
+- `ca_cert` - The client ca cert.
+- `client_cert` - The client cert.
+- `client_key` - The client key.
+- `client_config` - The vpn client config.
 
 ## Import
 
@@ -45,7 +50,3 @@ SSL-VPN client certificates can be imported using the id, e.g.
 ```
 $ terraform import alicloud_ssl_vpn_client_cert.example vsc-abc123456
 ```
-
-
-
-


### PR DESCRIPTION
Added additional outputs to the `alicloud_ssl_vpn_client_cert` resource. They were already available on the API result, but weren't passed to the terraform resource outputs.