### PR TITLE
added support for isp_cities in site_monitor

### DIFF
--- a/alicloud/resource_alicloud_cms_site_monitor_test.go
+++ b/alicloud/resource_alicloud_cms_site_monitor_test.go
@@ -58,6 +58,7 @@ func TestAccAlicloudCmsSiteMonitor_update(t *testing.T) {
 					resource.TestCheckResourceAttr("alicloud_cms_site_monitor.update", "task_name", "tf-testAccCmsSiteMonitor_update"),
 					resource.TestCheckResourceAttr("alicloud_cms_site_monitor.update", "interval", "5"),
 					resource.TestCheckResourceAttr("alicloud_cms_site_monitor.update", "address", "http://www.alibabacloud.com"),
+					resource.TestCheckResourceAttr("alicloud_cms_site_monitor.update", "isp_cities.#", "1"),
 				),
 			},
 
@@ -67,6 +68,7 @@ func TestAccAlicloudCmsSiteMonitor_update(t *testing.T) {
 					resource.TestCheckResourceAttr("alicloud_cms_site_monitor.update", "task_name", "tf-testAccCmsSiteMonitor_updateafter"),
 					resource.TestCheckResourceAttr("alicloud_cms_site_monitor.update", "interval", "1"),
 					resource.TestCheckResourceAttr("alicloud_cms_site_monitor.update", "address", "http://www.alibaba.com"),
+					resource.TestCheckResourceAttr("alicloud_cms_site_monitor.update", "isp_cities.#", "2"),
 				),
 			},
 		},
@@ -109,6 +111,10 @@ func testAccCmsSiteMonitor_basic() string {
 	  task_name = "tf-testAccCmsSiteMonitor_basic"
 	  task_type = "HTTP"
 	  interval = 5
+	  isp_cities {
+		  city = "546"
+		  isp = "465"
+	  }
 	}
 	`)
 }
@@ -122,6 +128,10 @@ resource "alicloud_cms_site_monitor" "update" {
 	task_name = "tf-testAccCmsSiteMonitor_update"
 	task_type = "HTTP"
 	interval = 5
+	isp_cities {
+		city = "546"
+		isp = "465"
+	}
 }
 `)
 }
@@ -136,6 +146,14 @@ func testAccCmsSiteMonitor_updateAfter() string {
 		task_name = "tf-testAccCmsSiteMonitor_updateafter"
 		task_type = "HTTP"
 		interval = 1
+		isp_cities {
+			city = "546"
+			isp = "465"
+		}
+		isp_cities {
+			city = "572"
+			isp = "465"
+		}
 	}
 	`)
 }

--- a/alicloud/service_alicloud_cms.go
+++ b/alicloud/service_alicloud_cms.go
@@ -16,6 +16,8 @@ type CmsService struct {
 	client *connectivity.AliyunClient
 }
 
+type IspCities []map[string]string
+
 func (s *CmsService) BuildCmsCommonRequest(region string) *requests.CommonRequest {
 	request := requests.NewCommonRequest()
 	return request
@@ -109,4 +111,27 @@ func (s *CmsService) DescribeSiteMonitor(id, keyword string) (siteMonitor cms.Si
 		}
 	}
 	return siteMonitor, GetNotFoundErrorFromString(GetNotFoundMessage("Site Monitor", id))
+}
+
+func (s *CmsService) GetIspCities(id string) (ispCities IspCities, err error) {
+	request := cms.CreateDescribeSiteMonitorAttributeRequest()
+	request.TaskId = id
+
+	raw, err := s.client.WithCmsClient(func(cmsClient *cms.Client) (interface{}, error) {
+		return cmsClient.DescribeSiteMonitorAttribute(request)
+	})
+
+	if err != nil {
+		return nil, err
+	}
+
+	response := raw.(*cms.DescribeSiteMonitorAttributeResponse)
+	ispCity := response.SiteMonitors.IspCities.IspCity
+
+	var list []map[string]string
+	for _, element := range ispCity {
+		list = append(list, map[string]string{"city": element.City, "isp": element.Isp})
+	}
+
+	return list, nil
 }

--- a/go.sum
+++ b/go.sum
@@ -264,6 +264,7 @@ github.com/hashicorp/terraform-config-inspect v0.0.0-20191115094559-17f92b0546e8
 github.com/hashicorp/terraform-config-inspect v0.0.0-20191115094559-17f92b0546e8/go.mod h1:p+ivJws3dpqbp1iP84+npOyAmTTOLMgCzrXd3GSdn/A=
 github.com/hashicorp/terraform-plugin-sdk v1.4.0 h1:b1LluARpES0Gq78oF4a9of3eS0iXM5JTwlt604vGvBY=
 github.com/hashicorp/terraform-plugin-sdk v1.4.0/go.mod h1:H5QLx/uhwfxBZ59Bc5SqT19M4i+fYt7LZjHTpbLZiAg=
+github.com/hashicorp/terraform-plugin-sdk v1.8.0 h1:HE1p52nzcgz88hIJmapUnkmM9noEjV3QhTOLaua5XUA=
 github.com/hashicorp/terraform-svchost v0.0.0-20191011084731-65d371908596 h1:hjyO2JsNZUKT1ym+FAdlBEkGPevazYsmVgIMw7dVELg=
 github.com/hashicorp/terraform-svchost v0.0.0-20191011084731-65d371908596/go.mod h1:kNDNcF7sN4DocDLBkQYz73HGKwN1ANB1blq4lIYLYvg=
 github.com/hashicorp/vault v0.10.4 h1:4x0lHxui/ZRp/B3E0Auv1QNBJpzETqHR2kQD3mHSBJU=

--- a/website/docs/r/cms_sitemonitor.html.markdown
+++ b/website/docs/r/cms_sitemonitor.html.markdown
@@ -24,6 +24,10 @@ resource "alicloud_cms_sitemonitor" "basic" {
 	  task_name = "tf-testAccCmsSiteMonitor_basic"
 	  task_type = "HTTP"
 	  interval = 5
+	  isp_cities {
+		city = "546"
+		isp = "465"
+	  }
 	}   
 }
 ```


### PR DESCRIPTION
This PR adds support for attribute `isp_cities` in site_monitor.
For example:
```
resource "alicloud_cms_sitemonitor" "basic" {
	  address = "http://www.alibabacloud.com"
	  task_name = "tf-testAccCmsSiteMonitor_basic"
	  task_type = "HTTP"
	  interval = 5
	  isp_cities {
		city = "546"
		isp = "465"
	  }  
}
```