### PR TITLE
A new resource vbr

### DIFF
--- a/alicloud/data_source_alicloud_virtual_border_routers.go
+++ b/alicloud/data_source_alicloud_virtual_border_routers.go
@@ -1,0 +1,260 @@
+package alicloud
+
+import (
+	"regexp"
+
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/validation"
+
+	"github.com/aliyun/alibaba-cloud-sdk-go/sdk/requests"
+	"github.com/aliyun/alibaba-cloud-sdk-go/services/vpc"
+	"github.com/terraform-providers/terraform-provider-alicloud/alicloud/connectivity"
+)
+
+func dataSourceAlicloudVirtualBorderRouters() *schema.Resource {
+	return &schema.Resource{
+		Read: dataSourceAlicloudVirtualBorderRoutersRead,
+
+		Schema: map[string]*schema.Schema{
+			"status": {
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: true,
+			},
+			"name_regex": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ValidateFunc: validation.ValidateRegexp,
+				ForceNew:     true,
+			},
+			"physical_connection_id": {
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: true,
+			},
+			"physical_connection_owner_uid": {
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: true,
+			},
+			"output_file": {
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: true,
+			},
+			"ids": {
+				Type:     schema.TypeList,
+				Optional: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+				ForceNew: true,
+				MinItems: 1,
+			},
+			"names": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+			},
+			// Computed values
+			"vbrs": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"status": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"name": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"description": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"vlan_id": {
+							Type:     schema.TypeInt,
+							Computed: true,
+						},
+						"route_table_id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"vlan_interface_id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"local_gateway_ip": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"peer_gateway_ip": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"peering_subnet_mask": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"physical_connection_id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"physical_connection_owner_uid": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"access_point_id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"creation_time": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"circuit_code": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func dataSourceAlicloudVirtualBorderRoutersRead(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*connectivity.AliyunClient)
+
+	request := vpc.CreateDescribeVirtualBorderRoutersRequest()
+	request.RegionId = string(client.Region)
+	request.PageSize = requests.NewInteger(PageSizeLarge)
+	request.PageNumber = requests.NewInteger(1)
+	var filters []vpc.DescribeVirtualBorderRoutersFilter
+	for _, key := range []string{"status", "physical_connection_id", "physical_connection_owner_uid"} {
+		if v, ok := d.GetOk(key); ok && v.(string) != "" {
+			value := []string{v.(string)}
+			filters = append(filters, vpc.DescribeVirtualBorderRoutersFilter{
+				Key:   terraformToAPI(key),
+				Value: &value,
+			})
+		}
+	}
+
+	request.Filter = &filters
+
+	idsMap := make(map[string]string)
+	if v, ok := d.GetOk("ids"); ok {
+		for _, vv := range v.([]interface{}) {
+			idsMap[Trim(vv.(string))] = Trim(vv.(string))
+		}
+	}
+
+	var allVirtualBorderRouters []vpc.VirtualBorderRouterType
+	invoker := NewInvoker()
+
+	for {
+		var response *vpc.DescribeVirtualBorderRoutersResponse
+		if err := invoker.Run(func() error {
+			raw, err := client.WithVpcClient(func(vpcClient *vpc.Client) (interface{}, error) {
+				return vpcClient.DescribeVirtualBorderRouters(request)
+			})
+			if err != nil {
+				return err
+			}
+			addDebug(request.GetActionName(), raw, request.RpcRequest, request)
+			response, _ = raw.(*vpc.DescribeVirtualBorderRoutersResponse)
+			return nil
+		}); err != nil {
+			return WrapErrorf(err, DataDefaultErrorMsg, "alicloud_virtual_border_routers", request.GetActionName(), AlibabaCloudSdkGoERROR)
+		}
+
+		if len(response.VirtualBorderRouterSet.VirtualBorderRouterType) < 1 {
+			break
+		}
+
+		allVirtualBorderRouters = append(allVirtualBorderRouters, response.VirtualBorderRouterSet.VirtualBorderRouterType...)
+
+		if len(response.VirtualBorderRouterSet.VirtualBorderRouterType) < PageSizeLarge {
+			break
+		}
+
+		if page, err := getNextpageNumber(request.PageNumber); err != nil {
+			return WrapError(err)
+		} else {
+			request.PageNumber = page
+		}
+
+	}
+
+	var filteredVirtualBorderRouters []vpc.VirtualBorderRouterType
+	var r *regexp.Regexp
+	if nameRegex, ok := d.GetOk("name_regex"); ok && nameRegex.(string) != "" {
+		r = regexp.MustCompile(nameRegex.(string))
+	}
+
+	for _, v := range allVirtualBorderRouters {
+		if len(idsMap) > 0 {
+			if _, ok := idsMap[v.VbrId]; !ok {
+				continue
+			}
+		}
+		if r != nil && !r.MatchString(v.Name) {
+			continue
+		}
+		filteredVirtualBorderRouters = append(filteredVirtualBorderRouters, v)
+	}
+
+	return vbrDescriptionAttributes(d, filteredVirtualBorderRouters, meta)
+}
+
+func vbrDescriptionAttributes(d *schema.ResourceData, vbrSetTypes []vpc.VirtualBorderRouterType, meta interface{}) error {
+	var ids []string
+	var names []string
+	var s []map[string]interface{}
+	for _, vbr := range vbrSetTypes {
+		mapping := map[string]interface{}{
+			"id":                            vbr.VbrId,
+			"status":                        vbr.Status,
+			"name":                          vbr.Name,
+			"description":                   vbr.Description,
+			"vlan_id":                       vbr.VlanId,
+			"route_table_id":                vbr.RouteTableId,
+			"vlan_interface_id":             vbr.VlanInterfaceId,
+			"local_gateway_ip":              vbr.LocalGatewayIp,
+			"peer_gateway_ip":               vbr.PeerGatewayIp,
+			"peering_subnet_mask":           vbr.PeeringSubnetMask,
+			"physical_connection_id":        vbr.PhysicalConnectionId,
+			"physical_connection_owner_uid": vbr.PhysicalConnectionOwnerUid,
+			"access_point_id":               vbr.AccessPointId,
+			"creation_time":                 vbr.CreationTime,
+			"circuit_code":                  vbr.CircuitCode,
+		}
+		ids = append(ids, vbr.VbrId)
+		names = append(names, vbr.Name)
+		s = append(s, mapping)
+	}
+
+	d.SetId(dataResourceIdHash(ids))
+	if err := d.Set("ids", ids); err != nil {
+		return WrapError(err)
+	}
+
+	if err := d.Set("names", names); err != nil {
+		return WrapError(err)
+	}
+
+	if err := d.Set("vbrs", s); err != nil {
+		return WrapError(err)
+	}
+
+	// create a json file in current directory and write data source to it.
+	if output, ok := d.GetOk("output_file"); ok && output.(string) != "" {
+		writeToFile(output.(string), s)
+	}
+	return nil
+}

