### PR TITLE
alicloud_kms_secret: mark secret_data as sensitive

### DIFF
--- a/alicloud/resource_alicloud_kms_secret.go
+++ b/alicloud/resource_alicloud_kms_secret.go
@@ -51,8 +51,9 @@ func resourceAlicloudKmsSecret() *schema.Resource {
 				},
 			},
 			"secret_data": {
-				Type:     schema.TypeString,
-				Required: true,
+				Type:      schema.TypeString,
+				Required:  true,
+				Sensitive: true,
 			},
 			"secret_data_type": {
 				Type:         schema.TypeString,


### PR DESCRIPTION
So that it doesn't show up in Terraform diffs.