### PR TITLE
user want api server's public ip when they set endpoint_public_access…

### DIFF
--- a/alicloud/resource_alicloud_cs_serverless_kubernetes.go
+++ b/alicloud/resource_alicloud_cs_serverless_kubernetes.go
@@ -248,7 +248,7 @@ func resourceAlicloudCSServerlessKubernetesRead(d *schema.ResourceData, meta int
 		if err := invoker.Run(func() error {
 			raw, err := client.WithCsClient(func(csClient *cs.Client) (interface{}, error) {
 				requestInfo = csClient
-				return csClient.DescribeClusterUserConfig(d.Id(), d.Get("endpoint_public_access_enabled").(bool))
+				return csClient.DescribeClusterUserConfig(d.Id(), !d.Get("endpoint_public_access_enabled").(bool))
 			})
 			response = raw
 			return err


### PR DESCRIPTION
…_enabled to true. the second parameter in DescribeClusterUserConfig is "privateIpAddress", so it should be endpoint_public_access_enabled's negative value.