--- a/alicloud/data_source_alicloud_virtual_border_routers_test.go
+++ b/alicloud/data_source_alicloud_virtual_border_routers_test.go
@@ -1,0 +1,130 @@
+package alicloud
+
+import (
+	"fmt"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/hashicorp/terraform/helper/acctest"
+)
+
+func TestAccAlicloudVirtualBorderRoutersDataSource(t *testing.T) {
+	rand := acctest.RandInt()
+	physicalConnectionIdConf := dataSourceTestAccConfig{
+		existConfig: testAccCheckAlicloudVirtualBorderRoutersDataSourceConfig(rand, map[string]string{
+			"physical_connection_id": `"${alicloud_virtual_border_router.default.physical_connection_id}"`,
+		}),
+		fakeConfig: testAccCheckAlicloudVirtualBorderRoutersDataSourceConfig(rand, map[string]string{
+			"physical_connection_id": `"${alicloud_virtual_border_router.default.physical_connection_id}_fake"`,
+		}),
+	}
+
+	statusConf := dataSourceTestAccConfig{
+		existConfig: testAccCheckAlicloudVirtualBorderRoutersDataSourceConfig(rand, map[string]string{
+			"physical_connection_id": `"${alicloud_virtual_border_router.default.physical_connection_id}"`,
+			"status":                 `"active"`,
+		}),
+		fakeConfig: testAccCheckAlicloudVirtualBorderRoutersDataSourceConfig(rand, map[string]string{
+			"physical_connection_id": `"${alicloud_virtual_border_router.default.physical_connection_id}_fake"`,
+			"status":                 `"terminated"`,
+		}),
+	}
+
+	nameRegexConf := dataSourceTestAccConfig{
+		existConfig: testAccCheckAlicloudVirtualBorderRoutersDataSourceConfig(rand, map[string]string{
+			"name_regex": `"${alicloud_virtual_border_router.default.name}"`,
+		}),
+		fakeConfig: testAccCheckAlicloudVirtualBorderRoutersDataSourceConfig(rand, map[string]string{
+			"name_regex": `"${alicloud_virtual_border_router.default.name}_fake"`,
+		}),
+	}
+
+	idsConf := dataSourceTestAccConfig{
+		existConfig: testAccCheckAlicloudVirtualBorderRoutersDataSourceConfig(rand, map[string]string{
+			"ids": `["${alicloud_virtual_border_router.default.id}"]`,
+		}),
+		fakeConfig: testAccCheckAlicloudVirtualBorderRoutersDataSourceConfig(rand, map[string]string{
+			"ids": `["${alicloud_virtual_border_router.default.id}_fake"]`,
+		}),
+	}
+
+	allConf := dataSourceTestAccConfig{
+		existConfig: testAccCheckAlicloudVirtualBorderRoutersDataSourceConfig(rand, map[string]string{
+			"physical_connection_id": `"${alicloud_virtual_border_router.default.physical_connection_id}"`,
+			"name_regex":             `"${alicloud_virtual_border_router.default.name}"`,
+			"ids":                    `["${alicloud_virtual_border_router.default.id}"]`,
+		}),
+		fakeConfig: testAccCheckAlicloudVirtualBorderRoutersDataSourceConfig(rand, map[string]string{
+			"physical_connection_id": `"${alicloud_virtual_border_router.default.physical_connection_id}_fake"`,
+			"name_regex":             `"${alicloud_virtual_border_router.default.name}_fake"`,
+			"ids":                    `["${alicloud_virtual_border_router.default.id}_fake"]`,
+		}),
+	}
+	var virtualBorderRoutersCheckInfo = dataSourceAttr{
+		resourceId:   "data.alicloud_virtual_border_routers.default",
+		existMapFunc: existVirtualBorderRoutersMapFunc,
+		fakeMapFunc:  fakeVirtualBorderRoutersMapFunc,
+	}
+	preCheck := func() {
+		testAccPreCheckWithPhysicalConnectionSetting(t)
+	}
+	virtualBorderRoutersCheckInfo.dataSourceTestCheckWithPreCheck(t, rand, preCheck,
+		physicalConnectionIdConf, statusConf, nameRegexConf,
+		idsConf, allConf)
+}
+
+func testAccCheckAlicloudVirtualBorderRoutersDataSourceConfig(rand int, attrMap map[string]string) string {
+	var pairs []string
+	for k, v := range attrMap {
+		pairs = append(pairs, k+" = "+v)
+	}
+
+	config := fmt.Sprintf(`
+variable "name" {
+	default = "tf-testAccCheckAlicloudVirtualBorderRoutersDataSourceBasic-%d"
+}
+
+resource "alicloud_virtual_border_router" "default" {
+	physical_connection_id = "%s"
+	vlan_id                = 2500
+	local_gateway_ip       = "10.0.0.3"
+	peer_gateway_ip        = "10.0.0.4"
+	peering_subnet_mask    = "255.255.255.0"
+	name                   = "${var.name}"
+	description            = "example"
+}
+
+data "alicloud_virtual_border_routers" "default" {
+	%s
+}`, rand, os.Getenv("ALICLOUD_PHYSICAL_CONNECTION_ID"), strings.Join(pairs, "\n  "))
+	return config
+}
+
+var existVirtualBorderRoutersMapFunc = func(rand int) map[string]string {
+	return map[string]string{
+		"vbrs.0.id":                            CHECKSET,
+		"vbrs.0.status":                        "active",
+		"vbrs.0.name":                          fmt.Sprintf("tf-testAccCheckAlicloudVirtualBorderRoutersDataSourceBasic-%d", rand),
+		"vbrs.0.description":                   "example",
+		"vbrs.0.vlan_id":                       "2500",
+		"vbrs.0.route_table_id":                CHECKSET,
+		"vbrs.0.vlan_interface_id":             CHECKSET,
+		"vbrs.0.local_gateway_ip":              "10.0.0.3",
+		"vbrs.0.peer_gateway_ip":               "10.0.0.4",
+		"vbrs.0.peering_subnet_mask":           "255.255.255.0",
+		"vbrs.0.physical_connection_id":        CHECKSET,
+		"vbrs.0.physical_connection_owner_uid": CHECKSET,
+		"vbrs.0.access_point_id":               CHECKSET,
+		"vbrs.0.creation_time":                 CHECKSET,
+		"vbrs.0.circuit_code":                  "",
+	}
+}
+
+var fakeVirtualBorderRoutersMapFunc = func(rand int) map[string]string {
+	return map[string]string{
+		"ids.#":   "0",
+		"names.#": "0",
+		"vbrs.#":  "0",
+	}
+}

