### PR TITLE
Support service_account_issuer and api_audiences in alicloud_cs_kubernetes and alicloud_cs_managed_kubernetes

### DIFF
--- a/alicloud/resource_alicloud_cs_kubernetes.go
+++ b/alicloud/resource_alicloud_cs_kubernetes.go
@@ -619,6 +619,19 @@ func resourceAlicloudCSKubernetes() *schema.Resource {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
+			"service_account_issuer": {
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: true,
+			},
+			"api_audiences": {
+				Type:     schema.TypeList,
+				Optional: true,
+				Elem: &schema.Schema{
+					Type: schema.TypeString,
+				},
+				ForceNew: true,
+			},
 		},
 	}
 }
@@ -1133,6 +1146,11 @@ func buildKubernetesArgs(d *schema.ResourceData, meta interface{}) (*cs.Delicate
 		}
 	}
 
+	var apiAudiences string
+	if list := expandStringList(d.Get("api_audiences").([]interface{})); len(list) > 0 {
+		apiAudiences = strings.Join(list, ",")
+	}
+
 	creationArgs := &cs.DelicatedKubernetesClusterCreationRequest{
 		ClusterArgs: cs.ClusterArgs{
 			DisableRollback: true,
@@ -1155,6 +1173,8 @@ func buildKubernetesArgs(d *schema.ResourceData, meta interface{}) (*cs.Delicate
 			SnatEntry:                 d.Get("new_nat_gateway").(bool),
 			NodeNameMode:              d.Get("node_name_mode").(string),
 			Addons:                    addons,
+			ServiceAccountIssuer:      d.Get("service_account_issuer").(string),
+			ApiAudiences:              apiAudiences,
 		},
 	}
 

--- a/alicloud/resource_alicloud_cs_managed_kubernetes.go
+++ b/alicloud/resource_alicloud_cs_managed_kubernetes.go
@@ -488,6 +488,19 @@ func resourceAlicloudCSManagedKubernetes() *schema.Resource {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
+			"service_account_issuer": {
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: true,
+			},
+			"api_audiences": {
+				Type:     schema.TypeList,
+				Optional: true,
+				Elem: &schema.Schema{
+					Type: schema.TypeString,
+				},
+				ForceNew: true,
+			},
 		},
 	}
 }

--- a/website/docs/r/cs_kubernetes.html.markdown
+++ b/website/docs/r/cs_kubernetes.html.markdown
@@ -106,7 +106,8 @@ The following arguments are supported:
   - encrypted: specifies whether to encrypt data disks. Valid values: true and false.
 * `security_group_id` - (Optional, Available in 1.91.0+) The ID of the security group to which the ECS instances in the cluster belong. If it is not specified, a new Security group will be built.
 * `is_enterprise_security_group` - (Optional, Available in 1.91.0+) Enable to create advanced security group. default: false. See [Advanced security group](https://www.alibabacloud.com/help/doc-detail/120621.htm).
-
+* `service_account_issuer` - (Optional, ForceNew, Available in 1.92.0+) The issuer of the Service Account token for [Service Account Token Volume Projection](https://www.alibabacloud.com/help/doc-detail/160384.htm), corresponds to the `iss` field in the token payload. Set this to `"kubernetes.default.svc"` to enable the Token Volume Projection feature (requires specifying `api_audiences` as well).
+* `api_audiences` - (Optional, ForceNew, Available in 1.92.0+) A list of API audiences for [Service Account Token Volume Projection](https://www.alibabacloud.com/help/doc-detail/160384.htm). Set this to `["kubernetes.default.svc"]` if you want to enable the Token Volume Projection feature (requires specifying `service_account_issuer` as well.
 
 #### Addons 
 It is a new field since 1.75.0. You can specific network plugin,log component,ingress component and so on.     

--- a/website/docs/r/cs_managed_kubernetes.html.markdown
+++ b/website/docs/r/cs_managed_kubernetes.html.markdown
@@ -109,7 +109,8 @@ The following arguments are supported:
   - encrypted: specifies whether to encrypt data disks. Valid values: true and false.
 * `security_group_id` - (Optional, Available in 1.91.0+) The ID of the security group to which the ECS instances in the cluster belong. If it is not specified, a new Security group will be built.
 * `is_enterprise_security_group` - (Optional, Available in 1.91.0+) Enable to create advanced security group. default: false. See [Advanced security group](https://www.alibabacloud.com/help/doc-detail/120621.htm).
-
+* `service_account_issuer` - (Optional, ForceNew, Available in 1.92.0+) The issuer of the Service Account token for [Service Account Token Volume Projection](https://www.alibabacloud.com/help/doc-detail/160384.htm), corresponds to the `iss` field in the token payload. Set this to `kubernetes.default.svc` to enable the Token Volume Projection feature.
+* `api_audiences` - (Optional, ForceNew, Available in 1.92.0+) A list of API audiences for [Service Account Token Volume Projection](https://www.alibabacloud.com/help/doc-detail/160384.htm). Set this to `["kubernetes.default.svc"]` if you want to enable the Token Volume Projection feature.
 
 #### Addons 
 It is a new field since 1.75.0. You can specific network plugin,log component,ingress component and so on.     


### PR DESCRIPTION
fixes #2567 

This adds the necessary fields to support of service_account_issuer and api_audiences that enables Service Account Token Volume Projection. Required a bump of the aliyungo SDK.

I'm not sure about some of the `vendor`changes to alibaba-cloud-sdk-go, I suspect that it wasn't properly updated during https://github.com/terraform-providers/terraform-provider-alicloud/commit/9d6b2611c35252f24c3a131edeca4f0cfc5d63e6