### PR TITLE
adding RAM role_name to data.alicloud_instances

### DIFF
--- a/website/docs/d/instances.html.markdown
+++ b/website/docs/d/instances.html.markdown
@@ -71,6 +71,7 @@ The following attributes are exported in addition to the arguments listed above:
   * `private_ip` - Instance private IP address.
   * `public_ip` - Instance public IP address.
   * `eip` - EIP address the VPC instance is using.
+  * `role_name` - The RAM role for this instance
   * `security_groups` - List of security group IDs the instance belongs to.
   * `key_name` - Key pair the instance is using.
   * `creation_time` - Instance creation time.


### PR DESCRIPTION
This PR adds `role_name` to the output for the `alicloud_instances` data source. This mirrors what's output for the `alicloud_instance` resource. 

Closes https://github.com/terraform-providers/terraform-provider-alicloud/issues/2053