--- a/alicloud/provider.go
+++ b/alicloud/provider.go
@@ -273,6 +273,7 @@ func Provider() terraform.ResourceProvider {
 			"alicloud_edas_applications":                 dataSourceAlicloudEdasApplications(),
 			"alicloud_edas_deploy_groups":                dataSourceAlicloudEdasDeployGroups(),
 			"alicloud_edas_clusters":                     dataSourceAlicloudEdasClusters(),
+			"alicloud_virtual_border_routers":            dataSourceAlicloudVirtualBorderRouters(),
 		},
 		ResourcesMap: map[string]*schema.Resource{
 			"alicloud_instance":                           resourceAliyunInstance(),
@@ -496,6 +497,7 @@ func Provider() terraform.ResourceProvider {
 			"alicloud_resource_manager_folder":             resourceAlicloudResourceManagerFolder(),
 			"alicloud_resource_manager_handshake":          resourceAlicloudResourceManagerHandshake(),
 			"alicloud_cen_private_zone":                    resourceAlicloudCenPrivateZone(),
+			"alicloud_virtual_border_router":               resourceAlicloudVirtualBorderRouter(),
 		},
 
 		ConfigureFunc: providerConfigure,

--- a/alicloud/provider_test.go
+++ b/alicloud/provider_test.go
@@ -181,6 +181,13 @@ func testAccPreCheckWithSmartAccessGatewayAppSetting(t *testing.T) {
 	}
 }
 
