### PR TITLE
export alicloud_cs_serverless_kubernetes client_cert/client_key/cluster_ca_cert/kube_config as attributes so we can pass them directly to kubernetes provider

### DIFF
--- a/examples/serverless-kubernetes/outputs.tf
+++ b/examples/serverless-kubernetes/outputs.tf
@@ -26,4 +26,3 @@ output "endpoint_public_access_enabled" {
 }
 
 
-


### PR DESCRIPTION
One common scenario of using alicloud_cs_serverless_kubernetes is we create a cluster and store it's key information in a backend, then another terraform stack can read these keys from remote state then provision the cluster. If we want to do so now, we need write these key informations into four files and read them into backend. Imagine if you'are using CI, and your CI agent is a container in a K8s cluster, the runner who created cluster is different than the runner who need to destroy it, and runner who want to destroy this cluster will find lacking of these four files and throw an error.

So the best way is export these keys directly as attributes so we can store them into backend or pass them to kubernetes provider instead of writing to any file.