### PR TITLE
improve(elasticsearch): data_source support tags

### DIFF
--- a/alicloud/data_source_alicloud_elasticsearch_instances_test.go
+++ b/alicloud/data_source_alicloud_elasticsearch_instances_test.go
@@ -33,16 +33,39 @@ func TestAccAlicloudElasticsearchDataSource(t *testing.T) {
 		}),
 	}
 
+	tagsConf := dataSourceTestAccConfig{
+		existConfig: testAccConfig(map[string]interface{}{
+			"tags": map[string]interface{}{
+				"Created": "TF",
+				"For":     "acceptance test",
+			},
+		}),
+		fakeConfig: testAccConfig(map[string]interface{}{
+			"tags": map[string]interface{}{
+				"Created": "TF-fake",
+				"For":     "acceptance test",
+			},
+		}),
+	}
+
 	allConf := dataSourceTestAccConfig{
 		existConfig: testAccConfig(map[string]interface{}{
 			"description_regex": "${alicloud_elasticsearch_instance.default.description}",
 			"ids":               []string{"${alicloud_elasticsearch_instance.default.id}"},
 			"version":           "5.5.3_with_X-Pack",
+			"tags": map[string]interface{}{
+				"Created": "TF",
+				"For":     "acceptance test",
+			},
 		}),
 		fakeConfig: testAccConfig(map[string]interface{}{
 			"description_regex": "${alicloud_elasticsearch_instance.default.description}-F",
 			"ids":               []string{"${alicloud_elasticsearch_instance.default.id}"},
 			"version":           "6.7.0_with_X-Pack",
+			"tags": map[string]interface{}{
+				"Created": "TF-fake",
+				"For":     "acceptance test",
+			},
 		}),
 	}
 
@@ -52,7 +75,7 @@ func TestAccAlicloudElasticsearchDataSource(t *testing.T) {
 		fakeMapFunc:  fakeElasticsearchMapFunc,
 	}
 
-	elasticsearchCheckInfo.dataSourceTestCheck(t, rand, descriptionRegexConf, idsConf, allConf)
+	elasticsearchCheckInfo.dataSourceTestCheck(t, rand, descriptionRegexConf, idsConf, tagsConf, allConf)
 }
 
 var existElasticsearchMapFunc = func(rand int) map[string]string {
@@ -69,6 +92,7 @@ var existElasticsearchMapFunc = func(rand int) map[string]string {
 		"instances.0.data_node_spec":       "elasticsearch.sn2ne.large",
 		"instances.0.status":               "active",
 		"instances.0.version":              CHECKSET,
+		"instances.0.tags.%":               CHECKSET,
 		"instances.0.created_at":           CHECKSET,
 		"instances.0.updated_at":           CHECKSET,
 		"instances.0.vswitch_id":           CHECKSET,
@@ -116,6 +140,10 @@ resource "alicloud_elasticsearch_instance" "default" {
   data_node_disk_type  = "cloud_ssd"
   instance_charge_type = "PostPaid"
   version              = "5.5.3_with_X-Pack"
+  tags                 = {
+	  "Created": "TF",
+	  "For":     "acceptance test",
+  }
 }
 `, name)
 }

--- a/alicloud/service_alicloud_elasticsearch.go
+++ b/alicloud/service_alicloud_elasticsearch.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 
-	"github.com/aliyun/alibaba-cloud-sdk-go/sdk/requests"
 	"github.com/aliyun/alibaba-cloud-sdk-go/services/elasticsearch"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 	"github.com/terraform-providers/terraform-provider-alicloud/alicloud/connectivity"
@@ -101,8 +100,6 @@ func (s *ElasticsearchService) DescribeElasticsearchTags(id string) (tags map[st
 
 	request := elasticsearch.CreateListTagResourcesRequest()
 	request.RegionId = s.client.RegionId
-	request.Size = requests.NewInteger(PageSizeLarge)
-	request.Page = requests.NewInteger(1)
 	request.ResourceIds = string(resourceIds)
 	request.ResourceType = strings.ToUpper(string(TagResourceInstance))
 

--- a/alicloud/tags.go
+++ b/alicloud/tags.go
@@ -13,6 +13,7 @@ import (
 	"github.com/aliyun/alibaba-cloud-sdk-go/services/cdn"
 
 	"github.com/aliyun/alibaba-cloud-sdk-go/services/ecs"
+	"github.com/aliyun/alibaba-cloud-sdk-go/services/elasticsearch"
 	"github.com/aliyun/alibaba-cloud-sdk-go/services/ess"
 	"github.com/aliyun/alibaba-cloud-sdk-go/services/ots"
 	"github.com/aliyun/alibaba-cloud-sdk-go/services/rds"
@@ -331,6 +332,15 @@ func tagsToMap(tags []ecs.Tag) map[string]string {
 		if !ecsTagIgnored(t) {
 			result[t.TagKey] = t.TagValue
 		}
+	}
+
+	return result
+}
+
+func elasticsearchTagsToMap(tags []elasticsearch.Tag) map[string]string {
+	result := make(map[string]string)
+	for _, t := range tags {
+		result[t.TagKey] = t.TagValue
 	}
 
 	return result

--- a/website/docs/d/elasticsearch.html.markdown
+++ b/website/docs/d/elasticsearch.html.markdown
@@ -10,7 +10,7 @@ description: |-
 # alicloud\_elasticsearch\_instances
 
 The `alicloud_elasticsearch_instances` data source provides a collection of Elasticsearch instances available in Alicloud account.
-Filters support description regex and other filters which are listed below.
+Filters support description regex, searches by tags, and other filters which are listed below.
 
 ## Example Usage
 
@@ -28,6 +28,7 @@ The following arguments are supported:
 * `description_regex` - (Optional) A regex string to apply to the instance description.
 * `ids` - (Optional, Available 1.52.1+) A list of Elasticsearch instance IDs.
 * `version` - (Optional) Elasticsearch version. Options are `5.5.3_with_X-Pack`, `6.3.2_with_X-Pack` and `6.7.0_with_X-Pack`. If no value is specified, all versions are returned.
+* `tags` - (Optional, Available 1.74.0+) A map of tags assigned to instances.
 * `output_file` - (Optional) File name where to save data source results (after running `terraform plan`).
 
 ## Attributes Reference
@@ -49,3 +50,4 @@ The following attributes are exported in addition to the arguments listed above:
   * `cerated_at` - The creation time of the instance. It's a GTM format, such as: "2019-01-08T15:50:50.623Z".
   * `updated_at` - The last modified time of the instance. It's a GMT format, such as: "2019-01-08T15:50:50.623Z".
   * `status` - Status of the instance. It includes `active`, `activating`, `inactive`
+  * `tags` - A map of tags assigned to the instance.


### PR DESCRIPTION
TF_ACC=1 go test ./alicloud -v -run=TestAccAlicloudElasticsearchDataSource --timeout=300m
^@=== RUN   TestAccAlicloudElasticsearchDataSource
^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@--- PASS: TestAccAlicloudElasticsearchDataSource (1667.44s)
PASS
ok    github.com/terraform-providers/terraform-provider-alicloud/alicloud  1667.506s