+func testAccPreCheckWithPhysicalConnectionSetting(t *testing.T) {
+	if v := strings.TrimSpace(os.Getenv("ALICLOUD_PHYSICAL_CONNECTION_ID")); v == "" {
+		t.Skipf("Skipping the test case with no physical connection id setting")
+		t.Skipped()
+	}
+}
+
 func testAccPreCheckWithTime(t *testing.T) {
 	if time.Now().Day() != 1 {
 		t.Skipf("Skipping the test case with not the 1st of every month")

--- a/alicloud/resource_alicloud_virtual_border_router.go
+++ b/alicloud/resource_alicloud_virtual_border_router.go
@@ -1,0 +1,219 @@
+package alicloud
+
+import (
+	"time"
+
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/validation"
+
+	"github.com/aliyun/alibaba-cloud-sdk-go/sdk/requests"
+	"github.com/aliyun/alibaba-cloud-sdk-go/services/vpc"
+	"github.com/terraform-providers/terraform-provider-alicloud/alicloud/connectivity"
+)
+
+func resourceAlicloudVirtualBorderRouter() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceAliyunVirtualBorderRouterCreate,
+		Read:   resourceAliyunVirtualBorderRouterRead,
+		Update: resourceAliyunVirtualBorderRouterUpdate,
+		Delete: resourceAliyunVirtualBorderRouterDelete,
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
+
+		Schema: map[string]*schema.Schema{
+			"physical_connection_id": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"vlan_id": {
+				Type:         schema.TypeInt,
+				Required:     true,
+				ValidateFunc: validation.IntBetween(1, 2999),
+			},
+			"local_gateway_ip": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"peer_gateway_ip": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"peering_subnet_mask": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"name": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"description": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ValidateFunc: validation.StringLenBetween(2, 256),
+			},
+			"vlan_interface_id": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"route_table_id": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func resourceAliyunVirtualBorderRouterCreate(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*connectivity.AliyunClient)
+
+	request := vpc.CreateCreateVirtualBorderRouterRequest()
+	request.RegionId = client.RegionId
+	request.PhysicalConnectionId = d.Get("physical_connection_id").(string)
+	request.VlanId = requests.NewInteger(d.Get("vlan_id").(int))
+	request.LocalGatewayIp = d.Get("local_gateway_ip").(string)
+	request.PeerGatewayIp = d.Get("peer_gateway_ip").(string)
+	request.PeeringSubnetMask = d.Get("peering_subnet_mask").(string)
+
+	if v, ok := d.GetOk("name"); ok && v != "" {
+		request.Name = v.(string)
+	}
+
+	if v, ok := d.GetOk("description"); ok && v != "" {
+		request.Description = v.(string)
+	}
+
+	request.ClientToken = buildClientToken(request.GetActionName())
+
+	if err := resource.Retry(3*time.Minute, func() *resource.RetryError {
+		raw, err := client.WithVpcClient(func(vpcClient *vpc.Client) (interface{}, error) {
+			return vpcClient.CreateVirtualBorderRouter(request)
+		})
+		if err != nil {
+			if IsExpectedErrors(err, []string{"TaskConflict", "UnknownError"}) {
+				return resource.RetryableError(err)
+			}
+			return resource.NonRetryableError(err)
+		}
+		addDebug(request.GetActionName(), raw, request.RpcRequest, request)
+		response, _ := raw.(*vpc.CreateVirtualBorderRouterResponse)
+		d.SetId(response.VbrId)
+		return nil
+	}); err != nil {
+		return WrapErrorf(err, DefaultErrorMsg, "alicloud_virtual_border_router", request.GetActionName(), AlibabaCloudSdkGoERROR)
+	}
+
+	return resourceAliyunVirtualBorderRouterRead(d, meta)
+}
+
+func resourceAliyunVirtualBorderRouterRead(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*connectivity.AliyunClient)
+
+	vpcService := VpcService{client}
+	object, err := vpcService.DescribeVirtualBorderRouter(d.Id())
+	if err != nil {
+		if NotFoundError(err) {
+			d.SetId("")
+			return nil
+		}
+		return WrapError(err)
+	}
+
+	d.Set("physical_connection_id", object.PhysicalConnectionId)
+	d.Set("vlan_id", object.VlanId)
+	d.Set("local_gateway_ip", object.LocalGatewayIp)
+	d.Set("peer_gateway_ip", object.PeerGatewayIp)
+	d.Set("peering_subnet_mask", object.PeeringSubnetMask)
+	d.Set("name", object.Name)
+	d.Set("description", object.Description)
+	d.Set("vlan_interface_id", object.VlanInterfaceId)
+	d.Set("route_table_id", object.RouteTableId)
+	return nil
+}
+
+func resourceAliyunVirtualBorderRouterUpdate(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*connectivity.AliyunClient)
+	d.Partial(true)
+	update := false
+	request := vpc.CreateModifyVirtualBorderRouterAttributeRequest()
+	request.RegionId = client.RegionId
+	request.VbrId = d.Id()
+	request.ClientToken = buildClientToken(request.GetActionName())
+	if d.HasChange("vlan_id") {
+		request.VlanId = requests.NewInteger(d.Get("vlan_id").(int))
+		update = true
+		d.SetPartial("vlan_id")
+	}
+
+	if d.HasChange("local_gateway_ip") {
+		request.LocalGatewayIp = d.Get("local_gateway_ip").(string)
+		update = true
+		d.SetPartial("local_gateway_ip")
+	}
+
+	if d.HasChange("peer_gateway_ip") {
+		request.PeerGatewayIp = d.Get("peer_gateway_ip").(string)
+		update = true
+		d.SetPartial("peer_gateway_ip")
+	}
+
+	if d.HasChange("peering_subnet_mask") {
+		request.PeeringSubnetMask = d.Get("peering_subnet_mask").(string)
+		update = true
+		d.SetPartial("peering_subnet_mask")
+	}
+
+	if d.HasChange("name") {
+		request.Name = d.Get("name").(string)
+		update = true
+		d.SetPartial("name")
+	}
+
+	if d.HasChange("description") {
+		request.Description = d.Get("description").(string)
+		update = true
+		d.SetPartial("description")
+	}
+
+	if update {
+		raw, err := client.WithVpcClient(func(vpcClient *vpc.Client) (interface{}, error) {
+			return vpcClient.ModifyVirtualBorderRouterAttribute(request)
+		})
+		if err != nil {
+			return WrapErrorf(err, DefaultErrorMsg, d.Id(), request.GetActionName(), AlibabaCloudSdkGoERROR)
+		}
+		addDebug(request.GetActionName(), raw, request.RpcRequest, request)
+	}
+
+	d.Partial(false)
+	return resourceAliyunVirtualBorderRouterRead(d, meta)
+}
+
+func resourceAliyunVirtualBorderRouterDelete(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*connectivity.AliyunClient)
+	vpcService := VpcService{client}
+	request := vpc.CreateDeleteVirtualBorderRouterRequest()
+	request.RegionId = client.RegionId
+	request.VbrId = d.Id()
+	request.ClientToken = buildClientToken(request.GetActionName())
+	err := resource.Retry(5*time.Minute, func() *resource.RetryError {
+		raw, err := client.WithVpcClient(func(vpcClient *vpc.Client) (interface{}, error) {
+			return vpcClient.DeleteVirtualBorderRouter(request)
+		})
+		if err != nil {
+			if IsExpectedErrors(err, []string{"InvalidVbrId.NotFound"}) {
+				return nil
+			}
+			return resource.RetryableError(err)
+		}
+		addDebug(request.GetActionName(), raw, request.RpcRequest, request)
+		return nil
+	})
+	if err != nil {
+		return WrapErrorf(err, DefaultErrorMsg, d.Id(), request.GetActionName(), AlibabaCloudSdkGoERROR)
+	}
+	return WrapError(vpcService.WaitForVirtualBorderRouter(d.Id(), Deleted, DefaultTimeout))
+
+}

--- a/alicloud/resource_alicloud_virtual_border_router_test.go
+++ b/alicloud/resource_alicloud_virtual_border_router_test.go
@@ -1,0 +1,221 @@
+package alicloud
+
+import (
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/aliyun/alibaba-cloud-sdk-go/services/vpc"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+	"github.com/hashicorp/terraform/helper/acctest"
+	"github.com/terraform-providers/terraform-provider-alicloud/alicloud/connectivity"
+)
+
+func TestAccAlicloudVirtualBorderRouter_basic(t *testing.T) {
+	var v vpc.VirtualBorderRouterType
+	resourceId := "alicloud_virtual_border_router.default"
+	ra := resourceAttrInit(resourceId, nil)
+	rc := resourceCheckInit(resourceId, &v, func() interface{} {
+		return &VpcService{testAccProvider.Meta().(*connectivity.AliyunClient)}
+	})
+	rac := resourceAttrCheckInit(rc, ra)
+
+	testAccCheck := rac.resourceAttrMapUpdateSet()
+	rand := acctest.RandIntRange(1000, 9999)
+	name := fmt.Sprintf("tf-testAccVbrBasic%d", rand)
+	testAccConfig := resourceTestAccConfigFunc(resourceId, name, resourceVirtualBorderRouterConfigDependence)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+			testAccPreCheckWithPhysicalConnectionSetting(t)
+		},
+		// module name
+		IDRefreshName: resourceId,
+		Providers:     testAccProviders,
+		CheckDestroy:  rac.checkResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"physical_connection_id": os.Getenv("ALICLOUD_PHYSICAL_CONNECTION_ID"),
+					"vlan_id":                "2500",
+					"local_gateway_ip":       "10.0.0.1",
+					"peer_gateway_ip":        "10.0.0.2",
+					"peering_subnet_mask":    "255.255.255.0",
+					"name":                   name,
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"name":              name,
+						"vlan_interface_id": CHECKSET,
+						"route_table_id":    CHECKSET,
+					}),
+				),
+			},
+			{
+				ResourceName:      resourceId,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"vlan_id": "2501",
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"vlan_id": "2501",
+					}),
+				),
+			},
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"local_gateway_ip": "10.0.0.3",
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"local_gateway_ip": "10.0.0.3",
+					}),
+				),
+			},
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"peer_gateway_ip": "10.0.0.4",
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"peer_gateway_ip": "10.0.0.4",
+					}),
+				),
+			},
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"peering_subnet_mask": "255.255.0.0",
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"peering_subnet_mask": "255.255.0.0",
+					}),
+				),
+			},
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"name": name,
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"name": name,
+					}),
+				),
+			},
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"description": fmt.Sprintf("tf-testAccVirtualBorderRouterBasic%d_description", rand),
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"description": fmt.Sprintf("tf-testAccVirtualBorderRouterBasic%d_description", rand),
+					}),
+				),
+			},
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"vlan_id":             "2502",
+					"local_gateway_ip":    "10.0.0.4",
+					"peer_gateway_ip":     "10.0.0.5",
+					"peering_subnet_mask": "255.255.252.0",
+					"name":                name,
+					"description":         fmt.Sprintf("tf-testAccVirtualBorderRouterBasic%d_description", rand),
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"vlan_id":             "2502",
+						"local_gateway_ip":    "10.0.0.4",
+						"peer_gateway_ip":     "10.0.0.5",
+						"peering_subnet_mask": "255.255.252.0",
+						"name":                name,
+						"description":         fmt.Sprintf("tf-testAccVirtualBorderRouterBasic%d_description", rand),
+						"vlan_interface_id":   CHECKSET,
+						"route_table_id":      CHECKSET,
+					}),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAlicloudVirtualBorderRouter_multi(t *testing.T) {
+	var v vpc.VirtualBorderRouterType
+	resourceId := "alicloud_virtual_border_router.default.1"
+	ra := resourceAttrInit(resourceId, nil)
+	rc := resourceCheckInit(resourceId, &v, func() interface{} {
+		return &VpcService{testAccProvider.Meta().(*connectivity.AliyunClient)}
+	})
+	rac := resourceAttrCheckInit(rc, ra)
+	testAccCheck := rac.resourceAttrMapUpdateSet()
+
+	rand := acctest.RandIntRange(1000, 9999)
+	name := fmt.Sprintf("tf-testAccVbrMulti%d", rand)
+
+	testAccConfig := resourceTestAccConfigFunc(resourceId, name, resourceVirtualBorderRouterConfigDependenceForMulti)
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+		},
+		// module name
+		IDRefreshName: resourceId,
+		Providers:     testAccProviders,
+		CheckDestroy:  rac.checkResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"count":                  "2",
+					"physical_connection_id": os.Getenv("ALICLOUD_PHYSICAL_CONNECTION_ID"),
+					"vlan_id":                "${element(var.vlan_id_list,count.index)}",
+					"local_gateway_ip":       "${element(var.local_gateway_ip_list,count.index)}",
+					"peer_gateway_ip":        "${element(var.peer_gateway_ip_list,count.index)}",
+					"peering_subnet_mask":    "255.255.255.0",
+					"name":                   name,
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"vlan_id":             "2504",
+						"local_gateway_ip":    "10.0.0.3",
+						"peer_gateway_ip":     "10.0.0.4",
+						"peering_subnet_mask": "255.255.255.0",
+						"name":                name,
+						"vlan_interface_id":   CHECKSET,
+						"route_table_id":      CHECKSET,
+					}),
+				),
+			},
+		},
+	})
+}
+
+func resourceVirtualBorderRouterConfigDependence(name string) string {
+	return fmt.Sprintf(`
+	variable "name" {
+		default = "%s"
+	}
+	`, name)
+}
+
+func resourceVirtualBorderRouterConfigDependenceForMulti(name string) string {
+	return fmt.Sprintf(`
+	variable "name" {
+		default = "%s"
+	}
+	variable "vlan_id_list" {
+		type = "list"
+		default = [ "2503", "2504" ]
+	}
+	variable "local_gateway_ip_list" {
+		type = "list"
+		default = [ "10.0.0.1", "10.0.0.3" ]
+	}
+	variable "peer_gateway_ip_list" {
+		type = "list"
+		default = [ "10.0.0.2", "10.0.0.4" ]
+	}
+	`, name)
+}

--- a/website/alicloud.erb
+++ b/website/alicloud.erb
@@ -1694,6 +1694,9 @@
                             <li>
                                 <a href="/docs/providers/alicloud/d/forward_entries.html">alicloud_forward_entries</a>
                             </li>
+                            <li>
+                                <a href="/docs/providers/alicloud/d/virtual_border_routers.html">alicloud_virtual_border_routers</a>
+                            </li>
                         </ul>
                       </li>
                       <li>
@@ -1749,6 +1752,9 @@
                             </li>
                             <li>
                                 <a href="/docs/providers/alicloud/r/vswitch.html">alicloud_vswitch</a>
+                            </li>
+                            <li>
+                                <a href="/docs/providers/alicloud/r/virtual_border_router.html">alicloud_virtual_border_router</a>
                             </li>
                         </ul>
                       </li>

--- a/website/docs/d/virtual_border_routers.html.markdown
+++ b/website/docs/d/virtual_border_routers.html.markdown
@@ -1,0 +1,58 @@
+---
+subcategory: "VPC"
+layout: "alicloud"
+page_title: "Alicloud: alicloud_virtual_border_routers"
+sidebar_current: "docs-alicloud-datasource-virtual-border-routers"
+description: |-
+    Provides a list of virtual border routers owned by an Alibaba Cloud account.
+---
+
+# alicloud\_virtual_border_routers
+
+This data source provides a list of virtual border routers owned by an Alibaba Cloud account.
+
+-> **NOTE:**  Available in 1.83.0+
+
+## Example Usage
+
+```
+data "alicloud_virtual_border_routers" "default" {
+}
+
+output "first_virtual_border_router_id" {
+  value = "${data.alicloud_virtual_border_routers.default.vbrs.0.id}"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `status` - (Optional) Expected status. Valid values are `active` and `terminated`.
+* `name_regex` - (Optional) A regex string used to filter by virtual border router name.
+* `physical_connection_id` - (Optional) The ID of the physical connection.
+* `physical_connection_owner_uid` - (Optional) The UID of the owner of the physical connection.
+* `output_file` - (Optional) File name where to save data source results (after running `terraform plan`).
+
+## Attributes Reference
+
+The following attributes are exported in addition to the arguments listed above:
+
+* `ids` - A list of virtual border router IDs.
+* `names` - A list of virtual border router names.
+* `vbrs` - A list of virtual border routers. Each element contains the following attributes:
+  * `id` - Virtual border router ID.
+  * `status` - Status of the VBR. Valid values are `active` and `terminated`.
+  * `name` - The name of the VBR.
+  * `description` - The description of the VBR.
+  * `vlan_id` - The VLAN ID of the VBR.
+  * `route_table_id` - The ID of the route table of the VBR.
+  * `vlan_interface_id` - ID of the VRouter located in the local region.
+  * `local_gateway_ip` - The Alibaba Cloud-side IP address used by the VBR.
+  * `peer_gateway_ip` - The customer-side IP address used by the VBR.
+  * `peering_subnet_mask` - The subnet mask for the Alibaba Cloud-side IP address and the customer-side IP address.
+  * `physical_connection_id` - The ID of the physical connection.
+  * `physical_connection_owner_uid` - The UID of the owner of the physical connection.
+  * `access_point_id` - The ID of the physical connection access point.
+  * `creation_time` - Virtual border router creation time.
+  * `circuit_code` - The leased line code provided by the service provider for the physical connection.

--- a/website/docs/r/virtual_border_router.html.markdown
+++ b/website/docs/r/virtual_border_router.html.markdown
@@ -1,0 +1,57 @@
+---
+subcategory: "VPC"
+layout: "alicloud"
+page_title: "Alicloud: alicloud_virtual_border_router"
+sidebar_current: "docs-alicloud-resource-virtual-border-router"
+description: |-
+  Provides a Alicloud Virtual Border Router (VBR) resource.
+---
+
+# alicloud\_virtual_border_router
+
+Provides a Alicloud Virtual Border Router (VBR) resource.
+
+-> **NOTE:**  Available in 1.83.0+
+
+For information about VBR and how to use it, see [What is a Virtual Border Router](https://www.alibabacloud.com/help/doc-detail/44854.htm).
+
+## Example Usage
+
+Basic Usage
+
+```
+resource "alicloud_virtual_border_router" "default" {
+  physical_connection_id = "pc-fakeid"
+  vlan_id                = 1000
+  local_gateway_ip       = "10.0.0.1"
+  peer_gateway_ip        = "10.0.0.2"
+  peering_subnet_mask    = "255.255.255.0"
+}
+```
+## Argument Reference
+
+The following arguments are supported:
+
+* `physical_connection_id` - (Required, ForceNew) The ID of the physical connection.
+* `vlan_id` - (Required) The VLAN ID of the VBR. Value range: 1 to 2999.
+* `local_gateway_ip` - (Required) The Alibaba Cloud-side IP address used by the VBR.
+* `peer_gateway_ip` - (Required) The customer-side IP address used by the VBR.
+* `peering_subnet_mask` - (Required) The subnet mask for the Alibaba Cloud-side IP address and the customer-side IP address. The two IP addresses must be in the same subnet.
+* `name` - (Optional) The name of the VBR. Defaults to null.
+* `description` - (Optional) The description of the VBR. Defaults to null.
+
+## Attributes Reference
+
+The following attributes are exported:
+
+* `id` - The ID of the VBR.
+* `vlan_interface_id` - ID of the VRouter located in the local region.
+* `route_table_id` - The ID of the route table of the VBR.
+
+## Import
+
+VBR can be imported using the id, e.g.
+
+```
+$ terraform import alicloud_virtual_border_router.example vbr-abc123456
+```


### PR DESCRIPTION
=== RUN   TestAccAlicloudVirtualBorderRoutersDataSource
--- PASS: TestAccAlicloudVirtualBorderRoutersDataSource (11.34s)
=== RUN   TestAccAlicloudVirtualBorderRouter_basic
--- PASS: TestAccAlicloudVirtualBorderRouter_basic (9.73s)
=== RUN   TestAccAlicloudVirtualBorderRouter_multi
--- PASS: TestAccAlicloudVirtualBorderRouter_multi (2.60s)
PASS